### PR TITLE
[#98] Add entrypoint for iox2 cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,14 @@ members = [
     "iceoryx2-pal/posix/",
     "iceoryx2-pal/configuration/",
 
+    "iceoryx2-cli/iox2",
+    "iceoryx2-cli/iox2-introspect",
+    "iceoryx2-cli/iox2-processes",
+    "iceoryx2-cli/iox2-pub",
+    "iceoryx2-cli/iox2-rpc",
+    "iceoryx2-cli/iox2-services",
+    "iceoryx2-cli/iox2-sub",
+
     "examples",
 
     "benchmarks/publish-subscribe",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,10 @@ cc = { version = "1.0.98" }
 cdr = { version = "0.2.4" }
 clap = { version = "4.5.4", features = ["derive"] }
 enum-iterator = { version = "2.1.0" }
+better-panic = { version = "0.3.0" }
+colored = { version = "2.1" }
 generic-tests = { version = "0.1.2" }
+human-panic = { version = "1.2.3" }
 lazy_static = { version = "1.4.0" }
 log = { version = "0.4.21" }
 once_cell = { version = "1.19.0" }
@@ -90,6 +93,7 @@ serde_test = { version = "1.0.176" }
 sha1_smol = { version = "1.0.0" }
 syn = { version = "2.0.66", features = ["full"] }
 termsize = { version = "0.1.6" }
+thiserror = { version = "1.0.56" }
 tiny-fn = { version = "0.1.5" }
 toml = { version = "0.8.13" }
 tracing = { version = "0.1.40" }

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -9,6 +9,8 @@
  <!-- NOTE: Add new entries sorted by issue number to minimize the possibility of conflicts when merging. -->
 
  * Subscriber buffer size can be reduced [#19](https://github.com/eclipse-iceoryx/iceoryx2/issues/19)
+ * CLI for iox2 [#98](https://github.com/eclipse-iceoryx/iceoryx2/issues/98)
+    * Add entrypoint CLI `iox2` in preparation for adding additional CLI commands
  * Introduce Nodes [#102](https://github.com/eclipse-iceoryx/iceoryx2/issues/102)
     * Implement Serialize,Deserialize for
         * `SemanticString`

--- a/iceoryx2-cli/iox2-introspect/Cargo.toml
+++ b/iceoryx2-cli/iox2-introspect/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "iox2-introspect"
+description = "Iceoryx2: CLI for introspecting iceoryx 2 internals"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/iceoryx2-cli/iox2-introspect/src/main.rs
+++ b/iceoryx2-cli/iox2-introspect/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/iceoryx2-cli/iox2-introspect/src/main.rs
+++ b/iceoryx2-cli/iox2-introspect/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-introspect/src/main.rs
+++ b/iceoryx2-cli/iox2-introspect/src/main.rs
@@ -11,5 +11,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 fn main() {
-    println!("Not implemented. Stay tuned !");
+    println!("Not implemented. Stay tuned!");
 }

--- a/iceoryx2-cli/iox2-introspect/src/main.rs
+++ b/iceoryx2-cli/iox2-introspect/src/main.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 fn main() {
     println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-processes/Cargo.toml
+++ b/iceoryx2-cli/iox2-processes/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "iox2-processes"
+description = "Iceoryx2: CLI for managing iceoryx2 processes"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/iceoryx2-cli/iox2-processes/src/main.rs
+++ b/iceoryx2-cli/iox2-processes/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/iceoryx2-cli/iox2-processes/src/main.rs
+++ b/iceoryx2-cli/iox2-processes/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-processes/src/main.rs
+++ b/iceoryx2-cli/iox2-processes/src/main.rs
@@ -11,5 +11,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 fn main() {
-    println!("Not implemented. Stay tuned !");
+    println!("Not implemented. Stay tuned!");
 }

--- a/iceoryx2-cli/iox2-processes/src/main.rs
+++ b/iceoryx2-cli/iox2-processes/src/main.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 fn main() {
     println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-pub/Cargo.toml
+++ b/iceoryx2-cli/iox2-pub/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "iox2-pub"
+description = "Iceoryx2: CLI for publishing to iceoryx2"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/iceoryx2-cli/iox2-pub/src/main.rs
+++ b/iceoryx2-cli/iox2-pub/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/iceoryx2-cli/iox2-pub/src/main.rs
+++ b/iceoryx2-cli/iox2-pub/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-pub/src/main.rs
+++ b/iceoryx2-cli/iox2-pub/src/main.rs
@@ -11,5 +11,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 fn main() {
-    println!("Not implemented. Stay tuned !");
+    println!("Not implemented. Stay tuned!");
 }

--- a/iceoryx2-cli/iox2-pub/src/main.rs
+++ b/iceoryx2-cli/iox2-pub/src/main.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 fn main() {
     println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-rpc/Cargo.toml
+++ b/iceoryx2-cli/iox2-rpc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "iox2-rpc"
+description = "Iceoryx2: CLI for rpc operations"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/iceoryx2-cli/iox2-rpc/src/main.rs
+++ b/iceoryx2-cli/iox2-rpc/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/iceoryx2-cli/iox2-rpc/src/main.rs
+++ b/iceoryx2-cli/iox2-rpc/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-rpc/src/main.rs
+++ b/iceoryx2-cli/iox2-rpc/src/main.rs
@@ -11,5 +11,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 fn main() {
-    println!("Not implemented. Stay tuned !");
+    println!("Not implemented. Stay tuned!");
 }

--- a/iceoryx2-cli/iox2-rpc/src/main.rs
+++ b/iceoryx2-cli/iox2-rpc/src/main.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 fn main() {
     println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-services/Cargo.toml
+++ b/iceoryx2-cli/iox2-services/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "iox2-services"
+description = "Iceoryx2: CLI for managing iceoryx2 services"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/iceoryx2-cli/iox2-services/src/main.rs
+++ b/iceoryx2-cli/iox2-services/src/main.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("Hello, world!");
+}
+
+

--- a/iceoryx2-cli/iox2-services/src/main.rs
+++ b/iceoryx2-cli/iox2-services/src/main.rs
@@ -1,5 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("Not implemented. Stay tuned !");
 }
-
-

--- a/iceoryx2-cli/iox2-services/src/main.rs
+++ b/iceoryx2-cli/iox2-services/src/main.rs
@@ -11,5 +11,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 fn main() {
-    println!("Not implemented. Stay tuned !");
+    println!("Not implemented. Stay tuned!");
 }

--- a/iceoryx2-cli/iox2-services/src/main.rs
+++ b/iceoryx2-cli/iox2-services/src/main.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 fn main() {
     println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-sub/Cargo.toml
+++ b/iceoryx2-cli/iox2-sub/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "iox2-sub"
+description = "Iceoryx2: CLI for subscribing to iceoryx2"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/iceoryx2-cli/iox2-sub/src/main.rs
+++ b/iceoryx2-cli/iox2-sub/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/iceoryx2-cli/iox2-sub/src/main.rs
+++ b/iceoryx2-cli/iox2-sub/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2-sub/src/main.rs
+++ b/iceoryx2-cli/iox2-sub/src/main.rs
@@ -11,5 +11,5 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 fn main() {
-    println!("Not implemented. Stay tuned !");
+    println!("Not implemented. Stay tuned!");
 }

--- a/iceoryx2-cli/iox2-sub/src/main.rs
+++ b/iceoryx2-cli/iox2-sub/src/main.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 fn main() {
     println!("Not implemented. Stay tuned !");
 }

--- a/iceoryx2-cli/iox2/Cargo.toml
+++ b/iceoryx2-cli/iox2/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "iox2"
+description = "Iceoryx2: CLI entry-point"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/iceoryx2-cli/iox2/Cargo.toml
+++ b/iceoryx2-cli/iox2/Cargo.toml
@@ -13,3 +13,5 @@ version = { workspace = true }
 [dependencies]
 human-panic = "1.2.3"
 better-panic = "0.3.0"
+clap = { version = "4.4.18", features = ["derive"] }
+colored = "2.0"

--- a/iceoryx2-cli/iox2/Cargo.toml
+++ b/iceoryx2-cli/iox2/Cargo.toml
@@ -15,3 +15,4 @@ human-panic = "1.2.3"
 better-panic = "0.3.0"
 clap = { version = "4.4.18", features = ["derive"] }
 colored = "2.0"
+thiserror = "1.0.56"

--- a/iceoryx2-cli/iox2/Cargo.toml
+++ b/iceoryx2-cli/iox2/Cargo.toml
@@ -11,3 +11,5 @@ rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
+human-panic = "1.2.3"
+better-panic = "0.3.0"

--- a/iceoryx2-cli/iox2/Cargo.toml
+++ b/iceoryx2-cli/iox2/Cargo.toml
@@ -14,5 +14,5 @@ version = { workspace = true }
 human-panic = "1.2.3"
 better-panic = "0.3.0"
 clap = { version = "4.4.18", features = ["derive"] }
-colored = "2.0"
+colored = "2.1"
 thiserror = "1.0.56"

--- a/iceoryx2-cli/iox2/Cargo.toml
+++ b/iceoryx2-cli/iox2/Cargo.toml
@@ -10,6 +10,4 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/iceoryx2-cli/iox2/Cargo.toml
+++ b/iceoryx2-cli/iox2/Cargo.toml
@@ -11,8 +11,8 @@ rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-human-panic = "1.2.3"
-better-panic = "0.3.0"
-clap = { version = "4.4.18", features = ["derive"] }
-colored = "2.1"
-thiserror = "1.0.56"
+human-panic = { workspace = true }
+better-panic = { workspace = true }
+clap = { workspace = true }
+colored = { workspace = true }
+thiserror = { workspace = true }

--- a/iceoryx2-cli/iox2/src/cli.rs
+++ b/iceoryx2-cli/iox2/src/cli.rs
@@ -13,6 +13,9 @@ use clap::Parser;
 pub struct Cli {
     #[arg(short, long, help = "List all installed commands")]
     pub list: bool,
+
+    #[arg(short, long, help = "Run development commands")]
+    pub dev: bool,
 }
 
 fn help_template() -> &'static str {

--- a/iceoryx2-cli/iox2/src/cli.rs
+++ b/iceoryx2-cli/iox2/src/cli.rs
@@ -18,6 +18,13 @@ pub struct Cli {
     #[arg(
         short,
         long,
+        help = "Display paths that will be checked for installed commands"
+    )]
+    pub paths: bool,
+
+    #[arg(
+        short,
+        long,
         help = "Specify to execute development versions of commands if they exist"
     )]
     pub dev: bool,

--- a/iceoryx2-cli/iox2/src/cli.rs
+++ b/iceoryx2-cli/iox2/src/cli.rs
@@ -16,6 +16,9 @@ pub struct Cli {
 
     #[arg(short, long, help = "Run development commands")]
     pub dev: bool,
+
+    #[arg(hide = true, required = false)]
+    pub external_command: Vec<String>,
 }
 
 fn help_template() -> &'static str {

--- a/iceoryx2-cli/iox2/src/cli.rs
+++ b/iceoryx2-cli/iox2/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use colored::*;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -14,17 +15,26 @@ pub struct Cli {
     #[arg(short, long, help = "List all installed commands")]
     pub list: bool,
 
-    #[arg(short, long, help = "Run development commands")]
+    #[arg(
+        short,
+        long,
+        help = "Specify to execute development versions of commands if they exist"
+    )]
     pub dev: bool,
 
     #[arg(hide = true, required = false)]
     pub external_command: Vec<String>,
 }
 
-fn help_template() -> &'static str {
-    "\
-    USAGE: iox2 [OPTIONS] <COMMAND>\n\n\
-    OPTIONS:\n{options}\n\n\
-    COMMANDS:\n{subcommands}\n\
-    \u{00A0}\u{00A0}...         See all installed commands with --list"
+fn help_template() -> String {
+    format!(
+        "{}{}{}\n\n{}\n{{options}}\n\n{}\n{{subcommands}}{}{}",
+        "Usage: ".bright_green().bold(),
+        "iox2 ".bold(),
+        "[OPTIONS] [COMMAND]",
+        "Options:".bright_green().bold(),
+        "Commands:".bright_green().bold(),
+        "  ...         ".bold(),
+        "See all installed commands with --list"
+    )
 }

--- a/iceoryx2-cli/iox2/src/cli.rs
+++ b/iceoryx2-cli/iox2/src/cli.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use clap::Parser;
 use colored::*;
 

--- a/iceoryx2-cli/iox2/src/cli.rs
+++ b/iceoryx2-cli/iox2/src/cli.rs
@@ -1,0 +1,24 @@
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "iox2",
+    about = "The command-line interface to iceoryx2",
+    long_about = None,
+    version = env!("CARGO_PKG_VERSION"),
+    disable_help_subcommand = true,
+    arg_required_else_help = true,
+    help_template = help_template(),
+)]
+pub struct Cli {
+    #[arg(short, long, help = "List all installed commands")]
+    pub list: bool,
+}
+
+fn help_template() -> &'static str {
+    "\
+    USAGE: iox2 [OPTIONS] <COMMAND>\n\n\
+    OPTIONS:\n{options}\n\n\
+    COMMANDS:\n{subcommands}\n\
+    \u{00A0}\u{00A0}...         See all installed commands with --list"
+}

--- a/iceoryx2-cli/iox2/src/commands.rs
+++ b/iceoryx2-cli/iox2/src/commands.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use colored::*;
 use std::env;
 use std::fs;

--- a/iceoryx2-cli/iox2/src/commands.rs
+++ b/iceoryx2-cli/iox2/src/commands.rs
@@ -1,8 +1,17 @@
+use colored::*;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-pub fn find() -> Vec<String> {
+pub fn list() {
+    println!("Installed Commands:");
+    let installed_commands = find();
+    for command in installed_commands {
+        println!("  {}", command.bold());
+    }
+}
+
+fn find() -> Vec<String> {
     let mut commands = find_command_binaries_in_development_dirs();
     if commands.is_empty() {
         commands = find_command_binaries_in_system_path();

--- a/iceoryx2-cli/iox2/src/commands.rs
+++ b/iceoryx2-cli/iox2/src/commands.rs
@@ -1,0 +1,75 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+pub fn find() -> Vec<String> {
+    let mut commands = find_command_binaries_in_development_dirs();
+    if commands.is_empty() {
+        commands = find_command_binaries_in_system_path();
+    }
+    commands
+}
+
+fn find_command_binaries_in_development_dirs() -> Vec<String> {
+    let mut commands = Vec::new();
+    let current_exe = match env::current_exe() {
+        Ok(exe) => exe,
+        Err(_) => return commands,
+    };
+    let target_dir_name = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let target_dir = current_exe
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join(target_dir_name);
+
+    if let Ok(entries) = fs::read_dir(&target_dir) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if is_valid_command_binary(&path) {
+                if let Some(command_name) = path.file_name().and_then(|n| n.to_str()) {
+                    let stripped = command_name.strip_prefix("iox2-").unwrap_or(command_name);
+                    commands.push(stripped.to_string());
+                }
+            }
+        }
+    }
+
+    commands
+}
+
+fn find_command_binaries_in_system_path() -> Vec<String> {
+    let mut commands = Vec::new();
+    if let Ok(path_var) = env::var("PATH") {
+        for path in env::split_paths(&path_var) {
+            if let Ok(entries) = fs::read_dir(path) {
+                for entry in entries.filter_map(Result::ok) {
+                    let path = entry.path();
+                    if is_valid_command_binary(&path) {
+                        if let Some(command_name) = path.file_name().and_then(|n| n.to_str()) {
+                            commands.push(command_name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    commands
+}
+
+fn is_valid_command_binary(path: &PathBuf) -> bool {
+    path.is_file()
+        && path
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("iox2-")
+        && path.extension().is_none() // Exclude files with extensions (e.g. '.d')
+}

--- a/iceoryx2-cli/iox2/src/commands.rs
+++ b/iceoryx2-cli/iox2/src/commands.rs
@@ -43,7 +43,7 @@ pub fn list() {
     println!("{}", "Installed Commands:".bright_green().bold());
 
     if let Ok(mut commands) = find_command_binaries() {
-        commands.sort_by_key(|command| {
+        commands.sort_by_cached_key(|command| {
             command
                 .path
                 .file_name()
@@ -64,7 +64,7 @@ pub fn list() {
                         .expect("Unable to extract command name from command path")
                         .bold(),
                     if command.command_type == CommandType::Development {
-                        "(dev) ".italic()
+                        "(dev)".italic()
                     } else {
                         "".italic()
                     },
@@ -72,7 +72,7 @@ pub fn list() {
             })
             .for_each(|formatted_command| println!("{}", formatted_command));
     } else {
-        // handle error ...
+        // TODO: handle error ...
     }
 }
 
@@ -208,7 +208,7 @@ pub fn execute_external_command(
                     == command_name
             })
             .ok_or_else(|| ExecutionError::NotFound(command_name.to_string()))?;
-        execute(&command_info, Some(args)) // TODO: Remove Some()
+        execute(&command_info, Some(args)) // TODO: Remove Some() - pass optional directly
     } else {
         Err(ExecutionError::NotFound(command_name.to_string()))
     }

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!")
+}

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -27,6 +27,8 @@ fn main() {
 
     if cli.list {
         commands::list();
+    } else if cli.paths {
+        commands::paths();
     } else if !cli.external_command.is_empty() {
         let command_name = &cli.external_command[0];
         let command_args = &cli.external_command[1..];

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -1,3 +1,80 @@
-fn main() {
-    println!("Hello, world!")
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+fn find_command_binaries_in_development_dirs() -> Vec<String> {
+    let mut commands = Vec::new();
+    let current_exe = match env::current_exe() {
+        Ok(exe) => exe,
+        Err(_) => return commands,
+    };
+    let target_dir_name = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    let target_dir = current_exe
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join(target_dir_name);
+
+    if let Ok(entries) = fs::read_dir(&target_dir) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            if is_valid_command_binary(&path) {
+                if let Some(command_name) = path.file_name().and_then(|n| n.to_str()) {
+                    let stripped = command_name.strip_prefix("iox2-").unwrap_or(command_name);
+                    commands.push(stripped.to_string());
+                }
+            }
+        }
+    }
+
+    commands
 }
+
+fn find_command_binaries_in_system_path() -> Vec<String> {
+    let mut commands = Vec::new();
+    if let Ok(path_var) = env::var("PATH") {
+        for path in env::split_paths(&path_var) {
+            if let Ok(entries) = fs::read_dir(path) {
+                for entry in entries.filter_map(Result::ok) {
+                    let path = entry.path();
+                    if is_valid_command_binary(&path) {
+                        if let Some(command_name) = path.file_name().and_then(|n| n.to_str()) {
+                            commands.push(command_name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    commands
+}
+
+fn is_valid_command_binary(path: &PathBuf) -> bool {
+    path.is_file()
+        && path
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("iox2-")
+        && path.extension().is_none() // Exclude files with extensions (e.g. '.d')
+}
+
+fn main() {
+    let mut commands = find_command_binaries_in_development_dirs();
+    if commands.is_empty() {
+        commands = find_command_binaries_in_system_path();
+    }
+
+    println!("Available commands:");
+    for command in commands {
+        println!("- {}", command);
+    }
+}
+

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -56,5 +56,7 @@ fn main() {
                 println!("Command found but execution failed ...");
             }
         }
+    } else {
+        println!("No CLI command detected. Exiting.");
     }
 }

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -1,3 +1,15 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(not(debug_assertions))]
 use human_panic::setup_panic;
 

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -1,80 +1,29 @@
-use std::env;
-use std::fs;
-use std::path::PathBuf;
+#[cfg(not(debug_assertions))]
+use human_panic::setup_panic;
 
-fn find_command_binaries_in_development_dirs() -> Vec<String> {
-    let mut commands = Vec::new();
-    let current_exe = match env::current_exe() {
-        Ok(exe) => exe,
-        Err(_) => return commands,
-    };
-    let target_dir_name = if cfg!(debug_assertions) {
-        "debug"
-    } else {
-        "release"
-    };
-    let target_dir = current_exe
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join(target_dir_name);
+#[cfg(debug_assertions)]
+extern crate better_panic;
 
-    if let Ok(entries) = fs::read_dir(&target_dir) {
-        for entry in entries.filter_map(Result::ok) {
-            let path = entry.path();
-            if is_valid_command_binary(&path) {
-                if let Some(command_name) = path.file_name().and_then(|n| n.to_str()) {
-                    let stripped = command_name.strip_prefix("iox2-").unwrap_or(command_name);
-                    commands.push(stripped.to_string());
-                }
-            }
-        }
-    }
-
-    commands
-}
-
-fn find_command_binaries_in_system_path() -> Vec<String> {
-    let mut commands = Vec::new();
-    if let Ok(path_var) = env::var("PATH") {
-        for path in env::split_paths(&path_var) {
-            if let Ok(entries) = fs::read_dir(path) {
-                for entry in entries.filter_map(Result::ok) {
-                    let path = entry.path();
-                    if is_valid_command_binary(&path) {
-                        if let Some(command_name) = path.file_name().and_then(|n| n.to_str()) {
-                            commands.push(command_name.to_string());
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    commands
-}
-
-fn is_valid_command_binary(path: &PathBuf) -> bool {
-    path.is_file()
-        && path
-            .file_stem()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .starts_with("iox2-")
-        && path.extension().is_none() // Exclude files with extensions (e.g. '.d')
-}
+mod commands;
 
 fn main() {
-    let mut commands = find_command_binaries_in_development_dirs();
-    if commands.is_empty() {
-        commands = find_command_binaries_in_system_path();
+    #[cfg(not(debug_assertions))]
+    {
+        setup_panic!();
     }
+    #[cfg(debug_assertions)]
+    {
+        better_panic::Settings::debug()
+            .most_recent_first(false)
+            .lineno_suffix(true)
+            .verbosity(better_panic::Verbosity::Full)
+            .install();
+    }
+
+    let commands = commands::find();
 
     println!("Available commands:");
     for command in commands {
         println!("- {}", command);
     }
 }
-

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -27,5 +27,20 @@ fn main() {
 
     if cli.list {
         commands::list();
+    } else if !cli.external_command.is_empty() {
+        let command_name = &cli.external_command[0];
+        let command_args = &cli.external_command[1..];
+        match commands::execute_external_command(command_name, command_args, cli.dev) {
+            Ok(()) => {
+                // Command executed successfully, nothing to do
+            }
+            Err(commands::ExecutionError::NotFound(_)) => {
+                // Command not found, print help
+                println!("Command not found. See all installed commands with --list.");
+            }
+            Err(commands::ExecutionError::Failed(_)) => {
+                println!("Command found but execution failed ...");
+            }
+        }
     }
 }

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -4,7 +4,10 @@ use human_panic::setup_panic;
 #[cfg(debug_assertions)]
 extern crate better_panic;
 
+mod cli;
 mod commands;
+
+use clap::Parser;
 
 fn main() {
     #[cfg(not(debug_assertions))]
@@ -20,10 +23,9 @@ fn main() {
             .install();
     }
 
-    let commands = commands::find();
+    let cli = cli::Cli::parse();
 
-    println!("Available commands:");
-    for command in commands {
-        println!("- {}", command);
+    if cli.list {
+        commands::list();
     }
 }


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

1. Adds the top-level entry-point CLI for `iox2`
    ```
    $ ./target/debug/iox2 --help
    ```
1. The top level CLI discovers available commands by looking for binaries with the prefix `iox2-` in the `$PATH` or in the cargo build directories
1. Binaries that are discovered can be viewed using `--list` - the same as how `cargo` handles external binaries
    ```
    $ ./target/debug/iox2 --list
    ```
1. The locations checked for binaries can be viewed using:
    ```
    $ ./target/debug/iox2 --paths
    ```
1. Discovered binaries in `PATH`  can be executed as if they were a defined sub command
    ```
    $ ./target/debug/iox2 services
    ```
1. Discovered binaries in cargo build directories can only be executed with the flag `--dev` set
    ```
    $ ./target/debug/iox2 --dev services
    ```
    1. This distinction is to deal with the case where a binary with the same name is found in both the `$PATH` and in the build directories

### Example Usage:

```console
➜  iceoryx2 git:(iox2-98-entrypoint-for-iox2-cli) ./target/debug/iox2 --help
Usage: iox2 [OPTIONS] [COMMAND]

Options:
  -l, --list     List all installed commands
  -p, --paths    Display paths that will be checked for installed commands
  -d, --dev      Specify to execute development versions of commands if they exist
  -h, --help     Print help
  -V, --version  Print version

Commands:
  ...         See all installed commands with --list
➜  iceoryx2 git:(iox2-98-entrypoint-for-iox2-cli) ./target/debug/iox2 --paths
Development Binary Paths:
  /Users/orecham/Code/iceoryx2/target/debug

Installed Binary Paths:
  /opt/homebrew/bin
  /opt/homebrew/sbin
  /usr/local/bin
  /usr/bin
  /bin
  /usr/sbin
  /sbin
  /Users/orecham/.cargo/bin
➜  iceoryx2 git:(iox2-98-entrypoint-for-iox2-cli) ./target/debug/iox2 --list
Installed Commands:
  introspect (dev)
  processes (dev)
  pub (dev)
  rpc (dev)
  services (dev)
  sub (dev)
➜  iceoryx2 git:(iox2-98-entrypoint-for-iox2-cli) ./target/debug/iox2 --dev introspect
Not implemented. Stay tuned !
```

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue.

Relates to #98 
