### PR TITLE
[#100] dynamic segment rc owned

### DIFF
--- a/iceoryx2-bb/lock-free/src/mpmc/container.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/container.rs
@@ -20,7 +20,7 @@
 //!
 //! To iterate/acquire all container elements
 //! a [`ContainerState`] has to be created with [`Container::get_state()`] and can be updated with
-//! [`ContainerState::update()`].
+//! [`Container::update_state()`].
 //!
 //! # Example
 //!
@@ -65,7 +65,7 @@ use std::{
 };
 
 /// Contains a state of the [`Container`]. Can be created with [`Container::get_state()`] and
-/// updated when the [`Container`] has changed with [`ContainerState::update()`].
+/// updated when the [`Container`] has changed with [`Container::update_state()`].
 #[derive(Debug)]
 pub struct ContainerState<T: Copy + Debug> {
     container_id: u64,
@@ -300,7 +300,7 @@ impl<T: Copy + Debug> Container<T> {
     ///
     ///  * Ensure that the either [`Container::new()`] was used or [`Container::init()`] was used
     ///     before calling this method
-    ///  * Use [`Container::remove_raw()`] to release the acquired index again. Otherwise, the
+    ///  * Use [`Container::remove_raw_index()`] to release the acquired index again. Otherwise, the
     ///     element will leak.
     ///
     pub unsafe fn add_raw(&self, value: T) -> Option<u32> {
@@ -513,7 +513,7 @@ impl<T: Copy + Debug, const CAPACITY: usize> FixedSizeContainer<T, CAPACITY> {
     ///
     /// # Safety
     ///
-    ///  * Use [`FixedSizeContainer::remove_raw()`] to release the acquired index again. Otherwise,
+    ///  * Use [`FixedSizeContainer::remove_raw_index()`] to release the acquired index again. Otherwise,
     ///     the element will leak.
     ///
     pub unsafe fn add_raw(&self, value: T) -> Option<u32> {

--- a/iceoryx2-bb/lock-free/tests/mpmc_container_tests.rs
+++ b/iceoryx2-bb/lock-free/tests/mpmc_container_tests.rs
@@ -187,7 +187,7 @@ mod mpmc_container {
         state.for_each(|_, _| counter += 1);
         assert_that!(counter, eq 0);
 
-        state.update();
+        unsafe { sut.update_state(&mut state) };
         state.for_each(|_, _| counter += 1);
         assert_that!(counter, eq 0);
     }
@@ -209,7 +209,7 @@ mod mpmc_container {
         let mut contained_values1 = vec![];
         state.for_each(|_: u32, value: &T| contained_values1.push((*value).into()));
 
-        assert_that!(state.update(), eq false);
+        assert_that!(unsafe { sut.update_state(&mut state) }, eq false);
         let mut contained_values2 = vec![];
         state.for_each(|_: u32, value: &T| contained_values2.push((*value).into()));
 
@@ -235,7 +235,7 @@ mod mpmc_container {
         let mut state = sut.get_state();
         stored_indices.clear();
 
-        assert_that!(state.update(), eq true);
+        assert_that!(unsafe { sut.update_state(&mut state) }, eq true);
         let mut contained_values = vec![];
         state.for_each(|_: u32, value: &T| contained_values.push((*value).into()));
 
@@ -266,7 +266,7 @@ mod mpmc_container {
             stored_indices.push(index.unwrap());
         }
 
-        assert_that!(state.update(), eq true);
+        assert_that!(unsafe { sut.update_state(&mut state) }, eq true);
         let mut contained_values = vec![];
         state.for_each(|_: u32, value: &T| contained_values.push((*value).into()));
 
@@ -291,7 +291,7 @@ mod mpmc_container {
             stored_values.push((index.as_ref().unwrap().value(), v));
             stored_indices.push(index.unwrap());
 
-            state.update();
+            unsafe { sut.update_state(&mut state) };
             let mut contained_values = vec![];
             state.for_each(|index: u32, value: &T| contained_values.push((index, (*value).into())));
 
@@ -305,7 +305,7 @@ mod mpmc_container {
             stored_indices.pop();
             stored_values.pop();
 
-            state.update();
+            unsafe { sut.update_state(&mut state) };
             let mut contained_values = vec![];
             state.for_each(|index: u32, value: &T| contained_values.push((index, (*value).into())));
 
@@ -383,7 +383,7 @@ mod mpmc_container {
                     while finished_threads_counter.load(Ordering::Relaxed)
                         != number_of_threads_per_op as u64
                     {
-                        if state.update() {
+                        if unsafe { sut.update_state(&mut state) } {
                             state.for_each(|index: u32, value: &T| {
                                 extracted_content[thread_number]
                                     .lock()

--- a/iceoryx2-bb/posix/tests/shared_memory_tests.rs
+++ b/iceoryx2-bb/posix/tests/shared_memory_tests.rs
@@ -219,7 +219,7 @@ fn shared_memory_acquire_ownership_works() {
     test_requires!(POSIX_SUPPORT_PERSISTENT_SHARED_MEMORY);
 
     let shm_name = generate_shm_name();
-    let mut sut_create = SharedMemoryBuilder::new(&shm_name)
+    let sut_create = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .size(1024)
         .permission(Permission::OWNER_ALL)

--- a/iceoryx2-cal/src/dynamic_storage/mod.rs
+++ b/iceoryx2-cal/src/dynamic_storage/mod.rs
@@ -134,11 +134,11 @@ pub trait DynamicStorage<T: Send + Sync>: Sized + Debug + NamedConceptMgmt + Nam
 
     /// Releases the ownership of the storage. When the object goes out of scope it is no longer
     /// removed.
-    fn release_ownership(&mut self);
+    fn release_ownership(&self);
 
     /// Acquires the ownership of the storage. When the object goes out of scope the underlying
     /// resources will be removed.
-    fn acquire_ownership(&mut self);
+    fn acquire_ownership(&self);
 
     /// Returns a const reference to the underlying object. It is const since the [`DynamicStorage`]
     /// can be accessed by multiple processes concurrently therefore it must be constant or

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -337,7 +337,7 @@ impl<T: Send + Sync + Debug> DynamicStorage<T> for Storage<T> {
         SharedMemory::does_support_persistency()
     }
 
-    fn acquire_ownership(&mut self) {
+    fn acquire_ownership(&self) {
         self.shm.acquire_ownership()
     }
 
@@ -349,7 +349,7 @@ impl<T: Send + Sync + Debug> DynamicStorage<T> for Storage<T> {
         self.shm.has_ownership()
     }
 
-    fn release_ownership(&mut self) {
+    fn release_ownership(&self) {
         self.shm.release_ownership()
     }
 }

--- a/iceoryx2-cal/src/zero_copy_connection/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/posix_shared_memory.rs
@@ -203,7 +203,7 @@ impl Builder {
         let msg = "Failed to acquire underlying shared memory";
         let full_name =
             unsafe { FileName::new_unchecked(self.config.path_for(&self.name).file_name()) };
-        let mut shm = fail!(from self, when SharedMemoryBuilder::new(&full_name)
+        let shm = fail!(from self, when SharedMemoryBuilder::new(&full_name)
                                                 .creation_mode(CreationMode::OpenOrCreate)
                                                 .size(shm_size)
                                                 .permission(Permission::OWNER_ALL)

--- a/iceoryx2-cal/tests/dynamic_storage_trait_tests.rs
+++ b/iceoryx2-cal/tests/dynamic_storage_trait_tests.rs
@@ -172,7 +172,7 @@ mod dynamic_storage {
         test_requires!(Sut::does_support_persistency());
         let storage_name = generate_name();
 
-        let mut sut = Sut::Builder::new(&storage_name)
+        let sut = Sut::Builder::new(&storage_name)
             .create(TestData::new(9887))
             .unwrap();
 
@@ -222,7 +222,7 @@ mod dynamic_storage {
         test_requires!(Sut::does_support_persistency());
         let storage_name = generate_name();
 
-        let mut sut = Sut::Builder::new(&storage_name)
+        let sut = Sut::Builder::new(&storage_name)
             .has_ownership(false)
             .create(TestData::new(9887))
             .unwrap();
@@ -259,7 +259,7 @@ mod dynamic_storage {
     fn has_ownership_works<Sut: DynamicStorage<TestData>>() {
         let storage_name = generate_name();
 
-        let mut sut = Sut::Builder::new(&storage_name)
+        let sut = Sut::Builder::new(&storage_name)
             .create(TestData::new(123))
             .unwrap();
 

--- a/iceoryx2/src/port/listener.rs
+++ b/iceoryx2/src/port/listener.rs
@@ -32,6 +32,7 @@
 //!
 //! See also [`crate::port::listener::Listener`]
 
+use iceoryx2_bb_lock_free::mpmc::container::ContainerHandle;
 use iceoryx2_bb_log::fail;
 use iceoryx2_cal::dynamic_storage::DynamicStorage;
 use iceoryx2_cal::event::{ListenerBuilder, ListenerWaitError};
@@ -48,7 +49,7 @@ use super::listen::{Listen, ListenerCreateError};
 /// Represents the receiving endpoint of an event based communication.
 #[derive(Debug)]
 pub struct Listener<Service: service::Service> {
-    dynamic_listener_handle: u32,
+    dynamic_listener_handle: ContainerHandle,
     listener: <Service::Event as iceoryx2_cal::event::Event<EventId>>::Listener,
     cache: Vec<EventId>,
     dynamic_storage: Rc<Service::DynamicStorage>,
@@ -59,7 +60,7 @@ impl<Service: service::Service> Drop for Listener<Service> {
         self.dynamic_storage
             .get()
             .event()
-            .release_listener_id(self.dynamic_listener_handle)
+            .release_listener_handle(self.dynamic_listener_handle)
     }
 }
 

--- a/iceoryx2/src/port/listener.rs
+++ b/iceoryx2/src/port/listener.rs
@@ -32,7 +32,6 @@
 //!
 //! See also [`crate::port::listener::Listener`]
 
-use iceoryx2_bb_lock_free::mpmc::unique_index_set::UniqueIndex;
 use iceoryx2_bb_log::fail;
 use iceoryx2_cal::dynamic_storage::DynamicStorage;
 use iceoryx2_cal::event::{ListenerBuilder, ListenerWaitError};
@@ -40,57 +39,67 @@ use iceoryx2_cal::named_concept::NamedConceptBuilder;
 
 use crate::service::naming_scheme::event_concept_name;
 use crate::{port::port_identifiers::UniqueListenerId, service};
-use std::{marker::PhantomData, time::Duration};
+use std::rc::Rc;
+use std::time::Duration;
 
 use super::event_id::EventId;
 use super::listen::{Listen, ListenerCreateError};
 
 /// Represents the receiving endpoint of an event based communication.
 #[derive(Debug)]
-pub struct Listener<'a, Service: service::Service> {
-    _dynamic_config_guard: Option<UniqueIndex<'a>>,
+pub struct Listener<Service: service::Service> {
+    dynamic_listener_handle: u32,
     listener: <Service::Event as iceoryx2_cal::event::Event<EventId>>::Listener,
     cache: Vec<EventId>,
-    _phantom_a: PhantomData<&'a Service>,
+    dynamic_storage: Rc<Service::DynamicStorage>,
 }
 
-impl<'a, Service: service::Service> Listener<'a, Service> {
-    pub(crate) fn new(service: &'a Service) -> Result<Self, ListenerCreateError> {
+impl<Service: service::Service> Drop for Listener<Service> {
+    fn drop(&mut self) {
+        self.dynamic_storage
+            .get()
+            .event()
+            .release_listener_id(self.dynamic_listener_handle)
+    }
+}
+
+impl<Service: service::Service> Listener<Service> {
+    pub(crate) fn new(service: &Service) -> Result<Self, ListenerCreateError> {
         let msg = "Failed to create listener";
         let origin = "Listener::new()";
         let port_id = UniqueListenerId::new();
 
         let event_name = event_concept_name(&port_id);
+        let dynamic_storage = Rc::clone(&service.state().dynamic_storage);
+
         let listener = fail!(from origin,
                              when <Service::Event as iceoryx2_cal::event::Event<EventId>>::ListenerBuilder::new(&event_name).create(),
                              with ListenerCreateError::ResourceCreationFailed,
                              "{} since the underlying event concept \"{}\" could not be created.", msg, event_name);
 
-        let mut new_self = Self {
-            _dynamic_config_guard: None,
-            listener,
-            cache: vec![],
-            _phantom_a: PhantomData,
-        };
-
         // !MUST! be the last task otherwise a listener is added to the dynamic config without
         // the creation of all required channels
-        new_self._dynamic_config_guard = Some(
-            match service
-                .state()
-                .dynamic_storage
-                .get()
-                .event()
-                .add_listener_id(port_id)
-            {
-                Some(unique_index) => unique_index,
-                None => {
-                    fail!(from origin, with ListenerCreateError::ExceedsMaxSupportedListeners,
+        let dynamic_listener_handle = match service
+            .state()
+            .dynamic_storage
+            .get()
+            .event()
+            .add_listener_id(port_id)
+        {
+            Some(unique_index) => unique_index,
+            None => {
+                fail!(from origin, with ListenerCreateError::ExceedsMaxSupportedListeners,
                                  "{} since it would exceed the maximum supported amount of listeners of {}.",
                                  msg, service.state().static_config.event().max_listeners);
-                }
-            },
-        );
+            }
+        };
+
+        let new_self = Self {
+            dynamic_storage,
+            dynamic_listener_handle,
+            listener,
+            cache: vec![],
+        };
 
         Ok(new_self)
     }
@@ -108,7 +117,7 @@ impl<'a, Service: service::Service> Listener<'a, Service> {
     }
 }
 
-impl<'a, Service: service::Service> Listen for Listener<'a, Service> {
+impl<Service: service::Service> Listen for Listener<Service> {
     fn cache(&self) -> &[EventId] {
         &self.cache
     }

--- a/iceoryx2/src/port/notifier.rs
+++ b/iceoryx2/src/port/notifier.rs
@@ -41,7 +41,7 @@ use crate::{
     port::port_identifiers::UniqueNotifierId,
     service::{self, naming_scheme::event_concept_name},
 };
-use iceoryx2_bb_lock_free::mpmc::container::ContainerState;
+use iceoryx2_bb_lock_free::mpmc::container::{ContainerHandle, ContainerState};
 use iceoryx2_bb_log::{fail, warn};
 use iceoryx2_cal::named_concept::NamedConceptBuilder;
 use iceoryx2_cal::{dynamic_storage::DynamicStorage, event::NotifierBuilder};
@@ -117,7 +117,7 @@ pub struct Notifier<Service: service::Service> {
     listener_list_state: UnsafeCell<ContainerState<UniqueListenerId>>,
     default_event_id: EventId,
     dynamic_storage: Rc<Service::DynamicStorage>,
-    dynamic_notifier_handle: u32,
+    dynamic_notifier_handle: ContainerHandle,
 }
 
 impl<Service: service::Service> Drop for Notifier<Service> {
@@ -125,7 +125,7 @@ impl<Service: service::Service> Drop for Notifier<Service> {
         self.dynamic_storage
             .get()
             .event()
-            .release_notifier_id(self.dynamic_notifier_handle)
+            .release_notifier_handle(self.dynamic_notifier_handle)
     }
 }
 

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -82,7 +82,7 @@ use crate::service::static_config::publish_subscribe;
 use crate::{config, sample_mut::SampleMut};
 use iceoryx2_bb_container::queue::Queue;
 use iceoryx2_bb_elementary::allocator::AllocationError;
-use iceoryx2_bb_lock_free::mpmc::container::ContainerState;
+use iceoryx2_bb_lock_free::mpmc::container::{ContainerHandle, ContainerState};
 use iceoryx2_bb_log::{fail, fatal_panic, warn};
 use iceoryx2_cal::dynamic_storage::DynamicStorage;
 use iceoryx2_cal::named_concept::NamedConceptBuilder;
@@ -108,7 +108,7 @@ pub struct Publisher<'a, Service: service::Service, MessageType: Debug> {
     service: &'a Service,
     degration_callback: Option<DegrationCallback<'a>>,
     loan_counter: AtomicUsize,
-    dynamic_publisher_handle: u32,
+    dynamic_publisher_handle: ContainerHandle,
     _phantom_message_type: PhantomData<MessageType>,
 }
 
@@ -119,7 +119,7 @@ impl<'a, Service: service::Service, MessageType: Debug> Drop
         self.dynamic_storage
             .get()
             .publish_subscribe()
-            .release_publisher_id(self.dynamic_publisher_handle)
+            .release_publisher_handle(self.dynamic_publisher_handle)
     }
 }
 

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -36,7 +36,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-use iceoryx2_bb_lock_free::mpmc::container::ContainerState;
+use iceoryx2_bb_lock_free::mpmc::container::{ContainerHandle, ContainerState};
 use iceoryx2_bb_log::{fail, fatal_panic, warn};
 use iceoryx2_cal::dynamic_storage::DynamicStorage;
 use iceoryx2_cal::{shared_memory::*, zero_copy_connection::*};
@@ -58,7 +58,7 @@ use super::DegrationCallback;
 /// The receiving endpoint of a publish-subscribe communication.
 #[derive(Debug)]
 pub struct Subscriber<'a, Service: service::Service, MessageType: Debug> {
-    dynamic_subscriber_handle: u32,
+    dynamic_subscriber_handle: ContainerHandle,
     publisher_connections: PublisherConnections<Service>,
     dynamic_storage: Rc<Service::DynamicStorage>,
     service: &'a Service,
@@ -75,7 +75,7 @@ impl<'a, Service: service::Service, MessageType: Debug> Drop
         self.dynamic_storage
             .get()
             .publish_subscribe()
-            .release_subscriber_id(self.dynamic_subscriber_handle)
+            .release_subscriber_handle(self.dynamic_subscriber_handle)
     }
 }
 

--- a/iceoryx2/src/service/builder/event.rs
+++ b/iceoryx2/src/service/builder/event.rs
@@ -177,9 +177,11 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
                 Ok(Some((static_config, static_storage))) => {
                     let static_config = self.verify_service_properties(&static_config)?;
 
-                    let dynamic_config = fail!(from self, when self.base.open_dynamic_config_storage(),
+                    let dynamic_config = Rc::new(
+                        fail!(from self, when self.base.open_dynamic_config_storage(),
                             with EventOpenError::UnableToOpenDynamicServiceInformation,
-                            "{} since the dynamic service informations could not be opened.", msg);
+                            "{} since the dynamic service informations could not be opened.", msg),
+                    );
 
                     self.base.service_config.messaging_pattern =
                         MessagingPattern::Event(static_config);
@@ -244,9 +246,9 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
                     ),
                     dynamic_config::event::DynamicConfig::memory_size(&dynamic_config_setting),
                 );
-                let dynamic_config = fail!(from self, when dynamic_config,
+                let dynamic_config = Rc::new(fail!(from self, when dynamic_config,
                     with EventCreateError::InternalFailure,
-                    "{} since the dynamic service segment could not be created.", msg);
+                    "{} since the dynamic service segment could not be created.", msg));
 
                 let service_config = fail!(from self, when ServiceType::ConfigSerializer::serialize(&self.base.service_config),
                                             with EventCreateError::Corrupted,

--- a/iceoryx2/src/service/builder/publish_subscribe.rs
+++ b/iceoryx2/src/service/builder/publish_subscribe.rs
@@ -284,9 +284,11 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
                 Ok(Some((static_config, static_storage))) => {
                     let static_config = self.verify_service_properties(&static_config)?;
 
-                    let dynamic_config = fail!(from self, when self.base.open_dynamic_config_storage(),
+                    let dynamic_config = Rc::new(
+                        fail!(from self, when self.base.open_dynamic_config_storage(),
                             with PublishSubscribeOpenError::UnableToOpenDynamicServiceInformation,
-                            "{} since the dynamic service information could not be opened.", msg);
+                            "{} since the dynamic service information could not be opened.", msg),
+                    );
 
                     self.base.service_config.messaging_pattern =
                         MessagingPattern::PublishSubscribe(static_config.clone());
@@ -378,9 +380,9 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
                         &dynamic_config_setting,
                     ),
                 );
-                let dynamic_config = fail!(from self, when dynamic_config,
+                let dynamic_config = Rc::new(fail!(from self, when dynamic_config,
                     with PublishSubscribeCreateError::InternalFailure,
-                    "{} since the dynamic service segment could not be created.", msg);
+                    "{} since the dynamic service segment could not be created.", msg));
 
                 let service_config = fail!(from self, when ServiceType::ConfigSerializer::serialize(&self.base.service_config),
                             with PublishSubscribeCreateError::Corrupted,

--- a/iceoryx2/src/service/dynamic_config/event.rs
+++ b/iceoryx2/src/service/dynamic_config/event.rs
@@ -83,7 +83,11 @@ impl DynamicConfig {
         unsafe { self.listeners.add(id) }
     }
 
-    pub(crate) fn add_notifier_id(&self, id: UniqueNotifierId) -> Option<UniqueIndex> {
-        unsafe { self.notifiers.add(id) }
+    pub(crate) fn add_notifier_id(&self, id: UniqueNotifierId) -> Option<u32> {
+        unsafe { self.notifiers.add_raw(id) }
+    }
+
+    pub(crate) fn release_notifier_id(&self, id: u32) {
+        unsafe { self.notifiers.remove_raw_index(id) }
     }
 }

--- a/iceoryx2/src/service/dynamic_config/event.rs
+++ b/iceoryx2/src/service/dynamic_config/event.rs
@@ -79,19 +79,19 @@ impl DynamicConfig {
         self.notifiers.len()
     }
 
-    pub(crate) fn add_listener_id(&self, id: UniqueListenerId) -> Option<u32> {
-        unsafe { self.listeners.add_raw(id) }
+    pub(crate) fn add_listener_id(&self, id: UniqueListenerId) -> Option<ContainerHandle> {
+        unsafe { self.listeners.add_with_handle(id) }
     }
 
-    pub(crate) fn release_listener_id(&self, id: u32) {
-        unsafe { self.listeners.remove_raw_index(id) }
+    pub(crate) fn release_listener_handle(&self, handle: ContainerHandle) {
+        unsafe { self.listeners.remove_with_handle(handle) }
     }
 
-    pub(crate) fn add_notifier_id(&self, id: UniqueNotifierId) -> Option<u32> {
-        unsafe { self.notifiers.add_raw(id) }
+    pub(crate) fn add_notifier_id(&self, id: UniqueNotifierId) -> Option<ContainerHandle> {
+        unsafe { self.notifiers.add_with_handle(id) }
     }
 
-    pub(crate) fn release_notifier_id(&self, id: u32) {
-        unsafe { self.notifiers.remove_raw_index(id) }
+    pub(crate) fn release_notifier_handle(&self, handle: ContainerHandle) {
+        unsafe { self.notifiers.remove_with_handle(handle) }
     }
 }

--- a/iceoryx2/src/service/dynamic_config/event.rs
+++ b/iceoryx2/src/service/dynamic_config/event.rs
@@ -27,7 +27,7 @@
 //! # }
 //! ```
 use iceoryx2_bb_elementary::relocatable_container::RelocatableContainer;
-use iceoryx2_bb_lock_free::mpmc::{container::*, unique_index_set::UniqueIndex};
+use iceoryx2_bb_lock_free::mpmc::container::*;
 use iceoryx2_bb_log::fatal_panic;
 use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
 
@@ -79,8 +79,12 @@ impl DynamicConfig {
         self.notifiers.len()
     }
 
-    pub(crate) fn add_listener_id(&self, id: UniqueListenerId) -> Option<UniqueIndex> {
-        unsafe { self.listeners.add(id) }
+    pub(crate) fn add_listener_id(&self, id: UniqueListenerId) -> Option<u32> {
+        unsafe { self.listeners.add_raw(id) }
+    }
+
+    pub(crate) fn release_listener_id(&self, id: u32) {
+        unsafe { self.listeners.remove_raw_index(id) }
     }
 
     pub(crate) fn add_notifier_id(&self, id: UniqueNotifierId) -> Option<u32> {

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -79,19 +79,19 @@ impl DynamicConfig {
         self.subscribers.len()
     }
 
-    pub(crate) fn add_subscriber_id(&self, id: UniqueSubscriberId) -> Option<u32> {
-        unsafe { self.subscribers.add_raw(id) }
+    pub(crate) fn add_subscriber_id(&self, id: UniqueSubscriberId) -> Option<ContainerHandle> {
+        unsafe { self.subscribers.add_with_handle(id) }
     }
 
-    pub(crate) fn release_subscriber_id(&self, id: u32) {
-        unsafe { self.subscribers.remove_raw_index(id) }
+    pub(crate) fn release_subscriber_handle(&self, handle: ContainerHandle) {
+        unsafe { self.subscribers.remove_with_handle(handle) }
     }
 
-    pub(crate) fn add_publisher_id(&self, id: UniquePublisherId) -> Option<u32> {
-        unsafe { self.publishers.add_raw(id) }
+    pub(crate) fn add_publisher_id(&self, id: UniquePublisherId) -> Option<ContainerHandle> {
+        unsafe { self.publishers.add_with_handle(id) }
     }
 
-    pub(crate) fn release_publisher_id(&self, id: u32) {
-        unsafe { self.publishers.remove_raw_index(id) }
+    pub(crate) fn release_publisher_handle(&self, handle: ContainerHandle) {
+        unsafe { self.publishers.remove_with_handle(handle) }
     }
 }

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -27,7 +27,7 @@
 //! # }
 //! ```
 use iceoryx2_bb_elementary::relocatable_container::RelocatableContainer;
-use iceoryx2_bb_lock_free::mpmc::{container::*, unique_index_set::UniqueIndex};
+use iceoryx2_bb_lock_free::mpmc::container::*;
 use iceoryx2_bb_log::fatal_panic;
 use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
 
@@ -79,8 +79,12 @@ impl DynamicConfig {
         self.subscribers.len()
     }
 
-    pub(crate) fn add_subscriber_id(&self, id: UniqueSubscriberId) -> Option<UniqueIndex> {
-        unsafe { self.subscribers.add(id) }
+    pub(crate) fn add_subscriber_id(&self, id: UniqueSubscriberId) -> Option<u32> {
+        unsafe { self.subscribers.add_raw(id) }
+    }
+
+    pub(crate) fn release_subscriber_id(&self, id: u32) {
+        unsafe { self.subscribers.remove_raw_index(id) }
     }
 
     pub(crate) fn add_publisher_id(&self, id: UniquePublisherId) -> Option<u32> {

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -83,7 +83,11 @@ impl DynamicConfig {
         unsafe { self.subscribers.add(id) }
     }
 
-    pub(crate) fn add_publisher_id(&self, id: UniquePublisherId) -> Option<UniqueIndex> {
-        unsafe { self.publishers.add(id) }
+    pub(crate) fn add_publisher_id(&self, id: UniquePublisherId) -> Option<u32> {
+        unsafe { self.publishers.add_raw(id) }
+    }
+
+    pub(crate) fn release_publisher_id(&self, id: u32) {
+        unsafe { self.publishers.remove_raw_index(id) }
     }
 }

--- a/iceoryx2/src/service/mod.rs
+++ b/iceoryx2/src/service/mod.rs
@@ -199,7 +199,7 @@ impl std::error::Error for ServiceListError {}
 pub struct ServiceState<Static: StaticStorage, Dynamic: DynamicStorage<DynamicConfig>> {
     pub(crate) static_config: StaticConfig,
     pub(crate) global_config: Rc<config::Config>,
-    pub(crate) dynamic_storage: Dynamic,
+    pub(crate) dynamic_storage: Rc<Dynamic>,
     pub(crate) static_storage: Static,
 }
 
@@ -207,7 +207,7 @@ impl<Static: StaticStorage, Dynamic: DynamicStorage<DynamicConfig>> ServiceState
     pub(crate) fn new(
         static_config: StaticConfig,
         global_config: Rc<config::Config>,
-        dynamic_storage: Dynamic,
+        dynamic_storage: Rc<Dynamic>,
         static_storage: Static,
     ) -> Self {
         let new_self = Self {

--- a/iceoryx2/src/service/port_factory/listener.rs
+++ b/iceoryx2/src/service/port_factory/listener.rs
@@ -44,7 +44,7 @@ pub struct PortFactoryListener<'factory, Service: service::Service> {
 
 impl<'factory, Service: service::Service> PortFactoryListener<'factory, Service> {
     /// Creates the [`Listener`] port or returns a [`ListenerCreateError`] on failure.
-    pub fn create(&self) -> Result<Listener<'factory, Service>, ListenerCreateError> {
+    pub fn create(&self) -> Result<Listener<Service>, ListenerCreateError> {
         Ok(fail!(from self, when Listener::new(&self.factory.service),
                     "Failed to create new Listener port."))
     }

--- a/iceoryx2/src/service/port_factory/notifier.rs
+++ b/iceoryx2/src/service/port_factory/notifier.rs
@@ -62,7 +62,7 @@ impl<'factory, Service: service::Service> PortFactoryNotifier<'factory, Service>
     }
 
     /// Creates a new [`Notifier`] port or returns a [`NotifierCreateError`] on failure.
-    pub fn create(&self) -> Result<Notifier<'factory, Service>, NotifierCreateError> {
+    pub fn create(&self) -> Result<Notifier<Service>, NotifierCreateError> {
         Ok(
             fail!(from self, when Notifier::new(&self.factory.service, self.default_event_id),
                     "Failed to create new Notifier port."),


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
 * Refactored the `ContainerState` so that it no longer requires a reference to the corresponding `Container`. Removed one lifetime entanglement.
 * Add non-RAII API to `Container`, removed another lifetime entanglement at the cost that values must be manually removed.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue.

Relates to  #100 