### PR TITLE
[#11] Activate flaky windows test

### DIFF
--- a/iceoryx2/tests/publisher_tests.rs
+++ b/iceoryx2/tests/publisher_tests.rs
@@ -20,6 +20,7 @@ mod publisher {
     use iceoryx2_bb_posix::barrier::{BarrierBuilder, BarrierHandle};
     use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_testing::assert_that;
+    use iceoryx2_bb_testing::watchdog::Watchdog;
 
     type TestResult<T> = core::result::Result<T, Box<dyn std::error::Error>>;
 
@@ -157,10 +158,9 @@ mod publisher {
         Ok(())
     }
 
-    //TODO iox2-#44
-    #[ignore]
     #[test]
     fn publisher_block_when_unable_to_deliver_blocks<Sut: Service>() -> TestResult<()> {
+        let _watchdog = Watchdog::new(Duration::from_secs(10));
         let service_name = generate_name()?;
         let service = Sut::new(&service_name)
             .publish_subscribe()


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This was fixed with #134, just to be sure, I introduced a watchdog for the test. If it is still deadlocking we know it after 10 seconds and not after the CI timeout.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #11 
