### PR TITLE
[#195] add sliced api

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let service = zero_copy::Service::new(&service_name)
         .publish_subscribe()
-        .open_or_create::<usize>()?;
+        .typed::<usize>()
+        .open_or_create()?;
 
     let publisher = service.publisher().create()?;
 
@@ -116,7 +117,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let service = zero_copy::Service::new(&service_name)
         .publish_subscribe()
-        .open_or_create::<usize>()?;
+        .typed::<usize>()
+        .open_or_create()?;
 
     let subscriber = service.subscriber().create()?;
 

--- a/benchmarks/publish-subscribe/src/main.rs
+++ b/benchmarks/publish-subscribe/src/main.rs
@@ -29,7 +29,8 @@ fn perform_benchmark<T: Service>(iterations: u64) {
         .history_size(0)
         .subscriber_max_buffer_size(1)
         .enable_safe_overflow(true)
-        .create::<u64>()
+        .typed::<u64>()
+        .create()
         .unwrap();
 
     let service_b2a = T::new(&service_name_b2a)
@@ -39,7 +40,8 @@ fn perform_benchmark<T: Service>(iterations: u64) {
         .history_size(0)
         .subscriber_max_buffer_size(1)
         .enable_safe_overflow(true)
-        .create::<u64>()
+        .typed::<u64>()
+        .create()
         .unwrap();
 
     let barrier_handle = BarrierHandle::new();

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -20,7 +20,7 @@
 
  <!-- NOTE: Add new entries sorted by issue number to minimize the possibility of conflicts when merging. -->
 
- * Example text [#1](https://github.com/eclipse-iceoryx/iceoryx2/issues/1)
+ * `open`, `open_or_create` and `create` are untyped in pubsub-builder [#195](https://github.com/eclipse-iceoryx/iceoryx2/issues/195)
 
 ### Workflow
 
@@ -36,12 +36,19 @@
 
 ### API Breaking Changes
 
-1. Example
+1. `open`, `open_or_create` and `create` are untyped for publish-subscribe services
 
     ```rust
     // old
-    let fuu = hello().is_it_me_you_re_looking_for()
+    let service = zero_copy::Service::new(&service_name)
+        .publish_subscribe()
+        .create::<u64>() // or open::<u64>(), or open_or_create::<u64>()
+        .unwrap();
 
     // new
-    let fuu = hypnotoad().all_glory_to_the_hypnotoad()
+    let service = zero_copy::Service::new(&service_name)
+        .publish_subscribe()
+        .typed::<u64>()
+        .create() // or open(), or open_or_create()
+        .unwrap();
     ```

--- a/examples/examples/complex_data_types/complex_data_types.rs
+++ b/examples/examples/complex_data_types/complex_data_types.rs
@@ -43,7 +43,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .publish_subscribe()
         .max_publishers(16)
         .max_subscribers(16)
-        .open_or_create::<ComplexDataType>()?;
+        .typed::<ComplexDataType>()
+        .open_or_create()?;
 
     let publisher = service.publisher().create()?;
     let subscriber = service.subscriber().create()?;

--- a/examples/examples/publish_subscribe/publisher.rs
+++ b/examples/examples/publish_subscribe/publisher.rs
@@ -21,7 +21,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let service = zero_copy::Service::new(&service_name)
         .publish_subscribe()
-        .open_or_create::<TransmissionData>()?;
+        .typed::<TransmissionData>()
+        .open_or_create()?;
 
     let publisher = service.publisher().create()?;
 

--- a/examples/examples/publish_subscribe/subscriber.rs
+++ b/examples/examples/publish_subscribe/subscriber.rs
@@ -21,7 +21,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let service = zero_copy::Service::new(&service_name)
         .publish_subscribe()
-        .open_or_create::<TransmissionData>()?;
+        .typed::<TransmissionData>()
+        .open_or_create()?;
 
     let subscriber = service.subscriber().create()?;
 

--- a/iceoryx2/src/config.rs
+++ b/iceoryx2/src/config.rs
@@ -27,7 +27,8 @@
 //!
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe_with_custom_config(&custom_config)
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! # Ok(())
 //! # }

--- a/iceoryx2/src/lib.rs
+++ b/iceoryx2/src/lib.rs
@@ -68,7 +68,8 @@
 //! // create our port factory by creating or opening the service
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let subscriber = service.subscriber().create()?;
 //!
@@ -94,7 +95,8 @@
 //! // create our port factory by creating or opening the service
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let publisher = service.publisher().create()?;
 //!
@@ -198,7 +200,8 @@
 //!     .max_subscribers(5)
 //!     // the maximum amount of publishers of this service
 //!     .max_publishers(2)
-//!     .create::<u64>()?;
+//!     .typed::<u64>()
+//!     .create()?;
 //!
 //! # Ok(())
 //! # }
@@ -245,7 +248,8 @@
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
 //!     .enable_safe_overflow(false)
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let publisher = service.publisher()
 //!     // the maximum amount of samples this publisher can loan in parallel

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -19,7 +19,8 @@
 //! let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let publisher = service
 //!     .publisher()
@@ -591,7 +592,8 @@ impl<Service: service::Service, MessageType: Debug> Publisher<Service, MessageTy
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// #
     /// # let publisher = service.publisher().create()?;
     ///
@@ -625,7 +627,8 @@ impl<Service: service::Service, MessageType: Debug> Publisher<Service, MessageTy
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// #
     /// # let publisher = service.publisher().create()?;
     ///
@@ -705,7 +708,8 @@ impl<Service: service::Service, MessageType: Default + Debug> Publisher<Service,
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// #
     /// # let publisher = service.publisher().create()?;
     ///

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -19,7 +19,8 @@
 //! let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let subscriber = service.subscriber().create()?;
 //!

--- a/iceoryx2/src/port/update_connections.rs
+++ b/iceoryx2/src/port/update_connections.rs
@@ -49,7 +49,8 @@ pub trait UpdateConnections {
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// #
     /// # let publisher = service.publisher().create()?;
     ///

--- a/iceoryx2/src/sample.rs
+++ b/iceoryx2/src/sample.rs
@@ -18,7 +18,8 @@
 //! # let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! # let service = zero_copy::Service::new(&service_name)
 //! #   .publish_subscribe()
-//! #   .open_or_create::<u64>()?;
+//! #   .typed::<u64>()
+//! #   .open_or_create()?;
 //! # let subscriber = service.subscriber().create()?;
 //!
 //! while let Some(sample) = subscriber.receive()? {

--- a/iceoryx2/src/sample_mut.rs
+++ b/iceoryx2/src/sample_mut.rs
@@ -19,7 +19,8 @@
 //! #
 //! # let service = zero_copy::Service::new(&service_name)
 //! #     .publish_subscribe()
-//! #     .open_or_create::<u64>()?;
+//! #     .typed::<u64>()
+//! #     .open_or_create()?;
 //! #
 //! # let publisher = service.publisher().create()?;
 //!
@@ -99,7 +100,8 @@ impl<MessageType: Debug, Service: crate::service::Service>
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// #
     /// # let publisher = service.publisher().create()?;
     ///
@@ -133,7 +135,8 @@ impl<MessageType: Debug, Service: crate::service::Service>
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// #
     /// # let publisher = service.publisher().create()?;
     ///
@@ -169,7 +172,8 @@ impl<
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// # let publisher = service.publisher().create()?;
     ///
     /// let sample = publisher.loan()?;
@@ -199,7 +203,8 @@ impl<
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// # let publisher = service.publisher().create()?;
     ///
     /// let sample = publisher.loan()?;
@@ -229,7 +234,8 @@ impl<
     /// #
     /// # let service = zero_copy::Service::new(&service_name)
     /// #     .publish_subscribe()
-    /// #     .open_or_create::<u64>()?;
+    /// #     .typed::<u64>()
+    /// #     .open_or_create()?;
     /// # let publisher = service.publisher().create()?;
     ///
     /// let mut sample = publisher.loan()?;

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -19,7 +19,8 @@
 //! let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! let pubsub = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! println!("number of active publishers:      {:?}", pubsub.dynamic_config().number_of_publishers());
 //! println!("number of active subscribers:     {:?}", pubsub.dynamic_config().number_of_subscribers());

--- a/iceoryx2/src/service/header/publish_subscribe.rs
+++ b/iceoryx2/src/service/header/publish_subscribe.rs
@@ -20,7 +20,8 @@
 //! # let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let subscriber = service.subscriber().create()?;
 //!

--- a/iceoryx2/src/service/mod.rs
+++ b/iceoryx2/src/service/mod.rs
@@ -30,8 +30,9 @@
 //!     .subscriber_max_buffer_size(3)
 //!     .max_subscribers(4)
 //!     .max_publishers(5)
+//!     .typed::<u64>()
 //!     // if the service already exists, open it, otherwise create it
-//!     .open_or_create::<u64>()?;
+//!     .open_or_create()?;
 //!
 //! # Ok(())
 //! # }
@@ -74,7 +75,8 @@
 //!
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe_with_custom_config(&custom_config)
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! # Ok(())
 //! # }

--- a/iceoryx2/src/service/port_factory/publish_subscribe.rs
+++ b/iceoryx2/src/service/port_factory/publish_subscribe.rs
@@ -19,7 +19,8 @@
 //! let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! let pubsub = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! println!("name:                             {:?}", pubsub.name());
 //! println!("uuid:                             {:?}", pubsub.uuid());
@@ -115,7 +116,8 @@ impl<Service: service::Service, MessageType: Debug> PortFactory<Service, Message
     /// let service_name = ServiceName::new("My/Funk/ServiceName")?;
     /// let pubsub = zero_copy::Service::new(&service_name)
     ///     .publish_subscribe()
-    ///     .open_or_create::<u64>()?;
+    ///     .typed::<u64>()
+    ///     .open_or_create()?;
     ///
     /// let subscriber = pubsub.subscriber().create()?;
     ///
@@ -139,7 +141,8 @@ impl<Service: service::Service, MessageType: Debug> PortFactory<Service, Message
     /// let service_name = ServiceName::new("My/Funk/ServiceName")?;
     /// let pubsub = zero_copy::Service::new(&service_name)
     ///     .publish_subscribe()
-    ///     .open_or_create::<u64>()?;
+    ///     .typed::<u64>()
+    ///     .open_or_create()?;
     ///
     /// let publisher = pubsub.publisher()
     ///                     .max_loaned_samples(6)

--- a/iceoryx2/src/service/port_factory/publisher.rs
+++ b/iceoryx2/src/service/port_factory/publisher.rs
@@ -20,7 +20,8 @@
 //! let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! let pubsub = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let publisher = pubsub.publisher()
 //!                     .max_loaned_samples(6)

--- a/iceoryx2/src/service/port_factory/subscriber.rs
+++ b/iceoryx2/src/service/port_factory/subscriber.rs
@@ -20,7 +20,8 @@
 //! let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! let pubsub = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let subscriber = pubsub.subscriber()
 //!                     .create()?;

--- a/iceoryx2/src/service/process_local.rs
+++ b/iceoryx2/src/service/process_local.rs
@@ -21,7 +21,8 @@
 //! // use `process_local` as communication variant
 //! let service = process_local::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let publisher = service.publisher().create()?;
 //! let subscriber = service.subscriber().create()?;

--- a/iceoryx2/src/service/static_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/static_config/publish_subscribe.rs
@@ -19,7 +19,8 @@
 //! let service_name = ServiceName::new("My/Funk/ServiceName")?;
 //! let pubsub = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! println!("type name:                        {:?}", pubsub.static_config().type_name());
 //! println!("max publishers:                   {:?}", pubsub.static_config().max_supported_publishers());

--- a/iceoryx2/src/service/zero_copy.rs
+++ b/iceoryx2/src/service/zero_copy.rs
@@ -21,7 +21,8 @@
 //! // use `zero_copy` as communication variant
 //! let service = zero_copy::Service::new(&service_name)
 //!     .publish_subscribe()
-//!     .open_or_create::<u64>()?;
+//!     .typed::<u64>()
+//!     .open_or_create()?;
 //!
 //! let publisher = service.publisher().create()?;
 //! let subscriber = service.subscriber().create()?;

--- a/iceoryx2/tests/publisher_tests.rs
+++ b/iceoryx2/tests/publisher_tests.rs
@@ -38,7 +38,8 @@ mod publisher {
         let service_name = generate_name()?;
         let service = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()?;
+            .typed::<u64>()
+            .create()?;
 
         let sut = service.publisher().max_loaned_samples(2).create()?;
 
@@ -54,7 +55,8 @@ mod publisher {
         let service_name = generate_name()?;
         let service = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()?;
+            .typed::<u64>()
+            .create()?;
 
         let sut = service.publisher().max_loaned_samples(2).create()?;
 
@@ -70,7 +72,8 @@ mod publisher {
         let service_name = generate_name()?;
         let service = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()?;
+            .typed::<u64>()
+            .create()?;
 
         let sut = service.publisher().max_loaned_samples(4).create()?;
 
@@ -100,7 +103,8 @@ mod publisher {
         let service_name = generate_name()?;
         let service = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()?;
+            .typed::<u64>()
+            .create()?;
 
         let sut = service.publisher().max_loaned_samples(2).create()?;
 
@@ -119,7 +123,8 @@ mod publisher {
         let service_name = generate_name()?;
         let service = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()?;
+            .typed::<u64>()
+            .create()?;
 
         let sut = service.publisher().max_loaned_samples(2).create()?;
 
@@ -141,7 +146,8 @@ mod publisher {
         let service_name = generate_name()?;
         let service = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()?;
+            .typed::<u64>()
+            .create()?;
 
         let sut = service.publisher().max_loaned_samples(2).create()?;
 
@@ -166,7 +172,8 @@ mod publisher {
             .publish_subscribe()
             .subscriber_max_buffer_size(1)
             .enable_safe_overflow(false)
-            .create::<u64>()?;
+            .typed::<u64>()
+            .create()?;
 
         let sut = service
             .publisher()
@@ -181,7 +188,8 @@ mod publisher {
                 let service = Sut::new(&service_name)
                     .publish_subscribe()
                     .subscriber_max_buffer_size(1)
-                    .open::<u64>()
+                    .typed::<u64>()
+                    .open()
                     .unwrap();
 
                 let subscriber = service.subscriber().create().unwrap();

--- a/iceoryx2/tests/sample_mut_tests.rs
+++ b/iceoryx2/tests/sample_mut_tests.rs
@@ -44,7 +44,8 @@ mod sample_mut {
             let service = Sut::new(&service_name)
                 .publish_subscribe()
                 .max_publishers(1)
-                .create::<u64>()
+                .typed::<u64>()
+                .create()
                 .unwrap();
 
             let publisher = service
@@ -144,7 +145,10 @@ mod sample_mut {
 
         drop(test_context);
 
-        let result = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let result = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(result, is_err);
         assert_that!(result.err().unwrap(), eq PublishSubscribeCreateError::OldConnectionsStillActive);
     }

--- a/iceoryx2/tests/sample_tests.rs
+++ b/iceoryx2/tests/sample_tests.rs
@@ -43,7 +43,8 @@ mod sample {
                 .publish_subscribe()
                 .max_publishers(2)
                 .max_subscribers(1)
-                .create::<u64>()
+                .typed::<u64>()
+                .create()
                 .unwrap();
 
             let publisher_1 = service.publisher().create().unwrap();
@@ -88,7 +89,10 @@ mod sample {
         drop(test_context);
 
         assert_that!(
-            Sut::new(&service_name).publish_subscribe().create::<u64>(),
+            Sut::new(&service_name)
+                .publish_subscribe()
+                .typed::<u64>()
+                .create(),
             is_ok
         );
     }

--- a/iceoryx2/tests/service_publish_subscribe_tests.rs
+++ b/iceoryx2/tests/service_publish_subscribe_tests.rs
@@ -42,7 +42,10 @@ mod service_publish_subscribe {
     #[test]
     fn creating_non_existing_service_works<Sut: Service>() {
         let service_name = generate_name();
-        let sut = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
 
         assert_that!(sut, is_ok);
         let sut = sut.unwrap();
@@ -52,10 +55,16 @@ mod service_publish_subscribe {
     #[test]
     fn creating_same_service_twice_fails<Sut: Service>() {
         let service_name = generate_name();
-        let sut = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut, is_ok);
 
-        let sut2 = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut2 = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut2, is_err);
         assert_that!(
             sut2.err().unwrap(), eq
@@ -66,19 +75,28 @@ mod service_publish_subscribe {
     #[test]
     fn recreate_after_drop_works<Sut: Service>() {
         let service_name = generate_name();
-        let sut = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut, is_ok);
 
         drop(sut);
 
-        let sut2 = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut2 = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut2, is_ok);
     }
 
     #[test]
     fn open_fails_when_service_does_not_exist<Sut: Service>() {
         let service_name = generate_name();
-        let sut = Sut::new(&service_name).publish_subscribe().open::<u64>();
+        let sut = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .open();
         assert_that!(sut, is_err);
         assert_that!(sut.err().unwrap(), eq PublishSubscribeOpenError::DoesNotExist);
     }
@@ -86,20 +104,32 @@ mod service_publish_subscribe {
     #[test]
     fn open_succeeds_when_service_does_exist<Sut: Service>() {
         let service_name = generate_name();
-        let sut = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut, is_ok);
 
-        let sut2 = Sut::new(&service_name).publish_subscribe().open::<u64>();
+        let sut2 = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .open();
         assert_that!(sut2, is_ok);
     }
 
     #[test]
     fn open_fails_when_service_has_wrong_type<Sut: Service>() {
         let service_name = generate_name();
-        let sut = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut, is_ok);
 
-        let sut2 = Sut::new(&service_name).publish_subscribe().open::<i64>();
+        let sut2 = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<i64>()
+            .open();
         assert_that!(sut2, is_err);
         assert_that!(sut2.err().unwrap(), eq PublishSubscribeOpenError::IncompatibleTypes);
     }
@@ -115,14 +145,16 @@ mod service_publish_subscribe {
             .history_size(2)
             .subscriber_max_borrowed_samples(2)
             .subscriber_max_buffer_size(2)
-            .create::<u64>();
+            .typed::<u64>()
+            .create();
         assert_that!(sut, is_ok);
 
         // max_publishers
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .max_publishers(3)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_err);
         assert_that!(
@@ -133,7 +165,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .max_publishers(1)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_ok);
 
@@ -141,7 +174,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .max_subscribers(3)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_err);
         assert_that!(
@@ -152,7 +186,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .max_subscribers(1)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_ok);
 
@@ -160,7 +195,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .enable_safe_overflow(true)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_err);
         assert_that!(
@@ -172,7 +208,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .history_size(3)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_err);
         assert_that!(
@@ -183,7 +220,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .history_size(1)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_ok);
 
@@ -191,7 +229,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .subscriber_max_borrowed_samples(3)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_err);
         assert_that!(
@@ -202,7 +241,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .subscriber_max_borrowed_samples(1)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_ok);
 
@@ -210,7 +250,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .subscriber_max_buffer_size(3)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_err);
         assert_that!(
@@ -221,7 +262,8 @@ mod service_publish_subscribe {
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
             .subscriber_max_buffer_size(1)
-            .open::<u64>();
+            .typed::<u64>()
+            .open();
 
         assert_that!(sut2, is_ok);
     }
@@ -229,31 +271,49 @@ mod service_publish_subscribe {
     #[test]
     fn open_does_not_fail_when_service_owner_is_dropped<Sut: Service>() {
         let service_name = generate_name();
-        let sut = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut, is_ok);
 
-        let sut2 = Sut::new(&service_name).publish_subscribe().open::<u64>();
+        let sut2 = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .open();
         assert_that!(sut2, is_ok);
 
         drop(sut);
 
-        let sut3 = Sut::new(&service_name).publish_subscribe().open::<u64>();
+        let sut3 = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .open();
         assert_that!(sut3, is_ok);
     }
 
     #[test]
     fn open_fails_when_all_previous_owners_have_been_dropped<Sut: Service>() {
         let service_name = generate_name();
-        let sut = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut, is_ok);
 
-        let sut2 = Sut::new(&service_name).publish_subscribe().open::<u64>();
+        let sut2 = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .open();
         assert_that!(sut2, is_ok);
 
         drop(sut);
         drop(sut2);
 
-        let sut3 = Sut::new(&service_name).publish_subscribe().open::<u64>();
+        let sut3 = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .open();
         assert_that!(sut3, is_err);
         assert_that!(sut3.err().unwrap(), eq PublishSubscribeOpenError::DoesNotExist);
     }
@@ -263,7 +323,8 @@ mod service_publish_subscribe {
         let service_name = generate_name();
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .open_or_create::<u64>();
+            .typed::<u64>()
+            .open_or_create();
 
         assert_that!(sut, is_ok);
     }
@@ -273,12 +334,14 @@ mod service_publish_subscribe {
         let service_name = generate_name();
         let _sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .open_or_create::<u64>();
+            .typed::<u64>()
+            .open_or_create();
 
         assert_that!(sut, is_ok);
     }
@@ -288,7 +351,8 @@ mod service_publish_subscribe {
         let service_name = generate_name();
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let defaults = &Config::get_global_config().defaults;
@@ -314,12 +378,14 @@ mod service_publish_subscribe {
             .history_size(6)
             .subscriber_max_borrowed_samples(7)
             .subscriber_max_buffer_size(8)
-            .create::<u64>();
+            .typed::<u64>()
+            .create();
         assert_that!(_sut, is_ok);
 
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .open::<u64>()
+            .typed::<u64>()
+            .open()
             .unwrap();
 
         assert_that!(sut.static_config().max_supported_publishers(), eq 4);
@@ -355,7 +421,8 @@ mod service_publish_subscribe {
 
         let sut = Sut::new(&service_name)
             .publish_subscribe_with_custom_config(&custom_config)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         assert_that!(sut.static_config().max_supported_publishers(), eq 9);
@@ -367,7 +434,8 @@ mod service_publish_subscribe {
 
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
-            .open::<u64>()
+            .typed::<u64>()
+            .open()
             .unwrap();
 
         assert_that!(sut2.static_config().max_supported_publishers(), eq 9);
@@ -386,12 +454,14 @@ mod service_publish_subscribe {
         let sut = Sut::new(&service_name)
             .publish_subscribe()
             .max_publishers(MAX_PUBLISHERS)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
-            .open::<u64>()
+            .typed::<u64>()
+            .open()
             .unwrap();
 
         let mut publishers = vec![];
@@ -423,7 +493,8 @@ mod service_publish_subscribe {
 
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         type MessageType = Message<iceoryx2::service::header::publish_subscribe::Header, u64>;
@@ -441,12 +512,14 @@ mod service_publish_subscribe {
         let sut = Sut::new(&service_name)
             .publish_subscribe()
             .max_subscribers(MAX_SUBSCRIBERS)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
-            .open::<u64>()
+            .typed::<u64>()
+            .open()
             .unwrap();
 
         let mut subscribers = vec![];
@@ -478,12 +551,14 @@ mod service_publish_subscribe {
 
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
-            .open::<u64>()
+            .typed::<u64>()
+            .open()
             .unwrap();
 
         let subscriber = sut.subscriber().create().unwrap();
@@ -512,12 +587,14 @@ mod service_publish_subscribe {
 
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
-            .open::<u64>()
+            .typed::<u64>()
+            .open()
             .unwrap();
 
         let publisher = sut.publisher().create().unwrap();
@@ -549,7 +626,8 @@ mod service_publish_subscribe {
             .history_size(0)
             .subscriber_max_borrowed_samples(1)
             .subscriber_max_buffer_size(3)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let publisher = sut.publisher().create().unwrap();
@@ -584,7 +662,8 @@ mod service_publish_subscribe {
             .history_size(0)
             .subscriber_max_borrowed_samples(1)
             .subscriber_max_buffer_size(3)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let publisher = sut.publisher().create().unwrap();
@@ -616,7 +695,8 @@ mod service_publish_subscribe {
             .history_size(0)
             .subscriber_max_borrowed_samples(1)
             .subscriber_max_buffer_size(1)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let subscriber = sut.subscriber().create().unwrap();
@@ -654,7 +734,8 @@ mod service_publish_subscribe {
             s.spawn(|| {
                 let sut2 = Sut::new(&service_name)
                     .publish_subscribe()
-                    .create::<u64>()
+                    .typed::<u64>()
+                    .create()
                     .unwrap();
                 let publisher = sut2.publisher().create().unwrap();
 
@@ -673,7 +754,8 @@ mod service_publish_subscribe {
                 threads.push(s.spawn(|| {
                     let sut = Sut::new(&service_name)
                         .publish_subscribe()
-                        .open::<u64>()
+                        .typed::<u64>()
+                        .open()
                         .unwrap();
 
                     let mut latest_counter = 0u64;
@@ -715,7 +797,8 @@ mod service_publish_subscribe {
                 let sut = Sut::new(&service_name)
                     .publish_subscribe()
                     .max_publishers(NUMBER_OF_PUBLISHER_THREADS)
-                    .open_or_create::<u64>()
+                    .typed::<u64>()
+                    .open_or_create()
                     .unwrap();
 
                 let subscriber = sut.subscriber().create().unwrap();
@@ -737,7 +820,8 @@ mod service_publish_subscribe {
                     let sut2 = Sut::new(&service_name)
                         .publish_subscribe()
                         .max_publishers(NUMBER_OF_PUBLISHER_THREADS)
-                        .open_or_create::<u64>()
+                        .typed::<u64>()
+                        .open_or_create()
                         .unwrap();
 
                     create_service_barrier.wait();
@@ -770,7 +854,8 @@ mod service_publish_subscribe {
             .publish_subscribe()
             .max_publishers(MAX_PUB)
             .max_subscribers(MAX_SUB)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let mut publishers = vec![];
@@ -813,7 +898,8 @@ mod service_publish_subscribe {
             .publish_subscribe()
             .max_publishers(MAX_PUB)
             .max_subscribers(MAX_SUB)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let mut channels = vec![];
@@ -823,7 +909,8 @@ mod service_publish_subscribe {
             channels.push(
                 Sut::new(&service_name)
                     .publish_subscribe()
-                    .open::<u64>()
+                    .typed::<u64>()
+                    .open()
                     .unwrap(),
             );
         }
@@ -866,7 +953,8 @@ mod service_publish_subscribe {
             .publish_subscribe()
             .enable_safe_overflow(true)
             .subscriber_max_buffer_size(BUFFER_SIZE)
-            .create::<usize>()
+            .typed::<usize>()
+            .create()
             .unwrap();
 
         let publisher = sut.publisher().create().unwrap();
@@ -895,7 +983,8 @@ mod service_publish_subscribe {
             .publish_subscribe()
             .enable_safe_overflow(false)
             .subscriber_max_buffer_size(BUFFER_SIZE)
-            .create::<usize>()
+            .typed::<usize>()
+            .create()
             .unwrap();
 
         let publisher = sut
@@ -928,7 +1017,8 @@ mod service_publish_subscribe {
             .enable_safe_overflow(false)
             .history_size(12)
             .subscriber_max_buffer_size(11)
-            .create::<usize>();
+            .typed::<usize>()
+            .create();
 
         assert_that!(sut, is_err);
         assert_that!(
@@ -946,7 +1036,8 @@ mod service_publish_subscribe {
             .publish_subscribe()
             .history_size(3)
             .subscriber_max_buffer_size(BUFFER_SIZE)
-            .create::<usize>()
+            .typed::<usize>()
+            .create()
             .unwrap();
 
         let sut_publisher = sut.publisher().create().unwrap();
@@ -973,7 +1064,8 @@ mod service_publish_subscribe {
             .publish_subscribe()
             .history_size(0)
             .subscriber_max_buffer_size(BUFFER_SIZE)
-            .create::<usize>()
+            .typed::<usize>()
+            .create()
             .unwrap();
 
         let sut_publisher = sut.publisher().create().unwrap();
@@ -998,7 +1090,8 @@ mod service_publish_subscribe {
             .history_size(0)
             .subscriber_max_buffer_size(BUFFER_SIZE)
             .subscriber_max_borrowed_samples(1)
-            .create::<usize>()
+            .typed::<usize>()
+            .create()
             .unwrap();
 
         let sut_publisher = sut.publisher().max_loaned_samples(1).create().unwrap();
@@ -1032,7 +1125,8 @@ mod service_publish_subscribe {
             .history_size(history_size)
             .subscriber_max_buffer_size(buffer_size)
             .subscriber_max_borrowed_samples(max_borrow)
-            .create::<usize>()
+            .typed::<usize>()
+            .create()
             .unwrap();
 
         let sut_publisher = sut
@@ -1211,7 +1305,8 @@ mod service_publish_subscribe {
             .history_size(0)
             .subscriber_max_buffer_size(buffer_size)
             .subscriber_max_borrowed_samples(max_borrow)
-            .create::<usize>()
+            .typed::<usize>()
+            .create()
             .unwrap();
 
         let sut_publisher = sut
@@ -1327,7 +1422,8 @@ mod service_publish_subscribe {
             .publish_subscribe()
             .max_publishers(MAX_PUBLISHERS)
             .max_subscribers(MAX_SUBSCRIBERS)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let mut publishers = vec![];
@@ -1379,7 +1475,8 @@ mod service_publish_subscribe {
         let sut = Sut::new(&service_name)
             .publish_subscribe()
             .max_publishers(0)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         assert_that!(sut.static_config().max_supported_publishers(), eq 1);
@@ -1391,7 +1488,8 @@ mod service_publish_subscribe {
         let sut = Sut::new(&service_name)
             .publish_subscribe()
             .max_subscribers(0)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         assert_that!(sut.static_config().max_supported_subscribers(), eq 1);
@@ -1403,7 +1501,8 @@ mod service_publish_subscribe {
         let sut = Sut::new(&service_name)
             .publish_subscribe()
             .subscriber_max_borrowed_samples(0)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         assert_that!(sut.static_config().subscriber_max_borrowed_samples(), eq 1);
@@ -1415,7 +1514,8 @@ mod service_publish_subscribe {
         let sut = Sut::new(&service_name)
             .publish_subscribe()
             .subscriber_max_buffer_size(0)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         assert_that!(sut.static_config().subscriber_max_buffer_size(), eq 1);
@@ -1428,7 +1528,8 @@ mod service_publish_subscribe {
 
         let _sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         assert_that!(Sut::does_exist(&service_name).unwrap(), eq true);
@@ -1453,7 +1554,8 @@ mod service_publish_subscribe {
             services.push(
                 Sut::new(&service_name)
                     .publish_subscribe()
-                    .create::<u64>()
+                    .typed::<u64>()
+                    .create()
                     .unwrap(),
             );
             service_names.push(service_name);
@@ -1511,7 +1613,8 @@ mod service_publish_subscribe {
             services.push(
                 Sut::new(&service_name)
                     .publish_subscribe()
-                    .create::<u64>()
+                    .typed::<u64>()
+                    .create()
                     .unwrap(),
             );
             service_names.push(service_name);
@@ -1537,7 +1640,8 @@ mod service_publish_subscribe {
         let service_name = generate_name();
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let publisher = sut.publisher().create().unwrap();
@@ -1557,7 +1661,8 @@ mod service_publish_subscribe {
         let service_name = generate_name();
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let subscriber = sut.subscriber().create().unwrap();
@@ -1567,20 +1672,25 @@ mod service_publish_subscribe {
 
         assert_that!(Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>().err().unwrap(),
+            .typed::<u64>()
+            .create().err().unwrap(),
             eq PublishSubscribeCreateError::OldConnectionsStillActive);
 
         drop(subscriber);
 
         assert_that!(Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>().err().unwrap(),
+            .typed::<u64>()
+            .create().err().unwrap(),
             eq PublishSubscribeCreateError::OldConnectionsStillActive);
 
         drop(publisher);
 
         assert_that!(
-            Sut::new(&service_name).publish_subscribe().create::<u64>(),
+            Sut::new(&service_name)
+                .publish_subscribe()
+                .typed::<u64>()
+                .create(),
             is_ok
         );
     }
@@ -1593,12 +1703,14 @@ mod service_publish_subscribe {
         let sut = Sut::new(&service_name)
             .publish_subscribe()
             .subscriber_max_buffer_size(BUFFER_SIZE)
-            .create::<usize>()
+            .typed::<usize>()
+            .create()
             .unwrap();
 
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
-            .open::<usize>()
+            .typed::<usize>()
+            .open()
             .unwrap();
 
         for i in 1..=BUFFER_SIZE {
@@ -1642,12 +1754,14 @@ mod service_publish_subscribe {
         let _sut = Sut::new(&service_name)
             .publish_subscribe()
             .subscriber_max_buffer_size(BUFFER_SIZE)
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let sut2 = Sut::new(&service_name)
             .publish_subscribe()
-            .open::<u64>()
+            .typed::<u64>()
+            .open()
             .unwrap();
 
         let subscriber = sut2.subscriber().buffer_size(BUFFER_SIZE + 1).create();
@@ -1660,7 +1774,8 @@ mod service_publish_subscribe {
         let service_name = generate_name();
         let sut = Sut::new(&service_name)
             .publish_subscribe()
-            .create::<u64>()
+            .typed::<u64>()
+            .create()
             .unwrap();
 
         let subscriber = sut.subscriber().buffer_size(0).create().unwrap();

--- a/iceoryx2/tests/service_tests.rs
+++ b/iceoryx2/tests/service_tests.rs
@@ -52,11 +52,17 @@ mod service {
         type OpenError = PublishSubscribeOpenError;
 
         fn create(service_name: &ServiceName) -> Result<Self::Factory, Self::CreateError> {
-            Sut::new(&service_name).publish_subscribe().create::<u64>()
+            Sut::new(&service_name)
+                .publish_subscribe()
+                .typed::<u64>()
+                .create()
         }
 
         fn open(service_name: &ServiceName) -> Result<Self::Factory, Self::OpenError> {
-            Sut::new(&service_name).publish_subscribe().open::<u64>()
+            Sut::new(&service_name)
+                .publish_subscribe()
+                .typed::<u64>()
+                .open()
         }
 
         fn assert_create_error(error: Self::CreateError) {
@@ -119,7 +125,10 @@ mod service {
     #[test]
     fn same_name_with_different_messaging_pattern_is_allowed<Sut: Service, Factory: SutFactory>() {
         let service_name = generate_name();
-        let sut_pub_sub = Sut::new(&service_name).publish_subscribe().create::<u64>();
+        let sut_pub_sub = Sut::new(&service_name)
+            .publish_subscribe()
+            .typed::<u64>()
+            .create();
         assert_that!(sut_pub_sub, is_ok);
         let sut_pub_sub = sut_pub_sub.unwrap();
 


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR prepares the API for the new untyped API by introducing `.typed::<T>()` in the pub/sub builder which returns a typed builder.

In the upcoming sliced and untyped API a similar method will be introduced called `.sliced::<T>()` or `.untyped()` that will return a sliced- or untyped-builder.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #195 
