### PR TITLE
[#3] Set 'RUSTFLAGS' as global env variable on cirrus ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -82,7 +82,7 @@ iox2_common_build_release_template: &IOX2_COMMON_BUILD_RELEASE
 
 iox2_common_build_and_test_no_doc_tests_release_template: &IOX2_COMMON_BUILD_AND_TEST_NO_DOC_TESTS_RELEASE
   <<: *IOX2_COMMON_BUILD_RELEASE
-  test_script: RUSTFLAGS="-C debug-assertions" cargo nextest run --release --tests --workspace --no-fail-fast
+  test_script: cargo nextest run --release --tests --workspace --no-fail-fast
 
 iox2_freebsd_setup_template: &IOX2_FREEBSD_SETUP
   setup_script:
@@ -103,6 +103,13 @@ iox2_freebsd_setup_template: &IOX2_FREEBSD_SETUP
 #
 
 only_if: $CIRRUS_BRANCH == 'main' || ($CIRRUS_PR != '' && $CIRRUS_BASE_BRANCH == 'main')
+
+#
+# Global environment variables
+#
+
+env:
+  RUSTFLAGS: "-C debug-assertions"
 
 #
 # Preflight-Check with Ubuntu x86 stable debug


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

On Cirrus-CI the test tasks are build with different flags than the build tasks. This results in rebuilding everything for the tests and increases the CI time quite a lot for the aarch64 release builds.

This PR sets the `RUSTFLAGS` in a global environment variable, similar to the github actions.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #3
