### PR TITLE
[#264] config api

### DIFF
--- a/iceoryx2-bb/container/src/semantic_string.rs
+++ b/iceoryx2-bb/container/src/semantic_string.rs
@@ -153,7 +153,7 @@ pub trait SemanticString<const CAPACITY: usize>:
     ///
     unsafe fn from_c_str(ptr: *const std::ffi::c_char) -> Result<Self, SemanticStringError> {
         Self::new(std::slice::from_raw_parts(
-            ptr as *const u8,
+            ptr.cast(),
             strnlen(ptr, CAPACITY + 1),
         ))
     }

--- a/iceoryx2-bb/container/src/semantic_string.rs
+++ b/iceoryx2-bb/container/src/semantic_string.rs
@@ -151,7 +151,7 @@ pub trait SemanticString<const CAPACITY: usize>:
     ///   * The contents must have a length that is less or equal CAPACITY
     ///   * The contents must not contain invalid UTF-8 characters
     ///
-    unsafe fn from_c_str(ptr: *mut std::ffi::c_char) -> Result<Self, SemanticStringError> {
+    unsafe fn from_c_str(ptr: *const std::ffi::c_char) -> Result<Self, SemanticStringError> {
         Self::new(std::slice::from_raw_parts(
             ptr as *const u8,
             strnlen(ptr, CAPACITY + 1),

--- a/iceoryx2-cal/src/communication_channel/message_queue.rs
+++ b/iceoryx2-cal/src/communication_channel/message_queue.rs
@@ -161,8 +161,8 @@ impl Default for Configuration {
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -170,13 +170,13 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path_hint = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path_hint = *value;
         self
     }
 

--- a/iceoryx2-cal/src/communication_channel/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/communication_channel/posix_shared_memory.rs
@@ -94,14 +94,14 @@ impl Default for Configuration {
 impl From<Configuration> for dynamic_storage::posix_shared_memory::Configuration<Management> {
     fn from(value: Configuration) -> Self {
         Self::default()
-            .suffix(value.suffix)
-            .path_hint(value.path_hint)
+            .suffix(&value.suffix)
+            .path_hint(&value.path_hint)
     }
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -109,13 +109,13 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path_hint = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path_hint = *value;
         self
     }
 

--- a/iceoryx2-cal/src/communication_channel/process_local.rs
+++ b/iceoryx2-cal/src/communication_channel/process_local.rs
@@ -77,8 +77,8 @@ impl Default for Configuration {
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -86,13 +86,13 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path_hint = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path_hint = *value;
         self
     }
 

--- a/iceoryx2-cal/src/communication_channel/unix_datagram.rs
+++ b/iceoryx2-cal/src/communication_channel/unix_datagram.rs
@@ -45,8 +45,8 @@ impl Default for Configuration {
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -54,13 +54,13 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path_hint = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path_hint = *value;
         self
     }
 

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -112,8 +112,8 @@ impl<T: Send + Sync + Debug> Default for Configuration<T> {
 impl<T: Send + Sync + Debug> DynamicStorageConfiguration<T> for Configuration<T> {}
 
 impl<T: Send + Sync + Debug> NamedConceptConfiguration for Configuration<T> {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -121,13 +121,13 @@ impl<T: Send + Sync + Debug> NamedConceptConfiguration for Configuration<T> {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path = *value;
         self
     }
 

--- a/iceoryx2-cal/src/dynamic_storage/process_local.rs
+++ b/iceoryx2-cal/src/dynamic_storage/process_local.rs
@@ -104,8 +104,8 @@ impl<T: Send + Sync + Debug> Default for Configuration<T> {
 impl<T: Send + Sync + Debug> DynamicStorageConfiguration<T> for Configuration<T> {}
 
 impl<T: Send + Sync + Debug> NamedConceptConfiguration for Configuration<T> {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -113,13 +113,13 @@ impl<T: Send + Sync + Debug> NamedConceptConfiguration for Configuration<T> {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path_hint = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path_hint = *value;
         self
     }
 

--- a/iceoryx2-cal/src/event/common.rs
+++ b/iceoryx2-cal/src/event/common.rs
@@ -83,9 +83,9 @@ pub mod details {
     {
         fn convert(&self) -> <Storage as NamedConceptMgmt>::Configuration {
             <Storage as NamedConceptMgmt>::Configuration::default()
-                .prefix(self.prefix)
-                .suffix(self.suffix)
-                .path_hint(self.path)
+                .prefix(&self.prefix)
+                .suffix(&self.suffix)
+                .path_hint(&self.path)
         }
     }
 
@@ -133,8 +133,8 @@ pub mod details {
             Storage: DynamicStorage<Management<Tracker, WaitMechanism>>,
         > NamedConceptConfiguration for Configuration<Tracker, WaitMechanism, Storage>
     {
-        fn prefix(mut self, value: FileName) -> Self {
-            self.prefix = value;
+        fn prefix(mut self, value: &FileName) -> Self {
+            self.prefix = *value;
             self
         }
 
@@ -142,13 +142,13 @@ pub mod details {
             &self.prefix
         }
 
-        fn suffix(mut self, value: FileName) -> Self {
-            self.suffix = value;
+        fn suffix(mut self, value: &FileName) -> Self {
+            self.suffix = *value;
             self
         }
 
-        fn path_hint(mut self, value: Path) -> Self {
-            self.path = value;
+        fn path_hint(mut self, value: &Path) -> Self {
+            self.path = *value;
             self
         }
 

--- a/iceoryx2-cal/src/event/process_local.rs
+++ b/iceoryx2-cal/src/event/process_local.rs
@@ -79,8 +79,8 @@ impl Default for Configuration {
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -88,13 +88,13 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path = *value;
         self
     }
 

--- a/iceoryx2-cal/src/event/unix_datagram_socket.rs
+++ b/iceoryx2-cal/src/event/unix_datagram_socket.rs
@@ -41,8 +41,8 @@ impl Default for Configuration {
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -50,13 +50,13 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path = *value;
         self
     }
 
@@ -71,7 +71,7 @@ impl NamedConceptConfiguration for Configuration {
 
 impl From<Configuration> for crate::communication_channel::unix_datagram::Configuration {
     fn from(value: Configuration) -> Self {
-        Self::default().suffix(value.suffix).path_hint(value.path)
+        Self::default().suffix(&value.suffix).path_hint(&value.path)
     }
 }
 

--- a/iceoryx2-cal/src/monitoring/file_lock.rs
+++ b/iceoryx2-cal/src/monitoring/file_lock.rs
@@ -339,8 +339,8 @@ impl Default for Configuration {
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -348,8 +348,8 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
@@ -357,8 +357,8 @@ impl NamedConceptConfiguration for Configuration {
         &self.suffix
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path_hint = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path_hint = *value;
         self
     }
 

--- a/iceoryx2-cal/src/monitoring/process_local.rs
+++ b/iceoryx2-cal/src/monitoring/process_local.rs
@@ -58,8 +58,8 @@ impl Default for Configuration {
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -67,8 +67,8 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
@@ -76,8 +76,8 @@ impl NamedConceptConfiguration for Configuration {
         &self.suffix
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path_hint = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path_hint = *value;
         self
     }
 

--- a/iceoryx2-cal/src/named_concept.rs
+++ b/iceoryx2-cal/src/named_concept.rs
@@ -51,18 +51,18 @@ pub enum NamedConceptPathHintRemoveError {
 /// underlying resource does not support it.
 pub trait NamedConceptConfiguration: Default + Clone + Debug {
     /// Defines the prefix that the concept will use.
-    fn prefix(self, value: FileName) -> Self;
+    fn prefix(self, value: &FileName) -> Self;
 
     /// Returns the configurations prefix.
     fn get_prefix(&self) -> &FileName;
 
     /// Defines the suffix that the concept will use.
-    fn suffix(self, value: FileName) -> Self;
+    fn suffix(self, value: &FileName) -> Self;
 
     /// Sets a path hint under which the underlying resources shall be stored. When the concept
     /// uses resources like [`iceoryx2_bb_posix::shared_memory::SharedMemory`] the path will be
     /// ignored.
-    fn path_hint(self, value: Path) -> Self;
+    fn path_hint(self, value: &Path) -> Self;
 
     /// Returns the configurations suffix.
     fn get_suffix(&self) -> &FileName;

--- a/iceoryx2-cal/src/shared_memory/common.rs
+++ b/iceoryx2-cal/src/shared_memory/common.rs
@@ -68,9 +68,9 @@ pub mod details {
             Self {
                 zero_memory: true,
                 dynamic_storage_config: Storage::Configuration::default()
-                    .path_hint(Memory::<Allocator, Storage>::default_path_hint())
-                    .suffix(Memory::<Allocator, Storage>::default_suffix())
-                    .prefix(Memory::<Allocator, Storage>::default_prefix()),
+                    .path_hint(&Memory::<Allocator, Storage>::default_path_hint())
+                    .suffix(&Memory::<Allocator, Storage>::default_suffix())
+                    .prefix(&Memory::<Allocator, Storage>::default_prefix()),
                 _phantom: PhantomData,
                 _phantom_storage: PhantomData,
             }
@@ -93,7 +93,7 @@ pub mod details {
     impl<Allocator: ShmAllocator + Debug, Storage: DynamicStorage<AllocatorDetails<Allocator>>>
         NamedConceptConfiguration for Configuration<Allocator, Storage>
     {
-        fn prefix(mut self, value: FileName) -> Self {
+        fn prefix(mut self, value: &FileName) -> Self {
             self.dynamic_storage_config = self.dynamic_storage_config.prefix(value);
             self
         }
@@ -102,12 +102,12 @@ pub mod details {
             self.dynamic_storage_config.get_prefix()
         }
 
-        fn suffix(mut self, value: FileName) -> Self {
+        fn suffix(mut self, value: &FileName) -> Self {
             self.dynamic_storage_config = self.dynamic_storage_config.suffix(value);
             self
         }
 
-        fn path_hint(mut self, value: Path) -> Self {
+        fn path_hint(mut self, value: &Path) -> Self {
             self.dynamic_storage_config = self.dynamic_storage_config.path_hint(value);
             self
         }

--- a/iceoryx2-cal/src/shared_memory_directory/mod.rs
+++ b/iceoryx2-cal/src/shared_memory_directory/mod.rs
@@ -75,7 +75,7 @@ impl SharedMemoryDirectoryCreator {
         when MgmtShm::Builder::new(&self.name)
             .config(
                 &MgmtShm::Configuration::default()
-                    .suffix(unsafe {FileName::new_unchecked(MGMT_SHM_SUFFIX)}),
+                    .suffix(unsafe {&FileName::new_unchecked(MGMT_SHM_SUFFIX)}),
             )
             .size(core::mem::size_of::<FileReferenceSet>() + core::mem::align_of::<FileReferenceSet>() - 1)
             .create(&<BumpAllocator as ShmAllocator>::Configuration::default()),
@@ -92,7 +92,7 @@ impl SharedMemoryDirectoryCreator {
         let data_shm = fail!(from self,
             when DataShm::Builder::new(&self.name).config(
                 &DataShm::Configuration::default()
-                    .suffix(unsafe{FileName::new_unchecked(DATA_SHM_SUFFIX)}),
+                    .suffix(unsafe{&FileName::new_unchecked(DATA_SHM_SUFFIX)}),
                 ).size(self.size).create(allocator_config),
             "{} since the data segment could not be created.", msg);
 
@@ -120,7 +120,7 @@ impl SharedMemoryDirectoryCreator {
         let data_shm = fail!(from self, when DataShm::Builder::new(&self.name)
                                 .config(
                                     &DataShm::Configuration::default()
-                                        .suffix(unsafe{FileName::new_unchecked(DATA_SHM_SUFFIX)}),
+                                        .suffix(unsafe{&FileName::new_unchecked(DATA_SHM_SUFFIX)}),
                                     )
                                 .open(),
                                 "{} since the data segment could not be opened.", msg);
@@ -128,7 +128,7 @@ impl SharedMemoryDirectoryCreator {
         let mgmt_shm = fail!(from self, when MgmtShm::Builder::new(&self.name)
                                 .config(
                                     &MgmtShm::Configuration::default()
-                                        .suffix(unsafe{FileName::new_unchecked(MGMT_SHM_SUFFIX)}),
+                                        .suffix(unsafe{&FileName::new_unchecked(MGMT_SHM_SUFFIX)}),
                                 )
                                 .open(),
                                 "{} since the management segment could not be opened.", msg);
@@ -220,14 +220,14 @@ impl<
 
         if !fail!(from origin, when DataShm::does_exist_cfg(
             name,
-            &DataShm::Configuration::default().suffix(unsafe{FileName::new_unchecked(DATA_SHM_SUFFIX)})),
+            &DataShm::Configuration::default().suffix(unsafe{&FileName::new_unchecked(DATA_SHM_SUFFIX)})),
             "{} \"{}\" exists due to a failure while checking the data segment.", msg, name)
         {
             return Ok(false);
         }
 
         let mgmt_result = fail!(from origin,
-            when MgmtShm::does_exist_cfg(name, &MgmtShm::Configuration::default().suffix(unsafe{FileName::new_unchecked(MGMT_SHM_SUFFIX)})),
+            when MgmtShm::does_exist_cfg(name, &MgmtShm::Configuration::default().suffix(unsafe{&FileName::new_unchecked(MGMT_SHM_SUFFIX)})),
             "{} \"{}\" exists due to a failure while checking the management segment.", msg, name
         );
 
@@ -239,7 +239,7 @@ impl<
         let origin = "SharedMemoryDirectory::list()";
 
         Ok(fail!(from origin, when DataShm::list_cfg(
-            &DataShm::Configuration::default().suffix(unsafe{FileName::new_unchecked(DATA_SHM_SUFFIX)})
+            &DataShm::Configuration::default().suffix(unsafe{&FileName::new_unchecked(DATA_SHM_SUFFIX)})
                 ),
             "{} since the data segments could not be listed.", msg))
     }
@@ -253,14 +253,14 @@ impl<
 
         if !fail!(from origin, when DataShm::remove_cfg(
             name,
-            &DataShm::Configuration::default().suffix(unsafe{FileName::new_unchecked(DATA_SHM_SUFFIX)})),
+            &DataShm::Configuration::default().suffix(unsafe{&FileName::new_unchecked(DATA_SHM_SUFFIX)})),
             "{} \"{}\" since the data segment could not be removed.", msg, name)
         {
             return Ok(false);
         }
 
         let mgmt_result = fail!(from origin,
-            when MgmtShm::remove_cfg(name, &MgmtShm::Configuration::default().suffix(unsafe{FileName::new_unchecked(MGMT_SHM_SUFFIX)})),
+            when MgmtShm::remove_cfg(name, &MgmtShm::Configuration::default().suffix(unsafe{&FileName::new_unchecked(MGMT_SHM_SUFFIX)})),
             "{} \"{}\" since the management segment could not be removed.", msg, name
         );
 

--- a/iceoryx2-cal/src/static_storage/file.rs
+++ b/iceoryx2-cal/src/static_storage/file.rs
@@ -74,8 +74,8 @@ impl Default for Configuration {
 }
 
 impl crate::named_concept::NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -83,13 +83,13 @@ impl crate::named_concept::NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path = *value;
         self
     }
 

--- a/iceoryx2-cal/src/static_storage/file.rs
+++ b/iceoryx2-cal/src/static_storage/file.rs
@@ -22,8 +22,8 @@
 //!
 //! let mut content = "some storage content".to_string();
 //! let custom_config = Configuration::default()
-//!                         .suffix(FileName::new(b".conifg").unwrap())
-//!                         .path_hint(Path::new(b"/tmp").unwrap());
+//!                         .suffix(&FileName::new(b".conifg").unwrap())
+//!                         .path_hint(&Path::new(b"/tmp").unwrap());
 //!
 //! let storage_name = FileName::new(b"myStaticStorage").unwrap();
 //! let owner = Builder::new(&storage_name)

--- a/iceoryx2-cal/src/static_storage/process_local.rs
+++ b/iceoryx2-cal/src/static_storage/process_local.rs
@@ -89,8 +89,8 @@ impl Default for Configuration {
 }
 
 impl NamedConceptConfiguration for Configuration {
-    fn prefix(mut self, value: FileName) -> Self {
-        self.prefix = value;
+    fn prefix(mut self, value: &FileName) -> Self {
+        self.prefix = *value;
         self
     }
 
@@ -98,13 +98,13 @@ impl NamedConceptConfiguration for Configuration {
         &self.prefix
     }
 
-    fn suffix(mut self, value: FileName) -> Self {
-        self.suffix = value;
+    fn suffix(mut self, value: &FileName) -> Self {
+        self.suffix = *value;
         self
     }
 
-    fn path_hint(mut self, value: Path) -> Self {
-        self.path = value;
+    fn path_hint(mut self, value: &Path) -> Self {
+        self.path = *value;
         self
     }
 

--- a/iceoryx2-cal/src/zero_copy_connection/common.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/common.rs
@@ -53,9 +53,9 @@ pub mod details {
         fn default() -> Self {
             Self {
                 dynamic_storage_config: Storage::Configuration::default()
-                    .path_hint(Connection::<Storage>::default_path_hint())
-                    .prefix(Connection::<Storage>::default_prefix())
-                    .suffix(Connection::<Storage>::default_suffix()),
+                    .path_hint(&Connection::<Storage>::default_path_hint())
+                    .prefix(&Connection::<Storage>::default_prefix())
+                    .suffix(&Connection::<Storage>::default_suffix()),
                 _data: PhantomData,
             }
         }
@@ -64,7 +64,7 @@ pub mod details {
     impl<Storage: DynamicStorage<SharedManagementData>> NamedConceptConfiguration
         for Configuration<Storage>
     {
-        fn prefix(mut self, value: FileName) -> Self {
+        fn prefix(mut self, value: &FileName) -> Self {
             self.dynamic_storage_config = self.dynamic_storage_config.prefix(value);
             self
         }
@@ -73,12 +73,12 @@ pub mod details {
             self.dynamic_storage_config.get_prefix()
         }
 
-        fn suffix(mut self, value: FileName) -> Self {
+        fn suffix(mut self, value: &FileName) -> Self {
             self.dynamic_storage_config = self.dynamic_storage_config.suffix(value);
             self
         }
 
-        fn path_hint(mut self, value: Path) -> Self {
+        fn path_hint(mut self, value: &Path) -> Self {
             self.dynamic_storage_config = self.dynamic_storage_config.path_hint(value);
             self
         }

--- a/iceoryx2-cal/tests/communication_channel_trait_tests.rs
+++ b/iceoryx2-cal/tests/communication_channel_trait_tests.rs
@@ -370,9 +370,9 @@ mod communication_channel {
         let _watch_dog = Watchdog::new();
 
         let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".s1") });
+            .suffix(unsafe { &FileName::new_unchecked(b".s1") });
         let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".s2") });
+            .suffix(unsafe { &FileName::new_unchecked(b".s2") });
 
         let sut_name = generate_name();
 

--- a/iceoryx2-cal/tests/dynamic_storage_trait_tests.rs
+++ b/iceoryx2-cal/tests/dynamic_storage_trait_tests.rs
@@ -418,9 +418,9 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".s1") });
+            .suffix(unsafe { &FileName::new_unchecked(b".s1") });
         let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".s2") });
+            .suffix(unsafe { &FileName::new_unchecked(b".s2") });
 
         let sut_name = generate_name();
 

--- a/iceoryx2-cal/tests/event_tests.rs
+++ b/iceoryx2-cal/tests/event_tests.rs
@@ -374,9 +374,9 @@ mod event {
     #[test]
     fn custom_suffix_keeps_events_separated<Sut: Event>() {
         let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".suffix_1") });
+            .suffix(unsafe { &FileName::new_unchecked(b".suffix_1") });
         let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".suffix_2") });
+            .suffix(unsafe { &FileName::new_unchecked(b".suffix_2") });
 
         let sut_name = generate_name();
 

--- a/iceoryx2-cal/tests/monitoring_tests.rs
+++ b/iceoryx2-cal/tests/monitoring_tests.rs
@@ -131,9 +131,9 @@ mod monitoring {
     #[test]
     fn custom_suffix_keeps_monitoring_token_separated<Sut: Monitoring>() {
         let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".suffix_1") });
+            .suffix(unsafe { &FileName::new_unchecked(b".suffix_1") });
         let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".suffix_2") });
+            .suffix(unsafe { &FileName::new_unchecked(b".suffix_2") });
 
         let sut_name = generate_name();
 

--- a/iceoryx2-cal/tests/shared_memory_trait_tests.rs
+++ b/iceoryx2-cal/tests/shared_memory_trait_tests.rs
@@ -268,9 +268,9 @@ mod shared_memory {
     #[test]
     fn custom_suffix_keeps_storages_separated<Sut: SharedMemory<DefaultAllocator>>() {
         let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".s1") });
+            .suffix(unsafe { &FileName::new_unchecked(b".s1") });
         let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".s2") });
+            .suffix(unsafe { &FileName::new_unchecked(b".s2") });
 
         let storage_name = generate_name();
 

--- a/iceoryx2-cal/tests/static_storage_file_tests.rs
+++ b/iceoryx2-cal/tests/static_storage_file_tests.rs
@@ -40,8 +40,8 @@ fn static_storage_file_custom_path_and_suffix_works() {
 
     let content = "some storage content".to_string();
     let config = Configuration::default()
-        .suffix(unsafe { FileName::new_unchecked(b".blubbme") })
-        .path_hint(test_directory());
+        .suffix(unsafe { &FileName::new_unchecked(b".blubbme") })
+        .path_hint(&test_directory());
 
     let storage_guard = Builder::new(&storage_name)
         .config(&config)
@@ -74,8 +74,8 @@ fn static_storage_file_path_is_created_when_it_does_not_exist() {
 
     Directory::remove(&non_existing_path.into()).ok();
     let config = Configuration::default()
-        .suffix(unsafe { FileName::new_unchecked(b".blubbme") })
-        .path_hint(non_existing_path.into());
+        .suffix(unsafe { &FileName::new_unchecked(b".blubbme") })
+        .path_hint(&non_existing_path.into());
 
     let storage_guard = Builder::new(&storage_name)
         .config(&config)
@@ -102,9 +102,9 @@ fn static_storage_file_path_is_created_when_it_does_not_exist() {
 fn static_storage_file_custom_path_and_suffix_list_storage_works() {
     const NUMBER_OF_STORAGES: u64 = 12;
     let config = Configuration::default()
-        .suffix(unsafe { FileName::new_unchecked(b".blubbme") })
+        .suffix(unsafe { &FileName::new_unchecked(b".blubbme") })
         .path_hint(
-            FilePath::from_path_and_file(
+            &FilePath::from_path_and_file(
                 &test_directory(),
                 &FileName::new(b"non_existing").unwrap(),
             )

--- a/iceoryx2-cal/tests/static_storage_trait_tests.rs
+++ b/iceoryx2-cal/tests/static_storage_trait_tests.rs
@@ -487,9 +487,9 @@ mod static_storage {
         let _test_guard = TEST_MUTEX.lock();
 
         let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".static_storage_1") });
+            .suffix(unsafe { &FileName::new_unchecked(b".static_storage_1") });
         let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".static_storage_2") });
+            .suffix(unsafe { &FileName::new_unchecked(b".static_storage_2") });
 
         let storage_name = generate_name();
 

--- a/iceoryx2-cal/tests/zero_copy_connection_trait_tests.rs
+++ b/iceoryx2-cal/tests/zero_copy_connection_trait_tests.rs
@@ -771,9 +771,9 @@ mod zero_copy_connection {
     #[test]
     fn custom_suffix_keeps_connections_separated<Sut: ZeroCopyConnection>() {
         let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".s1") });
+            .suffix(unsafe { &FileName::new_unchecked(b".s1") });
         let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { FileName::new_unchecked(b".s2") });
+            .suffix(unsafe { &FileName::new_unchecked(b".s2") });
 
         let sut_name = generate_name();
 

--- a/iceoryx2-ffi/cxx/include/iox2/config.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config.hpp
@@ -16,6 +16,7 @@
 #include "iox/duration.hpp"
 #include "iox/file_name.hpp"
 #include "iox/path.hpp"
+#include "iox2/config_creation_error.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 #include "iox2/unable_to_deliver_strategy.hpp"
 
@@ -25,19 +26,36 @@ class Config;
 namespace config {
 class Global;
 
+/// All configurable settings of a [`Node`].
 class Node {
   public:
+    /// The directory in which all node files are stored
     auto directory() && -> const char*;
+    /// Set the directory in which all node files are stored
     void set_directory(const iox::Path& value) &&;
+    /// The suffix of the monitor token
     auto monitor_suffix() && -> const char*;
+    /// Set the suffix of the monitor token
     void set_monitor_suffix(const iox::FileName& value) &&;
+    /// The suffix of the files where the node configuration is stored.
     auto static_config_suffix() && -> const char*;
+    /// Set the suffix of the files where the node configuration is stored.
     void set_static_config_suffix(const iox::FileName& value) &&;
+    /// The suffix of the service tags.
     auto service_tag_suffix() && -> const char*;
+    /// Set the suffix of the service tags.
     void set_service_tag_suffix(const iox::FileName& value) &&;
+    /// When true, the [`NodeBuilder`](NodeBuilder) checks for dead nodes and
+    /// cleans up all their stale resources whenever a new [`Node`](Node) is
+    /// created.
     auto cleanup_dead_nodes_on_creation() && -> bool;
+    /// Enable/disable the cleanup dead nodes on creation
     void set_cleanup_dead_nodes_on_creation(bool value) &&;
+    /// When true, the [`NodeBuilder`](NodeBuilder) checks for dead nodes and
+    /// cleans up all their stale resources whenever an existing [`Node`](Node) is
+    /// going out of scope.
     auto cleanup_dead_nodes_on_destruction() && -> bool;
+    /// Enable/disable the cleanup dead nodes on destruction
     void set_cleanup_dead_nodes_on_destruction(bool value) &&;
 
   private:
@@ -47,21 +65,37 @@ class Node {
     iox2_config_h* m_config;
 };
 
+/// All configurable settings of a [`Service`].
 class Service {
   public:
+    /// The directory in which all service files are stored
     auto directory() && -> const char*;
+    /// Set the directory in which all service files are stored
     void set_directory(const iox::Path& value) &&;
+    /// The suffix of the publishers data segment
     auto publisher_data_segment_suffix() && -> const char*;
+    /// Set the suffix of the publishers data segment
     void set_publisher_data_segment_suffix(const iox::FileName& value) &&;
+    /// The suffix of the static config file
     auto static_config_storage_suffix() && -> const char*;
+    /// Set the suffix of the static config file
     void set_static_config_storage_suffix(const iox::FileName& value) &&;
+    /// The suffix of the dynamic config file
     auto dynamic_config_storage_suffix() && -> const char*;
+    /// Set the suffix of the dynamic config file
     void set_dynamic_config_storage_suffix(const iox::FileName& value) &&;
+    /// Defines the time of how long another process will wait until the service creation is
+    /// finalized
     auto creation_timeout() && -> iox::units::Duration;
+    /// Set the creation timeout
     void set_creation_timeout(const iox::units::Duration& value) &&;
+    /// The suffix of a one-to-one connection
     auto connection_suffix() && -> const char*;
+    /// Set the suffix of a one-to-one connection
     void set_connection_suffix(const iox::FileName& value) &&;
+    /// The suffix of a one-to-one connection
     auto event_connection_suffix() && -> const char*;
+    /// Set the suffix of a one-to-one connection
     void set_event_connection_suffix(const iox::FileName& value) &&;
 
   private:
@@ -71,14 +105,22 @@ class Service {
     iox2_config_h* m_config;
 };
 
+/// The global settings
 class Global {
   public:
+    /// Prefix used for all files created during runtime
     auto prefix() && -> const char*;
+    /// Set the prefix used for all files created during runtime
     void set_prefix(const iox::FileName& value) &&;
+    /// The path under which all other directories or files will be created
     auto root_path() && -> const char*;
+    /// Defines the path under which all other directories or files will be created
     void set_root_path(const iox::Path& value) &&;
 
+    /// Returns the service part of the global configuration
     auto service() -> Service;
+
+    /// Returns the node part of the global configuration
     auto node() -> Node;
 
   private:
@@ -88,27 +130,57 @@ class Global {
     iox2_config_h* m_config;
 };
 
+/// Default settings for the publish-subscribe messaging pattern. These settings are used unless
+/// the user specifies custom QoS or port settings.
 class PublishSubscribe {
   public:
+    /// The maximum amount of supported [`Subscriber`]s
     auto max_subscribers() && -> size_t;
+    /// Set the maximum amount of supported [`Subscriber`]s
     void set_max_subscribers(size_t value) &&;
+    /// The maximum amount of supported [`Publisher`]s
     auto max_publishers() && -> size_t;
+    /// Set the maximum amount of supported [`Publisher`]s
     void set_max_publishers(size_t value) &&;
+    /// The maximum amount of supported [`Node`]s. Defines indirectly how many
+    /// processes can open the service at the same time.
     auto max_nodes() && -> size_t;
+    /// Set the maximum amount of supported [`Node`]s.
     void set_max_nodes(size_t value) &&;
+    /// The maximum buffer size a [`Subscriber`] can have
     auto subscriber_max_buffer_size() && -> size_t;
+    /// Set the maximum buffer size a [`Subscriber`] can have
     void set_subscriber_max_buffer_size(size_t value) &&;
+    /// The maximum amount of [`Sample`]s a [`Subscriber`] can hold at the same time.
     auto subscriber_max_borrowed_samples() && -> size_t;
+    /// Set the maximum amount of [`Sample`]s a [`Subscriber`] can hold at the same time.
     void set_subscriber_max_borrowed_samples(size_t value) &&;
+    /// The maximum amount of [`SampleMut`]s a [`Publisher`] can loan at the same time.
     auto publisher_max_loaned_samples() && -> size_t;
+    /// The maximum amount of [`SampleMut`]s a [`Publisher`] can loan at the same time.
     void set_publisher_max_loaned_samples(size_t value) &&;
+    /// The maximum history size a [`Subscriber`] can request from a [`Publisher`].
     auto publisher_history_size() && -> size_t;
+    /// Set the maximum history size a [`Subscriber`] can request from a [`Publisher`].
     void set_publisher_history_size(size_t value) &&;
+    /// Defines how the [`Subscriber`] buffer behaves when it is
+    /// full. When safe overflow is activated, the [`Publisher`] will
+    /// replace the oldest [`Sample`] with the newest one.
     auto enable_safe_overflow() && -> bool;
+    /// Enables/disables safe overflow
     void set_enable_safe_overflow(bool value) &&;
+    /// If safe overflow is deactivated it defines the deliver strategy of the
+    /// [`Publisher`] when the [`Subscriber`]s buffer is full.
     auto unable_to_deliver_strategy() && -> UnableToDeliverStrategy;
+    /// Define the unable to deliver strategy
     void set_unable_to_deliver_strategy(UnableToDeliverStrategy value) &&;
+    /// Defines the size of the internal [`Subscriber`]
+    /// buffer that contains expired connections. An
+    /// connection is expired when the [`Publisher`]
+    /// disconnected from a service and the connection
+    /// still contains unconsumed [`Sample`]s.
     auto subscriber_expired_connection_buffer() && -> size_t;
+    /// Set the expired connection buffer size
     void set_subscriber_expired_connection_buffer(size_t value) &&;
 
   private:
@@ -118,15 +190,26 @@ class PublishSubscribe {
     iox2_config_h* m_config;
 };
 
+/// Default settings for the event messaging pattern. These settings are used unless
+/// the user specifies custom QoS or port settings.
 class Event {
   public:
+    /// The maximum amount of supported [`Listener`]
     auto max_listeners() && -> size_t;
+    /// Set the maximum amount of supported [`Listener`]
     void set_max_listeners(size_t value) &&;
+    /// The maximum amount of supported [`Notifier`]
     auto max_notifiers() && -> size_t;
+    /// Set the maximum amount of supported [`Notifier`]
     void set_max_notifiers(size_t value) &&;
+    /// The maximum amount of supported [`Node`]s. Defines indirectly how many
+    /// processes can open the service at the same time.
     auto max_nodes() && -> size_t;
+    /// Set the maximum amount of supported [`Node`]s.
     void set_max_nodes(size_t value) &&;
+    /// The largest event id supported by the event service
     auto event_id_max_value() && -> size_t;
+    /// Set the largest event id supported by the event service
     void set_event_id_max_value(size_t value) &&;
 
   private:
@@ -136,9 +219,13 @@ class Event {
     iox2_config_h* m_config;
 };
 
+/// Default settings. These values are used when the user in the code does not specify anything
+/// else.
 class Defaults {
   public:
+    /// Returns the publish_subscribe part of the default settings
     auto publish_subscribe() && -> PublishSubscribe;
+    /// Returns the event part of the default settings
     auto event() && -> Event;
 
   private:
@@ -173,6 +260,10 @@ class ConfigView {
     iox2_config_ptr m_ptr;
 };
 
+/// Represents the configuration that iceoryx2 will utilize. It is divided into two sections:
+/// the [Global] settings, which must align with the iceoryx2 instance the application intends to
+/// join, and the [Defaults] for communication within that iceoryx2 instance. The user has the
+/// flexibility to override both sections.
 class Config {
   public:
     Config();
@@ -183,7 +274,13 @@ class Config {
     auto operator=(const Config& rhs) -> Config&;
     auto operator=(Config&& rhs) noexcept -> Config&;
 
+    /// Loads a configuration from a file. On success it returns a [`Config`] object otherwise a
+    /// [`ConfigCreationError`] describing the failure.
+    static auto from_file(const iox::FilePath& file) -> iox::expected<Config, ConfigCreationError>;
+
+    /// Returns the [`config::Global`] part of the config
     auto global() -> config::Global;
+    /// Returns the [`config::Defaults`] part of the config
     auto defaults() -> config::Defaults;
 
     /// Returns a [`ConfigView`] to the current global config.

--- a/iceoryx2-ffi/cxx/include/iox2/config.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config.hpp
@@ -13,6 +13,7 @@
 #ifndef IOX2_CONFIG_HPP
 #define IOX2_CONFIG_HPP
 
+#include "iox/expected.hpp"
 #include "iox/file_name.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 
@@ -23,7 +24,7 @@ namespace config {
 class Global {
   public:
     auto prefix() && -> const char*;
-    auto set_prefix(const char* value) &&;
+    void set_prefix(const iox::FileName& value) &&;
 
   private:
     friend class ::iox2::Config;

--- a/iceoryx2-ffi/cxx/include/iox2/config.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config.hpp
@@ -13,10 +13,26 @@
 #ifndef IOX2_CONFIG_HPP
 #define IOX2_CONFIG_HPP
 
+#include "iox/file_name.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 
 namespace iox2 {
 class Config;
+
+namespace config {
+class Global {
+  public:
+    auto prefix() && -> const char*;
+    auto set_prefix(const char* value) &&;
+
+  private:
+    friend class ::iox2::Config;
+    explicit Global(Config* config);
+
+    Config* m_config;
+};
+} // namespace config
+
 /// Non-owning view of a [`Config`].
 class ConfigView {
   public:
@@ -43,8 +59,26 @@ class ConfigView {
 
 class Config {
   public:
+    Config();
+    Config(const Config& rhs);
+    Config(Config&& rhs) noexcept;
+    ~Config();
+
+    auto operator=(const Config& rhs) -> Config&;
+    auto operator=(Config&& rhs) noexcept -> Config&;
+
+    auto global() -> config::Global;
+
     /// Returns a [`ConfigView`] to the current global config.
     static auto global_config() -> ConfigView;
+
+  private:
+    friend class ConfigView;
+    friend class config::Global;
+    explicit Config(iox2_config_h handle);
+    void drop();
+
+    iox2_config_h m_handle = nullptr;
 };
 } // namespace iox2
 

--- a/iceoryx2-ffi/cxx/include/iox2/config.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config.hpp
@@ -13,15 +13,64 @@
 #ifndef IOX2_CONFIG_HPP
 #define IOX2_CONFIG_HPP
 
-#include "iox/expected.hpp"
+#include "iox/duration.hpp"
 #include "iox/file_name.hpp"
 #include "iox/path.hpp"
 #include "iox2/internal/iceoryx2.hpp"
+#include "iox2/unable_to_deliver_strategy.hpp"
 
 namespace iox2 {
 class Config;
 
 namespace config {
+class Global;
+
+class Node {
+  public:
+    auto directory() && -> const char*;
+    auto set_directory(const iox::Path& value) &&;
+    auto monitor_suffix() && -> const char*;
+    auto set_monitor_suffix(const iox::FileName& value) &&;
+    auto static_config_suffix() && -> const char*;
+    auto set_static_config_suffix(const iox::FileName& value) &&;
+    auto service_tag_suffix() && -> const char*;
+    auto set_service_tag_suffix(const iox::FileName& value) &&;
+    auto cleanup_dead_nodes_on_creation() && -> bool;
+    auto set_cleanup_dead_nodes_on_creation(bool value) &&;
+    auto cleanup_dead_nodes_on_destruction() && -> bool;
+    auto set_cleanup_dead_nodes_on_destruction(bool value) &&;
+
+  private:
+    friend class Global;
+    explicit Node(Config* config);
+
+    Config* m_config;
+};
+
+class Service {
+  public:
+    auto directory() && -> const char*;
+    auto set_directory(const iox::Path& value) &&;
+    auto publisher_data_segment_suffix() && -> const char*;
+    auto set_publisher_data_segment_suffix(const iox::FileName& value) &&;
+    auto static_config_storage_suffix() && -> const char*;
+    auto set_static_config_storage_suffix(const iox::FileName& value) &&;
+    auto dynamic_config_storage_suffix() && -> const char*;
+    auto set_dynamic_config_storage_suffix(const iox::FileName& value) &&;
+    auto creation_timeout() && -> iox::units::Duration;
+    auto set_creation_timeout(const iox::units::Duration& value) &&;
+    auto connection_suffix() && -> const char*;
+    auto set_connection_suffix(const iox::FileName& value) &&;
+    auto event_connection_suffix() && -> const char*;
+    auto set_event_connection_suffix(const iox::FileName& value) &&;
+
+  private:
+    friend class Global;
+    explicit Service(Config* config);
+
+    Config* m_config;
+};
+
 class Global {
   public:
     auto prefix() && -> const char*;
@@ -29,12 +78,76 @@ class Global {
     auto root_path() && -> const char*;
     void set_root_path(const iox::Path& value) &&;
 
+    auto service() -> Service;
+    auto node() -> Node;
+
   private:
     friend class ::iox2::Config;
     explicit Global(Config* config);
 
     Config* m_config;
 };
+
+class PublishSubscribe {
+  public:
+    auto max_subscribers() -> size_t;
+    void set_max_subscribers(size_t value);
+    auto max_publishers() -> size_t;
+    void set_max_publishers(size_t value);
+    auto max_nodes() -> size_t;
+    void set_max_nodes(size_t value);
+    auto subscriber_max_buffer_size() -> size_t;
+    void set_subscriber_max_buffer_size(size_t value);
+    auto subscriber_max_borrowed_samples() -> size_t;
+    void set_subscriber_max_borrowed_samples(size_t value);
+    auto publisher_max_loaned_samples() -> size_t;
+    void set_publisher_max_loaned_samples(size_t value);
+    auto publisher_history_size() -> size_t;
+    void set_history_sizeed_samples(size_t value);
+    auto enable_safe_overflow() -> bool;
+    void set_enable_safe_overflow(bool value);
+    auto unable_to_deliver_strategy() -> UnableToDeliverStrategy;
+    void set_unable_to_deliver_strategy(UnableToDeliverStrategy value);
+    auto subscriber_expired_connection_buffer() -> size_t;
+    void set_subscriber_expired_connection_buffer(size_t value);
+
+  private:
+    friend class Defaults;
+    explicit PublishSubscribe(Config* config);
+
+    Config* m_config;
+};
+
+class Event {
+  public:
+    auto max_listeners() -> size_t;
+    void set_max_listeners(size_t value);
+    auto max_notifiers() -> size_t;
+    void set_max_notifiers(size_t value);
+    auto max_nodes() -> size_t;
+    void set_max_nodes(size_t value);
+    auto event_id_max_value() -> size_t;
+    void set_event_id_max_value(size_t value);
+
+  private:
+    friend class Defaults;
+    explicit Event(Config* config);
+
+    Config* m_config;
+};
+
+class Defaults {
+  public:
+    auto publish_subscribe() -> PublishSubscribe;
+    auto event() -> Event;
+
+  private:
+    friend class ::iox2::Config;
+    explicit Defaults(Config* config);
+
+    Config* m_config;
+};
+
 } // namespace config
 
 /// Non-owning view of a [`Config`].

--- a/iceoryx2-ffi/cxx/include/iox2/config.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config.hpp
@@ -147,7 +147,6 @@ class Defaults {
 
     Config* m_config;
 };
-
 } // namespace config
 
 /// Non-owning view of a [`Config`].
@@ -185,6 +184,7 @@ class Config {
     auto operator=(Config&& rhs) noexcept -> Config&;
 
     auto global() -> config::Global;
+    auto defaults() -> config::Defaults;
 
     /// Returns a [`ConfigView`] to the current global config.
     static auto global_config() -> ConfigView;

--- a/iceoryx2-ffi/cxx/include/iox2/config.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config.hpp
@@ -28,17 +28,17 @@ class Global;
 class Node {
   public:
     auto directory() && -> const char*;
-    auto set_directory(const iox::Path& value) &&;
+    void set_directory(const iox::Path& value) &&;
     auto monitor_suffix() && -> const char*;
-    auto set_monitor_suffix(const iox::FileName& value) &&;
+    void set_monitor_suffix(const iox::FileName& value) &&;
     auto static_config_suffix() && -> const char*;
-    auto set_static_config_suffix(const iox::FileName& value) &&;
+    void set_static_config_suffix(const iox::FileName& value) &&;
     auto service_tag_suffix() && -> const char*;
-    auto set_service_tag_suffix(const iox::FileName& value) &&;
+    void set_service_tag_suffix(const iox::FileName& value) &&;
     auto cleanup_dead_nodes_on_creation() && -> bool;
-    auto set_cleanup_dead_nodes_on_creation(bool value) &&;
+    void set_cleanup_dead_nodes_on_creation(bool value) &&;
     auto cleanup_dead_nodes_on_destruction() && -> bool;
-    auto set_cleanup_dead_nodes_on_destruction(bool value) &&;
+    void set_cleanup_dead_nodes_on_destruction(bool value) &&;
 
   private:
     friend class Global;
@@ -50,19 +50,19 @@ class Node {
 class Service {
   public:
     auto directory() && -> const char*;
-    auto set_directory(const iox::Path& value) &&;
+    void set_directory(const iox::Path& value) &&;
     auto publisher_data_segment_suffix() && -> const char*;
-    auto set_publisher_data_segment_suffix(const iox::FileName& value) &&;
+    void set_publisher_data_segment_suffix(const iox::FileName& value) &&;
     auto static_config_storage_suffix() && -> const char*;
-    auto set_static_config_storage_suffix(const iox::FileName& value) &&;
+    void set_static_config_storage_suffix(const iox::FileName& value) &&;
     auto dynamic_config_storage_suffix() && -> const char*;
-    auto set_dynamic_config_storage_suffix(const iox::FileName& value) &&;
+    void set_dynamic_config_storage_suffix(const iox::FileName& value) &&;
     auto creation_timeout() && -> iox::units::Duration;
-    auto set_creation_timeout(const iox::units::Duration& value) &&;
+    void set_creation_timeout(const iox::units::Duration& value) &&;
     auto connection_suffix() && -> const char*;
-    auto set_connection_suffix(const iox::FileName& value) &&;
+    void set_connection_suffix(const iox::FileName& value) &&;
     auto event_connection_suffix() && -> const char*;
-    auto set_event_connection_suffix(const iox::FileName& value) &&;
+    void set_event_connection_suffix(const iox::FileName& value) &&;
 
   private:
     friend class Global;

--- a/iceoryx2-ffi/cxx/include/iox2/config.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config.hpp
@@ -42,9 +42,9 @@ class Node {
 
   private:
     friend class Global;
-    explicit Node(Config* config);
+    explicit Node(iox2_config_h* config);
 
-    Config* m_config;
+    iox2_config_h* m_config;
 };
 
 class Service {
@@ -66,9 +66,9 @@ class Service {
 
   private:
     friend class Global;
-    explicit Service(Config* config);
+    explicit Service(iox2_config_h* config);
 
-    Config* m_config;
+    iox2_config_h* m_config;
 };
 
 class Global {
@@ -83,69 +83,69 @@ class Global {
 
   private:
     friend class ::iox2::Config;
-    explicit Global(Config* config);
+    explicit Global(iox2_config_h* config);
 
-    Config* m_config;
+    iox2_config_h* m_config;
 };
 
 class PublishSubscribe {
   public:
-    auto max_subscribers() -> size_t;
-    void set_max_subscribers(size_t value);
-    auto max_publishers() -> size_t;
-    void set_max_publishers(size_t value);
-    auto max_nodes() -> size_t;
-    void set_max_nodes(size_t value);
-    auto subscriber_max_buffer_size() -> size_t;
-    void set_subscriber_max_buffer_size(size_t value);
-    auto subscriber_max_borrowed_samples() -> size_t;
-    void set_subscriber_max_borrowed_samples(size_t value);
-    auto publisher_max_loaned_samples() -> size_t;
-    void set_publisher_max_loaned_samples(size_t value);
-    auto publisher_history_size() -> size_t;
-    void set_history_sizeed_samples(size_t value);
-    auto enable_safe_overflow() -> bool;
-    void set_enable_safe_overflow(bool value);
-    auto unable_to_deliver_strategy() -> UnableToDeliverStrategy;
-    void set_unable_to_deliver_strategy(UnableToDeliverStrategy value);
-    auto subscriber_expired_connection_buffer() -> size_t;
-    void set_subscriber_expired_connection_buffer(size_t value);
+    auto max_subscribers() && -> size_t;
+    void set_max_subscribers(size_t value) &&;
+    auto max_publishers() && -> size_t;
+    void set_max_publishers(size_t value) &&;
+    auto max_nodes() && -> size_t;
+    void set_max_nodes(size_t value) &&;
+    auto subscriber_max_buffer_size() && -> size_t;
+    void set_subscriber_max_buffer_size(size_t value) &&;
+    auto subscriber_max_borrowed_samples() && -> size_t;
+    void set_subscriber_max_borrowed_samples(size_t value) &&;
+    auto publisher_max_loaned_samples() && -> size_t;
+    void set_publisher_max_loaned_samples(size_t value) &&;
+    auto publisher_history_size() && -> size_t;
+    void set_publisher_history_size(size_t value) &&;
+    auto enable_safe_overflow() && -> bool;
+    void set_enable_safe_overflow(bool value) &&;
+    auto unable_to_deliver_strategy() && -> UnableToDeliverStrategy;
+    void set_unable_to_deliver_strategy(UnableToDeliverStrategy value) &&;
+    auto subscriber_expired_connection_buffer() && -> size_t;
+    void set_subscriber_expired_connection_buffer(size_t value) &&;
 
   private:
     friend class Defaults;
-    explicit PublishSubscribe(Config* config);
+    explicit PublishSubscribe(iox2_config_h* config);
 
-    Config* m_config;
+    iox2_config_h* m_config;
 };
 
 class Event {
   public:
-    auto max_listeners() -> size_t;
-    void set_max_listeners(size_t value);
-    auto max_notifiers() -> size_t;
-    void set_max_notifiers(size_t value);
-    auto max_nodes() -> size_t;
-    void set_max_nodes(size_t value);
-    auto event_id_max_value() -> size_t;
-    void set_event_id_max_value(size_t value);
+    auto max_listeners() && -> size_t;
+    void set_max_listeners(size_t value) &&;
+    auto max_notifiers() && -> size_t;
+    void set_max_notifiers(size_t value) &&;
+    auto max_nodes() && -> size_t;
+    void set_max_nodes(size_t value) &&;
+    auto event_id_max_value() && -> size_t;
+    void set_event_id_max_value(size_t value) &&;
 
   private:
     friend class Defaults;
-    explicit Event(Config* config);
+    explicit Event(iox2_config_h* config);
 
-    Config* m_config;
+    iox2_config_h* m_config;
 };
 
 class Defaults {
   public:
-    auto publish_subscribe() -> PublishSubscribe;
-    auto event() -> Event;
+    auto publish_subscribe() && -> PublishSubscribe;
+    auto event() && -> Event;
 
   private:
     friend class ::iox2::Config;
-    explicit Defaults(Config* config);
+    explicit Defaults(iox2_config_h* config);
 
-    Config* m_config;
+    iox2_config_h* m_config;
 };
 } // namespace config
 

--- a/iceoryx2-ffi/cxx/include/iox2/config.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config.hpp
@@ -15,6 +15,7 @@
 
 #include "iox/expected.hpp"
 #include "iox/file_name.hpp"
+#include "iox/path.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 
 namespace iox2 {
@@ -25,6 +26,8 @@ class Global {
   public:
     auto prefix() && -> const char*;
     void set_prefix(const iox::FileName& value) &&;
+    auto root_path() && -> const char*;
+    void set_root_path(const iox::Path& value) &&;
 
   private:
     friend class ::iox2::Config;

--- a/iceoryx2-ffi/cxx/include/iox2/config_creation_error.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config_creation_error.hpp
@@ -13,9 +13,11 @@
 #ifndef IOX2_CONFIG_CREATION_ERROR_HPP
 #define IOX2_CONFIG_CREATION_ERROR_HPP
 
+#include <cstdint>
+
 namespace iox2 {
 /// Failures occurring while creating a new [`Config`] object with [`Config::from_file()`].
-enum class ConfigCreationError {
+enum class ConfigCreationError : uint8_t {
     /// The config file could not be opened.
     FailedToOpenConfigFile,
     /// The config file could not be read.

--- a/iceoryx2-ffi/cxx/include/iox2/config_creation_error.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/config_creation_error.hpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef IOX2_CONFIG_CREATION_ERROR_HPP
+#define IOX2_CONFIG_CREATION_ERROR_HPP
+
+namespace iox2 {
+/// Failures occurring while creating a new [`Config`] object with [`Config::from_file()`].
+enum class ConfigCreationError {
+    /// The config file could not be opened.
+    FailedToOpenConfigFile,
+    /// The config file could not be read.
+    FailedToReadConfigFileContents,
+    /// Parts of the config file could not be deserialized. Indicates some kind of syntax error.
+    UnableToDeserializeContents
+};
+} // namespace iox2
+
+#endif

--- a/iceoryx2-ffi/cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/enum_translation.hpp
@@ -16,6 +16,7 @@
 #include "iox/assertions.hpp"
 #include "iox/into.hpp"
 #include "iox2/callback_progression.hpp"
+#include "iox2/config_creation_error.hpp"
 #include "iox2/connection_failure.hpp"
 #include "iox2/iceoryx2.h"
 #include "iox2/listener_error.hpp"
@@ -619,6 +620,24 @@ constexpr auto from<int, iox2::ConnectionFailure>(const int value) noexcept -> i
         return iox2::ConnectionFailure::FailedToEstablishConnection;
     case iox2_connection_failure_e_UNABLE_TO_MAP_PUBLISHERS_DATA_SEGMENT:
         return iox2::ConnectionFailure::UnableToMapPublishersDataSegment;
+    }
+
+    IOX_UNREACHABLE();
+}
+
+template <>
+constexpr auto from<int, iox2::ConfigCreationError>(const int value) noexcept -> iox2::ConfigCreationError {
+    const auto variant = static_cast<iox2_config_creation_error_e>(value);
+    switch (variant) {
+    case iox2_config_creation_error_e_FAILED_TO_OPEN_CONFIG_FILE:
+        return iox2::ConfigCreationError::FailedToOpenConfigFile;
+    case iox2_config_creation_error_e_FAILED_TO_READ_CONFIG_FILE_CONTENTS:
+        return iox2::ConfigCreationError::FailedToReadConfigFileContents;
+    case iox2_config_creation_error_e_UNABLE_TO_DESERIALIZE_CONTENTS:
+        return iox2::ConfigCreationError::UnableToDeserializeContents;
+    case iox2_config_creation_error_e_INVALID_FILE_PATH:
+        // unreachable since this error case is excluded by using the strong type iox::FilePath
+        IOX_UNREACHABLE();
     }
 
     IOX_UNREACHABLE();

--- a/iceoryx2-ffi/cxx/include/iox2/node_details.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/node_details.hpp
@@ -20,7 +20,7 @@ namespace iox2 {
 /// Contains details of a [`Node`].
 class NodeDetails {
   public:
-    NodeDetails(NodeName name, const Config& config);
+    NodeDetails(NodeName name, Config config);
 
     /// Returns a reference of the [`NodeName`].
     auto name() const -> const NodeName&;

--- a/iceoryx2-ffi/cxx/src/config.cpp
+++ b/iceoryx2-ffi/cxx/src/config.cpp
@@ -95,5 +95,16 @@ void Global::set_prefix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(m_config->m_handle);
     iox2_config_global_set_prefix(ref_handle, value.as_string().c_str());
 }
+
+auto Global::root_path() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(m_config->m_handle);
+    return iox2_config_global_root_path(ref_handle);
+}
+
+void Global::set_root_path(const iox::Path& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(m_config->m_handle);
+    iox2_config_global_set_root_path(ref_handle, value.as_string().c_str());
+}
+
 } // namespace config
 } // namespace iox2

--- a/iceoryx2-ffi/cxx/src/config.cpp
+++ b/iceoryx2-ffi/cxx/src/config.cpp
@@ -91,9 +91,9 @@ auto Global::prefix() && -> const char* {
     return iox2_config_global_prefix(ref_handle);
 }
 
-auto Global::set_prefix(const char* value) && {
+void Global::set_prefix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(m_config->m_handle);
-    iox2_config_global_set_prefix(ref_handle, value);
+    iox2_config_global_set_prefix(ref_handle, value.as_string().c_str());
 }
 } // namespace config
 } // namespace iox2

--- a/iceoryx2-ffi/cxx/src/config.cpp
+++ b/iceoryx2-ffi/cxx/src/config.cpp
@@ -125,6 +125,14 @@ void Global::set_root_path(const iox::Path& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_set_root_path(ref_handle, value.as_string().c_str());
 }
+
+auto Global::service() -> Service {
+    return Service(m_config);
+}
+
+auto Global::node() -> Node {
+    return Node(m_config);
+}
 /////////////////////////
 // END: Global
 /////////////////////////
@@ -321,7 +329,7 @@ auto Service::directory() && -> const char* {
     return iox2_config_global_service_directory(ref_handle);
 }
 
-auto Service::set_directory(const iox::Path& value) && {
+void Service::set_directory(const iox::Path& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_service_set_directory(ref_handle, value.as_string().c_str());
 }
@@ -331,7 +339,7 @@ auto Service::publisher_data_segment_suffix() && -> const char* {
     return iox2_config_global_service_publisher_data_segment_suffix(ref_handle);
 }
 
-auto Service::set_publisher_data_segment_suffix(const iox::FileName& value) && {
+void Service::set_publisher_data_segment_suffix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_service_set_publisher_data_segment_suffix(ref_handle, value.as_string().c_str());
 }
@@ -341,7 +349,7 @@ auto Service::static_config_storage_suffix() && -> const char* {
     return iox2_config_global_service_static_config_storage_suffix(ref_handle);
 }
 
-auto Service::set_static_config_storage_suffix(const iox::FileName& value) && {
+void Service::set_static_config_storage_suffix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_service_set_static_config_storage_suffix(ref_handle, value.as_string().c_str());
 }
@@ -351,7 +359,7 @@ auto Service::dynamic_config_storage_suffix() && -> const char* {
     return iox2_config_global_service_dynamic_config_storage_suffix(ref_handle);
 }
 
-auto Service::set_dynamic_config_storage_suffix(const iox::FileName& value) && {
+void Service::set_dynamic_config_storage_suffix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_service_set_dynamic_config_storage_suffix(ref_handle, value.as_string().c_str());
 }
@@ -364,7 +372,7 @@ auto Service::creation_timeout() && -> iox::units::Duration {
     return iox::units::Duration::fromSeconds(secs) + iox::units::Duration::fromNanoseconds(nsec);
 }
 
-auto Service::set_creation_timeout(const iox::units::Duration& value) && {
+void Service::set_creation_timeout(const iox::units::Duration& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     auto duration = value.timespec();
     iox2_config_global_service_set_creation_timeout(ref_handle, duration.tv_sec, duration.tv_nsec);
@@ -375,7 +383,7 @@ auto Service::connection_suffix() && -> const char* {
     return iox2_config_global_service_connection_suffix(ref_handle);
 }
 
-auto Service::set_connection_suffix(const iox::FileName& value) && {
+void Service::set_connection_suffix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_service_set_connection_suffix(ref_handle, value.as_string().c_str());
 }
@@ -385,7 +393,7 @@ auto Service::event_connection_suffix() && -> const char* {
     return iox2_config_global_service_event_connection_suffix(ref_handle);
 }
 
-auto Service::set_event_connection_suffix(const iox::FileName& value) && {
+void Service::set_event_connection_suffix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_service_set_event_connection_suffix(ref_handle, value.as_string().c_str());
 }
@@ -405,7 +413,7 @@ auto Node::directory() && -> const char* {
     return iox2_config_global_node_directory(ref_handle);
 }
 
-auto Node::set_directory(const iox::Path& value) && {
+void Node::set_directory(const iox::Path& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_node_set_directory(ref_handle, value.as_string().c_str());
 }
@@ -415,7 +423,7 @@ auto Node::monitor_suffix() && -> const char* {
     return iox2_config_global_node_monitor_suffix(ref_handle);
 }
 
-auto Node::set_monitor_suffix(const iox::FileName& value) && {
+void Node::set_monitor_suffix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_node_set_monitor_suffix(ref_handle, value.as_string().c_str());
 }
@@ -425,7 +433,7 @@ auto Node::static_config_suffix() && -> const char* {
     return iox2_config_global_node_static_config_suffix(ref_handle);
 }
 
-auto Node::set_static_config_suffix(const iox::FileName& value) && {
+void Node::set_static_config_suffix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_node_set_static_config_suffix(ref_handle, value.as_string().c_str());
 }
@@ -435,7 +443,7 @@ auto Node::service_tag_suffix() && -> const char* {
     return iox2_config_global_node_service_tag_suffix(ref_handle);
 }
 
-auto Node::set_service_tag_suffix(const iox::FileName& value) && {
+void Node::set_service_tag_suffix(const iox::FileName& value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_node_set_service_tag_suffix(ref_handle, value.as_string().c_str());
 }
@@ -445,7 +453,7 @@ auto Node::cleanup_dead_nodes_on_creation() && -> bool {
     return iox2_config_global_node_cleanup_dead_nodes_on_creation(ref_handle);
 }
 
-auto Node::set_cleanup_dead_nodes_on_creation(bool value) && {
+void Node::set_cleanup_dead_nodes_on_creation(bool value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_node_set_cleanup_dead_nodes_on_creation(ref_handle, value);
 }
@@ -455,7 +463,7 @@ auto Node::cleanup_dead_nodes_on_destruction() && -> bool {
     return iox2_config_global_node_cleanup_dead_nodes_on_destruction(ref_handle);
 }
 
-auto Node::set_cleanup_dead_nodes_on_destruction(bool value) && {
+void Node::set_cleanup_dead_nodes_on_destruction(bool value) && {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_node_set_cleanup_dead_nodes_on_destruction(ref_handle, value);
 }

--- a/iceoryx2-ffi/cxx/src/config.cpp
+++ b/iceoryx2-ffi/cxx/src/config.cpp
@@ -13,6 +13,9 @@
 #include "iox2/config.hpp"
 
 namespace iox2 {
+/////////////////////////
+// BEGIN: ConfigView
+/////////////////////////
 ConfigView::ConfigView(iox2_config_ptr ptr)
     : m_ptr { ptr } {
 }
@@ -24,6 +27,13 @@ auto ConfigView::to_owned() const -> Config {
     return Config(handle);
 }
 
+/////////////////////////
+// END: ConfigView
+/////////////////////////
+
+/////////////////////////
+// BEGIN: Config
+/////////////////////////
 Config::Config() {
     iox2_config_default(nullptr, &m_handle);
 }
@@ -74,37 +84,383 @@ Config::Config(iox2_config_h handle)
 }
 
 auto Config::global() -> config::Global {
-    return config::Global(this);
+    return config::Global(&this->m_handle);
+}
+
+auto Config::defaults() -> config::Defaults {
+    return config::Defaults(&this->m_handle);
 }
 
 auto Config::global_config() -> ConfigView {
     return ConfigView { iox2_config_global_config() };
 }
+/////////////////////////
+// END: Config
+/////////////////////////
 
 namespace config {
-Global::Global(Config* config)
+/////////////////////////
+// BEGIN: Global
+/////////////////////////
+Global::Global(iox2_config_h* config)
     : m_config { config } {
 }
 
 auto Global::prefix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(m_config->m_handle);
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     return iox2_config_global_prefix(ref_handle);
 }
 
 void Global::set_prefix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(m_config->m_handle);
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_set_prefix(ref_handle, value.as_string().c_str());
 }
 
 auto Global::root_path() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(m_config->m_handle);
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     return iox2_config_global_root_path(ref_handle);
 }
 
 void Global::set_root_path(const iox::Path& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(m_config->m_handle);
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
     iox2_config_global_set_root_path(ref_handle, value.as_string().c_str());
 }
+/////////////////////////
+// END: Global
+/////////////////////////
 
+/////////////////////////
+// BEGIN: Defaults
+/////////////////////////
+Defaults::Defaults(iox2_config_h* config)
+    : m_config { config } {
+}
+
+auto Defaults::publish_subscribe() && -> PublishSubscribe {
+    return PublishSubscribe(m_config);
+}
+
+auto Defaults::event() && -> Event {
+    return Event(m_config);
+}
+/////////////////////////
+// END: Defaults
+/////////////////////////
+
+/////////////////////////
+// BEGIN: Event
+/////////////////////////
+Event::Event(iox2_config_h* config)
+    : m_config { config } {
+}
+
+auto Event::max_listeners() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_event_max_listeners(ref_handle);
+}
+
+void Event::set_max_listeners(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_event_set_max_listeners(ref_handle, value);
+}
+
+auto Event::max_notifiers() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_event_max_notifiers(ref_handle);
+}
+
+void Event::set_max_notifiers(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_event_set_max_notifiers(ref_handle, value);
+}
+
+auto Event::max_nodes() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_event_max_nodes(ref_handle);
+}
+
+void Event::set_max_nodes(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_event_set_max_nodes(ref_handle, value);
+}
+
+auto Event::event_id_max_value() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_event_event_id_max_value(ref_handle);
+}
+
+void Event::set_event_id_max_value(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_event_set_event_id_max_value(ref_handle, value);
+}
+/////////////////////////
+// END: Event
+/////////////////////////
+
+/////////////////////////
+// BEGIN: PublishSubscribe
+/////////////////////////
+PublishSubscribe::PublishSubscribe(iox2_config_h* config)
+    : m_config { config } {
+}
+
+auto PublishSubscribe::max_subscribers() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_max_subscribers(ref_handle);
+}
+
+void PublishSubscribe::set_max_subscribers(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_max_subscribers(ref_handle, value);
+}
+
+auto PublishSubscribe::max_publishers() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_max_publishers(ref_handle);
+}
+
+void PublishSubscribe::set_max_publishers(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_max_publishers(ref_handle, value);
+}
+
+auto PublishSubscribe::max_nodes() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_max_nodes(ref_handle);
+}
+
+void PublishSubscribe::set_max_nodes(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_max_nodes(ref_handle, value);
+}
+
+auto PublishSubscribe::subscriber_max_buffer_size() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_subscriber_max_buffer_size(ref_handle);
+}
+
+void PublishSubscribe::set_subscriber_max_buffer_size(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_subscriber_max_buffer_size(ref_handle, value);
+}
+
+auto PublishSubscribe::subscriber_max_borrowed_samples() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_subscriber_max_borrowed_samples(ref_handle);
+}
+
+void PublishSubscribe::set_subscriber_max_borrowed_samples(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_subscriber_max_borrowed_samples(ref_handle, value);
+}
+
+auto PublishSubscribe::publisher_max_loaned_samples() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_publisher_max_loaned_samples(ref_handle);
+}
+
+void PublishSubscribe::set_publisher_max_loaned_samples(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_publisher_max_loaned_samples(ref_handle, value);
+}
+
+auto PublishSubscribe::publisher_history_size() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_publisher_history_size(ref_handle);
+}
+
+void PublishSubscribe::set_publisher_history_size(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_publisher_history_size(ref_handle, value);
+}
+
+auto PublishSubscribe::enable_safe_overflow() && -> bool {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_enable_safe_overflow(ref_handle);
+}
+
+void PublishSubscribe::set_enable_safe_overflow(bool value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_enable_safe_overflow(ref_handle, value);
+}
+
+auto PublishSubscribe::unable_to_deliver_strategy() && -> UnableToDeliverStrategy {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox::into<UnableToDeliverStrategy>(
+        iox2_config_defaults_publish_subscribe_unable_to_deliver_strategy(ref_handle));
+}
+
+void PublishSubscribe::set_unable_to_deliver_strategy(UnableToDeliverStrategy value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_unable_to_deliver_strategy(
+        ref_handle, static_cast<iox2_unable_to_deliver_strategy_e>(iox::into<int>(value)));
+}
+
+auto PublishSubscribe::subscriber_expired_connection_buffer() && -> size_t {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_defaults_publish_subscribe_subscriber_expired_connection_buffer(ref_handle);
+}
+
+void PublishSubscribe::set_subscriber_expired_connection_buffer(size_t value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_defaults_publish_subscribe_set_subscriber_expired_connection_buffer(ref_handle, value);
+}
+/////////////////////////
+// END: PublishSubscribe
+/////////////////////////
+
+/////////////////////////
+// BEGIN: Service
+/////////////////////////
+Service::Service(iox2_config_h* config)
+    : m_config { config } {
+}
+
+auto Service::directory() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_service_directory(ref_handle);
+}
+
+auto Service::set_directory(const iox::Path& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_service_set_directory(ref_handle, value.as_string().c_str());
+}
+
+auto Service::publisher_data_segment_suffix() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_service_publisher_data_segment_suffix(ref_handle);
+}
+
+auto Service::set_publisher_data_segment_suffix(const iox::FileName& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_service_set_publisher_data_segment_suffix(ref_handle, value.as_string().c_str());
+}
+
+auto Service::static_config_storage_suffix() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_service_static_config_storage_suffix(ref_handle);
+}
+
+auto Service::set_static_config_storage_suffix(const iox::FileName& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_service_set_static_config_storage_suffix(ref_handle, value.as_string().c_str());
+}
+
+auto Service::dynamic_config_storage_suffix() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_service_dynamic_config_storage_suffix(ref_handle);
+}
+
+auto Service::set_dynamic_config_storage_suffix(const iox::FileName& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_service_set_dynamic_config_storage_suffix(ref_handle, value.as_string().c_str());
+}
+
+auto Service::creation_timeout() && -> iox::units::Duration {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto secs = iox2_config_global_service_creation_timeout_sec(ref_handle);
+    auto nsec = iox2_config_global_service_creation_timeout_nsec_frac(ref_handle);
+
+    return iox::units::Duration::fromSeconds(secs) + iox::units::Duration::fromNanoseconds(nsec);
+}
+
+auto Service::set_creation_timeout(const iox::units::Duration& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto duration = value.timespec();
+    iox2_config_global_service_set_creation_timeout(ref_handle, duration.tv_sec, duration.tv_nsec);
+}
+
+auto Service::connection_suffix() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_service_connection_suffix(ref_handle);
+}
+
+auto Service::set_connection_suffix(const iox::FileName& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_service_set_connection_suffix(ref_handle, value.as_string().c_str());
+}
+
+auto Service::event_connection_suffix() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_service_event_connection_suffix(ref_handle);
+}
+
+auto Service::set_event_connection_suffix(const iox::FileName& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_service_set_event_connection_suffix(ref_handle, value.as_string().c_str());
+}
+/////////////////////////
+// END: Service
+/////////////////////////
+
+/////////////////////////
+// BEGIN: Node
+/////////////////////////
+Node::Node(iox2_config_h* config)
+    : m_config { config } {
+}
+
+auto Node::directory() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_node_directory(ref_handle);
+}
+
+auto Node::set_directory(const iox::Path& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_node_set_directory(ref_handle, value.as_string().c_str());
+}
+
+auto Node::monitor_suffix() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_node_monitor_suffix(ref_handle);
+}
+
+auto Node::set_monitor_suffix(const iox::FileName& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_node_set_monitor_suffix(ref_handle, value.as_string().c_str());
+}
+
+auto Node::static_config_suffix() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_node_static_config_suffix(ref_handle);
+}
+
+auto Node::set_static_config_suffix(const iox::FileName& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_node_set_static_config_suffix(ref_handle, value.as_string().c_str());
+}
+
+auto Node::service_tag_suffix() && -> const char* {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_node_service_tag_suffix(ref_handle);
+}
+
+auto Node::set_service_tag_suffix(const iox::FileName& value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_node_set_service_tag_suffix(ref_handle, value.as_string().c_str());
+}
+
+auto Node::cleanup_dead_nodes_on_creation() && -> bool {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_node_cleanup_dead_nodes_on_creation(ref_handle);
+}
+
+auto Node::set_cleanup_dead_nodes_on_creation(bool value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_node_set_cleanup_dead_nodes_on_creation(ref_handle, value);
+}
+
+auto Node::cleanup_dead_nodes_on_destruction() && -> bool {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    return iox2_config_global_node_cleanup_dead_nodes_on_destruction(ref_handle);
+}
+
+auto Node::set_cleanup_dead_nodes_on_destruction(bool value) && {
+    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    iox2_config_global_node_set_cleanup_dead_nodes_on_destruction(ref_handle, value);
+}
+/////////////////////////
+// END: Node
+/////////////////////////
 } // namespace config
 } // namespace iox2

--- a/iceoryx2-ffi/cxx/src/config.cpp
+++ b/iceoryx2-ffi/cxx/src/config.cpp
@@ -83,6 +83,16 @@ Config::Config(iox2_config_h handle)
     : m_handle { handle } {
 }
 
+auto Config::from_file(const iox::FilePath& file) -> iox::expected<Config, ConfigCreationError> {
+    iox2_config_h handle = nullptr;
+    auto result = iox2_config_from_file(nullptr, &handle, file.as_string().c_str());
+    if (result == IOX2_OK) {
+        return iox::ok(Config(handle));
+    }
+
+    return iox::err(iox::into<ConfigCreationError>(result));
+}
+
 auto Config::global() -> config::Global {
     return config::Global(&this->m_handle);
 }

--- a/iceoryx2-ffi/cxx/src/config.cpp
+++ b/iceoryx2-ffi/cxx/src/config.cpp
@@ -376,10 +376,11 @@ void Service::set_dynamic_config_storage_suffix(const iox::FileName& value) && {
 
 auto Service::creation_timeout() && -> iox::units::Duration {
     auto* ref_handle = iox2_cast_config_ref_h(*m_config);
-    auto secs = iox2_config_global_service_creation_timeout_sec(ref_handle);
-    auto nsec = iox2_config_global_service_creation_timeout_nsec_frac(ref_handle);
+    uint64_t secs = 0;
+    uint32_t nsecs = 0;
+    iox2_config_global_service_creation_timeout(ref_handle, &secs, &nsecs);
 
-    return iox::units::Duration::fromSeconds(secs) + iox::units::Duration::fromNanoseconds(nsec);
+    return iox::units::Duration::fromSeconds(secs) + iox::units::Duration::fromNanoseconds(nsecs);
 }
 
 void Service::set_creation_timeout(const iox::units::Duration& value) && {

--- a/iceoryx2-ffi/cxx/src/node_details.cpp
+++ b/iceoryx2-ffi/cxx/src/node_details.cpp
@@ -13,9 +13,9 @@
 #include "iox2/node_details.hpp"
 
 namespace iox2 {
-NodeDetails::NodeDetails(NodeName name, const Config& config)
+NodeDetails::NodeDetails(NodeName name, Config config)
     : m_node_name { std::move(name) }
-    , m_config { config } {
+    , m_config { std::move(config) } {
 }
 
 auto NodeDetails::name() const -> const NodeName& {

--- a/iceoryx2-ffi/cxx/tests/src/config_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/config_tests.cpp
@@ -24,4 +24,12 @@ TEST(Config, global_prefix_works) {
     config.global().set_prefix(test_value);
     ASSERT_THAT(config.global().prefix(), StrEq(test_value.as_string().c_str()));
 }
+
+TEST(Config, global_root_path_works) {
+    const auto test_value = iox::Path::create("some/path").expect("");
+    auto config = Config();
+
+    config.global().set_root_path(test_value);
+    ASSERT_THAT(config.global().root_path(), StrEq(test_value.as_string().c_str()));
+}
 } // namespace

--- a/iceoryx2-ffi/cxx/tests/src/config_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/config_tests.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include "iox2/config.hpp"
+
+#include "test.hpp"
+
+namespace {
+using namespace iox2;
+
+TEST(Config, global_prefix_works) {
+    const auto test_value = iox::FileName::create("oh_my_dot").expect("");
+    auto config = Config();
+
+    config.global().set_prefix(test_value);
+    ASSERT_THAT(config.global().prefix(), StrEq(test_value.as_string().c_str()));
+}
+} // namespace

--- a/iceoryx2-ffi/cxx/tests/src/config_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/config_tests.cpp
@@ -17,7 +17,7 @@
 namespace {
 using namespace iox2;
 
-TEST(Config, global_prefix_works) {
+TEST(Config, global_prefix) {
     const auto test_value = iox::FileName::create("oh_my_dot").expect("");
     auto config = Config();
 
@@ -25,11 +25,232 @@ TEST(Config, global_prefix_works) {
     ASSERT_THAT(config.global().prefix(), StrEq(test_value.as_string().c_str()));
 }
 
-TEST(Config, global_root_path_works) {
+TEST(Config, global_root_path) {
     const auto test_value = iox::Path::create("some/path").expect("");
     auto config = Config();
 
     config.global().set_root_path(test_value);
     ASSERT_THAT(config.global().root_path(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, defaults_event_max_listeners) {
+    const auto test_value = 123;
+    auto config = Config();
+
+    config.defaults().event().set_max_listeners(test_value);
+    ASSERT_THAT(config.defaults().event().max_listeners(), Eq(test_value));
+}
+
+TEST(Config, defaults_event_max_notifiers) {
+    const auto test_value = 45;
+    auto config = Config();
+
+    config.defaults().event().set_max_notifiers(test_value);
+    ASSERT_THAT(config.defaults().event().max_notifiers(), Eq(test_value));
+}
+
+TEST(Config, defaults_event_max_nodes) {
+    const auto test_value = 78;
+    auto config = Config();
+
+    config.defaults().event().set_max_nodes(test_value);
+    ASSERT_THAT(config.defaults().event().max_nodes(), Eq(test_value));
+}
+
+TEST(Config, defaults_event_event_id_max_value) {
+    const auto test_value = 799;
+    auto config = Config();
+
+    config.defaults().event().set_event_id_max_value(test_value);
+    ASSERT_THAT(config.defaults().event().event_id_max_value(), Eq(test_value));
+}
+
+TEST(Config, defaults_publish_subscribe_max_subscribers) {
+    const auto test_value = 313;
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_max_subscribers(test_value);
+    ASSERT_THAT(config.defaults().publish_subscribe().max_subscribers(), Eq(test_value));
+}
+
+TEST(Config, defaults_publish_subscribe_max_publishers) {
+    const auto test_value = 424;
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_max_publishers(test_value);
+    ASSERT_THAT(config.defaults().publish_subscribe().max_publishers(), Eq(test_value));
+}
+
+TEST(Config, defaults_publish_subscribe_max_nodes) {
+    const auto test_value = 535;
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_max_nodes(test_value);
+    ASSERT_THAT(config.defaults().publish_subscribe().max_nodes(), Eq(test_value));
+}
+
+TEST(Config, defaults_publish_subscribe_subscriber_max_buffer_size) {
+    const auto test_value = 646;
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_subscriber_max_buffer_size(test_value);
+    ASSERT_THAT(config.defaults().publish_subscribe().subscriber_max_buffer_size(), Eq(test_value));
+}
+
+TEST(Config, defaults_publish_subscribe_subscriber_max_borrowed_samples) {
+    const auto test_value = 757;
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_subscriber_max_borrowed_samples(test_value);
+    ASSERT_THAT(config.defaults().publish_subscribe().subscriber_max_borrowed_samples(), Eq(test_value));
+}
+
+TEST(Config, defaults_publish_subscribe_publisher_max_loaned_samples) {
+    const auto test_value = 868;
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_publisher_max_loaned_samples(test_value);
+    ASSERT_THAT(config.defaults().publish_subscribe().publisher_max_loaned_samples(), Eq(test_value));
+}
+
+TEST(Config, defaults_publish_subscribe_publisher_history_size) {
+    const auto test_value = 979;
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_publisher_history_size(test_value);
+    ASSERT_THAT(config.defaults().publish_subscribe().publisher_history_size(), Eq(test_value));
+}
+
+TEST(Config, defaults_publish_subscribe_enable_safe_overflow) {
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_enable_safe_overflow(true);
+    ASSERT_THAT(config.defaults().publish_subscribe().enable_safe_overflow(), Eq(true));
+    config.defaults().publish_subscribe().set_enable_safe_overflow(false);
+    ASSERT_THAT(config.defaults().publish_subscribe().enable_safe_overflow(), Eq(false));
+}
+
+TEST(Config, defaults_publish_subscribe_unable_to_deliver_strategy) {
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_unable_to_deliver_strategy(UnableToDeliverStrategy::Block);
+    ASSERT_THAT(config.defaults().publish_subscribe().unable_to_deliver_strategy(), Eq(UnableToDeliverStrategy::Block));
+    config.defaults().publish_subscribe().set_unable_to_deliver_strategy(UnableToDeliverStrategy::DiscardSample);
+    ASSERT_THAT(config.defaults().publish_subscribe().unable_to_deliver_strategy(),
+                Eq(UnableToDeliverStrategy::DiscardSample));
+}
+
+TEST(Config, defaults_publish_subscribe_subscriber_expired_connection_buffer) {
+    const auto test_value = 13113;
+    auto config = Config();
+
+    config.defaults().publish_subscribe().set_subscriber_expired_connection_buffer(test_value);
+    ASSERT_THAT(config.defaults().publish_subscribe().subscriber_expired_connection_buffer(), Eq(test_value));
+}
+
+TEST(Config, global_service_directory) {
+    const auto test_value = iox::Path::create("look/there/flies/a/dead/pidgin").expect("");
+    auto config = Config();
+
+    config.global().service().set_directory(test_value);
+    ASSERT_THAT(config.global().service().directory(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_service_publisher_data_segment_suffix) {
+    const auto test_value = iox::FileName::create("no_touchy_fishy").expect("");
+    auto config = Config();
+
+    config.global().service().set_publisher_data_segment_suffix(test_value);
+    ASSERT_THAT(config.global().service().publisher_data_segment_suffix(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_service_static_config_storage_suffix) {
+    const auto test_value = iox::FileName::create("its_a_smelly_fishy").expect("");
+    auto config = Config();
+
+    config.global().service().set_static_config_storage_suffix(test_value);
+    ASSERT_THAT(config.global().service().static_config_storage_suffix(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_service_dynamic_config_storage_suffix) {
+    const auto test_value = iox::FileName::create("nala_runs_while_dreaming").expect("");
+    auto config = Config();
+
+    config.global().service().set_dynamic_config_storage_suffix(test_value);
+    ASSERT_THAT(config.global().service().dynamic_config_storage_suffix(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_service_creation_timeout) {
+    const auto test_value = iox::units::Duration::fromSeconds(1234);
+    auto config = Config();
+
+    config.global().service().set_creation_timeout(test_value);
+    ASSERT_THAT(config.global().service().creation_timeout(), Eq(test_value));
+}
+
+TEST(Config, global_service_connection_suffix) {
+    const auto test_value = iox::FileName::create("what_dinosaur_ancester_has_the_pidgin").expect("");
+    auto config = Config();
+
+    config.global().service().set_connection_suffix(test_value);
+    ASSERT_THAT(config.global().service().connection_suffix(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_service_event_connection_suffix) {
+    const auto test_value = iox::FileName::create("dont_eat_elephants").expect("");
+    auto config = Config();
+
+    config.global().service().set_event_connection_suffix(test_value);
+    ASSERT_THAT(config.global().service().event_connection_suffix(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_node_directory) {
+    const auto test_value = iox::Path::create("eat/the/carrototier").expect("");
+    auto config = Config();
+
+    config.global().node().set_directory(test_value);
+    ASSERT_THAT(config.global().node().directory(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_node_monitor_suffix) {
+    const auto test_value = iox::FileName::create("why_i_am_so_happy_so_happy_oh_so_blurpy").expect("");
+    auto config = Config();
+
+    config.global().node().set_monitor_suffix(test_value);
+    ASSERT_THAT(config.global().node().monitor_suffix(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_node_static_config_suffix) {
+    const auto test_value = iox::FileName::create("spin_me_like_a_vinyl_record").expect("");
+    auto config = Config();
+
+    config.global().node().set_static_config_suffix(test_value);
+    ASSERT_THAT(config.global().node().static_config_suffix(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_node_service_tag_suffix) {
+    const auto test_value = iox::FileName::create("who_is_fluffy").expect("");
+    auto config = Config();
+
+    config.global().node().set_service_tag_suffix(test_value);
+    ASSERT_THAT(config.global().node().service_tag_suffix(), StrEq(test_value.as_string().c_str()));
+}
+
+TEST(Config, global_node_cleanup_dead_nodes_on_creation) {
+    auto config = Config();
+
+    config.global().node().set_cleanup_dead_nodes_on_creation(true);
+    ASSERT_THAT(config.global().node().cleanup_dead_nodes_on_creation(), Eq(true));
+    config.global().node().set_cleanup_dead_nodes_on_creation(false);
+    ASSERT_THAT(config.global().node().cleanup_dead_nodes_on_creation(), Eq(false));
+}
+
+TEST(Config, global_node_cleanup_dead_nodes_on_destruction) {
+    auto config = Config();
+
+    config.global().node().set_cleanup_dead_nodes_on_destruction(true);
+    ASSERT_THAT(config.global().node().cleanup_dead_nodes_on_destruction(), Eq(true));
+    config.global().node().set_cleanup_dead_nodes_on_destruction(false);
+    ASSERT_THAT(config.global().node().cleanup_dead_nodes_on_destruction(), Eq(false));
 }
 } // namespace

--- a/iceoryx2-ffi/cxx/tests/src/config_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/config_tests.cpp
@@ -26,7 +26,7 @@ TEST(Config, global_prefix) {
 }
 
 TEST(Config, global_root_path) {
-    const auto test_value = iox::Path::create("some/path").expect("");
+    const auto test_value = iox::Path::create("some_path").expect("");
     auto config = Config();
 
     config.global().set_root_path(test_value);

--- a/iceoryx2-ffi/ffi/Cargo.toml
+++ b/iceoryx2-ffi/ffi/Cargo.toml
@@ -26,6 +26,7 @@ iceoryx2 = { workspace = true }
 iceoryx2-bb-container = { workspace = true }
 iceoryx2-bb-elementary = { workspace = true }
 iceoryx2-bb-log = { workspace = true }
+iceoryx2-bb-system-types = { workspace = true }
 iceoryx2-cal = { workspace = true }
 iceoryx2-ffi-macros = { workspace = true }
 

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -18,6 +18,7 @@ use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
+use iceoryx2_bb_system_types::path::Path;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 use std::mem::ManuallyDrop;
 
@@ -242,6 +243,7 @@ pub unsafe extern "C" fn iox2_config_global_prefix(handle: iox2_config_ref_h) ->
     config.value.as_ref().value.global.prefix.as_c_str()
 }
 
+/// Returns: iox2_semantic_string_error
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_set_prefix(
     handle: iox2_config_ref_h,
@@ -253,6 +255,32 @@ pub unsafe extern "C" fn iox2_config_global_set_prefix(
     match FileName::from_c_str(value) {
         Ok(n) => {
             config.value.as_mut().value.global.prefix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_root_path(handle: iox2_config_ref_h) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config.value.as_ref().value.global.root_path().as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_set_root_path(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match Path::from_c_str(value) {
+        Ok(n) => {
+            config.value.as_mut().value.global.set_root_path(&n);
             IOX2_OK as _
         }
         Err(e) => e as c_int,

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -189,6 +189,7 @@ pub unsafe extern "C" fn iox2_config_from_file(
     config_file: *const c_char,
 ) -> c_int {
     debug_assert!(!handle_ptr.is_null());
+    debug_assert!(!config_file.is_null());
 
     let file = match FilePath::from_c_str(config_file) {
         Ok(file) => file,
@@ -878,50 +879,28 @@ pub unsafe extern "C" fn iox2_config_global_service_set_dynamic_config_storage_s
     }
 }
 
-/// Returns the second part of the time of how long another process will wait until the service
+/// Returns the duration how long another process will wait until the service
 /// creation is finalized
 ///
 /// # Safety
 ///
 /// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `secs` - A valid pointer pointing to a [`u64`].
+/// * `nsecs` - A valid pointer pointing to a [`u32`]
 #[no_mangle]
-pub unsafe extern "C" fn iox2_config_global_service_creation_timeout_sec(
+pub unsafe extern "C" fn iox2_config_global_service_creation_timeout(
     handle: iox2_config_ref_h,
-) -> u64 {
+    secs: *mut u64,
+    nsecs: *mut u32,
+) {
     debug_assert!(!handle.is_null());
+    debug_assert!(!secs.is_null());
+    debug_assert!(!nsecs.is_null());
 
     let config = &*handle.as_type();
-    config
-        .value
-        .as_ref()
-        .value
-        .global
-        .service
-        .creation_timeout
-        .as_secs()
-}
-
-/// Returns the nano second part of the time of how long another process will wait until the service
-/// creation is finalized
-///
-/// # Safety
-///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
-#[no_mangle]
-pub unsafe extern "C" fn iox2_config_global_service_creation_timeout_nsec_frac(
-    handle: iox2_config_ref_h,
-) -> u32 {
-    debug_assert!(!handle.is_null());
-
-    let config = &*handle.as_type();
-    config
-        .value
-        .as_ref()
-        .value
-        .global
-        .service
-        .creation_timeout
-        .subsec_nanos()
+    let timeout = config.value.as_ref().value.global.service.creation_timeout;
+    *secs = timeout.as_secs();
+    *nsecs = timeout.subsec_nanos();
 }
 
 /// Sets the creation timeout

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -12,9 +12,44 @@
 
 #![allow(non_camel_case_types)]
 
-use iceoryx2::prelude::*;
+use core::ffi::{c_char, c_int};
+use iceoryx2::config::{Config, ConfigCreationError};
+use iceoryx2_bb_container::semantic_string::*;
+use iceoryx2_bb_elementary::static_assert::*;
+use iceoryx2_bb_system_types::file_name::FileName;
+use iceoryx2_bb_system_types::file_path::FilePath;
+use iceoryx2_ffi_macros::iceoryx2_ffi;
+use std::mem::ManuallyDrop;
+
+use crate::IOX2_OK;
+
+use super::{HandleToType, IntoCInt};
 
 // BEGIN type definition
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub enum iox2_config_creation_error_e {
+    FAILED_TO_OPEN_CONFIG_FILE = IOX2_OK as isize + 1,
+    FAILED_TO_READ_CONFIG_FILE_CONTENTS,
+    UNABLE_TO_DESERIALIZE_CONTENTS,
+    INVALID_FILE_PATH,
+}
+
+impl IntoCInt for ConfigCreationError {
+    fn into_c_int(self) -> c_int {
+        (match self {
+            ConfigCreationError::FailedToOpenConfigFile => {
+                iox2_config_creation_error_e::FAILED_TO_OPEN_CONFIG_FILE
+            }
+            ConfigCreationError::FailedToReadConfigFileContents => {
+                iox2_config_creation_error_e::FAILED_TO_READ_CONFIG_FILE_CONTENTS
+            }
+            ConfigCreationError::UnableToDeserializeContents => {
+                iox2_config_creation_error_e::UNABLE_TO_DESERIALIZE_CONTENTS
+            }
+        }) as c_int
+    }
+}
 
 // NOTE check the README.md for using opaque types with renaming
 /// The immutable pointer to the underlying `Config`
@@ -22,12 +57,154 @@ pub type iox2_config_ptr = *const Config;
 /// The mutable pointer to the underlying `Config`
 pub type iox2_config_mut_ptr = *mut Config;
 
+pub(super) struct ConfigOwner {
+    value: ManuallyDrop<Config>,
+}
+
+#[repr(C)]
+#[repr(align(8))]
+pub struct iox2_config_storage_t {
+    internal: [u8; 3560],
+}
+
+#[repr(C)]
+#[iceoryx2_ffi(ConfigOwner)]
+pub struct iox2_config_t {
+    value: iox2_config_storage_t,
+    deleter: fn(*mut iox2_config_t),
+}
+
+impl iox2_config_t {
+    pub(super) fn init(&mut self, value: ManuallyDrop<Config>, deleter: fn(*mut iox2_config_t)) {
+        self.value.init(ConfigOwner { value });
+        self.deleter = deleter;
+    }
+}
+
+pub struct iox2_config_h_t;
+/// The owning handle for `iox2_config_t`. Passing the handle to an function transfers the ownership.
+pub type iox2_config_h = *mut iox2_config_h_t;
+
+pub struct iox2_config_ref_h_t;
+/// The non-owning handle for `iox2_config_t`. Passing the handle to an function does not transfers the ownership.
+pub type iox2_config_ref_h = *mut iox2_config_ref_h_t;
+
+impl HandleToType for iox2_config_h {
+    type Target = *mut iox2_config_t;
+
+    fn as_type(self) -> Self::Target {
+        self as *mut _ as _
+    }
+}
+
+impl HandleToType for iox2_config_ref_h {
+    type Target = *mut iox2_config_t;
+
+    fn as_type(self) -> Self::Target {
+        self as *mut _ as _
+    }
+}
+
 // END type definition
 
 // BEGIN C API
 #[no_mangle]
-pub extern "C" fn iox2_config_global_config() -> iox2_config_ptr {
-    Config::global_config()
+pub unsafe extern "C" fn iox2_config_global_config() -> iox2_config_ptr {
+    iceoryx2::config::Config::global_config()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_from_file(
+    handle: iox2_config_ref_h,
+    struct_ptr: *mut iox2_config_t,
+    handle_ptr: *mut iox2_config_h,
+    config_file: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+    debug_assert!(!handle_ptr.is_null());
+
+    let file = match FilePath::from_c_str(config_file) {
+        Ok(file) => file,
+        Err(_) => return iox2_config_creation_error_e::INVALID_FILE_PATH as c_int,
+    };
+
+    let mut struct_ptr = struct_ptr;
+    fn no_op(_: *mut iox2_config_t) {}
+    let mut deleter: fn(*mut iox2_config_t) = no_op;
+    if struct_ptr.is_null() {
+        struct_ptr = iox2_config_t::alloc();
+        deleter = iox2_config_t::dealloc;
+    }
+    debug_assert!(!struct_ptr.is_null());
+
+    let config_from_file = match Config::from_file(&file) {
+        Ok(config) => config,
+        Err(e) => {
+            deleter(struct_ptr);
+            return e.into_c_int();
+        }
+    };
+
+    (*struct_ptr).init(ManuallyDrop::new(config_from_file), deleter);
+
+    IOX2_OK
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_clone(
+    handle: iox2_config_ref_h,
+    struct_ptr: *mut iox2_config_t,
+    handle_ptr: *mut iox2_config_h,
+) {
+    debug_assert!(!handle.is_null());
+    debug_assert!(!handle_ptr.is_null());
+
+    let mut struct_ptr = struct_ptr;
+    fn no_op(_: *mut iox2_config_t) {}
+    let mut deleter: fn(*mut iox2_config_t) = no_op;
+    if struct_ptr.is_null() {
+        struct_ptr = iox2_config_t::alloc();
+        deleter = iox2_config_t::dealloc;
+    }
+    debug_assert!(!struct_ptr.is_null());
+
+    let config = &*handle.as_type();
+
+    (*struct_ptr).init(config.value.as_ref().value.clone(), deleter);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_drop(handle: iox2_config_h) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    ManuallyDrop::drop(&mut config.value.as_mut().value);
+    (config.deleter)(config)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_prefix(handle: iox2_config_ref_h) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config.value.as_ref().value.global.prefix.as_c_str()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_set_prefix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config.value.as_mut().value.global.prefix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
 }
 
 // END C API

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -147,12 +147,10 @@ pub unsafe extern "C" fn iox2_config_default(
 
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_from_file(
-    handle: iox2_config_ref_h,
     struct_ptr: *mut iox2_config_t,
     handle_ptr: *mut iox2_config_h,
     config_file: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
     debug_assert!(!handle_ptr.is_null());
 
     let file = match FilePath::from_c_str(config_file) {

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -12,7 +12,9 @@
 
 #![allow(non_camel_case_types)]
 
+use crate::{c_size_t, iox2_unable_to_deliver_strategy_e};
 use core::ffi::{c_char, c_int};
+use core::time::Duration;
 use iceoryx2::config::{Config, ConfigCreationError};
 use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_elementary::static_assert::*;
@@ -235,6 +237,10 @@ pub unsafe extern "C" fn iox2_config_drop(handle: iox2_config_h) {
     (config.deleter)(config)
 }
 
+/////////////////
+// BEGIN: global
+/////////////////
+
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_prefix(handle: iox2_config_ref_h) -> *const c_char {
     debug_assert!(!handle.is_null());
@@ -287,4 +293,939 @@ pub unsafe extern "C" fn iox2_config_global_set_root_path(
     }
 }
 
+/////////////////
+// END: global
+/////////////////
+
+/////////////////
+// BEGIN: node
+/////////////////
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_directory(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config.value.as_ref().value.global.node.directory.as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_set_directory(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match Path::from_c_str(value) {
+        Ok(n) => {
+            config.value.as_mut().value.global.node.directory = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_monitor_suffix(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .node
+        .monitor_suffix
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_set_monitor_suffix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config.value.as_mut().value.global.node.monitor_suffix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_static_config_suffix(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .node
+        .static_config_suffix
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_set_static_config_suffix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config.value.as_mut().value.global.node.static_config_suffix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_service_tag_suffix(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .node
+        .service_tag_suffix
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_set_service_tag_suffix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config.value.as_mut().value.global.node.service_tag_suffix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_creation(
+    handle: iox2_config_ref_h,
+) -> bool {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .node
+        .cleanup_dead_nodes_on_creation
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_creation(
+    handle: iox2_config_ref_h,
+    value: bool,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .global
+        .node
+        .cleanup_dead_nodes_on_creation = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_destruction(
+    handle: iox2_config_ref_h,
+) -> bool {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .node
+        .cleanup_dead_nodes_on_destruction
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_destruction(
+    handle: iox2_config_ref_h,
+    value: bool,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .global
+        .node
+        .cleanup_dead_nodes_on_destruction = value;
+}
+
+/////////////////
+// END: node
+/////////////////
+
+/////////////////
+// BEGIN: service
+/////////////////
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_directory(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .service
+        .directory
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_set_directory(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match Path::from_c_str(value) {
+        Ok(n) => {
+            config.value.as_mut().value.global.service.directory = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_publisher_data_segment_suffix(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .service
+        .publisher_data_segment_suffix
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_set_publisher_data_segment_suffix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config
+                .value
+                .as_mut()
+                .value
+                .global
+                .service
+                .publisher_data_segment_suffix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_static_config_storage_suffix(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .service
+        .static_config_storage_suffix
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_set_static_config_storage_suffix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config
+                .value
+                .as_mut()
+                .value
+                .global
+                .service
+                .static_config_storage_suffix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_dynamic_config_storage_suffix(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .service
+        .dynamic_config_storage_suffix
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_set_dynamic_config_storage_suffix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config
+                .value
+                .as_mut()
+                .value
+                .global
+                .service
+                .dynamic_config_storage_suffix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_creation_timeout_sec(
+    handle: iox2_config_ref_h,
+) -> u64 {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .service
+        .creation_timeout
+        .as_secs()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_creation_timeout_nsec_frac(
+    handle: iox2_config_ref_h,
+) -> u32 {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .service
+        .creation_timeout
+        .subsec_nanos()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_set_creation_timeout(
+    handle: iox2_config_ref_h,
+    sec: u64,
+    nsec: u32,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config.value.as_mut().value.global.service.creation_timeout =
+        Duration::from_secs(sec) + Duration::from_nanos(nsec as u64);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_connection_suffix(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .service
+        .connection_suffix
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_set_connection_suffix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config.value.as_mut().value.global.service.connection_suffix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_event_connection_suffix(
+    handle: iox2_config_ref_h,
+) -> *const c_char {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .global
+        .service
+        .event_connection_suffix
+        .as_c_str()
+}
+
+/// Returns: iox2_semantic_string_error
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_global_service_set_event_connection_suffix(
+    handle: iox2_config_ref_h,
+    value: *const c_char,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    match FileName::from_c_str(value) {
+        Ok(n) => {
+            config
+                .value
+                .as_mut()
+                .value
+                .global
+                .service
+                .event_connection_suffix = n;
+            IOX2_OK as _
+        }
+        Err(e) => e as c_int,
+    }
+}
+/////////////////
+// END: service
+/////////////////
+
+//////////////////////////
+// BEGIN: publish subscribe
+//////////////////////////
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_subscribers(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .max_subscribers
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_subscribers(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .max_subscribers = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_publishers(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .max_publishers
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_publishers(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .max_publishers = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_nodes(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .max_nodes
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_nodes(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .max_nodes = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_buffer_size(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .subscriber_max_buffer_size
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_max_buffer_size(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .subscriber_max_buffer_size = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_borrowed_samples(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .subscriber_max_borrowed_samples
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_max_borrowed_samples(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .subscriber_max_borrowed_samples = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_max_loaned_samples(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .publisher_max_loaned_samples
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_max_loaned_samples(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .publisher_max_loaned_samples = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_history_size(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .publisher_history_size
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_history_size(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .publisher_history_size = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_enable_safe_overflow(
+    handle: iox2_config_ref_h,
+) -> bool {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .enable_safe_overflow
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_enable_safe_overflow(
+    handle: iox2_config_ref_h,
+    value: bool,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .enable_safe_overflow = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_unable_to_deliver_strategy(
+    handle: iox2_config_ref_h,
+) -> c_int {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .unable_to_deliver_strategy
+        .into_c_int()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_unable_to_deliver_strategy(
+    handle: iox2_config_ref_h,
+    value: iox2_unable_to_deliver_strategy_e,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .unable_to_deliver_strategy = value.into();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_expired_connection_buffer(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .publish_subscribe
+        .subscriber_expired_connection_buffer
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_expired_connection_buffer(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .publish_subscribe
+        .subscriber_expired_connection_buffer = value;
+}
+//////////////////////////
+// END: publish subscribe
+//////////////////////////
+
+//////////////////////////
+// BEGIN: event
+//////////////////////////
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_event_max_listeners(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config.value.as_ref().value.defaults.event.max_listeners
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_event_set_max_listeners(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config.value.as_mut().value.defaults.event.max_listeners = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_event_max_notifiers(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config.value.as_ref().value.defaults.event.max_notifiers
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_event_set_max_notifiers(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config.value.as_mut().value.defaults.event.max_notifiers = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_event_max_nodes(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config.value.as_ref().value.defaults.event.max_nodes
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_event_set_max_nodes(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config.value.as_mut().value.defaults.event.max_nodes = value;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_event_event_id_max_value(
+    handle: iox2_config_ref_h,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+
+    let config = &*handle.as_type();
+    config
+        .value
+        .as_ref()
+        .value
+        .defaults
+        .event
+        .event_id_max_value
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_defaults_event_set_event_id_max_value(
+    handle: iox2_config_ref_h,
+    value: c_size_t,
+) {
+    debug_assert!(!handle.is_null());
+
+    let config = &mut *handle.as_type();
+    config
+        .value
+        .as_mut()
+        .value
+        .defaults
+        .event
+        .event_id_max_value = value;
+}
+//////////////////////////
+// END: event
+//////////////////////////
 // END C API

--- a/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
@@ -99,6 +99,12 @@ impl From<UnableToDeliverStrategy> for iox2_unable_to_deliver_strategy_e {
     }
 }
 
+impl IntoCInt for UnableToDeliverStrategy {
+    fn into_c_int(self) -> c_int {
+        Into::<iox2_unable_to_deliver_strategy_e>::into(self) as c_int
+    }
+}
+
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<PortFactoryPublisherBuilderUnion>
 pub struct iox2_port_factory_publisher_builder_storage_t {

--- a/iceoryx2-ffi/ffi/src/api/quirks_correction.rs
+++ b/iceoryx2-ffi/ffi/src/api/quirks_correction.rs
@@ -16,9 +16,9 @@
 pub type c_size_t = usize;
 
 use crate::{
-    iox2_event_open_or_create_error_e, iox2_listener_create_error_e, iox2_listener_wait_error_e,
-    iox2_node_creation_failure_e, iox2_node_event_e, iox2_node_list_failure_e,
-    iox2_notifier_create_error_e, iox2_notifier_notify_error_e,
+    iox2_config_creation_error_e, iox2_event_open_or_create_error_e, iox2_listener_create_error_e,
+    iox2_listener_wait_error_e, iox2_node_creation_failure_e, iox2_node_event_e,
+    iox2_node_list_failure_e, iox2_notifier_create_error_e, iox2_notifier_notify_error_e,
     iox2_pub_sub_open_or_create_error_e, iox2_publisher_create_error_e,
     iox2_publisher_loan_error_e, iox2_publisher_send_error_e, iox2_semantic_string_error_e,
     iox2_service_details_error_e, iox2_service_list_error_e, iox2_subscriber_create_error_e,
@@ -171,4 +171,12 @@ pub unsafe extern "C" fn __iox2_internal_service_list_error_stub() -> iox2_servi
 // TODO: enums are only exported when they are actually used by some function
 pub unsafe extern "C" fn __iox2_internal_connection_failure_stub() -> iox2_connection_failure_e {
     iox2_connection_failure_e::FAILED_TO_ESTABLISH_CONNECTION
+}
+
+#[doc(hidden)]
+#[no_mangle]
+// TODO: enums are only exported when they are actually used by some function
+pub unsafe extern "C" fn __iox2_internal_config_creation_error_stub() -> iox2_config_creation_error_e
+{
+    iox2_config_creation_error_e::INVALID_FILE_PATH
 }

--- a/iceoryx2/src/config.rs
+++ b/iceoryx2/src/config.rs
@@ -195,6 +195,18 @@ impl Global {
                 "Unable to initialize config since the internal root_path_unix \"{}\" is not a valid directory.", self.root_path_unix)
         }
     }
+
+    /// Defines the path under which all other directories or files will be created
+    pub fn set_root_path(&mut self, value: &Path) {
+        #[cfg(target_os = "windows")]
+        {
+            self.root_path_windows = *value;
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            self.root_path_unix = *value;
+        }
+    }
 }
 
 /// Default settings. These values are used when the user in the code does not specify anything

--- a/iceoryx2/src/config.rs
+++ b/iceoryx2/src/config.rs
@@ -78,7 +78,7 @@ use iceoryx2_bb_system_types::path::Path;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
-use iceoryx2_bb_log::{fail, fatal_panic, trace, warn};
+use iceoryx2_bb_log::{fail, trace, warn};
 
 use crate::service::port_factory::publisher::UnableToDeliverStrategy;
 
@@ -168,31 +168,27 @@ pub struct Global {
 impl Global {
     /// The absolute path to the service directory where all static service infos are stored
     pub fn service_dir(&self) -> Path {
-        let mut path = self.root_path();
+        let mut path = *self.root_path();
         path.add_path_entry(&self.service.directory).unwrap();
         path
     }
 
     /// The absolute path to the node directory where all node details are stored
     pub fn node_dir(&self) -> Path {
-        let mut path = self.root_path();
+        let mut path = *self.root_path();
         path.add_path_entry(&self.node.directory).unwrap();
         path
     }
 
     /// The path under which all other directories or files will be created
-    pub fn root_path(&self) -> Path {
+    pub fn root_path(&self) -> &Path {
         #[cfg(target_os = "windows")]
         {
-            fatal_panic!(from "Global::root_path_windows",
-                when Path::new(self.root_path_windows.as_bytes()),
-                "Unable to initialize config since the internal root_path_windows \"{}\" is not a valid directory.", self.root_path_windows)
+            &self.root_path_windows
         }
         #[cfg(not(target_os = "windows"))]
         {
-            fatal_panic!(from "Global::root_path_unix",
-                when Path::new(self.root_path_unix.as_bytes()),
-                "Unable to initialize config since the internal root_path_unix \"{}\" is not a valid directory.", self.root_path_unix)
+            &self.root_path_unix
         }
     }
 

--- a/iceoryx2/src/config.rs
+++ b/iceoryx2/src/config.rs
@@ -232,15 +232,15 @@ pub struct PublishSubscribe {
     /// The maximum amount of supported [`crate::port::publisher::Publisher`]
     pub max_publishers: usize,
     /// The maximum amount of supported [`crate::node::Node`]s. Defines indirectly how many
-    /// processes can open the service in parallel.
+    /// processes can open the service at the same time.
     pub max_nodes: usize,
     /// The maximum buffer size a [`crate::port::subscriber::Subscriber`] can have
     pub subscriber_max_buffer_size: usize,
     /// The maximum amount of [`crate::sample::Sample`]s a [`crate::port::subscriber::Subscriber`] can
-    /// hold in parallel.
+    /// hold at the same time.
     pub subscriber_max_borrowed_samples: usize,
     /// The maximum amount of [`crate::sample_mut::SampleMut`]s a [`crate::port::publisher::Publisher`] can
-    /// loan in parallel.
+    /// loan at the same time.
     pub publisher_max_loaned_samples: usize,
     /// The maximum history size a [`crate::port::subscriber::Subscriber`] can request from a
     /// [`crate::port::publisher::Publisher`].
@@ -249,7 +249,7 @@ pub struct PublishSubscribe {
     /// full. When safe overflow is activated, the [`crate::port::publisher::Publisher`] will
     /// replace the oldest [`crate::sample::Sample`] with the newest one.
     pub enable_safe_overflow: bool,
-    /// If no safe overflow is activated it defines the deliver strategy of the
+    /// If safe overflow is deactivated it defines the deliver strategy of the
     /// [`crate::port::publisher::Publisher`] when the [`crate::port::subscriber::Subscriber`]s
     /// buffer is full.
     pub unable_to_deliver_strategy: UnableToDeliverStrategy,
@@ -272,7 +272,7 @@ pub struct Event {
     /// The maximum amount of supported [`crate::port::notifier::Notifier`]
     pub max_notifiers: usize,
     /// The maximum amount of supported [`crate::node::Node`]s. Defines indirectly how many
-    /// processes can open the service in parallel.
+    /// processes can open the service at the same time.
     pub max_nodes: usize,
     /// The largest event id supported by the event service
     pub event_id_max_value: usize,

--- a/iceoryx2/src/service/config_scheme.rs
+++ b/iceoryx2/src/service/config_scheme.rs
@@ -20,7 +20,7 @@ pub(crate) fn dynamic_config_storage_config<Service: crate::service::Service>(
     <<Service::DynamicStorage as NamedConceptMgmt>::Configuration>::default()
         .prefix(&global_config.global.prefix)
         .suffix(&global_config.global.service.dynamic_config_storage_suffix)
-        .path_hint(&global_config.global.root_path())
+        .path_hint(global_config.global.root_path())
 }
 
 pub(crate) fn static_config_storage_config<Service: crate::service::Service>(
@@ -45,7 +45,7 @@ pub(crate) fn connection_config<Service: crate::service::Service>(
     <<Service::Connection as NamedConceptMgmt>::Configuration>::default()
         .prefix(&global_config.global.prefix)
         .suffix(&global_config.global.service.connection_suffix)
-        .path_hint(&global_config.global.root_path())
+        .path_hint(global_config.global.root_path())
 }
 
 pub(crate) fn event_config<Service: crate::service::Service>(
@@ -54,7 +54,7 @@ pub(crate) fn event_config<Service: crate::service::Service>(
     <<Service::Event as NamedConceptMgmt>::Configuration>::default()
         .prefix(&global_config.global.prefix)
         .suffix(&global_config.global.service.event_connection_suffix)
-        .path_hint(&global_config.global.root_path())
+        .path_hint(global_config.global.root_path())
 }
 
 pub(crate) fn data_segment_config<Service: crate::service::Service>(
@@ -63,7 +63,7 @@ pub(crate) fn data_segment_config<Service: crate::service::Service>(
     <<Service::SharedMemory as NamedConceptMgmt>::Configuration>::default()
         .prefix(&global_config.global.prefix)
         .suffix(&global_config.global.service.publisher_data_segment_suffix)
-        .path_hint(&global_config.global.root_path())
+        .path_hint(global_config.global.root_path())
 }
 
 pub(crate) fn node_monitoring_config<Service: crate::service::Service>(

--- a/iceoryx2/src/service/config_scheme.rs
+++ b/iceoryx2/src/service/config_scheme.rs
@@ -18,9 +18,9 @@ pub(crate) fn dynamic_config_storage_config<Service: crate::service::Service>(
     global_config: &config::Config,
 ) -> <Service::DynamicStorage as NamedConceptMgmt>::Configuration {
     <<Service::DynamicStorage as NamedConceptMgmt>::Configuration>::default()
-        .prefix(global_config.global.prefix)
-        .suffix(global_config.global.service.dynamic_config_storage_suffix)
-        .path_hint(global_config.global.root_path())
+        .prefix(&global_config.global.prefix)
+        .suffix(&global_config.global.service.dynamic_config_storage_suffix)
+        .path_hint(&global_config.global.root_path())
 }
 
 pub(crate) fn static_config_storage_config<Service: crate::service::Service>(
@@ -28,51 +28,51 @@ pub(crate) fn static_config_storage_config<Service: crate::service::Service>(
 ) -> <Service::StaticStorage as NamedConceptMgmt>::Configuration {
     let origin = "static_config_storage_config";
     let msg = "Unable to generate static config storage directory";
-    let mut path_hint = global_config.global.root_path();
+    let mut path_hint = *global_config.global.root_path();
     fatal_panic!(from origin, when path_hint.add_path_entry(&global_config.global.service.directory),
             "{} since the combination of root directory and service directory entry result in an invalid directory \"{}{}\".",
             msg, path_hint, global_config.global.service.directory);
 
     <<Service::StaticStorage as NamedConceptMgmt>::Configuration>::default()
-        .prefix(global_config.global.prefix)
-        .suffix(global_config.global.service.static_config_storage_suffix)
-        .path_hint(path_hint)
+        .prefix(&global_config.global.prefix)
+        .suffix(&global_config.global.service.static_config_storage_suffix)
+        .path_hint(&path_hint)
 }
 
 pub(crate) fn connection_config<Service: crate::service::Service>(
     global_config: &config::Config,
 ) -> <Service::Connection as NamedConceptMgmt>::Configuration {
     <<Service::Connection as NamedConceptMgmt>::Configuration>::default()
-        .prefix(global_config.global.prefix)
-        .suffix(global_config.global.service.connection_suffix)
-        .path_hint(global_config.global.root_path())
+        .prefix(&global_config.global.prefix)
+        .suffix(&global_config.global.service.connection_suffix)
+        .path_hint(&global_config.global.root_path())
 }
 
 pub(crate) fn event_config<Service: crate::service::Service>(
     global_config: &config::Config,
 ) -> <Service::Event as NamedConceptMgmt>::Configuration {
     <<Service::Event as NamedConceptMgmt>::Configuration>::default()
-        .prefix(global_config.global.prefix)
-        .suffix(global_config.global.service.event_connection_suffix)
-        .path_hint(global_config.global.root_path())
+        .prefix(&global_config.global.prefix)
+        .suffix(&global_config.global.service.event_connection_suffix)
+        .path_hint(&global_config.global.root_path())
 }
 
 pub(crate) fn data_segment_config<Service: crate::service::Service>(
     global_config: &config::Config,
 ) -> <Service::SharedMemory as NamedConceptMgmt>::Configuration {
     <<Service::SharedMemory as NamedConceptMgmt>::Configuration>::default()
-        .prefix(global_config.global.prefix)
-        .suffix(global_config.global.service.publisher_data_segment_suffix)
-        .path_hint(global_config.global.root_path())
+        .prefix(&global_config.global.prefix)
+        .suffix(&global_config.global.service.publisher_data_segment_suffix)
+        .path_hint(&global_config.global.root_path())
 }
 
 pub(crate) fn node_monitoring_config<Service: crate::service::Service>(
     global_config: &config::Config,
 ) -> <Service::Monitoring as NamedConceptMgmt>::Configuration {
     <<Service::Monitoring as NamedConceptMgmt>::Configuration>::default()
-        .prefix(global_config.global.prefix)
-        .suffix(global_config.global.node.monitor_suffix)
-        .path_hint(global_config.global.node_dir())
+        .prefix(&global_config.global.prefix)
+        .suffix(&global_config.global.node.monitor_suffix)
+        .path_hint(&global_config.global.node_dir())
 }
 
 pub(crate) fn node_details_path(
@@ -91,9 +91,9 @@ pub(crate) fn node_details_config<Service: crate::service::Service>(
     node_id: &NodeId,
 ) -> <Service::StaticStorage as NamedConceptMgmt>::Configuration {
     <<Service::StaticStorage as NamedConceptMgmt>::Configuration>::default()
-        .prefix(global_config.global.prefix)
-        .suffix(global_config.global.node.static_config_suffix)
-        .path_hint(node_details_path(global_config, node_id))
+        .prefix(&global_config.global.prefix)
+        .suffix(&global_config.global.node.static_config_suffix)
+        .path_hint(&node_details_path(global_config, node_id))
 }
 
 pub(crate) fn service_tag_config<Service: crate::service::Service>(
@@ -101,7 +101,7 @@ pub(crate) fn service_tag_config<Service: crate::service::Service>(
     node_id: &NodeId,
 ) -> <Service::StaticStorage as NamedConceptMgmt>::Configuration {
     <<Service::StaticStorage as NamedConceptMgmt>::Configuration>::default()
-        .prefix(global_config.global.prefix)
-        .suffix(global_config.global.node.service_tag_suffix)
-        .path_hint(node_details_path(global_config, node_id))
+        .prefix(&global_config.global.prefix)
+        .suffix(&global_config.global.node.service_tag_suffix)
+        .path_hint(&node_details_path(global_config, node_id))
 }

--- a/iceoryx2/tests/node_tests.rs
+++ b/iceoryx2/tests/node_tests.rs
@@ -211,7 +211,7 @@ mod node {
             assert_node_presence::<S>(&node_details_2, &config);
         }
 
-        let mut path = config.global.root_path();
+        let mut path = *config.global.root_path();
         path.add_path_entry(&config.global.node.directory).unwrap();
         let _ = Directory::remove(&path);
     }


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
 * Contains the C/C++ binding for iceoryx2::config::Config
 * The C++ binding is implemented on basis of the C binding
 * One of the global configs use case is to configure multiple non-interacting iceoryx2 domains by defining either a unique global prefix or setting a unique global directory

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #264 
