### PR TITLE
[#98] add `iox2 nodes` cli 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
 
     "iceoryx2-cli/iox2",
     "iceoryx2-cli/iox2-introspect",
+    "iceoryx2-cli/iox2-nodes",
     "iceoryx2-cli/iox2-processes",
     "iceoryx2-cli/iox2-pub",
     "iceoryx2-cli/iox2-rpc",

--- a/iceoryx2-cli/iox2-nodes/Cargo.toml
+++ b/iceoryx2-cli/iox2-nodes/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "iox2-nodes"
+description = "CLI for managing iceoryx2 nodes"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+iceoryx2 = { workspace = true }
+iceoryx2-bb-log = { workspace = true }
+iceoryx2-cli-utils = { workspace = true }
+
+anyhow = { workspace = true }
+better-panic = { workspace = true }
+clap = { workspace = true }
+human-panic = { workspace = true }
+serde = { workspace = true }

--- a/iceoryx2-cli/iox2-nodes/Cargo.toml
+++ b/iceoryx2-cli/iox2-nodes/Cargo.toml
@@ -14,6 +14,7 @@ version = { workspace = true }
 iceoryx2 = { workspace = true }
 iceoryx2-bb-log = { workspace = true }
 iceoryx2-cli-utils = { workspace = true }
+iceoryx2-pal-posix = {workspace = true}
 
 anyhow = { workspace = true }
 better-panic = { workspace = true }

--- a/iceoryx2-cli/iox2-nodes/src/cli.rs
+++ b/iceoryx2-cli/iox2-nodes/src/cli.rs
@@ -10,11 +10,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use std::str::FromStr;
+
+use clap::Args;
 use clap::Parser;
 use clap::Subcommand;
+use clap::ValueEnum;
 
 use iceoryx2_cli_utils::help_template;
 use iceoryx2_cli_utils::Format;
+use iceoryx2_pal_posix::posix::pid_t;
 
 #[derive(Parser)]
 #[command(
@@ -30,20 +35,78 @@ pub struct Cli {
     #[clap(subcommand)]
     pub action: Option<Action>,
 
-    #[clap(long, short = 'f', value_enum, global = true)]
-    pub format: Option<Format>,
+    #[clap(long, short = 'f', value_enum, global = true, value_enum, default_value_t = Format::Ron)]
+    pub format: Format,
 }
 
-#[derive(Parser)]
+#[derive(Clone, Debug)]
+pub enum NodeIdentifier {
+    Name(String),
+    Id(String),
+    Pid(pid_t),
+}
+
+fn is_valid_hex(s: &str) -> bool {
+    s.len() == 32 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+impl FromStr for NodeIdentifier {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(pid) = s.parse::<pid_t>() {
+            Ok(NodeIdentifier::Pid(pid))
+        } else if is_valid_hex(s) {
+            Ok(NodeIdentifier::Id(s.to_string()))
+        } else {
+            Ok(NodeIdentifier::Name(s.to_string()))
+        }
+    }
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+#[clap(rename_all = "PascalCase")]
+#[derive(Default)]
+pub enum StateFilter {
+    Alive,
+    Dead,
+    Inaccessible,
+    Undefined,
+    #[default]
+    All,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct ListFilter {
+    #[clap(short, long, value_enum, default_value_t = StateFilter::All)]
+    pub state: StateFilter,
+}
+
+#[derive(Args)]
+pub struct ListOptions {
+    #[command(flatten)]
+    pub filter: ListFilter,
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct DetailsFilter {
+    #[clap(short, long, value_enum, default_value_t = StateFilter::All)]
+    pub state: StateFilter,
+}
+
+#[derive(Args)]
 pub struct DetailsOptions {
-    #[clap(help = "")]
-    pub node: String,
+    #[clap(help = "Name, ID or PID")]
+    pub node: NodeIdentifier,
+
+    #[command(flatten)]
+    pub filter: DetailsFilter,
 }
 
 #[derive(Subcommand)]
 pub enum Action {
-    #[clap(about = "")]
-    List,
-    #[clap(about = "")]
+    #[clap(about = "List all existing nodes")]
+    List(ListOptions),
+    #[clap(about = "Show details of an existing node")]
     Details(DetailsOptions),
 }

--- a/iceoryx2-cli/iox2-nodes/src/cli.rs
+++ b/iceoryx2-cli/iox2-nodes/src/cli.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use clap::Parser;
+use clap::Subcommand;
+
+use iceoryx2_cli_utils::help_template;
+use iceoryx2_cli_utils::Format;
+
+#[derive(Parser)]
+#[command(
+    name = "iox2-nodes",
+    about = "Query information about iceoryx2 nodes",
+    long_about = None,
+    version = env!("CARGO_PKG_VERSION"),
+    disable_help_subcommand = true,
+    arg_required_else_help = false,
+    help_template = help_template("iox2-nodes", false),
+)]
+pub struct Cli {
+    #[clap(subcommand)]
+    pub action: Option<Action>,
+
+    #[clap(long, short = 'f', value_enum, global = true)]
+    pub format: Option<Format>,
+}
+
+#[derive(Parser)]
+pub struct DetailsOptions {
+    #[clap(help = "")]
+    pub node: String,
+}
+
+#[derive(Subcommand)]
+pub enum Action {
+    #[clap(about = "")]
+    List,
+    #[clap(about = "")]
+    Details(DetailsOptions),
+}

--- a/iceoryx2-cli/iox2-nodes/src/cli.rs
+++ b/iceoryx2-cli/iox2-nodes/src/cli.rs
@@ -77,7 +77,7 @@ pub enum StateFilter {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct ListFilter {
+pub struct OutputFilter {
     #[clap(short, long, value_enum, default_value_t = StateFilter::All)]
     pub state: StateFilter,
 }
@@ -85,28 +85,22 @@ pub struct ListFilter {
 #[derive(Args)]
 pub struct ListOptions {
     #[command(flatten)]
-    pub filter: ListFilter,
-}
-
-#[derive(Debug, Clone, Args)]
-pub struct DetailsFilter {
-    #[clap(short, long, value_enum, default_value_t = StateFilter::All)]
-    pub state: StateFilter,
+    pub filter: OutputFilter,
 }
 
 #[derive(Args)]
 pub struct DetailsOptions {
-    #[clap(help = "Name, ID or PID")]
+    #[clap(help = "Name, ID or PID of the node")]
     pub node: NodeIdentifier,
 
     #[command(flatten)]
-    pub filter: DetailsFilter,
+    pub filter: OutputFilter,
 }
 
 #[derive(Subcommand)]
 pub enum Action {
-    #[clap(about = "List all existing nodes")]
+    #[clap(about = "List all nodes")]
     List(ListOptions),
-    #[clap(about = "Show details of an existing node")]
+    #[clap(about = "Show details of a node")]
     Details(DetailsOptions),
 }

--- a/iceoryx2-cli/iox2-nodes/src/commands.rs
+++ b/iceoryx2-cli/iox2-nodes/src/commands.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use anyhow::{Context, Result};
+use iceoryx2::prelude::*;
+use iceoryx2_cli_utils::output::NodeDescriptor;
+use iceoryx2_cli_utils::output::NodeList;
+use iceoryx2_cli_utils::Format;
+
+pub fn list(format: Format) -> Result<()> {
+    let mut nodes = Vec::<NodeDescriptor>::new();
+    Node::<ipc::Service>::list(Config::global_config(), |node_state| {
+        nodes.push(NodeDescriptor::from(&node_state));
+        CallbackProgression::Continue
+    })
+    .context("failed to retrieve nodes")?;
+
+    print!(
+        "{}",
+        format.as_string(&NodeList {
+            num: nodes.len(),
+            details: nodes
+        })?
+    );
+
+    Ok(())
+}

--- a/iceoryx2-cli/iox2-nodes/src/commands.rs
+++ b/iceoryx2-cli/iox2-nodes/src/commands.rs
@@ -18,11 +18,10 @@ use iceoryx2_cli_utils::output::NodeList;
 use iceoryx2_cli_utils::Filter;
 use iceoryx2_cli_utils::Format;
 
-use crate::cli::DetailsFilter;
-use crate::cli::ListFilter;
 use crate::cli::NodeIdentifier;
+use crate::cli::OutputFilter;
 
-pub fn list(filter: ListFilter, format: Format) -> Result<()> {
+pub fn list(filter: OutputFilter, format: Format) -> Result<()> {
     let mut nodes = Vec::<NodeDescriptor>::new();
     Node::<ipc::Service>::list(Config::global_config(), |node| {
         if filter.matches(&node) {
@@ -43,7 +42,7 @@ pub fn list(filter: ListFilter, format: Format) -> Result<()> {
     Ok(())
 }
 
-pub fn details(identifier: NodeIdentifier, filter: DetailsFilter, format: Format) -> Result<()> {
+pub fn details(identifier: NodeIdentifier, filter: OutputFilter, format: Format) -> Result<()> {
     let mut error: Option<Error> = None;
 
     Node::<ipc::Service>::list(Config::global_config(), |node| {

--- a/iceoryx2-cli/iox2-nodes/src/filter.rs
+++ b/iceoryx2-cli/iox2-nodes/src/filter.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::cli::DetailsFilter;
+use crate::cli::ListFilter;
+use crate::cli::NodeIdentifier;
+use crate::cli::StateFilter;
+use iceoryx2::node::NodeState;
+use iceoryx2::node::NodeView;
+use iceoryx2::service::ipc::Service;
+use iceoryx2_cli_utils::output::NodeIdString;
+use iceoryx2_cli_utils::Filter;
+
+impl Filter<NodeState<Service>> for NodeIdentifier {
+    fn matches(&self, node: &NodeState<Service>) -> bool {
+        match self {
+            NodeIdentifier::Name(ref name) => match node {
+                NodeState::Alive(view) => view
+                    .details()
+                    .as_ref()
+                    .map(|details| details.name().as_str() == name)
+                    .unwrap_or(false),
+                NodeState::Dead(view) => view
+                    .details()
+                    .as_ref()
+                    .map(|details| details.name().as_str() == name)
+                    .unwrap_or(false),
+                NodeState::Inaccessible(_) | NodeState::Undefined(_) => false,
+            },
+            NodeIdentifier::Id(ref id) => match node {
+                NodeState::Alive(view) => NodeIdString::from(view.id()) == **id,
+                NodeState::Dead(view) => NodeIdString::from(view.id()) == **id,
+                NodeState::Inaccessible(node_id) => NodeIdString::from(node_id) == **id,
+                NodeState::Undefined(node_id) => NodeIdString::from(node_id) == **id,
+            },
+            NodeIdentifier::Pid(pid) => match node {
+                NodeState::Alive(view) => view.id().pid().value() == *pid,
+                NodeState::Dead(view) => view.id().pid().value() == *pid,
+                NodeState::Inaccessible(node_id) => node_id.pid().value() == *pid,
+                NodeState::Undefined(node_id) => node_id.pid().value() == *pid,
+            },
+        }
+    }
+}
+
+impl Filter<NodeState<Service>> for StateFilter {
+    fn matches(&self, node: &NodeState<Service>) -> bool {
+        matches!(
+            (self, node),
+            (StateFilter::Alive, NodeState::Alive(_))
+                | (StateFilter::Dead, NodeState::Dead(_))
+                | (StateFilter::Inaccessible, NodeState::Inaccessible(_))
+                | (StateFilter::Undefined, NodeState::Undefined(_))
+                | (StateFilter::All, _)
+        )
+    }
+}
+
+impl Filter<NodeState<Service>> for ListFilter {
+    fn matches(&self, node: &NodeState<Service>) -> bool {
+        self.state.matches(node)
+    }
+}
+
+impl Filter<NodeState<Service>> for DetailsFilter {
+    fn matches(&self, node: &NodeState<Service>) -> bool {
+        self.state.matches(node)
+    }
+}

--- a/iceoryx2-cli/iox2-nodes/src/filter.rs
+++ b/iceoryx2-cli/iox2-nodes/src/filter.rs
@@ -10,9 +10,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::cli::DetailsFilter;
-use crate::cli::ListFilter;
 use crate::cli::NodeIdentifier;
+use crate::cli::OutputFilter;
 use crate::cli::StateFilter;
 use iceoryx2::node::NodeState;
 use iceoryx2::node::NodeView;
@@ -65,13 +64,7 @@ impl Filter<NodeState<Service>> for StateFilter {
     }
 }
 
-impl Filter<NodeState<Service>> for ListFilter {
-    fn matches(&self, node: &NodeState<Service>) -> bool {
-        self.state.matches(node)
-    }
-}
-
-impl Filter<NodeState<Service>> for DetailsFilter {
+impl Filter<NodeState<Service>> for OutputFilter {
     fn matches(&self, node: &NodeState<Service>) -> bool {
         self.state.matches(node)
     }

--- a/iceoryx2-cli/iox2-nodes/src/main.rs
+++ b/iceoryx2-cli/iox2-nodes/src/main.rs
@@ -12,12 +12,12 @@
 
 mod cli;
 mod commands;
+mod filter;
 
 use clap::CommandFactory;
 use clap::Parser;
 use cli::Cli;
 use iceoryx2_bb_log::{set_log_level, LogLevel};
-use iceoryx2_cli_utils::Format;
 
 #[cfg(not(debug_assertions))]
 use human_panic::setup_panic;
@@ -44,12 +44,17 @@ fn main() {
         Ok(cli) => {
             if let Some(action) = cli.action {
                 match action {
-                    cli::Action::List => {
-                        if let Err(e) = commands::list(cli.format.unwrap_or(Format::Ron)) {
+                    cli::Action::List(options) => {
+                        if let Err(e) = commands::list(options.filter, cli.format) {
                             eprintln!("Failed to list nodes: {}", e);
                         }
                     }
-                    cli::Action::Details(_) => todo!(),
+                    cli::Action::Details(options) => {
+                        if let Err(e) = commands::details(options.node, options.filter, cli.format)
+                        {
+                            eprintln!("Failed to retrieve node details: {}", e);
+                        }
+                    }
                 }
             } else {
                 Cli::command().print_help().expect("Failed to print help");

--- a/iceoryx2-cli/iox2-nodes/src/main.rs
+++ b/iceoryx2-cli/iox2-nodes/src/main.rs
@@ -16,6 +16,7 @@ mod filter;
 
 use clap::CommandFactory;
 use clap::Parser;
+use cli::Action;
 use cli::Cli;
 use iceoryx2_bb_log::{set_log_level, LogLevel};
 
@@ -44,12 +45,12 @@ fn main() {
         Ok(cli) => {
             if let Some(action) = cli.action {
                 match action {
-                    cli::Action::List(options) => {
+                    Action::List(options) => {
                         if let Err(e) = commands::list(options.filter, cli.format) {
                             eprintln!("Failed to list nodes: {}", e);
                         }
                     }
-                    cli::Action::Details(options) => {
+                    Action::Details(options) => {
                         if let Err(e) = commands::details(options.node, options.filter, cli.format)
                         {
                             eprintln!("Failed to retrieve node details: {}", e);

--- a/iceoryx2-cli/iox2-nodes/src/main.rs
+++ b/iceoryx2-cli/iox2-nodes/src/main.rs
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+mod cli;
+mod commands;
+
+use clap::CommandFactory;
+use clap::Parser;
+use cli::Cli;
+use iceoryx2_bb_log::{set_log_level, LogLevel};
+use iceoryx2_cli_utils::Format;
+
+#[cfg(not(debug_assertions))]
+use human_panic::setup_panic;
+#[cfg(debug_assertions)]
+extern crate better_panic;
+
+fn main() {
+    #[cfg(not(debug_assertions))]
+    {
+        setup_panic!();
+    }
+    #[cfg(debug_assertions)]
+    {
+        better_panic::Settings::debug()
+            .most_recent_first(false)
+            .lineno_suffix(true)
+            .verbosity(better_panic::Verbosity::Full)
+            .install();
+    }
+
+    set_log_level(LogLevel::Warn);
+
+    match Cli::try_parse() {
+        Ok(cli) => {
+            if let Some(action) = cli.action {
+                match action {
+                    cli::Action::List => {
+                        if let Err(e) = commands::list(cli.format.unwrap_or(Format::Ron)) {
+                            eprintln!("Failed to list nodes: {}", e);
+                        }
+                    }
+                    cli::Action::Details(_) => todo!(),
+                }
+            } else {
+                Cli::command().print_help().expect("Failed to print help");
+            }
+        }
+        Err(e) => {
+            eprintln!("{}", e);
+        }
+    }
+}

--- a/iceoryx2-cli/iox2-services/Cargo.toml
+++ b/iceoryx2-cli/iox2-services/Cargo.toml
@@ -10,8 +10,6 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 iceoryx2 = { workspace = true }
 iceoryx2-bb-log = { workspace = true }

--- a/iceoryx2-cli/iox2-services/src/cli.rs
+++ b/iceoryx2-cli/iox2-services/src/cli.rs
@@ -32,8 +32,8 @@ pub struct Cli {
     #[clap(subcommand)]
     pub action: Option<Action>,
 
-    #[clap(long, short = 'f', value_enum, global = true)]
-    pub format: Option<Format>,
+    #[clap(long, short = 'f', value_enum, global = true, value_enum, default_value_t = Format::Ron)]
+    pub format: Format,
 }
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -47,9 +47,15 @@ pub enum MessagingPatternFilter {
 }
 
 #[derive(Debug, Clone, Args)]
-pub struct DetailsFilter {
+pub struct OutputFilter {
     #[clap(short, long, value_enum, default_value_t = MessagingPatternFilter::All)]
     pub pattern: MessagingPatternFilter,
+}
+
+#[derive(Args)]
+pub struct ListOptions {
+    #[command(flatten)]
+    pub filter: OutputFilter,
 }
 
 #[derive(Parser)]
@@ -58,13 +64,13 @@ pub struct DetailsOptions {
     pub service: String,
 
     #[command(flatten)]
-    pub filter: DetailsFilter,
+    pub filter: OutputFilter,
 }
 
 #[derive(Subcommand)]
 pub enum Action {
-    #[clap(about = "List all existing services")]
-    List,
-    #[clap(about = "Show details of an existing service")]
+    #[clap(about = "List all services")]
+    List(ListOptions),
+    #[clap(about = "Show service details")]
     Details(DetailsOptions),
 }

--- a/iceoryx2-cli/iox2-services/src/cli.rs
+++ b/iceoryx2-cli/iox2-services/src/cli.rs
@@ -16,8 +16,7 @@ use clap::Subcommand;
 use clap::ValueEnum;
 
 use iceoryx2_cli_utils::help_template;
-
-use crate::Format;
+use iceoryx2_cli_utils::Format;
 
 #[derive(Parser)]
 #[command(

--- a/iceoryx2-cli/iox2-services/src/commands.rs
+++ b/iceoryx2-cli/iox2-services/src/commands.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::cli::DetailsFilter;
 use anyhow::{Context, Error, Result};
 use iceoryx2::prelude::*;
 use iceoryx2_cli_utils::output::ServiceDescription;
@@ -18,6 +17,8 @@ use iceoryx2_cli_utils::output::ServiceDescriptor;
 use iceoryx2_cli_utils::output::ServiceList;
 use iceoryx2_cli_utils::Filter;
 use iceoryx2_cli_utils::Format;
+
+use crate::cli::DetailsFilter;
 
 pub fn list(format: Format) -> Result<()> {
     let mut services = ServiceList::new();

--- a/iceoryx2-cli/iox2-services/src/commands.rs
+++ b/iceoryx2-cli/iox2-services/src/commands.rs
@@ -11,9 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::cli::DetailsFilter;
-use crate::output::*;
 use anyhow::{Context, Error, Result};
 use iceoryx2::prelude::*;
+use iceoryx2_cli_utils::output::ServiceDescription;
+use iceoryx2_cli_utils::output::ServiceDescriptor;
+use iceoryx2_cli_utils::output::ServiceList;
 use iceoryx2_cli_utils::Filter;
 use iceoryx2_cli_utils::Format;
 

--- a/iceoryx2-cli/iox2-services/src/filter.rs
+++ b/iceoryx2-cli/iox2-services/src/filter.rs
@@ -10,16 +10,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::cli::DetailsFilter;
 use crate::cli::MessagingPatternFilter;
+use crate::cli::OutputFilter;
+use iceoryx2::service::ipc::Service;
 use iceoryx2::service::static_config::messaging_pattern::MessagingPattern;
-use iceoryx2_cli_utils::output::ServiceDescription;
+use iceoryx2::service::ServiceDetails;
 use iceoryx2_cli_utils::Filter;
 
-impl Filter<ServiceDescription> for MessagingPatternFilter {
-    fn matches(&self, description: &ServiceDescription) -> bool {
+impl Filter<ServiceDetails<Service>> for MessagingPatternFilter {
+    fn matches(&self, service: &ServiceDetails<Service>) -> bool {
         matches!(
-            (self, &description.pattern),
+            (self, &service.static_details.messaging_pattern()),
             (
                 MessagingPatternFilter::PublishSubscribe,
                 MessagingPattern::PublishSubscribe(_)
@@ -29,8 +30,8 @@ impl Filter<ServiceDescription> for MessagingPatternFilter {
     }
 }
 
-impl Filter<ServiceDescription> for DetailsFilter {
-    fn matches(&self, description: &ServiceDescription) -> bool {
-        self.pattern.matches(description)
+impl Filter<ServiceDetails<Service>> for OutputFilter {
+    fn matches(&self, service: &ServiceDetails<Service>) -> bool {
+        self.pattern.matches(service)
     }
 }

--- a/iceoryx2-cli/iox2-services/src/filter.rs
+++ b/iceoryx2-cli/iox2-services/src/filter.rs
@@ -12,8 +12,8 @@
 
 use crate::cli::DetailsFilter;
 use crate::cli::MessagingPatternFilter;
-use crate::output::ServiceDescription;
 use iceoryx2::service::static_config::messaging_pattern::MessagingPattern;
+use iceoryx2_cli_utils::output::ServiceDescription;
 use iceoryx2_cli_utils::Filter;
 
 impl Filter<ServiceDescription> for MessagingPatternFilter {

--- a/iceoryx2-cli/iox2-services/src/main.rs
+++ b/iceoryx2-cli/iox2-services/src/main.rs
@@ -18,7 +18,6 @@ extern crate better_panic;
 mod cli;
 mod commands;
 mod filter;
-mod output;
 
 use clap::CommandFactory;
 use clap::Parser;

--- a/iceoryx2-cli/iox2-services/src/main.rs
+++ b/iceoryx2-cli/iox2-services/src/main.rs
@@ -24,7 +24,6 @@ use clap::Parser;
 use cli::Action;
 use cli::Cli;
 use iceoryx2_bb_log::{set_log_level, LogLevel};
-use iceoryx2_cli_utils::Format;
 
 fn main() {
     #[cfg(not(debug_assertions))]
@@ -46,17 +45,15 @@ fn main() {
         Ok(cli) => {
             if let Some(action) = cli.action {
                 match action {
-                    Action::List => {
-                        if let Err(e) = commands::list(cli.format.unwrap_or(Format::Ron)) {
+                    Action::List(options) => {
+                        if let Err(e) = commands::list(options.filter, cli.format) {
                             eprintln!("Failed to list services: {}", e);
                         }
                     }
                     Action::Details(options) => {
-                        if let Err(e) = commands::details(
-                            options.service,
-                            options.filter,
-                            cli.format.unwrap_or(Format::Ron),
-                        ) {
+                        if let Err(e) =
+                            commands::details(options.service, options.filter, cli.format)
+                        {
                             eprintln!("Failed to retrieve service details: {}", e);
                         }
                     }

--- a/iceoryx2-cli/iox2/src/cli.rs
+++ b/iceoryx2-cli/iox2/src/cli.rs
@@ -36,13 +36,6 @@ pub struct Cli {
     pub paths: bool,
 
     #[arg(
-        short,
-        long,
-        help = "Specify to execute development versions of commands if they exist"
-    )]
-    pub dev: bool,
-
-    #[arg(
         hide = true,
         required = false,
         trailing_var_arg = true,

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -21,6 +21,7 @@ mod commands;
 
 use clap::CommandFactory;
 use clap::Parser;
+use cli::Cli;
 
 fn main() {
     #[cfg(not(debug_assertions))]
@@ -36,29 +37,32 @@ fn main() {
             .install();
     }
 
-    let cli = cli::Cli::parse();
-
-    if cli.list {
-        if let Err(e) = commands::list() {
-            eprintln!("Failed to list commands: {}", e);
+    match Cli::try_parse() {
+        Ok(cli) => {
+            if cli.list {
+                if let Err(e) = commands::list() {
+                    eprintln!("Failed to list commands: {}", e);
+                }
+            } else if cli.paths {
+                if let Err(e) = commands::paths() {
+                    eprintln!("Failed to list search paths: {}", e);
+                }
+            } else if !cli.external_command.is_empty() {
+                let command_name = &cli.external_command[0];
+                let command_args = if cli.external_command.len() > 1 {
+                    Some(&cli.external_command[1..])
+                } else {
+                    None
+                };
+                if let Err(e) = commands::execute(command_name, command_args) {
+                    eprintln!("Failed to execute command: {}", e);
+                }
+            } else {
+                Cli::command().print_help().expect("Failed to print help");
+            }
         }
-    } else if cli.paths {
-        if let Err(e) = commands::paths() {
-            eprintln!("Failed to list search paths: {}", e);
+        Err(e) => {
+            eprintln!("{}", e);
         }
-    } else if !cli.external_command.is_empty() {
-        let command_name = &cli.external_command[0];
-        let command_args = if cli.external_command.len() > 1 {
-            Some(&cli.external_command[1..])
-        } else {
-            None
-        };
-        if let Err(e) = commands::execute(command_name, command_args) {
-            eprintln!("Failed to execute command: {}", e);
-        }
-    } else {
-        cli::Cli::command()
-            .print_help()
-            .expect("Unrecognized CLI input. Exiting.");
     }
 }

--- a/iceoryx2-cli/utils/Cargo.toml
+++ b/iceoryx2-cli/utils/Cargo.toml
@@ -13,6 +13,8 @@ version = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+iceoryx2 = { workspace = true }
+
 anyhow = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }

--- a/iceoryx2-cli/utils/Cargo.toml
+++ b/iceoryx2-cli/utils/Cargo.toml
@@ -14,6 +14,7 @@ version = { workspace = true }
 
 [dependencies]
 iceoryx2 = { workspace = true }
+iceoryx2-pal-posix = {workspace = true}
 
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/iceoryx2-cli/utils/src/lib.rs
+++ b/iceoryx2-cli/utils/src/lib.rs
@@ -14,6 +14,8 @@ mod cli;
 mod filter;
 mod format;
 
+pub mod output;
+
 pub use cli::help_template;
 pub use filter::Filter;
 pub use format::Format;


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

1. enables commands `iox2 nodes list` and `iox2 nodes details`
    1. node ids are represented as hex rather than separate elements (pid, timestamps, counter)
    1. to retrieve node details, node id (as hex), node name, or pid can be provided
        1. if there are multiple nodes matching, all nodes should be provided
    1. output can be filtered by node state (Alive, Dead, etc.)
    1. functionality for outputting in multiple formats has been inherited (RON, JSON, YAML)
3. cleanliness tweaks across all cli
    1. made implementations consistent
    3. reused output structs across clis

**Usage:**

<details>
<summary>iox2-nodes</summary>

```bash
$ iox2-nodes --help
Query information about iceoryx2 nodes

Usage: iox2-nodes [OPTIONS] [COMMAND]

Options:
  -f, --format <FORMAT>  [default: RON] [possible values: RON, JSON, YAML]
  -h, --help             Print help
  -V, --version          Print version

Commands:
  list     List all existing nodes
  details  Show details of an existing node
```

</details>

<details>
<summary>iox2-nodes list</summary>

```bash
$ iox2-nodes list --help
List all existing nodes

Usage: iox2-nodes list [OPTIONS]

Options:
  -s, --state <STATE>    [default: All] [possible values: Alive, Dead, Inaccessible, Undefined, All]
  -f, --format <FORMAT>  [default: RON] [possible values: RON, JSON, YAML]
  -h, --help             Print help
```

```bash
$ iox2-nodes list 
(
    num: 1,
    details: [
        (
            state: Alive,
            id: ("00000000059fd39166e761ac0003d3e7"),
            pid: 250855,
            executable: Some("publish_subscribe_subscriber"),
            name: Some(""),
        ),
    ],
)
```

</details>

<details>
<summary>iox2-nodes details</summary>

```bash
$ iox2-nodes details --help
Show details of an existing node

Usage: iox2-nodes details [OPTIONS] <NODE>

Arguments:
  <NODE>  Name, ID or PID

Options:
  -s, --state <STATE>    [default: All] [possible values: Alive, Dead, Inaccessible, Undefined, All]
  -f, --format <FORMAT>  [default: RON] [possible values: RON, JSON, YAML]
  -h, --help             Print help
```

```bash
$ iox2-nodes details 250855
{
    "state": Alive,
    "id": ("00000000059fd39166e761ac0003d3e7"),
    "pid": 250855,
    "executable": "publish_subscribe_subscriber",
    "name": "",
    "config": (
        global: (
            r#root-path-unix: "/tmp/iceoryx2/",
            r#root-path-windows: "c:\\Temp\\iceoryx2\\",
            prefix: "iox2_",
            service: (
                directory: "services",
                r#publisher-data-segment-suffix: ".publisher_data",
                r#static-config-storage-suffix: ".service",
                r#dynamic-config-storage-suffix: ".dynamic",
                r#creation-timeout: (
                    secs: 0,
                    nanos: 500000000,
                ),
                r#connection-suffix: ".connection",
                r#event-connection-suffix: ".event",
            ),
            node: (
                directory: "nodes",
                r#monitor-suffix: ".node_monitor",
                r#static-config-suffix: ".details",
                r#service-tag-suffix: ".service_tag",
                r#cleanup-dead-nodes-on-creation: true,
                r#cleanup-dead-nodes-on-destruction: true,
            ),
        ),
        defaults: (
            r#publish-subscribe: (
                r#max-subscribers: 8,
                r#max-publishers: 2,
                r#max-nodes: 20,
                r#subscriber-max-buffer-size: 2,
                r#subscriber-max-borrowed-samples: 2,
                r#publisher-max-loaned-samples: 2,
                r#publisher-history-size: 1,
                r#enable-safe-overflow: true,
                r#unable-to-deliver-strategy: "Block",
                r#subscriber-expired-connection-buffer: 128,
            ),
            event: (
                r#max-listeners: 2,
                r#max-notifiers: 16,
                r#max-nodes: 36,
                r#event-id-max-value: 32,
            ),
        ),
    ),
}
```

</details>

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] ~~Tests follow the [best practice for testing][testing]~~
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #98 <!-- Add issue number after '#' -->
