### PR TITLE
[#401] Lock-free Atomics for 32-bit architectures

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -23,9 +23,11 @@ insufficient, a new publisher with a larger `max_slice_len` can be created.
 
 ## How To Make 32-bit and 64-bit iceoryx2 Applications Interoperatable
 
-Use the feature flag `enforce_32bit_rwlock_atomic` which enforces 32-bit atomics
-for all targets at the cost of the lock-free guarantee. Meaning, when an
-application crashes at the wrong point in time it can lead to a system deadlock.
+This is currently not possible since we cannot guarantee to have the same
+layout of the data structures in the shared memory. On 32-bit architectures
+64-bit POD are aligned to a 4 byte boundary but to a 8 byte boundary on
+64-bit architectures. Some additional work is required to make 32-bit and
+64-bit applications interoperabel.
 
 ## My Transmission Type Is Too Large, Encounter Stack Overflow On Initialization
 

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -87,6 +87,8 @@
   [#370](https://github.com/eclipse-iceoryx/iceoryx2/issues/370)
 * Add colcon package for iceoryx2 with C/C++ bindings
   [#381](https://github.com/eclipse-iceoryx/iceoryx2/issues/381)
+* Lock-free atomics on 32-bit architectures
+  [#401](https://github.com/eclipse-iceoryx/iceoryx2/issues/401)
 
 ### Bugfixes
 

--- a/iceoryx2-pal/concurrency-sync/Cargo.toml
+++ b/iceoryx2-pal/concurrency-sync/Cargo.toml
@@ -10,11 +10,6 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }
 
-[features]
-# Enables 64-bit applications to communicate with 32-bit applications at the cost of being no
-# longer lock-free. Meaning, a crash at the wrong time can lead to a system deadlock.
-enforce_32bit_rwlock_atomic = []
-
 [dependencies]
 
 [dev-dependencies]

--- a/iceoryx2-pal/concurrency-sync/src/iox_atomic.rs
+++ b/iceoryx2-pal/concurrency-sync/src/iox_atomic.rs
@@ -55,29 +55,13 @@ pub type IoxAtomicI16 = core::sync::atomic::AtomicI16;
 #[allow(clippy::disallowed_types)]
 pub type IoxAtomicI32 = core::sync::atomic::AtomicI32;
 
-#[cfg(all(
-    target_pointer_width = "64",
-    not(feature = "enforce_32bit_rwlock_atomic")
-))]
 /// Behaves like [`core::sync::atomic::AtomicI64`]
 #[allow(clippy::disallowed_types)]
 pub type IoxAtomicI64 = core::sync::atomic::AtomicI64;
 
-#[cfg(all(
-    target_pointer_width = "64",
-    not(feature = "enforce_32bit_rwlock_atomic")
-))]
 /// Behaves like [`core::sync::atomic::AtomicU64`]
 #[allow(clippy::disallowed_types)]
 pub type IoxAtomicU64 = core::sync::atomic::AtomicU64;
-
-#[cfg(any(target_pointer_width = "32", feature = "enforce_32bit_rwlock_atomic"))]
-/// Non lock-free implementation that behaves like [`core::sync::atomic::AtomicI64`]
-pub type IoxAtomicI64 = IoxAtomic<i64>;
-
-#[cfg(any(target_pointer_width = "32", feature = "enforce_32bit_rwlock_atomic"))]
-/// Non lock-free implementation that behaves like [`core::sync::atomic::AtomicU64`]
-pub type IoxAtomicU64 = IoxAtomic<u64>;
 
 type LockType = RwLockWriterPreference;
 

--- a/iceoryx2/Cargo.toml
+++ b/iceoryx2/Cargo.toml
@@ -16,9 +16,6 @@ version = { workspace = true }
 logger_log = ["iceoryx2-bb-log/logger_log"]
 # Enables https://crates.io/crates/tracing as default logger
 logger_tracing = ["iceoryx2-bb-log/logger_tracing"]
-# Enables 64-bit applications to communicate with 32-bit applications at the cost of being no
-# longer lock-free. Meaning, a crash at the wrong time can lead to a system deadlock.
-enforce_32bit_rwlock_atomic = ["iceoryx2-pal-concurrency-sync/enforce_32bit_rwlock_atomic"]
 
 [dependencies]
 iceoryx2-bb-container = { workspace = true }

--- a/iceoryx2/src/lib.rs
+++ b/iceoryx2/src/lib.rs
@@ -270,10 +270,6 @@
 //!  * `logger_log` - Uses the [log crate](https://crates.io/crates/log) as default log backend
 //!  * `logger_tracing` - Uses the [tracing crate](https://crates.io/crates/tracing) as default log
 //!     backend
-//!  * `enforce_32bit_rwlock_atomic` - Enforces the 32-bit atomic also on 64-bit platforms. Enables
-//!     32-bit and 64-bit applications to communicate but at the expense of the lock-free
-//!     guarantee. Enabling the feature can cause a deadlock of the whole system when one
-//!     application crashes at the wrong time.
 //!
 //! # Custom Configuration
 //!


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR enables lock-free atomics for 32-bit architectures. Since all common 32-bit architectures support 8 byte CAS operations, the reader-writer lock implementation is not required.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Unit tests have been written for new behavior
- [ ] Public API is documented
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #401
