### PR TITLE
[#210] Fix node and service name C API

### DIFF
--- a/iceoryx2-ffi/cxx/src/node_name.cpp
+++ b/iceoryx2-ffi/cxx/src/node_name.cpp
@@ -20,13 +20,13 @@
 namespace iox2 {
 auto NodeNameView::to_string() const -> iox::string<IOX2_NODE_NAME_LENGTH> {
     size_t len = 0;
-    const auto* c_ptr = iox2_node_name_as_c_str(m_ptr, &len);
+    const auto* c_ptr = iox2_node_name_as_str(m_ptr, &len);
     return { iox::TruncateToCapacity, c_ptr, len };
 }
 
 auto NodeNameView::to_owned() const -> NodeName {
     size_t len = 0;
-    const auto* c_ptr = iox2_node_name_as_c_str(m_ptr, &len);
+    const auto* c_ptr = iox2_node_name_as_str(m_ptr, &len);
     return NodeName::create_impl(c_ptr, len).expect("NodeNameView contains always valid NodeName");
 }
 
@@ -68,7 +68,7 @@ auto NodeName::operator=(const NodeName& rhs) -> NodeName& {
 
         const auto* ptr = iox2_cast_node_name_ptr(rhs.m_handle);
         size_t len = 0;
-        const auto* c_ptr = iox2_node_name_as_c_str(ptr, &len);
+        const auto* c_ptr = iox2_node_name_as_str(ptr, &len);
         IOX_ASSERT(iox2_node_name_new(nullptr, c_ptr, len, &m_handle) == IOX2_OK,
                    "NodeName shall always contain a valid value.");
     }

--- a/iceoryx2-ffi/cxx/src/node_name.cpp
+++ b/iceoryx2-ffi/cxx/src/node_name.cpp
@@ -20,14 +20,14 @@
 namespace iox2 {
 auto NodeNameView::to_string() const -> iox::string<IOX2_NODE_NAME_LENGTH> {
     size_t len = 0;
-    const auto* c_ptr = iox2_node_name_as_str(m_ptr, &len);
-    return { iox::TruncateToCapacity, c_ptr, len };
+    const auto* chars = iox2_node_name_as_chars(m_ptr, &len);
+    return { iox::TruncateToCapacity, chars, len };
 }
 
 auto NodeNameView::to_owned() const -> NodeName {
     size_t len = 0;
-    const auto* c_ptr = iox2_node_name_as_str(m_ptr, &len);
-    return NodeName::create_impl(c_ptr, len).expect("NodeNameView contains always valid NodeName");
+    const auto* chars = iox2_node_name_as_chars(m_ptr, &len);
+    return NodeName::create_impl(chars, len).expect("NodeNameView contains always valid NodeName");
 }
 
 NodeNameView::NodeNameView(iox2_node_name_ptr ptr)
@@ -68,8 +68,8 @@ auto NodeName::operator=(const NodeName& rhs) -> NodeName& {
 
         const auto* ptr = iox2_cast_node_name_ptr(rhs.m_handle);
         size_t len = 0;
-        const auto* c_ptr = iox2_node_name_as_str(ptr, &len);
-        IOX_ASSERT(iox2_node_name_new(nullptr, c_ptr, len, &m_handle) == IOX2_OK,
+        const auto* chars = iox2_node_name_as_chars(ptr, &len);
+        IOX_ASSERT(iox2_node_name_new(nullptr, chars, len, &m_handle) == IOX2_OK,
                    "NodeName shall always contain a valid value.");
     }
 

--- a/iceoryx2-ffi/cxx/src/service_name.cpp
+++ b/iceoryx2-ffi/cxx/src/service_name.cpp
@@ -19,13 +19,13 @@
 namespace iox2 {
 auto ServiceNameView::to_string() const -> iox::string<IOX2_NODE_NAME_LENGTH> {
     size_t len = 0;
-    const auto* c_ptr = iox2_service_name_as_c_str(m_ptr, &len);
+    const auto* c_ptr = iox2_service_name_as_str(m_ptr, &len);
     return { iox::TruncateToCapacity, c_ptr, len };
 }
 
 auto ServiceNameView::to_owned() const -> ServiceName {
     size_t len = 0;
-    const auto* c_ptr = iox2_service_name_as_c_str(m_ptr, &len);
+    const auto* c_ptr = iox2_service_name_as_str(m_ptr, &len);
     return ServiceName::create_impl(c_ptr, len).expect("ServiceNameView always contains valid ServiceName");
 }
 
@@ -67,7 +67,7 @@ auto ServiceName::operator=(const ServiceName& rhs) -> ServiceName& {
 
         const auto* ptr = iox2_cast_service_name_ptr(rhs.m_handle);
         size_t len = 0;
-        const auto* c_ptr = iox2_service_name_as_c_str(ptr, &len);
+        const auto* c_ptr = iox2_service_name_as_str(ptr, &len);
         IOX_ASSERT(iox2_service_name_new(nullptr, c_ptr, len, &m_handle) == IOX2_OK,
                    "ServiceName shall always contain a valid value.");
     }

--- a/iceoryx2-ffi/cxx/src/service_name.cpp
+++ b/iceoryx2-ffi/cxx/src/service_name.cpp
@@ -19,14 +19,14 @@
 namespace iox2 {
 auto ServiceNameView::to_string() const -> iox::string<IOX2_NODE_NAME_LENGTH> {
     size_t len = 0;
-    const auto* c_ptr = iox2_service_name_as_str(m_ptr, &len);
-    return { iox::TruncateToCapacity, c_ptr, len };
+    const auto* chars = iox2_service_name_as_chars(m_ptr, &len);
+    return { iox::TruncateToCapacity, chars, len };
 }
 
 auto ServiceNameView::to_owned() const -> ServiceName {
     size_t len = 0;
-    const auto* c_ptr = iox2_service_name_as_str(m_ptr, &len);
-    return ServiceName::create_impl(c_ptr, len).expect("ServiceNameView always contains valid ServiceName");
+    const auto* chars = iox2_service_name_as_chars(m_ptr, &len);
+    return ServiceName::create_impl(chars, len).expect("ServiceNameView always contains valid ServiceName");
 }
 
 ServiceNameView::ServiceNameView(iox2_service_name_ptr ptr)
@@ -67,8 +67,8 @@ auto ServiceName::operator=(const ServiceName& rhs) -> ServiceName& {
 
         const auto* ptr = iox2_cast_service_name_ptr(rhs.m_handle);
         size_t len = 0;
-        const auto* c_ptr = iox2_service_name_as_str(ptr, &len);
-        IOX_ASSERT(iox2_service_name_new(nullptr, c_ptr, len, &m_handle) == IOX2_OK,
+        const auto* chars = iox2_service_name_as_chars(ptr, &len);
+        IOX_ASSERT(iox2_service_name_new(nullptr, chars, len, &m_handle) == IOX2_OK,
                    "ServiceName shall always contain a valid value.");
     }
 

--- a/iceoryx2-ffi/ffi/src/api/node_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/node_name.rs
@@ -158,21 +158,21 @@ pub unsafe extern "C" fn iox2_cast_node_name_ptr(
     (*node_name_handle.as_type()).value.as_ref()
 }
 
-/// This function gives access to the node name as a non-zero-terminated char string
+/// This function gives access to the node name as a non-zero-terminated char array
 ///
 /// # Arguments
 ///
 /// * `node_name_ptr` obtained by e.g. [`iox2_cast_node_name_ptr`] or a function returning a [`iox2_node_name_ptr`]
-/// * `node_name_len` must be used to get the length of the char string
+/// * `node_name_len` must be used to get the length of the char array
 ///
-/// Returns a non-zero-terminated char string
+/// Returns a non-zero-terminated char array
 ///
 /// # Safety
 ///
 /// * The `node_name_ptr` must be a valid pointer to a node name.
 /// * The `node_name_len` must be a valid pointer to a size_t.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_node_name_as_str(
+pub unsafe extern "C" fn iox2_node_name_as_chars(
     node_name_ptr: iox2_node_name_ptr,
     node_name_len: *mut c_size_t,
 ) -> *const c_char {

--- a/iceoryx2-ffi/ffi/src/api/node_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/node_name.rs
@@ -158,24 +158,26 @@ pub unsafe extern "C" fn iox2_cast_node_name_ptr(
     (*node_name_handle.as_type()).value.as_ref()
 }
 
-/// This function gives access to the node name as a C-style string
+/// This function gives access to the node name as a non-zero-terminated char string
 ///
 /// # Arguments
 ///
 /// * `node_name_ptr` obtained by e.g. [`iox2_cast_node_name_ptr`] or a function returning a [`iox2_node_name_ptr`]
-/// * `node_name_len` can be used to get the length of the C-style string if not `NULL`
+/// * `node_name_len` must be used to get the length of the char string
 ///
-/// Returns zero terminated C-style string
+/// Returns a non-zero-terminated char string
 ///
 /// # Safety
 ///
 /// * The `node_name_ptr` must be a valid pointer to a node name.
+/// * The `node_name_len` must be a valid pointer to a size_t.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_node_name_as_c_str(
+pub unsafe extern "C" fn iox2_node_name_as_str(
     node_name_ptr: iox2_node_name_ptr,
     node_name_len: *mut c_size_t,
 ) -> *const c_char {
     debug_assert!(!node_name_ptr.is_null());
+    debug_assert!(!node_name_len.is_null());
 
     let node_name = &*node_name_ptr;
 

--- a/iceoryx2-ffi/ffi/src/api/service_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_name.rs
@@ -158,24 +158,26 @@ pub unsafe extern "C" fn iox2_cast_service_name_ptr(
     (*service_name_handle.as_type()).value.as_ref()
 }
 
-/// This function gives access to the node name as a C-style string
+/// This function gives access to the node name as a non-zero-terminated char string
 ///
 /// # Arguments
 ///
 /// * `service_name_ptr` obtained by e.g. [`iox2_cast_service_name_ptr`] or a function returning a [`iox2_service_name_ptr`]
-/// * `service_name_len` can be used to get the length of the C-style string if not `NULL`
+/// * `service_name_len` must be used to get the length of the char string
 ///
-/// Returns zero terminated C-style string
+/// Returns non-zero-terminated char string
 ///
 /// # Safety
 ///
 /// * The `service_name_ptr` must be a valid pointer to a node name.
+/// * The `service_name_len` must be a valid pointer to a size_t.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_service_name_as_c_str(
+pub unsafe extern "C" fn iox2_service_name_as_str(
     service_name_ptr: iox2_service_name_ptr,
     service_name_len: *mut c_size_t,
 ) -> *const c_char {
     debug_assert!(!service_name_ptr.is_null());
+    debug_assert!(!service_name_len.is_null());
 
     let service_name = &*service_name_ptr;
 

--- a/iceoryx2-ffi/ffi/src/api/service_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_name.rs
@@ -158,21 +158,21 @@ pub unsafe extern "C" fn iox2_cast_service_name_ptr(
     (*service_name_handle.as_type()).value.as_ref()
 }
 
-/// This function gives access to the node name as a non-zero-terminated char string
+/// This function gives access to the node name as a non-zero-terminated char array
 ///
 /// # Arguments
 ///
 /// * `service_name_ptr` obtained by e.g. [`iox2_cast_service_name_ptr`] or a function returning a [`iox2_service_name_ptr`]
-/// * `service_name_len` must be used to get the length of the char string
+/// * `service_name_len` must be used to get the length of the char array
 ///
-/// Returns non-zero-terminated char string
+/// Returns non-zero-terminated char array
 ///
 /// # Safety
 ///
 /// * The `service_name_ptr` must be a valid pointer to a node name.
 /// * The `service_name_len` must be a valid pointer to a size_t.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_service_name_as_str(
+pub unsafe extern "C" fn iox2_service_name_as_chars(
     service_name_ptr: iox2_service_name_ptr,
     service_name_len: *mut c_size_t,
 ) -> *const c_char {

--- a/iceoryx2-ffi/ffi/src/tests/node_name_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/node_name_tests.rs
@@ -29,12 +29,12 @@ fn basic_node_name_test() -> Result<(), Box<dyn std::error::Error>> {
         assert_that!(ret_val, eq(IOX2_OK));
 
         let mut node_name_len = 0;
-        let node_name_c_str = iox2_node_name_as_c_str(
+        let node_name_c_ptr = iox2_node_name_as_str(
             iox2_cast_node_name_ptr(node_name_handle),
             &mut node_name_len,
         );
 
-        let slice = slice::from_raw_parts(node_name_c_str as *const _, node_name_len as _);
+        let slice = slice::from_raw_parts(node_name_c_ptr as *const _, node_name_len as _);
         let node_name = str::from_utf8(slice)?;
 
         assert_that!(node_name, eq(expected_node_name.as_str()));

--- a/iceoryx2-ffi/ffi/src/tests/node_name_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/node_name_tests.rs
@@ -29,12 +29,12 @@ fn basic_node_name_test() -> Result<(), Box<dyn std::error::Error>> {
         assert_that!(ret_val, eq(IOX2_OK));
 
         let mut node_name_len = 0;
-        let node_name_c_ptr = iox2_node_name_as_str(
+        let node_name_chars = iox2_node_name_as_chars(
             iox2_cast_node_name_ptr(node_name_handle),
             &mut node_name_len,
         );
 
-        let slice = slice::from_raw_parts(node_name_c_ptr as *const _, node_name_len as _);
+        let slice = slice::from_raw_parts(node_name_chars as *const _, node_name_len as _);
         let node_name = str::from_utf8(slice)?;
 
         assert_that!(node_name, eq(expected_node_name.as_str()));

--- a/iceoryx2-ffi/ffi/src/tests/node_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/node_tests.rs
@@ -51,9 +51,9 @@ mod node {
             let node_name = iox2_node_name(iox2_cast_node_ref_h(node_handle));
 
             let mut node_name_len = 0;
-            let node_name_c_ptr = iox2_node_name_as_str(node_name, &mut node_name_len);
+            let node_name_chars = iox2_node_name_as_chars(node_name, &mut node_name_len);
 
-            let slice = slice::from_raw_parts(node_name_c_ptr as *const _, node_name_len as _);
+            let slice = slice::from_raw_parts(node_name_chars as *const _, node_name_len as _);
             let node_name_str = str::from_utf8(slice)?;
 
             assert_that!(node_name_str, eq("hypnotoad"));

--- a/iceoryx2-ffi/ffi/src/tests/node_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/node_tests.rs
@@ -51,9 +51,9 @@ mod node {
             let node_name = iox2_node_name(iox2_cast_node_ref_h(node_handle));
 
             let mut node_name_len = 0;
-            let node_name_c_str = iox2_node_name_as_c_str(node_name, &mut node_name_len);
+            let node_name_c_ptr = iox2_node_name_as_str(node_name, &mut node_name_len);
 
-            let slice = slice::from_raw_parts(node_name_c_str as *const _, node_name_len as _);
+            let slice = slice::from_raw_parts(node_name_c_ptr as *const _, node_name_len as _);
             let node_name_str = str::from_utf8(slice)?;
 
             assert_that!(node_name_str, eq("hypnotoad"));

--- a/iceoryx2-ffi/ffi/src/tests/service_name_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/service_name_tests.rs
@@ -29,12 +29,12 @@ fn basic_service_name_test() -> Result<(), Box<dyn std::error::Error>> {
         assert_that!(ret_val, eq(IOX2_OK));
 
         let mut service_name_len = 0;
-        let service_name_c_str = iox2_service_name_as_c_str(
+        let service_name_c_ptr = iox2_service_name_as_str(
             iox2_cast_service_name_ptr(service_name_handle),
             &mut service_name_len,
         );
 
-        let slice = slice::from_raw_parts(service_name_c_str as *const _, service_name_len as _);
+        let slice = slice::from_raw_parts(service_name_c_ptr as *const _, service_name_len as _);
         let service_name = str::from_utf8(slice)?;
 
         assert_that!(service_name, eq(expected_service_name.as_str()));

--- a/iceoryx2-ffi/ffi/src/tests/service_name_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/service_name_tests.rs
@@ -29,12 +29,12 @@ fn basic_service_name_test() -> Result<(), Box<dyn std::error::Error>> {
         assert_that!(ret_val, eq(IOX2_OK));
 
         let mut service_name_len = 0;
-        let service_name_c_ptr = iox2_service_name_as_str(
+        let service_name_chars = iox2_service_name_as_chars(
             iox2_cast_service_name_ptr(service_name_handle),
             &mut service_name_len,
         );
 
-        let slice = slice::from_raw_parts(service_name_c_ptr as *const _, service_name_len as _);
+        let slice = slice::from_raw_parts(service_name_chars as *const _, service_name_len as _);
         let service_name = str::from_utf8(slice)?;
 
         assert_that!(service_name, eq(expected_service_name.as_str()));


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The node and service name C-API pretent to return a null terminated C-style string. This is not the case though, since the Rust `NodeName` and `ServiceName` is based on a Rust `String` and not on an iceoryx2 `SemanticString`.

This PR fixes the documentation and makes passing a pointer for the string length mandatory.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #210
