### PR TITLE
[#210] Adjust naming conventions for c binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 cmake_minimum_required(VERSION 3.22)
-set(IOX2_VERSION_STRING "0.3.0")
+set(IOX2_VERSION_STRING "0.4.0")
 project(iceoryx2 VERSION ${IOX2_VERSION_STRING})
 
 #TODO how to handle feature flags

--- a/doc/how-to-create-an-iceoryx2-release.md
+++ b/doc/how-to-create-an-iceoryx2-release.md
@@ -49,7 +49,8 @@ blog-article.
 
 ## Technical Side
 
-Assume that the new version number is `X.Y.Z`.
+Assume that the new version number is `X.Y.Z` and the previous version
+number is `Xold.Yold.Zold`.
 
 1. Use generic release issue ([#77]) and create a new branch
    `iox2-77-X.Y.Z-release`
@@ -72,10 +73,13 @@ Assume that the new version number is `X.Y.Z`.
    version number `X.Y.Z`.
    * **IMPORTANT** change version to `X.Y.Z` for all `iceoryx2-**` packages
      under `[workspace.dependencies]`
-9. **Merge all changes to `main`.**
-10. Set tag on GitHub and add the release document as notes to the tag
+9. Adjust the `<version>` to `X.Y.Z` in `$GIT_ROOT$/package.xml`.
+10. Call `rg "Xold\.Yold\.Zold"` and adjust all findings.
+    * C and C++ examples, `BUILD.bazel` & `CMakeLists.txt`
+11. **Merge all changes to `main`.**
+12. Set tag on GitHub and add the release document as notes to the tag
     description. Add also a link to the file.
-11. Check the order of all dependencies in
+13. Check the order of all dependencies in
     `$GIT_ROOT$/./internal/scripts/crates_io_publish_script.sh`.
     When calling `cargo publish -p $PACKAGE$` all dependencies, also dev-dependencies,
     must be already published to `crates.io` via `cargo publish -p`. Verify the
@@ -85,7 +89,7 @@ Assume that the new version number is `X.Y.Z`.
     * If the publish script was started and a crate requires a dependency which
       is not available on `crates.io` the release has to be redone and the patch
       version has to increase by one for the whole workspace.
-12. Call `$GIT_ROOT$/./internal/scripts/crates_io_publish_script.sh` and publish
+14. Call `$GIT_ROOT$/./internal/scripts/crates_io_publish_script.sh` and publish
     all crates on `crates.io` and `docs.rs`.
-13. Verify that the release looks fine on `docs.rs` (click through the
+15. Verify that the release looks fine on `docs.rs` (click through the
     documentation to check if everything was generated correctly)

--- a/examples/c/discovery/CMakeLists.txt
+++ b/examples/c/discovery/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_c_discovery LANGUAGES C)
 
-find_package(iceoryx2-c 0.3.0 REQUIRED)
+find_package(iceoryx2-c 0.4.0 REQUIRED)
 
 add_executable(example_c_discovery src/main.c)
 

--- a/examples/c/domains/CMakeLists.txt
+++ b/examples/c/domains/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_c_domains LANGUAGES C)
 
-find_package(iceoryx2-c 0.3.0 REQUIRED)
+find_package(iceoryx2-c 0.4.0 REQUIRED)
 
 add_executable(example_c_domains_publisher src/publisher.c)
 target_link_libraries(example_c_domains_publisher iceoryx2-c::static-lib)

--- a/examples/c/domains/src/discovery.c
+++ b/examples/c/domains/src/discovery.c
@@ -28,12 +28,11 @@ int main(int argc, char** argv) {
     iox2_config_ptr config_ptr = iox2_config_global_config();
     iox2_config_h config = NULL;
     iox2_config_from_ptr(config_ptr, NULL, &config);
-    iox2_config_h_ref config_ref = iox2_cast_config_h_ref(config);
     config_ptr = iox2_cast_config_ptr(config);
 
     // The domain name becomes the prefix for all resources.
     // Therefore, different domain names never share the same resources.
-    if (iox2_config_global_set_prefix(config_ref, argv[1]) != IOX2_OK) {
+    if (iox2_config_global_set_prefix(&config, argv[1]) != IOX2_OK) {
         iox2_config_drop(config);
         printf("invalid domain name\"%s\"\n", argv[1]);
         exit(-1);

--- a/examples/c/domains/src/discovery.c
+++ b/examples/c/domains/src/discovery.c
@@ -28,7 +28,7 @@ int main(int argc, char** argv) {
     iox2_config_ptr config_ptr = iox2_config_global_config();
     iox2_config_h config = NULL;
     iox2_config_from_ptr(config_ptr, NULL, &config);
-    iox2_config_ref_h config_ref = iox2_cast_config_ref_h(config);
+    iox2_config_h_ref config_ref = iox2_cast_config_h_ref(config);
     config_ptr = iox2_cast_config_ptr(config);
 
     // The domain name becomes the prefix for all resources.

--- a/examples/c/domains/src/publisher.c
+++ b/examples/c/domains/src/publisher.c
@@ -32,11 +32,10 @@ int main(int argc, char** argv) {
     iox2_config_ptr config_ptr = iox2_config_global_config();
     iox2_config_h config = NULL;
     iox2_config_from_ptr(config_ptr, NULL, &config);
-    iox2_config_h_ref config_ref = iox2_cast_config_h_ref(config);
 
     // The domain name becomes the prefix for all resources.
     // Therefore, different domain names never share the same resources.
-    if (iox2_config_global_set_prefix(config_ref, argv[1]) != IOX2_OK) {
+    if (iox2_config_global_set_prefix(&config, argv[1]) != IOX2_OK) {
         printf("invalid domain name\"%s\"\n", argv[1]);
         goto drop_config;
     }
@@ -44,11 +43,10 @@ int main(int argc, char** argv) {
     // create new node
     iox2_node_builder_h node_builder_handle = iox2_node_builder_new(NULL);
     iox2_node_h node_handle = NULL;
-    iox2_node_builder_h_ref node_builder_ref = iox2_cast_node_builder_h_ref(node_builder_handle);
 
     // use the custom config when creating the custom node
     // every service constructed by the node will use this config
-    iox2_node_builder_set_config(node_builder_ref, config_ref);
+    iox2_node_builder_set_config(&node_builder_handle, &config);
     if (iox2_node_builder_create(node_builder_handle, NULL, iox2_service_type_e_IPC, &node_handle) != IOX2_OK) {
         goto drop_config;
     }
@@ -63,15 +61,12 @@ int main(int argc, char** argv) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(&node_handle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "16TransmissionData";
-    if (iox2_service_builder_pub_sub_set_payload_type_details(service_builder_pub_sub_ref,
+    if (iox2_service_builder_pub_sub_set_payload_type_details(&service_builder_pub_sub,
                                                               iox2_type_variant_e_FIXED_SIZE,
                                                               payload_type_name,
                                                               strlen(payload_type_name),
@@ -90,31 +85,28 @@ int main(int argc, char** argv) {
     }
 
     // create publisher
-    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_publisher_builder_h publisher_builder =
-        iox2_port_factory_pub_sub_publisher_builder(ref_service, NULL);
+        iox2_port_factory_pub_sub_publisher_builder(&service, NULL);
     iox2_publisher_h publisher = NULL;
     if (iox2_port_factory_publisher_builder_create(publisher_builder, NULL, &publisher) != IOX2_OK) {
         printf("Unable to create publisher!\n");
         goto drop_service;
     }
-    iox2_publisher_h_ref publisher_ref = iox2_cast_publisher_h_ref(publisher);
 
     int32_t counter = 0;
-    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(&node_handle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // loan sample
         iox2_sample_mut_h sample = NULL;
-        if (iox2_publisher_loan(publisher_ref, NULL, &sample) != IOX2_OK) {
+        if (iox2_publisher_loan(&publisher, NULL, &sample) != IOX2_OK) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }
-        iox2_sample_mut_h_ref sample_ref = iox2_cast_sample_mut_h_ref(sample);
 
         // write payload
         struct TransmissionData* payload = NULL;
-        iox2_sample_mut_payload_mut(sample_ref, (void**) &payload, NULL);
+        iox2_sample_mut_payload_mut(&sample, (void**) &payload, NULL);
         payload->x = counter;
         payload->y = counter * 3;
         payload->funky = counter * 812.12; // NOLINT

--- a/examples/c/domains/src/publisher.c
+++ b/examples/c/domains/src/publisher.c
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
     iox2_config_ptr config_ptr = iox2_config_global_config();
     iox2_config_h config = NULL;
     iox2_config_from_ptr(config_ptr, NULL, &config);
-    iox2_config_ref_h config_ref = iox2_cast_config_ref_h(config);
+    iox2_config_h_ref config_ref = iox2_cast_config_h_ref(config);
 
     // The domain name becomes the prefix for all resources.
     // Therefore, different domain names never share the same resources.
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
     // create new node
     iox2_node_builder_h node_builder_handle = iox2_node_builder_new(NULL);
     iox2_node_h node_handle = NULL;
-    iox2_node_builder_ref_h node_builder_ref = iox2_cast_node_builder_ref_h(node_builder_handle);
+    iox2_node_builder_h_ref node_builder_ref = iox2_cast_node_builder_h_ref(node_builder_handle);
 
     // use the custom config when creating the custom node
     // every service constructed by the node will use this config
@@ -63,11 +63,11 @@ int main(int argc, char** argv) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_ref_h node_ref_handle = iox2_cast_node_ref_h(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_ref_handle, NULL, service_name_ptr);
+    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_ref_h service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_ref_h(service_builder_pub_sub);
+    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
+        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "16TransmissionData";
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
     }
 
     // create publisher
-    iox2_port_factory_pub_sub_ref_h ref_service = iox2_cast_port_factory_pub_sub_ref_h(service);
+    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_publisher_builder_h publisher_builder =
         iox2_port_factory_pub_sub_publisher_builder(ref_service, NULL);
     iox2_publisher_h publisher = NULL;
@@ -98,10 +98,10 @@ int main(int argc, char** argv) {
         printf("Unable to create publisher!\n");
         goto drop_service;
     }
-    iox2_publisher_ref_h publisher_ref = iox2_cast_publisher_ref_h(publisher);
+    iox2_publisher_h_ref publisher_ref = iox2_cast_publisher_h_ref(publisher);
 
     int32_t counter = 0;
-    while (iox2_node_wait(node_ref_handle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // loan sample
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }
-        iox2_sample_mut_ref_h sample_ref = iox2_cast_sample_mut_ref_h(sample);
+        iox2_sample_mut_h_ref sample_ref = iox2_cast_sample_mut_h_ref(sample);
 
         // write payload
         struct TransmissionData* payload = NULL;

--- a/examples/c/domains/src/subscriber.c
+++ b/examples/c/domains/src/subscriber.c
@@ -32,11 +32,10 @@ int main(int argc, char** argv) {
     iox2_config_ptr config_ptr = iox2_config_global_config();
     iox2_config_h config = NULL;
     iox2_config_from_ptr(config_ptr, NULL, &config);
-    iox2_config_h_ref config_ref = iox2_cast_config_h_ref(config);
 
     // The domain name becomes the prefix for all resources.
     // Therefore, different domain names never share the same resources.
-    if (iox2_config_global_set_prefix(config_ref, argv[1]) != IOX2_OK) {
+    if (iox2_config_global_set_prefix(&config, argv[1]) != IOX2_OK) {
         printf("invalid domain name\"%s\"\n", argv[1]);
         goto drop_config;
     }
@@ -44,11 +43,10 @@ int main(int argc, char** argv) {
     // create new node
     iox2_node_builder_h node_builder_handle = iox2_node_builder_new(NULL);
     iox2_node_h node_handle = NULL;
-    iox2_node_builder_h_ref node_builder_ref = iox2_cast_node_builder_h_ref(node_builder_handle);
 
     // use the custom config when creating the custom node
     // every service constructed by the node will use this config
-    iox2_node_builder_set_config(node_builder_ref, config_ref);
+    iox2_node_builder_set_config(&node_builder_handle, &config);
     if (iox2_node_builder_create(node_builder_handle, NULL, iox2_service_type_e_IPC, &node_handle) != IOX2_OK) {
         printf("Could not create node!\n");
         goto end;
@@ -64,15 +62,12 @@ int main(int argc, char** argv) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(&node_handle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "16TransmissionData";
-    if (iox2_service_builder_pub_sub_set_payload_type_details(service_builder_pub_sub_ref,
+    if (iox2_service_builder_pub_sub_set_payload_type_details(&service_builder_pub_sub,
                                                               iox2_type_variant_e_FIXED_SIZE,
                                                               payload_type_name,
                                                               strlen(payload_type_name),
@@ -91,32 +86,29 @@ int main(int argc, char** argv) {
     }
 
     // create subscriber
-    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_subscriber_builder_h subscriber_builder =
-        iox2_port_factory_pub_sub_subscriber_builder(ref_service, NULL);
+        iox2_port_factory_pub_sub_subscriber_builder(&service, NULL);
     iox2_subscriber_h subscriber = NULL;
     if (iox2_port_factory_subscriber_builder_create(subscriber_builder, NULL, &subscriber) != IOX2_OK) {
         printf("Unable to create subscriber!\n");
         goto drop_service;
     }
-    iox2_subscriber_h_ref subscriber_ref = iox2_cast_subscriber_h_ref(subscriber);
 
     uint64_t counter = 0;
     printf("subscribed to: [domain: \"%s\", service: \"%s\"]\n", argv[1], argv[2]);
-    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(&node_handle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // receive sample
         iox2_sample_h sample = NULL;
-        if (iox2_subscriber_receive(subscriber_ref, NULL, &sample) != IOX2_OK) {
+        if (iox2_subscriber_receive(&subscriber, NULL, &sample) != IOX2_OK) {
             printf("Failed to receive sample\n");
             goto drop_subscriber;
         }
 
         if (sample != NULL) {
-            iox2_sample_h_ref sample_ref = iox2_cast_sample_h_ref(sample);
             struct TransmissionData* payload = NULL;
-            iox2_sample_payload(sample_ref, (const void**) &payload, NULL);
+            iox2_sample_payload(&sample, (const void**) &payload, NULL);
 
             printf(
                 "received: TransmissionData { .x: %d, .y: %d, .funky: %lf}\n", payload->x, payload->y, payload->funky);

--- a/examples/c/domains/src/subscriber.c
+++ b/examples/c/domains/src/subscriber.c
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
     iox2_config_ptr config_ptr = iox2_config_global_config();
     iox2_config_h config = NULL;
     iox2_config_from_ptr(config_ptr, NULL, &config);
-    iox2_config_ref_h config_ref = iox2_cast_config_ref_h(config);
+    iox2_config_h_ref config_ref = iox2_cast_config_h_ref(config);
 
     // The domain name becomes the prefix for all resources.
     // Therefore, different domain names never share the same resources.
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
     // create new node
     iox2_node_builder_h node_builder_handle = iox2_node_builder_new(NULL);
     iox2_node_h node_handle = NULL;
-    iox2_node_builder_ref_h node_builder_ref = iox2_cast_node_builder_ref_h(node_builder_handle);
+    iox2_node_builder_h_ref node_builder_ref = iox2_cast_node_builder_h_ref(node_builder_handle);
 
     // use the custom config when creating the custom node
     // every service constructed by the node will use this config
@@ -64,11 +64,11 @@ int main(int argc, char** argv) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_ref_h node_ref_handle = iox2_cast_node_ref_h(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_ref_handle, NULL, service_name_ptr);
+    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_ref_h service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_ref_h(service_builder_pub_sub);
+    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
+        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "16TransmissionData";
@@ -91,7 +91,7 @@ int main(int argc, char** argv) {
     }
 
     // create subscriber
-    iox2_port_factory_pub_sub_ref_h ref_service = iox2_cast_port_factory_pub_sub_ref_h(service);
+    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_subscriber_builder_h subscriber_builder =
         iox2_port_factory_pub_sub_subscriber_builder(ref_service, NULL);
     iox2_subscriber_h subscriber = NULL;
@@ -99,11 +99,11 @@ int main(int argc, char** argv) {
         printf("Unable to create subscriber!\n");
         goto drop_service;
     }
-    iox2_subscriber_ref_h subscriber_ref = iox2_cast_subscriber_ref_h(subscriber);
+    iox2_subscriber_h_ref subscriber_ref = iox2_cast_subscriber_h_ref(subscriber);
 
     uint64_t counter = 0;
     printf("subscribed to: [domain: \"%s\", service: \"%s\"]\n", argv[1], argv[2]);
-    while (iox2_node_wait(node_ref_handle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // receive sample
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
         }
 
         if (sample != NULL) {
-            iox2_sample_ref_h sample_ref = iox2_cast_sample_ref_h(sample);
+            iox2_sample_h_ref sample_ref = iox2_cast_sample_h_ref(sample);
             struct TransmissionData* payload = NULL;
             iox2_sample_payload(sample_ref, (const void**) &payload, NULL);
 

--- a/examples/c/event/CMakeLists.txt
+++ b/examples/c/event/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_c_event LANGUAGES C)
 
-find_package(iceoryx2-c 0.3.0 REQUIRED)
+find_package(iceoryx2-c 0.4.0 REQUIRED)
 
 add_executable(example_c_event_listener src/listener.c)
 target_link_libraries(example_c_event_listener iceoryx2-c::static-lib)

--- a/examples/c/event/src/listener.c
+++ b/examples/c/event/src/listener.c
@@ -35,8 +35,8 @@ int main(void) {
 
     // create service
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_ref_h node_ref_handle = iox2_cast_node_ref_h(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_ref_handle, NULL, service_name_ptr);
+    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
     iox2_service_builder_event_h service_builder_event = iox2_service_builder_event(service_builder);
     iox2_port_factory_event_h service = NULL;
     if (iox2_service_builder_event_open_or_create(service_builder_event, NULL, &service) != IOX2_OK) {
@@ -45,17 +45,17 @@ int main(void) {
     }
 
     // create listener
-    iox2_port_factory_event_ref_h ref_service = iox2_cast_port_factory_event_ref_h(service);
+    iox2_port_factory_event_h_ref ref_service = iox2_cast_port_factory_event_h_ref(service);
     iox2_port_factory_listener_builder_h listener_builder = iox2_port_factory_event_listener_builder(ref_service, NULL);
     iox2_listener_h listener = NULL;
     if (iox2_port_factory_listener_builder_create(listener_builder, NULL, &listener) != IOX2_OK) {
         printf("Unable to create listener!\n");
         goto drop_service;
     }
-    iox2_listener_ref_h listener_ref = iox2_cast_listener_ref_h(listener);
+    iox2_listener_h_ref listener_ref = iox2_cast_listener_h_ref(listener);
     iox2_event_id_t event_id;
 
-    while (iox2_node_wait(node_ref_handle, 0, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(node_h_refandle, 0, 0) == iox2_node_event_e_TICK) {
         bool has_received_one = false;
         if (iox2_listener_timed_wait_one(listener_ref, &event_id, &has_received_one, 1, 0) != IOX2_OK) {
             printf("Unable to wait for notification!\n");

--- a/examples/c/event/src/listener.c
+++ b/examples/c/event/src/listener.c
@@ -35,8 +35,7 @@ int main(void) {
 
     // create service
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(&node_handle, NULL, service_name_ptr);
     iox2_service_builder_event_h service_builder_event = iox2_service_builder_event(service_builder);
     iox2_port_factory_event_h service = NULL;
     if (iox2_service_builder_event_open_or_create(service_builder_event, NULL, &service) != IOX2_OK) {
@@ -45,19 +44,17 @@ int main(void) {
     }
 
     // create listener
-    iox2_port_factory_event_h_ref ref_service = iox2_cast_port_factory_event_h_ref(service);
-    iox2_port_factory_listener_builder_h listener_builder = iox2_port_factory_event_listener_builder(ref_service, NULL);
+    iox2_port_factory_listener_builder_h listener_builder = iox2_port_factory_event_listener_builder(&service, NULL);
     iox2_listener_h listener = NULL;
     if (iox2_port_factory_listener_builder_create(listener_builder, NULL, &listener) != IOX2_OK) {
         printf("Unable to create listener!\n");
         goto drop_service;
     }
-    iox2_listener_h_ref listener_ref = iox2_cast_listener_h_ref(listener);
     iox2_event_id_t event_id;
 
-    while (iox2_node_wait(node_h_refandle, 0, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(&node_handle, 0, 0) == iox2_node_event_e_TICK) {
         bool has_received_one = false;
-        if (iox2_listener_timed_wait_one(listener_ref, &event_id, &has_received_one, 1, 0) != IOX2_OK) {
+        if (iox2_listener_timed_wait_one(&listener, &event_id, &has_received_one, 1, 0) != IOX2_OK) {
             printf("Unable to wait for notification!\n");
             goto drop_listener;
         }

--- a/examples/c/event/src/notifier.c
+++ b/examples/c/event/src/notifier.c
@@ -42,8 +42,8 @@ int main(void) {
 
     // create service
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_ref_h node_ref_handle = iox2_cast_node_ref_h(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_ref_handle, NULL, service_name_ptr);
+    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
     iox2_service_builder_event_h service_builder_event = iox2_service_builder_event(service_builder);
     iox2_port_factory_event_h service = NULL;
     if (iox2_service_builder_event_open_or_create(service_builder_event, NULL, &service) != IOX2_OK) {
@@ -52,17 +52,17 @@ int main(void) {
     }
 
     // create notifier
-    iox2_port_factory_event_ref_h ref_service = iox2_cast_port_factory_event_ref_h(service);
+    iox2_port_factory_event_h_ref ref_service = iox2_cast_port_factory_event_h_ref(service);
     iox2_port_factory_notifier_builder_h notifier_builder = iox2_port_factory_event_notifier_builder(ref_service, NULL);
     iox2_notifier_h notifier = NULL;
     if (iox2_port_factory_notifier_builder_create(notifier_builder, NULL, &notifier) != IOX2_OK) {
         printf("Unable to create notifier!\n");
         goto drop_service;
     }
-    iox2_notifier_ref_h notifier_ref = iox2_cast_notifier_ref_h(notifier);
+    iox2_notifier_h_ref notifier_ref = iox2_cast_notifier_h_ref(notifier);
 
     uint64_t counter = 0;
-    while (iox2_node_wait(node_ref_handle, 0, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(node_h_refandle, 0, 0) == iox2_node_event_e_TICK) {
         counter += 1;
         iox2_event_id_t event_id = { .value = counter % 12 }; // NOLINT
         if (iox2_notifier_notify_with_custom_event_id(notifier_ref, &event_id, NULL) != IOX2_OK) {

--- a/examples/c/event/src/notifier.c
+++ b/examples/c/event/src/notifier.c
@@ -42,8 +42,7 @@ int main(void) {
 
     // create service
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(&node_handle, NULL, service_name_ptr);
     iox2_service_builder_event_h service_builder_event = iox2_service_builder_event(service_builder);
     iox2_port_factory_event_h service = NULL;
     if (iox2_service_builder_event_open_or_create(service_builder_event, NULL, &service) != IOX2_OK) {
@@ -52,20 +51,18 @@ int main(void) {
     }
 
     // create notifier
-    iox2_port_factory_event_h_ref ref_service = iox2_cast_port_factory_event_h_ref(service);
-    iox2_port_factory_notifier_builder_h notifier_builder = iox2_port_factory_event_notifier_builder(ref_service, NULL);
+    iox2_port_factory_notifier_builder_h notifier_builder = iox2_port_factory_event_notifier_builder(&service, NULL);
     iox2_notifier_h notifier = NULL;
     if (iox2_port_factory_notifier_builder_create(notifier_builder, NULL, &notifier) != IOX2_OK) {
         printf("Unable to create notifier!\n");
         goto drop_service;
     }
-    iox2_notifier_h_ref notifier_ref = iox2_cast_notifier_h_ref(notifier);
 
     uint64_t counter = 0;
-    while (iox2_node_wait(node_h_refandle, 0, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(&node_handle, 0, 0) == iox2_node_event_e_TICK) {
         counter += 1;
         iox2_event_id_t event_id = { .value = counter % 12 }; // NOLINT
-        if (iox2_notifier_notify_with_custom_event_id(notifier_ref, &event_id, NULL) != IOX2_OK) {
+        if (iox2_notifier_notify_with_custom_event_id(&notifier, &event_id, NULL) != IOX2_OK) {
             printf("Failed to notify listener!\n");
             goto drop_notifier;
         }

--- a/examples/c/publish_subscribe/CMakeLists.txt
+++ b/examples/c/publish_subscribe/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_c_publish_subscribe LANGUAGES C)
 
-find_package(iceoryx2-c 0.3.0 REQUIRED)
+find_package(iceoryx2-c 0.4.0 REQUIRED)
 
 add_executable(example_c_publisher src/publisher.c)
 target_link_libraries(example_c_publisher iceoryx2-c::static-lib)

--- a/examples/c/publish_subscribe/src/publisher.c
+++ b/examples/c/publish_subscribe/src/publisher.c
@@ -41,15 +41,12 @@ int main(void) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(&node_handle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "16TransmissionData";
-    if (iox2_service_builder_pub_sub_set_payload_type_details(service_builder_pub_sub_ref,
+    if (iox2_service_builder_pub_sub_set_payload_type_details(&service_builder_pub_sub,
                                                               iox2_type_variant_e_FIXED_SIZE,
                                                               payload_type_name,
                                                               strlen(payload_type_name),
@@ -68,31 +65,28 @@ int main(void) {
     }
 
     // create publisher
-    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_publisher_builder_h publisher_builder =
-        iox2_port_factory_pub_sub_publisher_builder(ref_service, NULL);
+        iox2_port_factory_pub_sub_publisher_builder(&service, NULL);
     iox2_publisher_h publisher = NULL;
     if (iox2_port_factory_publisher_builder_create(publisher_builder, NULL, &publisher) != IOX2_OK) {
         printf("Unable to create publisher!\n");
         goto drop_service;
     }
-    iox2_publisher_h_ref publisher_ref = iox2_cast_publisher_h_ref(publisher);
 
     int32_t counter = 0;
-    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(&node_handle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // loan sample
         iox2_sample_mut_h sample = NULL;
-        if (iox2_publisher_loan(publisher_ref, NULL, &sample) != IOX2_OK) {
+        if (iox2_publisher_loan(&publisher, NULL, &sample) != IOX2_OK) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }
-        iox2_sample_mut_h_ref sample_ref = iox2_cast_sample_mut_h_ref(sample);
 
         // write payload
         struct TransmissionData* payload = NULL;
-        iox2_sample_mut_payload_mut(sample_ref, (void**) &payload, NULL);
+        iox2_sample_mut_payload_mut(&sample, (void**) &payload, NULL);
         payload->x = counter;
         payload->y = counter * 3;
         payload->funky = counter * 812.12; // NOLINT

--- a/examples/c/publish_subscribe/src/publisher.c
+++ b/examples/c/publish_subscribe/src/publisher.c
@@ -41,11 +41,11 @@ int main(void) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_ref_h node_ref_handle = iox2_cast_node_ref_h(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_ref_handle, NULL, service_name_ptr);
+    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_ref_h service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_ref_h(service_builder_pub_sub);
+    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
+        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "16TransmissionData";
@@ -68,7 +68,7 @@ int main(void) {
     }
 
     // create publisher
-    iox2_port_factory_pub_sub_ref_h ref_service = iox2_cast_port_factory_pub_sub_ref_h(service);
+    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_publisher_builder_h publisher_builder =
         iox2_port_factory_pub_sub_publisher_builder(ref_service, NULL);
     iox2_publisher_h publisher = NULL;
@@ -76,10 +76,10 @@ int main(void) {
         printf("Unable to create publisher!\n");
         goto drop_service;
     }
-    iox2_publisher_ref_h publisher_ref = iox2_cast_publisher_ref_h(publisher);
+    iox2_publisher_h_ref publisher_ref = iox2_cast_publisher_h_ref(publisher);
 
     int32_t counter = 0;
-    while (iox2_node_wait(node_ref_handle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // loan sample
@@ -88,7 +88,7 @@ int main(void) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }
-        iox2_sample_mut_ref_h sample_ref = iox2_cast_sample_mut_ref_h(sample);
+        iox2_sample_mut_h_ref sample_ref = iox2_cast_sample_mut_h_ref(sample);
 
         // write payload
         struct TransmissionData* payload = NULL;

--- a/examples/c/publish_subscribe/src/subscriber.c
+++ b/examples/c/publish_subscribe/src/subscriber.c
@@ -41,15 +41,12 @@ int main(void) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(&node_handle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "16TransmissionData";
-    if (iox2_service_builder_pub_sub_set_payload_type_details(service_builder_pub_sub_ref,
+    if (iox2_service_builder_pub_sub_set_payload_type_details(&service_builder_pub_sub,
                                                               iox2_type_variant_e_FIXED_SIZE,
                                                               payload_type_name,
                                                               strlen(payload_type_name),
@@ -68,31 +65,28 @@ int main(void) {
     }
 
     // create subscriber
-    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_subscriber_builder_h subscriber_builder =
-        iox2_port_factory_pub_sub_subscriber_builder(ref_service, NULL);
+        iox2_port_factory_pub_sub_subscriber_builder(&service, NULL);
     iox2_subscriber_h subscriber = NULL;
     if (iox2_port_factory_subscriber_builder_create(subscriber_builder, NULL, &subscriber) != IOX2_OK) {
         printf("Unable to create subscriber!\n");
         goto drop_service;
     }
-    iox2_subscriber_h_ref subscriber_ref = iox2_cast_subscriber_h_ref(subscriber);
 
     uint64_t counter = 0;
-    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(&node_handle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // receive sample
         iox2_sample_h sample = NULL;
-        if (iox2_subscriber_receive(subscriber_ref, NULL, &sample) != IOX2_OK) {
+        if (iox2_subscriber_receive(&subscriber, NULL, &sample) != IOX2_OK) {
             printf("Failed to receive sample\n");
             goto drop_subscriber;
         }
 
         if (sample != NULL) {
-            iox2_sample_h_ref sample_ref = iox2_cast_sample_h_ref(sample);
             struct TransmissionData* payload = NULL;
-            iox2_sample_payload(sample_ref, (const void**) &payload, NULL);
+            iox2_sample_payload(&sample, (const void**) &payload, NULL);
 
             printf(
                 "received: TransmissionData { .x: %d, .y: %d, .funky: %lf}\n", payload->x, payload->y, payload->funky);

--- a/examples/c/publish_subscribe/src/subscriber.c
+++ b/examples/c/publish_subscribe/src/subscriber.c
@@ -41,11 +41,11 @@ int main(void) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_ref_h node_ref_handle = iox2_cast_node_ref_h(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_ref_handle, NULL, service_name_ptr);
+    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_ref_h service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_ref_h(service_builder_pub_sub);
+    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
+        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "16TransmissionData";
@@ -68,7 +68,7 @@ int main(void) {
     }
 
     // create subscriber
-    iox2_port_factory_pub_sub_ref_h ref_service = iox2_cast_port_factory_pub_sub_ref_h(service);
+    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_subscriber_builder_h subscriber_builder =
         iox2_port_factory_pub_sub_subscriber_builder(ref_service, NULL);
     iox2_subscriber_h subscriber = NULL;
@@ -76,10 +76,10 @@ int main(void) {
         printf("Unable to create subscriber!\n");
         goto drop_service;
     }
-    iox2_subscriber_ref_h subscriber_ref = iox2_cast_subscriber_ref_h(subscriber);
+    iox2_subscriber_h_ref subscriber_ref = iox2_cast_subscriber_h_ref(subscriber);
 
     uint64_t counter = 0;
-    while (iox2_node_wait(node_ref_handle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // receive sample
@@ -90,7 +90,7 @@ int main(void) {
         }
 
         if (sample != NULL) {
-            iox2_sample_ref_h sample_ref = iox2_cast_sample_ref_h(sample);
+            iox2_sample_h_ref sample_ref = iox2_cast_sample_h_ref(sample);
             struct TransmissionData* payload = NULL;
             iox2_sample_payload(sample_ref, (const void**) &payload, NULL);
 

--- a/examples/c/publish_subscribe_with_user_header/CMakeLists.txt
+++ b/examples/c/publish_subscribe_with_user_header/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_c_publish_subscribe_with_user_header LANGUAGES C)
 
-find_package(iceoryx2-c 0.3.0 REQUIRED)
+find_package(iceoryx2-c 0.4.0 REQUIRED)
 
 add_executable(example_c_with_user_header_publisher src/publisher.c)
 target_link_libraries(example_c_with_user_header_publisher iceoryx2-c::static-lib)

--- a/examples/c/publish_subscribe_with_user_header/src/publisher.c
+++ b/examples/c/publish_subscribe_with_user_header/src/publisher.c
@@ -41,15 +41,12 @@ int main(void) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(&node_handle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "m";
-    if (iox2_service_builder_pub_sub_set_payload_type_details(service_builder_pub_sub_ref,
+    if (iox2_service_builder_pub_sub_set_payload_type_details(&service_builder_pub_sub,
                                                               iox2_type_variant_e_FIXED_SIZE,
                                                               payload_type_name,
                                                               strlen(payload_type_name),
@@ -62,7 +59,7 @@ int main(void) {
 
     // set pub sub user header type
     const char* user_header_type_name = "12CustomHeader";
-    if (iox2_service_builder_pub_sub_set_user_header_type_details(service_builder_pub_sub_ref,
+    if (iox2_service_builder_pub_sub_set_user_header_type_details(&service_builder_pub_sub,
                                                                   iox2_type_variant_e_FIXED_SIZE,
                                                                   user_header_type_name,
                                                                   strlen(user_header_type_name),
@@ -81,35 +78,32 @@ int main(void) {
     }
 
     // create publisher
-    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_publisher_builder_h publisher_builder =
-        iox2_port_factory_pub_sub_publisher_builder(ref_service, NULL);
+        iox2_port_factory_pub_sub_publisher_builder(&service, NULL);
     iox2_publisher_h publisher = NULL;
     if (iox2_port_factory_publisher_builder_create(publisher_builder, NULL, &publisher) != IOX2_OK) {
         printf("Unable to create publisher!\n");
         goto drop_service;
     }
-    iox2_publisher_h_ref publisher_ref = iox2_cast_publisher_h_ref(publisher);
 
     int32_t counter = 0;
-    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(&node_handle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // loan sample
         iox2_sample_mut_h sample = NULL;
-        if (iox2_publisher_loan(publisher_ref, NULL, &sample) != IOX2_OK) {
+        if (iox2_publisher_loan(&publisher, NULL, &sample) != IOX2_OK) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }
-        iox2_sample_mut_h_ref sample_ref = iox2_cast_sample_mut_h_ref(sample);
 
         // write payload
         uint64_t* payload = NULL;
-        iox2_sample_mut_payload_mut(sample_ref, (void**) &payload, NULL);
+        iox2_sample_mut_payload_mut(&sample, (void**) &payload, NULL);
         *payload = counter;
 
         struct CustomHeader* header = NULL;
-        iox2_sample_mut_user_header_mut(sample_ref, (void**) &header);
+        iox2_sample_mut_user_header_mut(&sample, (void**) &header);
         header->version = 123;               // NOLINT
         header->timestamp = 80337 + counter; // NOLINT
 

--- a/examples/c/publish_subscribe_with_user_header/src/publisher.c
+++ b/examples/c/publish_subscribe_with_user_header/src/publisher.c
@@ -41,11 +41,11 @@ int main(void) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_ref_h node_ref_handle = iox2_cast_node_ref_h(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_ref_handle, NULL, service_name_ptr);
+    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_ref_h service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_ref_h(service_builder_pub_sub);
+    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
+        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "m";
@@ -81,7 +81,7 @@ int main(void) {
     }
 
     // create publisher
-    iox2_port_factory_pub_sub_ref_h ref_service = iox2_cast_port_factory_pub_sub_ref_h(service);
+    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_publisher_builder_h publisher_builder =
         iox2_port_factory_pub_sub_publisher_builder(ref_service, NULL);
     iox2_publisher_h publisher = NULL;
@@ -89,10 +89,10 @@ int main(void) {
         printf("Unable to create publisher!\n");
         goto drop_service;
     }
-    iox2_publisher_ref_h publisher_ref = iox2_cast_publisher_ref_h(publisher);
+    iox2_publisher_h_ref publisher_ref = iox2_cast_publisher_h_ref(publisher);
 
     int32_t counter = 0;
-    while (iox2_node_wait(node_ref_handle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // loan sample
@@ -101,7 +101,7 @@ int main(void) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }
-        iox2_sample_mut_ref_h sample_ref = iox2_cast_sample_mut_ref_h(sample);
+        iox2_sample_mut_h_ref sample_ref = iox2_cast_sample_mut_h_ref(sample);
 
         // write payload
         uint64_t* payload = NULL;

--- a/examples/c/publish_subscribe_with_user_header/src/subscriber.c
+++ b/examples/c/publish_subscribe_with_user_header/src/subscriber.c
@@ -41,15 +41,12 @@ int main(void) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(&node_handle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "m";
-    if (iox2_service_builder_pub_sub_set_payload_type_details(service_builder_pub_sub_ref,
+    if (iox2_service_builder_pub_sub_set_payload_type_details(&service_builder_pub_sub,
                                                               iox2_type_variant_e_FIXED_SIZE,
                                                               payload_type_name,
                                                               strlen(payload_type_name),
@@ -62,7 +59,7 @@ int main(void) {
 
     // set pub sub user header type
     const char* user_header_type_name = "12CustomHeader";
-    if (iox2_service_builder_pub_sub_set_user_header_type_details(service_builder_pub_sub_ref,
+    if (iox2_service_builder_pub_sub_set_user_header_type_details(&service_builder_pub_sub,
                                                                   iox2_type_variant_e_FIXED_SIZE,
                                                                   user_header_type_name,
                                                                   strlen(user_header_type_name),
@@ -81,34 +78,31 @@ int main(void) {
     }
 
     // create subscriber
-    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_subscriber_builder_h subscriber_builder =
-        iox2_port_factory_pub_sub_subscriber_builder(ref_service, NULL);
+        iox2_port_factory_pub_sub_subscriber_builder(&service, NULL);
     iox2_subscriber_h subscriber = NULL;
     if (iox2_port_factory_subscriber_builder_create(subscriber_builder, NULL, &subscriber) != IOX2_OK) {
         printf("Unable to create subscriber!\n");
         goto drop_service;
     }
-    iox2_subscriber_h_ref subscriber_ref = iox2_cast_subscriber_h_ref(subscriber);
 
     uint64_t counter = 0;
-    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(&node_handle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // receive sample
         iox2_sample_h sample = NULL;
-        if (iox2_subscriber_receive(subscriber_ref, NULL, &sample) != IOX2_OK) {
+        if (iox2_subscriber_receive(&subscriber, NULL, &sample) != IOX2_OK) {
             printf("Failed to receive sample\n");
             goto drop_subscriber;
         }
 
         if (sample != NULL) {
-            iox2_sample_h_ref sample_ref = iox2_cast_sample_h_ref(sample);
             uint64_t* payload = NULL;
-            iox2_sample_payload(sample_ref, (const void**) &payload, NULL);
+            iox2_sample_payload(&sample, (const void**) &payload, NULL);
 
             const struct CustomHeader* user_header = NULL;
-            iox2_sample_user_header(sample_ref, (const void**) &user_header);
+            iox2_sample_user_header(&sample, (const void**) &user_header);
 
             printf("received: %lu, user_header: version = %d, timestamp = %lu\n",
                    (long unsigned) *payload,

--- a/examples/c/publish_subscribe_with_user_header/src/subscriber.c
+++ b/examples/c/publish_subscribe_with_user_header/src/subscriber.c
@@ -41,11 +41,11 @@ int main(void) {
 
     // create service builder
     iox2_service_name_ptr service_name_ptr = iox2_cast_service_name_ptr(service_name);
-    iox2_node_ref_h node_ref_handle = iox2_cast_node_ref_h(node_handle);
-    iox2_service_builder_h service_builder = iox2_node_service_builder(node_ref_handle, NULL, service_name_ptr);
+    iox2_node_h_ref node_h_refandle = iox2_cast_node_h_ref(node_handle);
+    iox2_service_builder_h service_builder = iox2_node_service_builder(node_h_refandle, NULL, service_name_ptr);
     iox2_service_builder_pub_sub_h service_builder_pub_sub = iox2_service_builder_pub_sub(service_builder);
-    iox2_service_builder_pub_sub_ref_h service_builder_pub_sub_ref =
-        iox2_cast_service_builder_pub_sub_ref_h(service_builder_pub_sub);
+    iox2_service_builder_pub_sub_h_ref service_builder_pub_sub_ref =
+        iox2_cast_service_builder_pub_sub_h_ref(service_builder_pub_sub);
 
     // set pub sub payload type
     const char* payload_type_name = "m";
@@ -81,7 +81,7 @@ int main(void) {
     }
 
     // create subscriber
-    iox2_port_factory_pub_sub_ref_h ref_service = iox2_cast_port_factory_pub_sub_ref_h(service);
+    iox2_port_factory_pub_sub_h_ref ref_service = iox2_cast_port_factory_pub_sub_h_ref(service);
     iox2_port_factory_subscriber_builder_h subscriber_builder =
         iox2_port_factory_pub_sub_subscriber_builder(ref_service, NULL);
     iox2_subscriber_h subscriber = NULL;
@@ -89,10 +89,10 @@ int main(void) {
         printf("Unable to create subscriber!\n");
         goto drop_service;
     }
-    iox2_subscriber_ref_h subscriber_ref = iox2_cast_subscriber_ref_h(subscriber);
+    iox2_subscriber_h_ref subscriber_ref = iox2_cast_subscriber_h_ref(subscriber);
 
     uint64_t counter = 0;
-    while (iox2_node_wait(node_ref_handle, 1, 0) == iox2_node_event_e_TICK) {
+    while (iox2_node_wait(node_h_refandle, 1, 0) == iox2_node_event_e_TICK) {
         counter += 1;
 
         // receive sample
@@ -103,7 +103,7 @@ int main(void) {
         }
 
         if (sample != NULL) {
-            iox2_sample_ref_h sample_ref = iox2_cast_sample_ref_h(sample);
+            iox2_sample_h_ref sample_ref = iox2_cast_sample_h_ref(sample);
             uint64_t* payload = NULL;
             iox2_sample_payload(sample_ref, (const void**) &payload, NULL);
 

--- a/examples/cxx/complex_data_types/CMakeLists.txt
+++ b/examples/cxx/complex_data_types/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_cxx_complex_data_types LANGUAGES CXX)
 
-find_package(iceoryx2-cxx 0.3.0 REQUIRED)
+find_package(iceoryx2-cxx 0.4.0 REQUIRED)
 
 add_executable(example_cxx_complex_data_types src/complex_data_types.cpp)
 target_link_libraries(example_cxx_complex_data_types iceoryx2-cxx::static-lib-cxx)

--- a/examples/cxx/discovery/CMakeLists.txt
+++ b/examples/cxx/discovery/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_cxx_discovery LANGUAGES CXX)
 
-find_package(iceoryx2-cxx 0.3.0 REQUIRED)
+find_package(iceoryx2-cxx 0.4.0 REQUIRED)
 
 add_executable(example_cxx_discovery src/discovery.cpp)
 target_link_libraries(example_cxx_discovery iceoryx2-cxx::static-lib-cxx)

--- a/examples/cxx/domains/CMakeLists.txt
+++ b/examples/cxx/domains/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_cxx_domains LANGUAGES CXX)
 
-find_package(iceoryx2-cxx 0.3.0 REQUIRED)
+find_package(iceoryx2-cxx 0.4.0 REQUIRED)
 
 add_executable(example_cxx_domains_publisher src/publisher.cpp)
 target_link_libraries(example_cxx_domains_publisher iceoryx2-cxx::static-lib-cxx)

--- a/examples/cxx/event/CMakeLists.txt
+++ b/examples/cxx/event/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_cxx_event LANGUAGES CXX)
 
-find_package(iceoryx2-cxx 0.3.0 REQUIRED)
+find_package(iceoryx2-cxx 0.4.0 REQUIRED)
 
 add_executable(example_cxx_event_listener src/listener.cpp)
 target_link_libraries(example_cxx_event_listener iceoryx2-cxx::static-lib-cxx)

--- a/examples/cxx/publish_subscribe/CMakeLists.txt
+++ b/examples/cxx/publish_subscribe/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_cxx_publish_subscribe LANGUAGES CXX)
 
-find_package(iceoryx2-cxx 0.3.0 REQUIRED)
+find_package(iceoryx2-cxx 0.4.0 REQUIRED)
 
 add_executable(example_cxx_publish_subscribe_publisher src/publisher.cpp)
 target_link_libraries(example_cxx_publish_subscribe_publisher iceoryx2-cxx::static-lib-cxx)

--- a/examples/cxx/publish_subscribe_dynamic_data/CMakeLists.txt
+++ b/examples/cxx/publish_subscribe_dynamic_data/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_cxx_publish_subscribe_dynamic_data LANGUAGES CXX)
 
-find_package(iceoryx2-cxx 0.3.0 REQUIRED)
+find_package(iceoryx2-cxx 0.4.0 REQUIRED)
 
 add_executable(example_cxx_publish_subscribe_dyn_publisher src/publisher.cpp)
 target_link_libraries(example_cxx_publish_subscribe_dyn_publisher iceoryx2-cxx::static-lib-cxx)

--- a/examples/cxx/publish_subscribe_with_user_header/CMakeLists.txt
+++ b/examples/cxx/publish_subscribe_with_user_header/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_cxx_publish_subscribe_with_user_header LANGUAGES CXX)
 
-find_package(iceoryx2-cxx 0.3.0 REQUIRED)
+find_package(iceoryx2-cxx 0.4.0 REQUIRED)
 
 add_executable(example_cxx_publish_subscribe_user_header_publisher src/publisher.cpp)
 target_link_libraries(example_cxx_publish_subscribe_user_header_publisher iceoryx2-cxx::static-lib-cxx)

--- a/examples/cxx/service_attributes/CMakeLists.txt
+++ b/examples/cxx/service_attributes/CMakeLists.txt
@@ -13,7 +13,7 @@
 cmake_minimum_required(VERSION 3.22)
 project(example_cxx_service_attributes LANGUAGES CXX)
 
-find_package(iceoryx2-cxx 0.3.0 REQUIRED)
+find_package(iceoryx2-cxx 0.4.0 REQUIRED)
 
 add_executable(example_cxx_service_attributes_creator src/creator.cpp)
 target_link_libraries(example_cxx_service_attributes_creator iceoryx2-cxx::static-lib-cxx)

--- a/iceoryx2-ffi/c/BUILD.bazel
+++ b/iceoryx2-ffi/c/BUILD.bazel
@@ -22,7 +22,7 @@ filegroup(
 cmake(
     name = "iceoryx2-c",
     cache_entries = {
-        "IOX2_VERSION_STRING": "0.3.0",
+        "IOX2_VERSION_STRING": "0.4.0",
     },
     build_data = [
         ":cmake_srcs",
@@ -49,7 +49,7 @@ cmake(
         "//:win-msvc": "lib",
         "//conditions:default": "",
     }),
-    out_include_dir = "include/iceoryx2/v0.3.0/",
+    out_include_dir = "include/iceoryx2/v0.4.0/",
     exec_properties = {
         "requires-network": "true",
     },

--- a/iceoryx2-ffi/c/cmake/iceoryx2-cConfigVersion.cmake
+++ b/iceoryx2-ffi/c/cmake/iceoryx2-cConfigVersion.cmake
@@ -14,7 +14,7 @@
 ########## dummyConfig.cmake to be able to use find_package with a specific version with the source tree ##########
 #
 
-set(IOX2_VERSION_STRING "0.3.0")
+set(IOX2_VERSION_STRING "0.4.0")
 set(PACKAGE_VERSION ${IOX2_VERSION_STRING})
 
 if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)

--- a/iceoryx2-ffi/cxx/cmake/iceoryx2-cxxConfigVersion.cmake
+++ b/iceoryx2-ffi/cxx/cmake/iceoryx2-cxxConfigVersion.cmake
@@ -14,7 +14,7 @@
 ########## dummyConfig.cmake to be able to use find_package with a specific version with the source tree ##########
 #
 
-set(IOX2_VERSION_STRING "0.3.0")
+set(IOX2_VERSION_STRING "0.4.0")
 set(PACKAGE_VERSION ${IOX2_VERSION_STRING})
 
 if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_publish_subscribe.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_publish_subscribe.hpp
@@ -138,7 +138,7 @@ inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::attributes() co
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::static_config() const -> StaticConfigPublishSubscribe {
-    auto* ref_handle = iox2_cast_port_factory_pub_sub_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_pub_sub_h_ref(m_handle);
     iox2_static_config_publish_subscribe_t static_config {};
     iox2_port_factory_pub_sub_static_config(ref_handle, &static_config);
 
@@ -160,7 +160,7 @@ inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::nodes(
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::subscriber_builder() const
     -> PortFactorySubscriber<S, Payload, UserHeader> {
-    auto* ref_handle = iox2_cast_port_factory_pub_sub_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_pub_sub_h_ref(m_handle);
     return PortFactorySubscriber<S, Payload, UserHeader>(
         iox2_port_factory_pub_sub_subscriber_builder(ref_handle, nullptr));
 }
@@ -168,7 +168,7 @@ inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::subscriber_buil
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::publisher_builder() const
     -> PortFactoryPublisher<S, Payload, UserHeader> {
-    auto* ref_handle = iox2_cast_port_factory_pub_sub_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_pub_sub_h_ref(m_handle);
     return PortFactoryPublisher<S, Payload, UserHeader>(
         iox2_port_factory_pub_sub_publisher_builder(ref_handle, nullptr));
 }

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_publish_subscribe.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_publish_subscribe.hpp
@@ -138,9 +138,8 @@ inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::attributes() co
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::static_config() const -> StaticConfigPublishSubscribe {
-    auto* ref_handle = iox2_cast_port_factory_pub_sub_h_ref(m_handle);
     iox2_static_config_publish_subscribe_t static_config {};
-    iox2_port_factory_pub_sub_static_config(ref_handle, &static_config);
+    iox2_port_factory_pub_sub_static_config(&m_handle, &static_config);
 
     return StaticConfigPublishSubscribe(static_config);
 }
@@ -160,17 +159,15 @@ inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::nodes(
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::subscriber_builder() const
     -> PortFactorySubscriber<S, Payload, UserHeader> {
-    auto* ref_handle = iox2_cast_port_factory_pub_sub_h_ref(m_handle);
     return PortFactorySubscriber<S, Payload, UserHeader>(
-        iox2_port_factory_pub_sub_subscriber_builder(ref_handle, nullptr));
+        iox2_port_factory_pub_sub_subscriber_builder(&m_handle, nullptr));
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::publisher_builder() const
     -> PortFactoryPublisher<S, Payload, UserHeader> {
-    auto* ref_handle = iox2_cast_port_factory_pub_sub_h_ref(m_handle);
     return PortFactoryPublisher<S, Payload, UserHeader>(
-        iox2_port_factory_pub_sub_publisher_builder(ref_handle, nullptr));
+        iox2_port_factory_pub_sub_publisher_builder(&m_handle, nullptr));
 }
 
 

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
@@ -67,15 +67,13 @@ template <ServiceType S, typename Payload, typename UserHeader>
 inline auto
 PortFactoryPublisher<S, Payload, UserHeader>::create() && -> iox::expected<Publisher<S, Payload, UserHeader>,
                                                                            PublisherCreateError> {
-    auto* ref_handle = iox2_cast_port_factory_publisher_builder_h_ref(m_handle);
-
     m_unable_to_deliver_strategy.and_then([&](auto value) {
         iox2_port_factory_publisher_builder_unable_to_deliver_strategy(
-            ref_handle, static_cast<iox2_unable_to_deliver_strategy_e>(iox::into<int>(value)));
+            &m_handle, static_cast<iox2_unable_to_deliver_strategy_e>(iox::into<int>(value)));
     });
     m_max_slice_len.and_then([](auto) { IOX_TODO(); });
     m_max_loaned_samples.and_then(
-        [&](auto value) { iox2_port_factory_publisher_builder_set_max_loaned_samples(ref_handle, value); });
+        [&](auto value) { iox2_port_factory_publisher_builder_set_max_loaned_samples(&m_handle, value); });
 
     iox2_publisher_h pub_handle {};
 

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
@@ -67,7 +67,7 @@ template <ServiceType S, typename Payload, typename UserHeader>
 inline auto
 PortFactoryPublisher<S, Payload, UserHeader>::create() && -> iox::expected<Publisher<S, Payload, UserHeader>,
                                                                            PublisherCreateError> {
-    auto* ref_handle = iox2_cast_port_factory_publisher_builder_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_publisher_builder_h_ref(m_handle);
 
     m_unable_to_deliver_strategy.and_then([&](auto value) {
         iox2_port_factory_publisher_builder_unable_to_deliver_strategy(

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_subscriber.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_subscriber.hpp
@@ -60,8 +60,7 @@ template <ServiceType S, typename Payload, typename UserHeader>
 inline auto
 PortFactorySubscriber<S, Payload, UserHeader>::create() && -> iox::expected<Subscriber<S, Payload, UserHeader>,
                                                                             SubscriberCreateError> {
-    m_buffer_size.and_then(
-        [&](auto value) { iox2_port_factory_subscriber_builder_set_buffer_size(&m_handle, value); });
+    m_buffer_size.and_then([&](auto value) { iox2_port_factory_subscriber_builder_set_buffer_size(&m_handle, value); });
 
     iox2_subscriber_h sub_handle {};
     auto result = iox2_port_factory_subscriber_builder_create(m_handle, nullptr, &sub_handle);

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_subscriber.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_subscriber.hpp
@@ -60,7 +60,7 @@ template <ServiceType S, typename Payload, typename UserHeader>
 inline auto
 PortFactorySubscriber<S, Payload, UserHeader>::create() && -> iox::expected<Subscriber<S, Payload, UserHeader>,
                                                                             SubscriberCreateError> {
-    auto* ref_handle = iox2_cast_port_factory_subscriber_builder_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_subscriber_builder_h_ref(m_handle);
     m_buffer_size.and_then(
         [&](auto value) { iox2_port_factory_subscriber_builder_set_buffer_size(ref_handle, value); });
 

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_subscriber.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_subscriber.hpp
@@ -60,9 +60,8 @@ template <ServiceType S, typename Payload, typename UserHeader>
 inline auto
 PortFactorySubscriber<S, Payload, UserHeader>::create() && -> iox::expected<Subscriber<S, Payload, UserHeader>,
                                                                             SubscriberCreateError> {
-    auto* ref_handle = iox2_cast_port_factory_subscriber_builder_h_ref(m_handle);
     m_buffer_size.and_then(
-        [&](auto value) { iox2_port_factory_subscriber_builder_set_buffer_size(ref_handle, value); });
+        [&](auto value) { iox2_port_factory_subscriber_builder_set_buffer_size(&m_handle, value); });
 
     iox2_subscriber_h sub_handle {};
     auto result = iox2_port_factory_subscriber_builder_create(m_handle, nullptr, &sub_handle);

--- a/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
@@ -153,8 +153,8 @@ inline auto Publisher<S, Payload, UserHeader>::send_copy(const Payload& payload)
     static_assert(std::is_trivially_copyable<Payload>::value);
 
     size_t number_of_recipients = 0;
-    auto result = iox2_publisher_send_copy(
-        &m_handle, static_cast<const void*>(&payload), sizeof(Payload), &number_of_recipients);
+    auto result =
+        iox2_publisher_send_copy(&m_handle, static_cast<const void*>(&payload), sizeof(Payload), &number_of_recipients);
 
     if (result == IOX2_OK) {
         return iox::ok(number_of_recipients);

--- a/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
@@ -136,13 +136,13 @@ inline Publisher<S, Payload, UserHeader>::~Publisher() {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::unable_to_deliver_strategy() const -> UnableToDeliverStrategy {
-    auto* ref_handle = iox2_cast_publisher_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
     return iox::into<UnableToDeliverStrategy>(static_cast<int>(iox2_publisher_unable_to_deliver_strategy(ref_handle)));
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::id() const -> UniquePublisherId {
-    auto* ref_handle = iox2_cast_publisher_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
     iox2_unique_publisher_id_h id_handle = nullptr;
 
     iox2_publisher_id(ref_handle, nullptr, &id_handle);
@@ -154,7 +154,7 @@ inline auto Publisher<S, Payload, UserHeader>::send_copy(const Payload& payload)
     -> iox::expected<size_t, PublisherSendError> {
     static_assert(std::is_trivially_copyable<Payload>::value);
 
-    auto* ref_handle = iox2_cast_publisher_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
 
     size_t number_of_recipients = 0;
     auto result = iox2_publisher_send_copy(
@@ -170,7 +170,7 @@ inline auto Publisher<S, Payload, UserHeader>::send_copy(const Payload& payload)
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::loan_uninit()
     -> iox::expected<SampleMutUninit<S, Payload, UserHeader>, PublisherLoanError> {
-    auto* ref_handle = iox2_cast_publisher_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
     SampleMutUninit<S, Payload, UserHeader> sample;
 
     auto result = iox2_publisher_loan(ref_handle, &sample.m_sample.m_sample, &sample.m_sample.m_handle);
@@ -212,7 +212,7 @@ inline auto Publisher<S, Payload, UserHeader>::loan_slice_uninit(const uint64_t 
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::update_connections() -> iox::expected<void, ConnectionFailure> {
-    auto* ref_handle = iox2_cast_publisher_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
     auto result = iox2_publisher_update_connections(ref_handle);
     if (result != IOX2_OK) {
         return iox::err(iox::into<ConnectionFailure>(result));

--- a/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
@@ -136,16 +136,14 @@ inline Publisher<S, Payload, UserHeader>::~Publisher() {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::unable_to_deliver_strategy() const -> UnableToDeliverStrategy {
-    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
-    return iox::into<UnableToDeliverStrategy>(static_cast<int>(iox2_publisher_unable_to_deliver_strategy(ref_handle)));
+    return iox::into<UnableToDeliverStrategy>(static_cast<int>(iox2_publisher_unable_to_deliver_strategy(&m_handle)));
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::id() const -> UniquePublisherId {
-    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
     iox2_unique_publisher_id_h id_handle = nullptr;
 
-    iox2_publisher_id(ref_handle, nullptr, &id_handle);
+    iox2_publisher_id(&m_handle, nullptr, &id_handle);
     return UniquePublisherId { id_handle };
 }
 
@@ -154,11 +152,9 @@ inline auto Publisher<S, Payload, UserHeader>::send_copy(const Payload& payload)
     -> iox::expected<size_t, PublisherSendError> {
     static_assert(std::is_trivially_copyable<Payload>::value);
 
-    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
-
     size_t number_of_recipients = 0;
     auto result = iox2_publisher_send_copy(
-        ref_handle, static_cast<const void*>(&payload), sizeof(Payload), &number_of_recipients);
+        &m_handle, static_cast<const void*>(&payload), sizeof(Payload), &number_of_recipients);
 
     if (result == IOX2_OK) {
         return iox::ok(number_of_recipients);
@@ -170,10 +166,9 @@ inline auto Publisher<S, Payload, UserHeader>::send_copy(const Payload& payload)
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::loan_uninit()
     -> iox::expected<SampleMutUninit<S, Payload, UserHeader>, PublisherLoanError> {
-    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
     SampleMutUninit<S, Payload, UserHeader> sample;
 
-    auto result = iox2_publisher_loan(ref_handle, &sample.m_sample.m_sample, &sample.m_sample.m_handle);
+    auto result = iox2_publisher_loan(&m_handle, &sample.m_sample.m_sample, &sample.m_sample.m_handle);
 
     if (result == IOX2_OK) {
         return iox::ok(std::move(sample));
@@ -212,8 +207,7 @@ inline auto Publisher<S, Payload, UserHeader>::loan_slice_uninit(const uint64_t 
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::update_connections() -> iox::expected<void, ConnectionFailure> {
-    auto* ref_handle = iox2_cast_publisher_h_ref(m_handle);
-    auto result = iox2_publisher_update_connections(ref_handle);
+    auto result = iox2_publisher_update_connections(&m_handle);
     if (result != IOX2_OK) {
         return iox::err(iox::into<ConnectionFailure>(result));
     }

--- a/iceoryx2-ffi/cxx/include/iox2/sample.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample.hpp
@@ -122,11 +122,10 @@ inline auto Sample<S, Payload, UserHeader>::operator->() const -> const Payload*
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Sample<S, Payload, UserHeader>::payload() const -> const Payload& {
-    auto* ref_handle = iox2_cast_sample_h_ref(m_handle);
     const void* payload_ptr = nullptr;
     size_t payload_len = 0;
 
-    iox2_sample_payload(ref_handle, &payload_ptr, &payload_len);
+    iox2_sample_payload(&m_handle, &payload_ptr, &payload_len);
     IOX_ASSERT(sizeof(Payload) <= payload_len, "");
 
     return *static_cast<const Payload*>(payload_ptr);
@@ -135,19 +134,17 @@ inline auto Sample<S, Payload, UserHeader>::payload() const -> const Payload& {
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto Sample<S, Payload, UserHeader>::user_header() const -> const T& {
-    auto* ref_handle = iox2_cast_sample_h_ref(m_handle);
     const void* header_ptr = nullptr;
 
-    iox2_sample_user_header(ref_handle, &header_ptr);
+    iox2_sample_user_header(&m_handle, &header_ptr);
 
     return *static_cast<const T*>(header_ptr);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Sample<S, Payload, UserHeader>::header() const -> HeaderPublishSubscribe {
-    auto* ref_handle = iox2_cast_sample_h_ref(m_handle);
     iox2_publish_subscribe_header_h header_handle = nullptr;
-    iox2_sample_header(ref_handle, nullptr, &header_handle);
+    iox2_sample_header(&m_handle, nullptr, &header_handle);
 
     return HeaderPublishSubscribe { header_handle };
 }

--- a/iceoryx2-ffi/cxx/include/iox2/sample.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample.hpp
@@ -122,7 +122,7 @@ inline auto Sample<S, Payload, UserHeader>::operator->() const -> const Payload*
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Sample<S, Payload, UserHeader>::payload() const -> const Payload& {
-    auto* ref_handle = iox2_cast_sample_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_sample_h_ref(m_handle);
     const void* payload_ptr = nullptr;
     size_t payload_len = 0;
 
@@ -135,7 +135,7 @@ inline auto Sample<S, Payload, UserHeader>::payload() const -> const Payload& {
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto Sample<S, Payload, UserHeader>::user_header() const -> const T& {
-    auto* ref_handle = iox2_cast_sample_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_sample_h_ref(m_handle);
     const void* header_ptr = nullptr;
 
     iox2_sample_user_header(ref_handle, &header_ptr);
@@ -145,7 +145,7 @@ inline auto Sample<S, Payload, UserHeader>::user_header() const -> const T& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Sample<S, Payload, UserHeader>::header() const -> HeaderPublishSubscribe {
-    auto* ref_handle = iox2_cast_sample_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_sample_h_ref(m_handle);
     iox2_publish_subscribe_header_h header_handle = nullptr;
     iox2_sample_header(ref_handle, nullptr, &header_handle);
 

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
@@ -159,9 +159,8 @@ inline auto SampleMut<S, Payload, UserHeader>::operator->() -> Payload* {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto SampleMut<S, Payload, UserHeader>::header() const -> HeaderPublishSubscribe {
-    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     iox2_publish_subscribe_header_h header_handle = nullptr;
-    iox2_sample_mut_header(ref_handle, nullptr, &header_handle);
+    iox2_sample_mut_header(&m_handle, nullptr, &header_handle);
 
     return HeaderPublishSubscribe { header_handle };
 }
@@ -169,10 +168,9 @@ inline auto SampleMut<S, Payload, UserHeader>::header() const -> HeaderPublishSu
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto SampleMut<S, Payload, UserHeader>::user_header() const -> const T& {
-    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     const void* ptr = nullptr;
 
-    iox2_sample_mut_user_header(ref_handle, &ptr);
+    iox2_sample_mut_user_header(&m_handle, &ptr);
 
     return *static_cast<const T*>(ptr);
 }
@@ -180,21 +178,19 @@ inline auto SampleMut<S, Payload, UserHeader>::user_header() const -> const T& {
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto SampleMut<S, Payload, UserHeader>::user_header_mut() -> T& {
-    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     void* ptr = nullptr;
 
-    iox2_sample_mut_user_header_mut(ref_handle, &ptr);
+    iox2_sample_mut_user_header_mut(&m_handle, &ptr);
 
     return *static_cast<T*>(ptr);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto SampleMut<S, Payload, UserHeader>::payload() const -> const Payload& {
-    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     const void* ptr = nullptr;
     size_t payload_len = 0;
 
-    iox2_sample_mut_payload(ref_handle, &ptr, &payload_len);
+    iox2_sample_mut_payload(&m_handle, &ptr, &payload_len);
     IOX_ASSERT(sizeof(Payload) <= payload_len, "");
 
     return *static_cast<const Payload*>(ptr);
@@ -202,11 +198,10 @@ inline auto SampleMut<S, Payload, UserHeader>::payload() const -> const Payload&
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto SampleMut<S, Payload, UserHeader>::payload_mut() -> Payload& {
-    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     void* ptr = nullptr;
     size_t payload_len = 0;
 
-    iox2_sample_mut_payload_mut(ref_handle, &ptr, &payload_len);
+    iox2_sample_mut_payload_mut(&m_handle, &ptr, &payload_len);
     IOX_ASSERT(sizeof(Payload) <= payload_len, "");
 
     return *static_cast<Payload*>(ptr);

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
@@ -159,7 +159,7 @@ inline auto SampleMut<S, Payload, UserHeader>::operator->() -> Payload* {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto SampleMut<S, Payload, UserHeader>::header() const -> HeaderPublishSubscribe {
-    auto* ref_handle = iox2_cast_sample_mut_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     iox2_publish_subscribe_header_h header_handle = nullptr;
     iox2_sample_mut_header(ref_handle, nullptr, &header_handle);
 
@@ -169,7 +169,7 @@ inline auto SampleMut<S, Payload, UserHeader>::header() const -> HeaderPublishSu
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto SampleMut<S, Payload, UserHeader>::user_header() const -> const T& {
-    auto* ref_handle = iox2_cast_sample_mut_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     const void* ptr = nullptr;
 
     iox2_sample_mut_user_header(ref_handle, &ptr);
@@ -180,7 +180,7 @@ inline auto SampleMut<S, Payload, UserHeader>::user_header() const -> const T& {
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto SampleMut<S, Payload, UserHeader>::user_header_mut() -> T& {
-    auto* ref_handle = iox2_cast_sample_mut_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     void* ptr = nullptr;
 
     iox2_sample_mut_user_header_mut(ref_handle, &ptr);
@@ -190,7 +190,7 @@ inline auto SampleMut<S, Payload, UserHeader>::user_header_mut() -> T& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto SampleMut<S, Payload, UserHeader>::payload() const -> const Payload& {
-    auto* ref_handle = iox2_cast_sample_mut_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     const void* ptr = nullptr;
     size_t payload_len = 0;
 
@@ -202,7 +202,7 @@ inline auto SampleMut<S, Payload, UserHeader>::payload() const -> const Payload&
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto SampleMut<S, Payload, UserHeader>::payload_mut() -> Payload& {
-    auto* ref_handle = iox2_cast_sample_mut_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_sample_mut_h_ref(m_handle);
     void* ptr = nullptr;
     size_t payload_len = 0;
 

--- a/iceoryx2-ffi/cxx/include/iox2/service_builder.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/service_builder.hpp
@@ -42,13 +42,13 @@ class ServiceBuilder {
   private:
     template <ServiceType>
     friend class Node;
-    ServiceBuilder(iox2_node_ref_h node_handle, iox2_service_name_ptr service_name_ptr);
+    ServiceBuilder(iox2_node_h_ref node_handle, iox2_service_name_ptr service_name_ptr);
 
     iox2_service_builder_h m_handle;
 };
 
 template <ServiceType S>
-inline ServiceBuilder<S>::ServiceBuilder(iox2_node_ref_h node_handle, iox2_service_name_ptr service_name_ptr)
+inline ServiceBuilder<S>::ServiceBuilder(iox2_node_h_ref node_handle, iox2_service_name_ptr service_name_ptr)
     : m_handle { iox2_node_service_builder(node_handle, nullptr, service_name_ptr) } {
 }
 

--- a/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -125,7 +125,7 @@ inline ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::ServiceBuilderPub
 
 template <typename Payload, typename UserHeader, ServiceType S>
 inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_parameters() {
-    auto* ref_handle = iox2_cast_service_builder_pub_sub_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_service_builder_pub_sub_h_ref(m_handle);
 
     m_payload_alignment.and_then([](auto) { IOX_TODO(); });
     m_enable_safe_overflow.and_then(

--- a/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -133,8 +133,7 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
     m_history_size.and_then([&](auto value) { iox2_service_builder_pub_sub_set_history_size(&m_handle, value); });
     m_subscriber_max_buffer_size.and_then(
         [&](auto value) { iox2_service_builder_pub_sub_set_subscriber_max_buffer_size(&m_handle, value); });
-    m_max_subscribers.and_then(
-        [&](auto value) { iox2_service_builder_pub_sub_set_max_subscribers(&m_handle, value); });
+    m_max_subscribers.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_subscribers(&m_handle, value); });
     m_max_publishers.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_publishers(&m_handle, value); });
     m_max_nodes.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_nodes(&m_handle, value); });
 

--- a/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -125,20 +125,18 @@ inline ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::ServiceBuilderPub
 
 template <typename Payload, typename UserHeader, ServiceType S>
 inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_parameters() {
-    auto* ref_handle = iox2_cast_service_builder_pub_sub_h_ref(m_handle);
-
     m_payload_alignment.and_then([](auto) { IOX_TODO(); });
     m_enable_safe_overflow.and_then(
-        [&](auto value) { iox2_service_builder_pub_sub_set_enable_safe_overflow(ref_handle, value); });
+        [&](auto value) { iox2_service_builder_pub_sub_set_enable_safe_overflow(&m_handle, value); });
     m_subscriber_max_borrowed_samples.and_then(
-        [&](auto value) { iox2_service_builder_pub_sub_set_subscriber_max_borrowed_samples(ref_handle, value); });
-    m_history_size.and_then([&](auto value) { iox2_service_builder_pub_sub_set_history_size(ref_handle, value); });
+        [&](auto value) { iox2_service_builder_pub_sub_set_subscriber_max_borrowed_samples(&m_handle, value); });
+    m_history_size.and_then([&](auto value) { iox2_service_builder_pub_sub_set_history_size(&m_handle, value); });
     m_subscriber_max_buffer_size.and_then(
-        [&](auto value) { iox2_service_builder_pub_sub_set_subscriber_max_buffer_size(ref_handle, value); });
+        [&](auto value) { iox2_service_builder_pub_sub_set_subscriber_max_buffer_size(&m_handle, value); });
     m_max_subscribers.and_then(
-        [&](auto value) { iox2_service_builder_pub_sub_set_max_subscribers(ref_handle, value); });
-    m_max_publishers.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_publishers(ref_handle, value); });
-    m_max_nodes.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_nodes(ref_handle, value); });
+        [&](auto value) { iox2_service_builder_pub_sub_set_max_subscribers(&m_handle, value); });
+    m_max_publishers.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_publishers(&m_handle, value); });
+    m_max_nodes.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_nodes(&m_handle, value); });
 
     // payload type details
     const auto* payload_type_name = typeid(Payload).name();
@@ -146,7 +144,7 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
     const auto payload_type_size = sizeof(Payload);
     const auto payload_type_align = alignof(Payload);
 
-    const auto payload_result = iox2_service_builder_pub_sub_set_payload_type_details(ref_handle,
+    const auto payload_result = iox2_service_builder_pub_sub_set_payload_type_details(&m_handle,
                                                                                       iox2_type_variant_e_FIXED_SIZE,
                                                                                       payload_type_name,
                                                                                       payload_type_name_len,
@@ -165,7 +163,7 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
     const auto user_header_type_align = header_layout.alignment();
 
     const auto user_header_result =
-        iox2_service_builder_pub_sub_set_user_header_type_details(ref_handle,
+        iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
                                                                   iox2_type_variant_e_FIXED_SIZE,
                                                                   user_header_type_name,
                                                                   user_header_type_name_len,

--- a/iceoryx2-ffi/cxx/include/iox2/subscriber.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/subscriber.hpp
@@ -104,9 +104,8 @@ inline void Subscriber<S, Payload, UserHeader>::drop() {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::has_samples() const -> iox::expected<bool, ConnectionFailure> {
-    auto* ref_handle = iox2_cast_subscriber_h_ref(m_handle);
     bool has_samples_result = false;
-    auto result = iox2_subscriber_has_samples(ref_handle, &has_samples_result);
+    auto result = iox2_subscriber_has_samples(&m_handle, &has_samples_result);
 
     if (result == IOX2_OK) {
         return iox::ok(has_samples_result);
@@ -117,10 +116,9 @@ inline auto Subscriber<S, Payload, UserHeader>::has_samples() const -> iox::expe
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::id() const -> UniqueSubscriberId {
-    auto* ref_handle = iox2_cast_subscriber_h_ref(m_handle);
     iox2_unique_subscriber_id_h id_handle = nullptr;
 
-    iox2_subscriber_id(ref_handle, nullptr, &id_handle);
+    iox2_subscriber_id(&m_handle, nullptr, &id_handle);
     return UniqueSubscriberId { id_handle };
 }
 
@@ -132,11 +130,9 @@ inline auto Subscriber<S, Payload, UserHeader>::buffer_size() const -> uint64_t 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::receive() const
     -> iox::expected<iox::optional<Sample<S, Payload, UserHeader>>, SubscriberReceiveError> {
-    auto* ref_handle = iox2_cast_subscriber_h_ref(m_handle);
-
     Sample<S, Payload, UserHeader> sample;
     iox2_sample_h sample_handle {};
-    auto result = iox2_subscriber_receive(ref_handle, &sample.m_sample, &sample.m_handle);
+    auto result = iox2_subscriber_receive(&m_handle, &sample.m_sample, &sample.m_handle);
 
     if (result == IOX2_OK) {
         if (sample.m_handle != nullptr) {
@@ -150,8 +146,7 @@ inline auto Subscriber<S, Payload, UserHeader>::receive() const
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::update_connections() const -> iox::expected<void, ConnectionFailure> {
-    auto* ref_handle = iox2_cast_subscriber_h_ref(m_handle);
-    auto result = iox2_subscriber_update_connections(ref_handle);
+    auto result = iox2_subscriber_update_connections(&m_handle);
     if (result != IOX2_OK) {
         return iox::err(iox::into<ConnectionFailure>(result));
     }

--- a/iceoryx2-ffi/cxx/include/iox2/subscriber.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/subscriber.hpp
@@ -104,7 +104,7 @@ inline void Subscriber<S, Payload, UserHeader>::drop() {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::has_samples() const -> iox::expected<bool, ConnectionFailure> {
-    auto* ref_handle = iox2_cast_subscriber_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_subscriber_h_ref(m_handle);
     bool has_samples_result = false;
     auto result = iox2_subscriber_has_samples(ref_handle, &has_samples_result);
 
@@ -117,7 +117,7 @@ inline auto Subscriber<S, Payload, UserHeader>::has_samples() const -> iox::expe
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::id() const -> UniqueSubscriberId {
-    auto* ref_handle = iox2_cast_subscriber_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_subscriber_h_ref(m_handle);
     iox2_unique_subscriber_id_h id_handle = nullptr;
 
     iox2_subscriber_id(ref_handle, nullptr, &id_handle);
@@ -132,7 +132,7 @@ inline auto Subscriber<S, Payload, UserHeader>::buffer_size() const -> uint64_t 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::receive() const
     -> iox::expected<iox::optional<Sample<S, Payload, UserHeader>>, SubscriberReceiveError> {
-    auto* ref_handle = iox2_cast_subscriber_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_subscriber_h_ref(m_handle);
 
     Sample<S, Payload, UserHeader> sample;
     iox2_sample_h sample_handle {};
@@ -150,7 +150,7 @@ inline auto Subscriber<S, Payload, UserHeader>::receive() const
 
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::update_connections() const -> iox::expected<void, ConnectionFailure> {
-    auto* ref_handle = iox2_cast_subscriber_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_subscriber_h_ref(m_handle);
     auto result = iox2_subscriber_update_connections(ref_handle);
     if (result != IOX2_OK) {
         return iox::err(iox::into<ConnectionFailure>(result));

--- a/iceoryx2-ffi/cxx/src/config.cpp
+++ b/iceoryx2-ffi/cxx/src/config.cpp
@@ -46,7 +46,7 @@ void Config::drop() {
 }
 
 Config::Config(const Config& rhs) {
-    auto* ref_handle = iox2_cast_config_ref_h(rhs.m_handle);
+    auto* ref_handle = iox2_cast_config_h_ref(rhs.m_handle);
     iox2_config_clone(ref_handle, nullptr, &m_handle);
 }
 
@@ -62,7 +62,7 @@ Config::~Config() {
 auto Config::operator=(const Config& rhs) -> Config& {
     if (this != &rhs) {
         drop();
-        auto* ref_handle = iox2_cast_config_ref_h(rhs.m_handle);
+        auto* ref_handle = iox2_cast_config_h_ref(rhs.m_handle);
         iox2_config_clone(ref_handle, nullptr, &m_handle);
     }
     return *this;
@@ -121,22 +121,22 @@ Global::Global(iox2_config_h* config)
 }
 
 auto Global::prefix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_prefix(ref_handle);
 }
 
 void Global::set_prefix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_set_prefix(ref_handle, value.as_string().c_str());
 }
 
 auto Global::root_path() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_root_path(ref_handle);
 }
 
 void Global::set_root_path(const iox::Path& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_set_root_path(ref_handle, value.as_string().c_str());
 }
 
@@ -177,42 +177,42 @@ Event::Event(iox2_config_h* config)
 }
 
 auto Event::max_listeners() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_event_max_listeners(ref_handle);
 }
 
 void Event::set_max_listeners(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_event_set_max_listeners(ref_handle, value);
 }
 
 auto Event::max_notifiers() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_event_max_notifiers(ref_handle);
 }
 
 void Event::set_max_notifiers(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_event_set_max_notifiers(ref_handle, value);
 }
 
 auto Event::max_nodes() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_event_max_nodes(ref_handle);
 }
 
 void Event::set_max_nodes(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_event_set_max_nodes(ref_handle, value);
 }
 
 auto Event::event_id_max_value() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_event_event_id_max_value(ref_handle);
 }
 
 void Event::set_event_id_max_value(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_event_set_event_id_max_value(ref_handle, value);
 }
 /////////////////////////
@@ -227,104 +227,104 @@ PublishSubscribe::PublishSubscribe(iox2_config_h* config)
 }
 
 auto PublishSubscribe::max_subscribers() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_max_subscribers(ref_handle);
 }
 
 void PublishSubscribe::set_max_subscribers(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_max_subscribers(ref_handle, value);
 }
 
 auto PublishSubscribe::max_publishers() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_max_publishers(ref_handle);
 }
 
 void PublishSubscribe::set_max_publishers(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_max_publishers(ref_handle, value);
 }
 
 auto PublishSubscribe::max_nodes() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_max_nodes(ref_handle);
 }
 
 void PublishSubscribe::set_max_nodes(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_max_nodes(ref_handle, value);
 }
 
 auto PublishSubscribe::subscriber_max_buffer_size() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_subscriber_max_buffer_size(ref_handle);
 }
 
 void PublishSubscribe::set_subscriber_max_buffer_size(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_subscriber_max_buffer_size(ref_handle, value);
 }
 
 auto PublishSubscribe::subscriber_max_borrowed_samples() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_subscriber_max_borrowed_samples(ref_handle);
 }
 
 void PublishSubscribe::set_subscriber_max_borrowed_samples(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_subscriber_max_borrowed_samples(ref_handle, value);
 }
 
 auto PublishSubscribe::publisher_max_loaned_samples() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_publisher_max_loaned_samples(ref_handle);
 }
 
 void PublishSubscribe::set_publisher_max_loaned_samples(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_publisher_max_loaned_samples(ref_handle, value);
 }
 
 auto PublishSubscribe::publisher_history_size() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_publisher_history_size(ref_handle);
 }
 
 void PublishSubscribe::set_publisher_history_size(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_publisher_history_size(ref_handle, value);
 }
 
 auto PublishSubscribe::enable_safe_overflow() && -> bool {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_enable_safe_overflow(ref_handle);
 }
 
 void PublishSubscribe::set_enable_safe_overflow(bool value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_enable_safe_overflow(ref_handle, value);
 }
 
 auto PublishSubscribe::unable_to_deliver_strategy() && -> UnableToDeliverStrategy {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox::into<UnableToDeliverStrategy>(
         iox2_config_defaults_publish_subscribe_unable_to_deliver_strategy(ref_handle));
 }
 
 void PublishSubscribe::set_unable_to_deliver_strategy(UnableToDeliverStrategy value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_unable_to_deliver_strategy(
         ref_handle, static_cast<iox2_unable_to_deliver_strategy_e>(iox::into<int>(value)));
 }
 
 auto PublishSubscribe::subscriber_expired_connection_buffer() && -> size_t {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_defaults_publish_subscribe_subscriber_expired_connection_buffer(ref_handle);
 }
 
 void PublishSubscribe::set_subscriber_expired_connection_buffer(size_t value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_subscriber_expired_connection_buffer(ref_handle, value);
 }
 /////////////////////////
@@ -339,47 +339,47 @@ Service::Service(iox2_config_h* config)
 }
 
 auto Service::directory() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_service_directory(ref_handle);
 }
 
 void Service::set_directory(const iox::Path& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_service_set_directory(ref_handle, value.as_string().c_str());
 }
 
 auto Service::publisher_data_segment_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_service_publisher_data_segment_suffix(ref_handle);
 }
 
 void Service::set_publisher_data_segment_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_service_set_publisher_data_segment_suffix(ref_handle, value.as_string().c_str());
 }
 
 auto Service::static_config_storage_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_service_static_config_storage_suffix(ref_handle);
 }
 
 void Service::set_static_config_storage_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_service_set_static_config_storage_suffix(ref_handle, value.as_string().c_str());
 }
 
 auto Service::dynamic_config_storage_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_service_dynamic_config_storage_suffix(ref_handle);
 }
 
 void Service::set_dynamic_config_storage_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_service_set_dynamic_config_storage_suffix(ref_handle, value.as_string().c_str());
 }
 
 auto Service::creation_timeout() && -> iox::units::Duration {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     uint64_t secs = 0;
     uint32_t nsecs = 0;
     iox2_config_global_service_creation_timeout(ref_handle, &secs, &nsecs);
@@ -388,28 +388,28 @@ auto Service::creation_timeout() && -> iox::units::Duration {
 }
 
 void Service::set_creation_timeout(const iox::units::Duration& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     auto duration = value.timespec();
     iox2_config_global_service_set_creation_timeout(ref_handle, duration.tv_sec, duration.tv_nsec);
 }
 
 auto Service::connection_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_service_connection_suffix(ref_handle);
 }
 
 void Service::set_connection_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_service_set_connection_suffix(ref_handle, value.as_string().c_str());
 }
 
 auto Service::event_connection_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_service_event_connection_suffix(ref_handle);
 }
 
 void Service::set_event_connection_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_service_set_event_connection_suffix(ref_handle, value.as_string().c_str());
 }
 /////////////////////////
@@ -424,62 +424,62 @@ Node::Node(iox2_config_h* config)
 }
 
 auto Node::directory() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_node_directory(ref_handle);
 }
 
 void Node::set_directory(const iox::Path& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_node_set_directory(ref_handle, value.as_string().c_str());
 }
 
 auto Node::monitor_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_node_monitor_suffix(ref_handle);
 }
 
 void Node::set_monitor_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_node_set_monitor_suffix(ref_handle, value.as_string().c_str());
 }
 
 auto Node::static_config_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_node_static_config_suffix(ref_handle);
 }
 
 void Node::set_static_config_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_node_set_static_config_suffix(ref_handle, value.as_string().c_str());
 }
 
 auto Node::service_tag_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_node_service_tag_suffix(ref_handle);
 }
 
 void Node::set_service_tag_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_node_set_service_tag_suffix(ref_handle, value.as_string().c_str());
 }
 
 auto Node::cleanup_dead_nodes_on_creation() && -> bool {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_node_cleanup_dead_nodes_on_creation(ref_handle);
 }
 
 void Node::set_cleanup_dead_nodes_on_creation(bool value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_node_set_cleanup_dead_nodes_on_creation(ref_handle, value);
 }
 
 auto Node::cleanup_dead_nodes_on_destruction() && -> bool {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox2_config_global_node_cleanup_dead_nodes_on_destruction(ref_handle);
 }
 
 void Node::set_cleanup_dead_nodes_on_destruction(bool value) && {
-    auto* ref_handle = iox2_cast_config_ref_h(*m_config);
+    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_global_node_set_cleanup_dead_nodes_on_destruction(ref_handle, value);
 }
 /////////////////////////

--- a/iceoryx2-ffi/cxx/src/config.cpp
+++ b/iceoryx2-ffi/cxx/src/config.cpp
@@ -46,8 +46,7 @@ void Config::drop() {
 }
 
 Config::Config(const Config& rhs) {
-    auto* ref_handle = iox2_cast_config_h_ref(rhs.m_handle);
-    iox2_config_clone(ref_handle, nullptr, &m_handle);
+    iox2_config_clone(&rhs.m_handle, nullptr, &m_handle);
 }
 
 Config::Config(Config&& rhs) noexcept
@@ -62,8 +61,7 @@ Config::~Config() {
 auto Config::operator=(const Config& rhs) -> Config& {
     if (this != &rhs) {
         drop();
-        auto* ref_handle = iox2_cast_config_h_ref(rhs.m_handle);
-        iox2_config_clone(ref_handle, nullptr, &m_handle);
+        iox2_config_clone(&rhs.m_handle, nullptr, &m_handle);
     }
     return *this;
 }
@@ -121,23 +119,19 @@ Global::Global(iox2_config_h* config)
 }
 
 auto Global::prefix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_prefix(ref_handle);
+    return iox2_config_global_prefix(m_config);
 }
 
 void Global::set_prefix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_set_prefix(ref_handle, value.as_string().c_str());
+    iox2_config_global_set_prefix(m_config, value.as_string().c_str());
 }
 
 auto Global::root_path() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_root_path(ref_handle);
+    return iox2_config_global_root_path(m_config);
 }
 
 void Global::set_root_path(const iox::Path& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_set_root_path(ref_handle, value.as_string().c_str());
+    iox2_config_global_set_root_path(m_config, value.as_string().c_str());
 }
 
 auto Global::service() -> Service {
@@ -177,43 +171,35 @@ Event::Event(iox2_config_h* config)
 }
 
 auto Event::max_listeners() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_event_max_listeners(ref_handle);
+    return iox2_config_defaults_event_max_listeners(m_config);
 }
 
 void Event::set_max_listeners(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_event_set_max_listeners(ref_handle, value);
+    iox2_config_defaults_event_set_max_listeners(m_config, value);
 }
 
 auto Event::max_notifiers() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_event_max_notifiers(ref_handle);
+    return iox2_config_defaults_event_max_notifiers(m_config);
 }
 
 void Event::set_max_notifiers(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_event_set_max_notifiers(ref_handle, value);
+    iox2_config_defaults_event_set_max_notifiers(m_config, value);
 }
 
 auto Event::max_nodes() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_event_max_nodes(ref_handle);
+    return iox2_config_defaults_event_max_nodes(m_config);
 }
 
 void Event::set_max_nodes(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_event_set_max_nodes(ref_handle, value);
+    iox2_config_defaults_event_set_max_nodes(m_config, value);
 }
 
 auto Event::event_id_max_value() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_event_event_id_max_value(ref_handle);
+    return iox2_config_defaults_event_event_id_max_value(m_config);
 }
 
 void Event::set_event_id_max_value(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_event_set_event_id_max_value(ref_handle, value);
+    iox2_config_defaults_event_set_event_id_max_value(m_config, value);
 }
 /////////////////////////
 // END: Event
@@ -227,105 +213,85 @@ PublishSubscribe::PublishSubscribe(iox2_config_h* config)
 }
 
 auto PublishSubscribe::max_subscribers() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_max_subscribers(ref_handle);
+    return iox2_config_defaults_publish_subscribe_max_subscribers(m_config);
 }
 
 void PublishSubscribe::set_max_subscribers(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_max_subscribers(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_max_subscribers(m_config, value);
 }
 
 auto PublishSubscribe::max_publishers() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_max_publishers(ref_handle);
+    return iox2_config_defaults_publish_subscribe_max_publishers(m_config);
 }
 
 void PublishSubscribe::set_max_publishers(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_max_publishers(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_max_publishers(m_config, value);
 }
 
 auto PublishSubscribe::max_nodes() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_max_nodes(ref_handle);
+    return iox2_config_defaults_publish_subscribe_max_nodes(m_config);
 }
 
 void PublishSubscribe::set_max_nodes(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_max_nodes(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_max_nodes(m_config, value);
 }
 
 auto PublishSubscribe::subscriber_max_buffer_size() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_subscriber_max_buffer_size(ref_handle);
+    return iox2_config_defaults_publish_subscribe_subscriber_max_buffer_size(m_config);
 }
 
 void PublishSubscribe::set_subscriber_max_buffer_size(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_subscriber_max_buffer_size(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_subscriber_max_buffer_size(m_config, value);
 }
 
 auto PublishSubscribe::subscriber_max_borrowed_samples() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_subscriber_max_borrowed_samples(ref_handle);
+    return iox2_config_defaults_publish_subscribe_subscriber_max_borrowed_samples(m_config);
 }
 
 void PublishSubscribe::set_subscriber_max_borrowed_samples(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_subscriber_max_borrowed_samples(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_subscriber_max_borrowed_samples(m_config, value);
 }
 
 auto PublishSubscribe::publisher_max_loaned_samples() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_publisher_max_loaned_samples(ref_handle);
+    return iox2_config_defaults_publish_subscribe_publisher_max_loaned_samples(m_config);
 }
 
 void PublishSubscribe::set_publisher_max_loaned_samples(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_publisher_max_loaned_samples(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_publisher_max_loaned_samples(m_config, value);
 }
 
 auto PublishSubscribe::publisher_history_size() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_publisher_history_size(ref_handle);
+    return iox2_config_defaults_publish_subscribe_publisher_history_size(m_config);
 }
 
 void PublishSubscribe::set_publisher_history_size(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_publisher_history_size(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_publisher_history_size(m_config, value);
 }
 
 auto PublishSubscribe::enable_safe_overflow() && -> bool {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_enable_safe_overflow(ref_handle);
+    return iox2_config_defaults_publish_subscribe_enable_safe_overflow(m_config);
 }
 
 void PublishSubscribe::set_enable_safe_overflow(bool value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_enable_safe_overflow(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_enable_safe_overflow(m_config, value);
 }
 
 auto PublishSubscribe::unable_to_deliver_strategy() && -> UnableToDeliverStrategy {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     return iox::into<UnableToDeliverStrategy>(
-        iox2_config_defaults_publish_subscribe_unable_to_deliver_strategy(ref_handle));
+        iox2_config_defaults_publish_subscribe_unable_to_deliver_strategy(m_config));
 }
 
 void PublishSubscribe::set_unable_to_deliver_strategy(UnableToDeliverStrategy value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     iox2_config_defaults_publish_subscribe_set_unable_to_deliver_strategy(
-        ref_handle, static_cast<iox2_unable_to_deliver_strategy_e>(iox::into<int>(value)));
+        m_config, static_cast<iox2_unable_to_deliver_strategy_e>(iox::into<int>(value)));
 }
 
 auto PublishSubscribe::subscriber_expired_connection_buffer() && -> size_t {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_defaults_publish_subscribe_subscriber_expired_connection_buffer(ref_handle);
+    return iox2_config_defaults_publish_subscribe_subscriber_expired_connection_buffer(m_config);
 }
 
 void PublishSubscribe::set_subscriber_expired_connection_buffer(size_t value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_defaults_publish_subscribe_set_subscriber_expired_connection_buffer(ref_handle, value);
+    iox2_config_defaults_publish_subscribe_set_subscriber_expired_connection_buffer(m_config, value);
 }
 /////////////////////////
 // END: PublishSubscribe
@@ -339,78 +305,64 @@ Service::Service(iox2_config_h* config)
 }
 
 auto Service::directory() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_service_directory(ref_handle);
+    return iox2_config_global_service_directory(m_config);
 }
 
 void Service::set_directory(const iox::Path& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_service_set_directory(ref_handle, value.as_string().c_str());
+    iox2_config_global_service_set_directory(m_config, value.as_string().c_str());
 }
 
 auto Service::publisher_data_segment_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_service_publisher_data_segment_suffix(ref_handle);
+    return iox2_config_global_service_publisher_data_segment_suffix(m_config);
 }
 
 void Service::set_publisher_data_segment_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_service_set_publisher_data_segment_suffix(ref_handle, value.as_string().c_str());
+    iox2_config_global_service_set_publisher_data_segment_suffix(m_config, value.as_string().c_str());
 }
 
 auto Service::static_config_storage_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_service_static_config_storage_suffix(ref_handle);
+    return iox2_config_global_service_static_config_storage_suffix(m_config);
 }
 
 void Service::set_static_config_storage_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_service_set_static_config_storage_suffix(ref_handle, value.as_string().c_str());
+    iox2_config_global_service_set_static_config_storage_suffix(m_config, value.as_string().c_str());
 }
 
 auto Service::dynamic_config_storage_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_service_dynamic_config_storage_suffix(ref_handle);
+    return iox2_config_global_service_dynamic_config_storage_suffix(m_config);
 }
 
 void Service::set_dynamic_config_storage_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_service_set_dynamic_config_storage_suffix(ref_handle, value.as_string().c_str());
+    iox2_config_global_service_set_dynamic_config_storage_suffix(m_config, value.as_string().c_str());
 }
 
 auto Service::creation_timeout() && -> iox::units::Duration {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     uint64_t secs = 0;
     uint32_t nsecs = 0;
-    iox2_config_global_service_creation_timeout(ref_handle, &secs, &nsecs);
+    iox2_config_global_service_creation_timeout(m_config, &secs, &nsecs);
 
     return iox::units::Duration::fromSeconds(secs) + iox::units::Duration::fromNanoseconds(nsecs);
 }
 
 void Service::set_creation_timeout(const iox::units::Duration& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
     auto duration = value.timespec();
-    iox2_config_global_service_set_creation_timeout(ref_handle, duration.tv_sec, duration.tv_nsec);
+    iox2_config_global_service_set_creation_timeout(m_config, duration.tv_sec, duration.tv_nsec);
 }
 
 auto Service::connection_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_service_connection_suffix(ref_handle);
+    return iox2_config_global_service_connection_suffix(m_config);
 }
 
 void Service::set_connection_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_service_set_connection_suffix(ref_handle, value.as_string().c_str());
+    iox2_config_global_service_set_connection_suffix(m_config, value.as_string().c_str());
 }
 
 auto Service::event_connection_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_service_event_connection_suffix(ref_handle);
+    return iox2_config_global_service_event_connection_suffix(m_config);
 }
 
 void Service::set_event_connection_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_service_set_event_connection_suffix(ref_handle, value.as_string().c_str());
+    iox2_config_global_service_set_event_connection_suffix(m_config, value.as_string().c_str());
 }
 /////////////////////////
 // END: Service
@@ -424,63 +376,51 @@ Node::Node(iox2_config_h* config)
 }
 
 auto Node::directory() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_node_directory(ref_handle);
+    return iox2_config_global_node_directory(m_config);
 }
 
 void Node::set_directory(const iox::Path& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_node_set_directory(ref_handle, value.as_string().c_str());
+    iox2_config_global_node_set_directory(m_config, value.as_string().c_str());
 }
 
 auto Node::monitor_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_node_monitor_suffix(ref_handle);
+    return iox2_config_global_node_monitor_suffix(m_config);
 }
 
 void Node::set_monitor_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_node_set_monitor_suffix(ref_handle, value.as_string().c_str());
+    iox2_config_global_node_set_monitor_suffix(m_config, value.as_string().c_str());
 }
 
 auto Node::static_config_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_node_static_config_suffix(ref_handle);
+    return iox2_config_global_node_static_config_suffix(m_config);
 }
 
 void Node::set_static_config_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_node_set_static_config_suffix(ref_handle, value.as_string().c_str());
+    iox2_config_global_node_set_static_config_suffix(m_config, value.as_string().c_str());
 }
 
 auto Node::service_tag_suffix() && -> const char* {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_node_service_tag_suffix(ref_handle);
+    return iox2_config_global_node_service_tag_suffix(m_config);
 }
 
 void Node::set_service_tag_suffix(const iox::FileName& value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_node_set_service_tag_suffix(ref_handle, value.as_string().c_str());
+    iox2_config_global_node_set_service_tag_suffix(m_config, value.as_string().c_str());
 }
 
 auto Node::cleanup_dead_nodes_on_creation() && -> bool {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_node_cleanup_dead_nodes_on_creation(ref_handle);
+    return iox2_config_global_node_cleanup_dead_nodes_on_creation(m_config);
 }
 
 void Node::set_cleanup_dead_nodes_on_creation(bool value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_node_set_cleanup_dead_nodes_on_creation(ref_handle, value);
+    iox2_config_global_node_set_cleanup_dead_nodes_on_creation(m_config, value);
 }
 
 auto Node::cleanup_dead_nodes_on_destruction() && -> bool {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    return iox2_config_global_node_cleanup_dead_nodes_on_destruction(ref_handle);
+    return iox2_config_global_node_cleanup_dead_nodes_on_destruction(m_config);
 }
 
 void Node::set_cleanup_dead_nodes_on_destruction(bool value) && {
-    auto* ref_handle = iox2_cast_config_h_ref(*m_config);
-    iox2_config_global_node_set_cleanup_dead_nodes_on_destruction(ref_handle, value);
+    iox2_config_global_node_set_cleanup_dead_nodes_on_destruction(m_config, value);
 }
 /////////////////////////
 // END: Node

--- a/iceoryx2-ffi/cxx/src/header_publish_subscribe.cpp
+++ b/iceoryx2-ffi/cxx/src/header_publish_subscribe.cpp
@@ -45,7 +45,7 @@ HeaderPublishSubscribe::~HeaderPublishSubscribe() {
 }
 
 auto HeaderPublishSubscribe::publisher_id() const -> UniquePublisherId {
-    auto* handle_ref = iox2_cast_publish_subscribe_header_ref_h(m_handle);
+    auto* handle_ref = iox2_cast_publish_subscribe_header_h_ref(m_handle);
     iox2_unique_publisher_id_h id_handle = nullptr;
 
     iox2_publish_subscribe_header_publisher_id(handle_ref, nullptr, &id_handle);
@@ -53,7 +53,7 @@ auto HeaderPublishSubscribe::publisher_id() const -> UniquePublisherId {
 }
 
 auto HeaderPublishSubscribe::payload_type_layout() const -> iox::Layout {
-    auto* handle_ref = iox2_cast_publish_subscribe_header_ref_h(m_handle);
+    auto* handle_ref = iox2_cast_publish_subscribe_header_h_ref(m_handle);
     auto size = iox2_publish_subscribe_header_payload_type_size(handle_ref);
     auto alignment = iox2_publish_subscribe_header_payload_type_alignment(handle_ref);
 

--- a/iceoryx2-ffi/cxx/src/header_publish_subscribe.cpp
+++ b/iceoryx2-ffi/cxx/src/header_publish_subscribe.cpp
@@ -45,17 +45,15 @@ HeaderPublishSubscribe::~HeaderPublishSubscribe() {
 }
 
 auto HeaderPublishSubscribe::publisher_id() const -> UniquePublisherId {
-    auto* handle_ref = iox2_cast_publish_subscribe_header_h_ref(m_handle);
     iox2_unique_publisher_id_h id_handle = nullptr;
 
-    iox2_publish_subscribe_header_publisher_id(handle_ref, nullptr, &id_handle);
+    iox2_publish_subscribe_header_publisher_id(&m_handle, nullptr, &id_handle);
     return UniquePublisherId { id_handle };
 }
 
 auto HeaderPublishSubscribe::payload_type_layout() const -> iox::Layout {
-    auto* handle_ref = iox2_cast_publish_subscribe_header_h_ref(m_handle);
-    auto size = iox2_publish_subscribe_header_payload_type_size(handle_ref);
-    auto alignment = iox2_publish_subscribe_header_payload_type_alignment(handle_ref);
+    auto size = iox2_publish_subscribe_header_payload_type_size(&m_handle);
+    auto alignment = iox2_publish_subscribe_header_payload_type_alignment(&m_handle);
 
     return iox::Layout::create(size, alignment).expect("Payload layout is always valid.");
 }

--- a/iceoryx2-ffi/cxx/src/listener.cpp
+++ b/iceoryx2-ffi/cxx/src/listener.cpp
@@ -51,7 +51,7 @@ void Listener<S>::drop() {
 
 template <ServiceType S>
 auto Listener<S>::id() const -> UniqueListenerId {
-    auto* ref_handle = iox2_cast_listener_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     iox2_unique_listener_id_h id_handle = nullptr;
 
     iox2_listener_id(ref_handle, nullptr, &id_handle);
@@ -65,7 +65,7 @@ void wait_callback(const iox2_event_id_t* event_id, iox2_callback_context contex
 
 template <ServiceType S>
 auto Listener<S>::try_wait_all(const iox::function<void(EventId)>& callback) -> iox::expected<void, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     auto ctx = internal::ctx(callback);
 
     auto result = iox2_listener_try_wait_all(ref_handle, wait_callback, static_cast<void*>(&ctx));
@@ -79,7 +79,7 @@ auto Listener<S>::try_wait_all(const iox::function<void(EventId)>& callback) -> 
 template <ServiceType S>
 auto Listener<S>::timed_wait_all(const iox::function<void(EventId)>& callback,
                                  const iox::units::Duration& timeout) -> iox::expected<void, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     auto ctx = internal::ctx(callback);
     auto timeout_timespec = timeout.timespec();
 
@@ -95,7 +95,7 @@ auto Listener<S>::timed_wait_all(const iox::function<void(EventId)>& callback,
 template <ServiceType S>
 auto Listener<S>::blocking_wait_all(const iox::function<void(EventId)>& callback)
     -> iox::expected<void, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     auto ctx = internal::ctx(callback);
 
     auto result = iox2_listener_blocking_wait_all(ref_handle, wait_callback, static_cast<void*>(&ctx));
@@ -108,7 +108,7 @@ auto Listener<S>::blocking_wait_all(const iox::function<void(EventId)>& callback
 
 template <ServiceType S>
 auto Listener<S>::try_wait_one() -> iox::expected<iox::optional<EventId>, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     iox2_event_id_t event_id {};
     bool has_received_one { false };
 
@@ -128,7 +128,7 @@ auto Listener<S>::try_wait_one() -> iox::expected<iox::optional<EventId>, Listen
 template <ServiceType S>
 auto Listener<S>::timed_wait_one(const iox::units::Duration& timeout)
     -> iox::expected<iox::optional<EventId>, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     iox2_event_id_t event_id {};
     bool has_received_one { false };
 
@@ -149,7 +149,7 @@ auto Listener<S>::timed_wait_one(const iox::units::Duration& timeout)
 
 template <ServiceType S>
 auto Listener<S>::blocking_wait_one() -> iox::expected<iox::optional<EventId>, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     iox2_event_id_t event_id {};
     bool has_received_one { false };
 

--- a/iceoryx2-ffi/cxx/src/listener.cpp
+++ b/iceoryx2-ffi/cxx/src/listener.cpp
@@ -51,10 +51,9 @@ void Listener<S>::drop() {
 
 template <ServiceType S>
 auto Listener<S>::id() const -> UniqueListenerId {
-    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     iox2_unique_listener_id_h id_handle = nullptr;
 
-    iox2_listener_id(ref_handle, nullptr, &id_handle);
+    iox2_listener_id(&m_handle, nullptr, &id_handle);
     return UniqueListenerId { id_handle };
 }
 
@@ -65,10 +64,9 @@ void wait_callback(const iox2_event_id_t* event_id, iox2_callback_context contex
 
 template <ServiceType S>
 auto Listener<S>::try_wait_all(const iox::function<void(EventId)>& callback) -> iox::expected<void, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     auto ctx = internal::ctx(callback);
 
-    auto result = iox2_listener_try_wait_all(ref_handle, wait_callback, static_cast<void*>(&ctx));
+    auto result = iox2_listener_try_wait_all(&m_handle, wait_callback, static_cast<void*>(&ctx));
     if (result == IOX2_OK) {
         return iox::ok();
     }
@@ -79,12 +77,11 @@ auto Listener<S>::try_wait_all(const iox::function<void(EventId)>& callback) -> 
 template <ServiceType S>
 auto Listener<S>::timed_wait_all(const iox::function<void(EventId)>& callback,
                                  const iox::units::Duration& timeout) -> iox::expected<void, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     auto ctx = internal::ctx(callback);
     auto timeout_timespec = timeout.timespec();
 
     auto result = iox2_listener_timed_wait_all(
-        ref_handle, wait_callback, static_cast<void*>(&ctx), timeout_timespec.tv_sec, timeout_timespec.tv_nsec);
+        &m_handle, wait_callback, static_cast<void*>(&ctx), timeout_timespec.tv_sec, timeout_timespec.tv_nsec);
     if (result == IOX2_OK) {
         return iox::ok();
     }
@@ -95,10 +92,9 @@ auto Listener<S>::timed_wait_all(const iox::function<void(EventId)>& callback,
 template <ServiceType S>
 auto Listener<S>::blocking_wait_all(const iox::function<void(EventId)>& callback)
     -> iox::expected<void, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     auto ctx = internal::ctx(callback);
 
-    auto result = iox2_listener_blocking_wait_all(ref_handle, wait_callback, static_cast<void*>(&ctx));
+    auto result = iox2_listener_blocking_wait_all(&m_handle, wait_callback, static_cast<void*>(&ctx));
     if (result == IOX2_OK) {
         return iox::ok();
     }
@@ -108,11 +104,10 @@ auto Listener<S>::blocking_wait_all(const iox::function<void(EventId)>& callback
 
 template <ServiceType S>
 auto Listener<S>::try_wait_one() -> iox::expected<iox::optional<EventId>, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     iox2_event_id_t event_id {};
     bool has_received_one { false };
 
-    auto result = iox2_listener_try_wait_one(ref_handle, &event_id, &has_received_one);
+    auto result = iox2_listener_try_wait_one(&m_handle, &event_id, &has_received_one);
 
     if (result == IOX2_OK) {
         if (has_received_one) {
@@ -128,13 +123,12 @@ auto Listener<S>::try_wait_one() -> iox::expected<iox::optional<EventId>, Listen
 template <ServiceType S>
 auto Listener<S>::timed_wait_one(const iox::units::Duration& timeout)
     -> iox::expected<iox::optional<EventId>, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     iox2_event_id_t event_id {};
     bool has_received_one { false };
 
     auto timespec_timeout = timeout.timespec();
     auto result = iox2_listener_timed_wait_one(
-        ref_handle, &event_id, &has_received_one, timespec_timeout.tv_sec, timespec_timeout.tv_nsec);
+        &m_handle, &event_id, &has_received_one, timespec_timeout.tv_sec, timespec_timeout.tv_nsec);
 
     if (result == IOX2_OK) {
         if (has_received_one) {
@@ -149,11 +143,10 @@ auto Listener<S>::timed_wait_one(const iox::units::Duration& timeout)
 
 template <ServiceType S>
 auto Listener<S>::blocking_wait_one() -> iox::expected<iox::optional<EventId>, ListenerWaitError> {
-    auto* ref_handle = iox2_cast_listener_h_ref(m_handle);
     iox2_event_id_t event_id {};
     bool has_received_one { false };
 
-    auto result = iox2_listener_blocking_wait_one(ref_handle, &event_id, &has_received_one);
+    auto result = iox2_listener_blocking_wait_one(&m_handle, &event_id, &has_received_one);
 
     if (result == IOX2_OK) {
         if (has_received_one) {

--- a/iceoryx2-ffi/cxx/src/node.cpp
+++ b/iceoryx2-ffi/cxx/src/node.cpp
@@ -44,7 +44,7 @@ Node<T>::~Node() {
 
 template <ServiceType T>
 auto Node<T>::name() const -> NodeNameView {
-    const auto* node_name_ptr = iox2_node_name(iox2_cast_node_ref_h(m_handle));
+    const auto* node_name_ptr = iox2_node_name(iox2_cast_node_h_ref(m_handle));
     return NodeNameView { node_name_ptr };
 }
 
@@ -56,12 +56,12 @@ auto Node<T>::id() const -> NodeId {
 template <ServiceType T>
 auto Node<T>::wait(iox::units::Duration cycle_time) const -> NodeEvent {
     auto time = cycle_time.timespec();
-    return iox::into<NodeEvent>(iox2_node_wait(iox2_cast_node_ref_h(m_handle), time.tv_sec, time.tv_nsec));
+    return iox::into<NodeEvent>(iox2_node_wait(iox2_cast_node_h_ref(m_handle), time.tv_sec, time.tv_nsec));
 }
 
 template <ServiceType T>
 auto Node<T>::service_builder(const ServiceName& name) const -> ServiceBuilder<T> {
-    auto* ref_handle = iox2_cast_node_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_node_h_ref(m_handle);
     return ServiceBuilder<T> { ref_handle, name.as_view().m_ptr };
 }
 
@@ -129,7 +129,7 @@ NodeBuilder::NodeBuilder()
 
 template <ServiceType T>
 auto NodeBuilder::create() const&& -> iox::expected<Node<T>, NodeCreationFailure> {
-    auto* handle_ref = iox2_cast_node_builder_ref_h(m_handle);
+    auto* handle_ref = iox2_cast_node_builder_h_ref(m_handle);
 
     if (m_name.has_value()) {
         const auto* name_ptr = iox2_cast_node_name_ptr(m_name->m_handle);
@@ -137,7 +137,7 @@ auto NodeBuilder::create() const&& -> iox::expected<Node<T>, NodeCreationFailure
     }
 
     if (m_config.has_value()) {
-        auto* config_handle_ref = iox2_cast_config_ref_h(m_config.value().m_handle);
+        auto* config_handle_ref = iox2_cast_config_h_ref(m_config.value().m_handle);
         iox2_node_builder_set_config(handle_ref, config_handle_ref);
     }
 

--- a/iceoryx2-ffi/cxx/src/node.cpp
+++ b/iceoryx2-ffi/cxx/src/node.cpp
@@ -44,7 +44,7 @@ Node<T>::~Node() {
 
 template <ServiceType T>
 auto Node<T>::name() const -> NodeNameView {
-    const auto* node_name_ptr = iox2_node_name(iox2_cast_node_h_ref(m_handle));
+    const auto* node_name_ptr = iox2_node_name(&m_handle);
     return NodeNameView { node_name_ptr };
 }
 
@@ -56,13 +56,12 @@ auto Node<T>::id() const -> NodeId {
 template <ServiceType T>
 auto Node<T>::wait(iox::units::Duration cycle_time) const -> NodeEvent {
     auto time = cycle_time.timespec();
-    return iox::into<NodeEvent>(iox2_node_wait(iox2_cast_node_h_ref(m_handle), time.tv_sec, time.tv_nsec));
+    return iox::into<NodeEvent>(iox2_node_wait(&m_handle, time.tv_sec, time.tv_nsec));
 }
 
 template <ServiceType T>
 auto Node<T>::service_builder(const ServiceName& name) const -> ServiceBuilder<T> {
-    auto* ref_handle = iox2_cast_node_h_ref(m_handle);
-    return ServiceBuilder<T> { ref_handle, name.as_view().m_ptr };
+    return ServiceBuilder<T> { &m_handle, name.as_view().m_ptr };
 }
 
 template <ServiceType T>
@@ -129,16 +128,13 @@ NodeBuilder::NodeBuilder()
 
 template <ServiceType T>
 auto NodeBuilder::create() const&& -> iox::expected<Node<T>, NodeCreationFailure> {
-    auto* handle_ref = iox2_cast_node_builder_h_ref(m_handle);
-
     if (m_name.has_value()) {
         const auto* name_ptr = iox2_cast_node_name_ptr(m_name->m_handle);
-        iox2_node_builder_set_name(handle_ref, name_ptr);
+        iox2_node_builder_set_name(&m_handle, name_ptr);
     }
 
     if (m_config.has_value()) {
-        auto* config_handle_ref = iox2_cast_config_h_ref(m_config.value().m_handle);
-        iox2_node_builder_set_config(handle_ref, config_handle_ref);
+        iox2_node_builder_set_config(&m_handle, &m_config.value().m_handle);
     }
 
     iox2_node_h node_handle {};

--- a/iceoryx2-ffi/cxx/src/notifier.cpp
+++ b/iceoryx2-ffi/cxx/src/notifier.cpp
@@ -42,18 +42,16 @@ Notifier<S>::~Notifier() {
 
 template <ServiceType S>
 auto Notifier<S>::id() const -> UniqueNotifierId {
-    auto* ref_handle = iox2_cast_notifier_h_ref(m_handle);
     iox2_unique_notifier_id_h id_handle = nullptr;
 
-    iox2_notifier_id(ref_handle, nullptr, &id_handle);
+    iox2_notifier_id(&m_handle, nullptr, &id_handle);
     return UniqueNotifierId { id_handle };
 }
 
 template <ServiceType S>
 auto Notifier<S>::notify() const -> iox::expected<size_t, NotifierNotifyError> {
-    auto* ref_handle = iox2_cast_notifier_h_ref(m_handle);
     size_t number_of_notified_listeners = 0;
-    auto result = iox2_notifier_notify(ref_handle, &number_of_notified_listeners);
+    auto result = iox2_notifier_notify(&m_handle, &number_of_notified_listeners);
 
     if (result == IOX2_OK) {
         return iox::ok(number_of_notified_listeners);
@@ -64,10 +62,9 @@ auto Notifier<S>::notify() const -> iox::expected<size_t, NotifierNotifyError> {
 
 template <ServiceType S>
 auto Notifier<S>::notify_with_custom_event_id(EventId event_id) const -> iox::expected<size_t, NotifierNotifyError> {
-    auto* ref_handle = iox2_cast_notifier_h_ref(m_handle);
     size_t number_of_notified_listeners = 0;
     auto result =
-        iox2_notifier_notify_with_custom_event_id(ref_handle, &event_id.m_value, &number_of_notified_listeners);
+        iox2_notifier_notify_with_custom_event_id(&m_handle, &event_id.m_value, &number_of_notified_listeners);
 
     if (result == IOX2_OK) {
         return iox::ok(number_of_notified_listeners);

--- a/iceoryx2-ffi/cxx/src/notifier.cpp
+++ b/iceoryx2-ffi/cxx/src/notifier.cpp
@@ -42,7 +42,7 @@ Notifier<S>::~Notifier() {
 
 template <ServiceType S>
 auto Notifier<S>::id() const -> UniqueNotifierId {
-    auto* ref_handle = iox2_cast_notifier_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_notifier_h_ref(m_handle);
     iox2_unique_notifier_id_h id_handle = nullptr;
 
     iox2_notifier_id(ref_handle, nullptr, &id_handle);
@@ -51,7 +51,7 @@ auto Notifier<S>::id() const -> UniqueNotifierId {
 
 template <ServiceType S>
 auto Notifier<S>::notify() const -> iox::expected<size_t, NotifierNotifyError> {
-    auto* ref_handle = iox2_cast_notifier_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_notifier_h_ref(m_handle);
     size_t number_of_notified_listeners = 0;
     auto result = iox2_notifier_notify(ref_handle, &number_of_notified_listeners);
 
@@ -64,7 +64,7 @@ auto Notifier<S>::notify() const -> iox::expected<size_t, NotifierNotifyError> {
 
 template <ServiceType S>
 auto Notifier<S>::notify_with_custom_event_id(EventId event_id) const -> iox::expected<size_t, NotifierNotifyError> {
-    auto* ref_handle = iox2_cast_notifier_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_notifier_h_ref(m_handle);
     size_t number_of_notified_listeners = 0;
     auto result =
         iox2_notifier_notify_with_custom_event_id(ref_handle, &event_id.m_value, &number_of_notified_listeners);

--- a/iceoryx2-ffi/cxx/src/port_factory_event.cpp
+++ b/iceoryx2-ffi/cxx/src/port_factory_event.cpp
@@ -52,8 +52,7 @@ void PortFactoryEvent<S>::drop() noexcept {
 
 template <ServiceType S>
 auto PortFactoryEvent<S>::name() const -> ServiceNameView {
-    auto* ref_handle = iox2_cast_port_factory_event_h_ref(m_handle);
-    const auto* service_name_ptr = iox2_port_factory_event_service_name(ref_handle);
+    const auto* service_name_ptr = iox2_port_factory_event_service_name(&m_handle);
     return ServiceNameView(service_name_ptr);
 }
 
@@ -69,9 +68,8 @@ auto PortFactoryEvent<S>::attributes() const -> const AttributeSet& {
 
 template <ServiceType S>
 auto PortFactoryEvent<S>::static_config() const -> StaticConfigEvent {
-    auto* ref_handle = iox2_cast_port_factory_event_h_ref(m_handle);
     iox2_static_config_event_t static_config {};
-    iox2_port_factory_event_static_config(ref_handle, &static_config);
+    iox2_port_factory_event_static_config(&m_handle, &static_config);
 
     return StaticConfigEvent(static_config);
 }
@@ -89,14 +87,12 @@ auto PortFactoryEvent<S>::nodes(const iox::function<CallbackProgression(NodeStat
 
 template <ServiceType S>
 auto PortFactoryEvent<S>::listener_builder() const -> PortFactoryListener<S> {
-    auto* ref_handle = iox2_cast_port_factory_event_h_ref(m_handle);
-    return PortFactoryListener<S> { iox2_port_factory_event_listener_builder(ref_handle, nullptr) };
+    return PortFactoryListener<S> { iox2_port_factory_event_listener_builder(&m_handle, nullptr) };
 }
 
 template <ServiceType S>
 auto PortFactoryEvent<S>::notifier_builder() const -> PortFactoryNotifier<S> {
-    auto* ref_handle = iox2_cast_port_factory_event_h_ref(m_handle);
-    return PortFactoryNotifier<S> { iox2_port_factory_event_notifier_builder(ref_handle, nullptr) };
+    return PortFactoryNotifier<S> { iox2_port_factory_event_notifier_builder(&m_handle, nullptr) };
 }
 
 template class PortFactoryEvent<ServiceType::Ipc>;

--- a/iceoryx2-ffi/cxx/src/port_factory_event.cpp
+++ b/iceoryx2-ffi/cxx/src/port_factory_event.cpp
@@ -52,7 +52,7 @@ void PortFactoryEvent<S>::drop() noexcept {
 
 template <ServiceType S>
 auto PortFactoryEvent<S>::name() const -> ServiceNameView {
-    auto* ref_handle = iox2_cast_port_factory_event_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_event_h_ref(m_handle);
     const auto* service_name_ptr = iox2_port_factory_event_service_name(ref_handle);
     return ServiceNameView(service_name_ptr);
 }
@@ -69,7 +69,7 @@ auto PortFactoryEvent<S>::attributes() const -> const AttributeSet& {
 
 template <ServiceType S>
 auto PortFactoryEvent<S>::static_config() const -> StaticConfigEvent {
-    auto* ref_handle = iox2_cast_port_factory_event_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_event_h_ref(m_handle);
     iox2_static_config_event_t static_config {};
     iox2_port_factory_event_static_config(ref_handle, &static_config);
 
@@ -89,13 +89,13 @@ auto PortFactoryEvent<S>::nodes(const iox::function<CallbackProgression(NodeStat
 
 template <ServiceType S>
 auto PortFactoryEvent<S>::listener_builder() const -> PortFactoryListener<S> {
-    auto* ref_handle = iox2_cast_port_factory_event_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_event_h_ref(m_handle);
     return PortFactoryListener<S> { iox2_port_factory_event_listener_builder(ref_handle, nullptr) };
 }
 
 template <ServiceType S>
 auto PortFactoryEvent<S>::notifier_builder() const -> PortFactoryNotifier<S> {
-    auto* ref_handle = iox2_cast_port_factory_event_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_event_h_ref(m_handle);
     return PortFactoryNotifier<S> { iox2_port_factory_event_notifier_builder(ref_handle, nullptr) };
 }
 

--- a/iceoryx2-ffi/cxx/src/port_factory_notifier.cpp
+++ b/iceoryx2-ffi/cxx/src/port_factory_notifier.cpp
@@ -20,9 +20,8 @@ PortFactoryNotifier<S>::PortFactoryNotifier(iox2_port_factory_notifier_builder_h
 
 template <ServiceType S>
 auto PortFactoryNotifier<S>::create() && -> iox::expected<Notifier<S>, NotifierCreateError> {
-    auto* ref_handle = iox2_cast_port_factory_notifier_builder_h_ref(m_handle);
     m_default_event_id.and_then(
-        [&](auto value) { iox2_port_factory_notifier_builder_set_default_event_id(ref_handle, &value.m_value); });
+        [&](auto value) { iox2_port_factory_notifier_builder_set_default_event_id(&m_handle, &value.m_value); });
 
     iox2_notifier_h notifier_handle {};
     auto result = iox2_port_factory_notifier_builder_create(m_handle, nullptr, &notifier_handle);

--- a/iceoryx2-ffi/cxx/src/port_factory_notifier.cpp
+++ b/iceoryx2-ffi/cxx/src/port_factory_notifier.cpp
@@ -20,7 +20,7 @@ PortFactoryNotifier<S>::PortFactoryNotifier(iox2_port_factory_notifier_builder_h
 
 template <ServiceType S>
 auto PortFactoryNotifier<S>::create() && -> iox::expected<Notifier<S>, NotifierCreateError> {
-    auto* ref_handle = iox2_cast_port_factory_notifier_builder_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_port_factory_notifier_builder_h_ref(m_handle);
     m_default_event_id.and_then(
         [&](auto value) { iox2_port_factory_notifier_builder_set_default_event_id(ref_handle, &value.m_value); });
 

--- a/iceoryx2-ffi/cxx/src/service_builder_event.cpp
+++ b/iceoryx2-ffi/cxx/src/service_builder_event.cpp
@@ -21,10 +21,8 @@ ServiceBuilderEvent<S>::ServiceBuilderEvent(iox2_service_builder_h handle)
 
 template <ServiceType S>
 void ServiceBuilderEvent<S>::set_parameters() {
-    auto* ref_handle = iox2_cast_service_builder_event_h_ref(m_handle);
-
-    m_max_notifiers.and_then([&](auto value) { iox2_service_builder_event_set_max_notifiers(ref_handle, value); });
-    m_max_listeners.and_then([&](auto value) { iox2_service_builder_event_set_max_listeners(ref_handle, value); });
+    m_max_notifiers.and_then([&](auto value) { iox2_service_builder_event_set_max_notifiers(&m_handle, value); });
+    m_max_listeners.and_then([&](auto value) { iox2_service_builder_event_set_max_listeners(&m_handle, value); });
     m_max_nodes.and_then([](auto) { IOX_TODO(); });
     m_event_id_max_value.and_then([](auto) { IOX_TODO(); });
 }

--- a/iceoryx2-ffi/cxx/src/service_builder_event.cpp
+++ b/iceoryx2-ffi/cxx/src/service_builder_event.cpp
@@ -21,7 +21,7 @@ ServiceBuilderEvent<S>::ServiceBuilderEvent(iox2_service_builder_h handle)
 
 template <ServiceType S>
 void ServiceBuilderEvent<S>::set_parameters() {
-    auto* ref_handle = iox2_cast_service_builder_event_ref_h(m_handle);
+    auto* ref_handle = iox2_cast_service_builder_event_h_ref(m_handle);
 
     m_max_notifiers.and_then([&](auto value) { iox2_service_builder_event_set_max_notifiers(ref_handle, value); });
     m_max_listeners.and_then([&](auto value) { iox2_service_builder_event_set_max_listeners(ref_handle, value); });

--- a/iceoryx2-ffi/cxx/src/unique_port_id.cpp
+++ b/iceoryx2-ffi/cxx/src/unique_port_id.cpp
@@ -32,14 +32,14 @@ UniquePublisherId::~UniquePublisherId() {
 }
 
 auto operator==(const UniquePublisherId& lhs, const UniquePublisherId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_publisher_id_ref_h(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_publisher_id_ref_h(rhs.m_handle);
+    auto* lhs_ref = iox2_cast_unique_publisher_id_h_ref(lhs.m_handle);
+    auto* rhs_ref = iox2_cast_unique_publisher_id_h_ref(rhs.m_handle);
     return iox2_unique_publisher_id_eq(lhs_ref, rhs_ref);
 }
 
 auto operator<(const UniquePublisherId& lhs, const UniquePublisherId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_publisher_id_ref_h(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_publisher_id_ref_h(rhs.m_handle);
+    auto* lhs_ref = iox2_cast_unique_publisher_id_h_ref(lhs.m_handle);
+    auto* rhs_ref = iox2_cast_unique_publisher_id_h_ref(rhs.m_handle);
     return iox2_unique_publisher_id_less(lhs_ref, rhs_ref);
 }
 
@@ -73,14 +73,14 @@ UniqueSubscriberId::~UniqueSubscriberId() {
 }
 
 auto operator==(const UniqueSubscriberId& lhs, const UniqueSubscriberId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_subscriber_id_ref_h(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_subscriber_id_ref_h(rhs.m_handle);
+    auto* lhs_ref = iox2_cast_unique_subscriber_id_h_ref(lhs.m_handle);
+    auto* rhs_ref = iox2_cast_unique_subscriber_id_h_ref(rhs.m_handle);
     return iox2_unique_subscriber_id_eq(lhs_ref, rhs_ref);
 }
 
 auto operator<(const UniqueSubscriberId& lhs, const UniqueSubscriberId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_subscriber_id_ref_h(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_subscriber_id_ref_h(rhs.m_handle);
+    auto* lhs_ref = iox2_cast_unique_subscriber_id_h_ref(lhs.m_handle);
+    auto* rhs_ref = iox2_cast_unique_subscriber_id_h_ref(rhs.m_handle);
     return iox2_unique_subscriber_id_less(lhs_ref, rhs_ref);
 }
 
@@ -115,14 +115,14 @@ UniqueNotifierId::~UniqueNotifierId() {
 }
 
 auto operator==(const UniqueNotifierId& lhs, const UniqueNotifierId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_notifier_id_ref_h(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_notifier_id_ref_h(rhs.m_handle);
+    auto* lhs_ref = iox2_cast_unique_notifier_id_h_ref(lhs.m_handle);
+    auto* rhs_ref = iox2_cast_unique_notifier_id_h_ref(rhs.m_handle);
     return iox2_unique_notifier_id_eq(lhs_ref, rhs_ref);
 }
 
 auto operator<(const UniqueNotifierId& lhs, const UniqueNotifierId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_notifier_id_ref_h(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_notifier_id_ref_h(rhs.m_handle);
+    auto* lhs_ref = iox2_cast_unique_notifier_id_h_ref(lhs.m_handle);
+    auto* rhs_ref = iox2_cast_unique_notifier_id_h_ref(rhs.m_handle);
     return iox2_unique_notifier_id_less(lhs_ref, rhs_ref);
 }
 
@@ -156,14 +156,14 @@ UniqueListenerId::~UniqueListenerId() {
 }
 
 auto operator==(const UniqueListenerId& lhs, const UniqueListenerId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_listener_id_ref_h(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_listener_id_ref_h(rhs.m_handle);
+    auto* lhs_ref = iox2_cast_unique_listener_id_h_ref(lhs.m_handle);
+    auto* rhs_ref = iox2_cast_unique_listener_id_h_ref(rhs.m_handle);
     return iox2_unique_listener_id_eq(lhs_ref, rhs_ref);
 }
 
 auto operator<(const UniqueListenerId& lhs, const UniqueListenerId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_listener_id_ref_h(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_listener_id_ref_h(rhs.m_handle);
+    auto* lhs_ref = iox2_cast_unique_listener_id_h_ref(lhs.m_handle);
+    auto* rhs_ref = iox2_cast_unique_listener_id_h_ref(rhs.m_handle);
     return iox2_unique_listener_id_less(lhs_ref, rhs_ref);
 }
 

--- a/iceoryx2-ffi/cxx/src/unique_port_id.cpp
+++ b/iceoryx2-ffi/cxx/src/unique_port_id.cpp
@@ -32,15 +32,11 @@ UniquePublisherId::~UniquePublisherId() {
 }
 
 auto operator==(const UniquePublisherId& lhs, const UniquePublisherId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_publisher_id_h_ref(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_publisher_id_h_ref(rhs.m_handle);
-    return iox2_unique_publisher_id_eq(lhs_ref, rhs_ref);
+    return iox2_unique_publisher_id_eq(&lhs.m_handle, &rhs.m_handle);
 }
 
 auto operator<(const UniquePublisherId& lhs, const UniquePublisherId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_publisher_id_h_ref(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_publisher_id_h_ref(rhs.m_handle);
-    return iox2_unique_publisher_id_less(lhs_ref, rhs_ref);
+    return iox2_unique_publisher_id_less(&lhs.m_handle, &rhs.m_handle);
 }
 
 UniquePublisherId::UniquePublisherId(iox2_unique_publisher_id_h handle)
@@ -73,15 +69,11 @@ UniqueSubscriberId::~UniqueSubscriberId() {
 }
 
 auto operator==(const UniqueSubscriberId& lhs, const UniqueSubscriberId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_subscriber_id_h_ref(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_subscriber_id_h_ref(rhs.m_handle);
-    return iox2_unique_subscriber_id_eq(lhs_ref, rhs_ref);
+    return iox2_unique_subscriber_id_eq(&lhs.m_handle, &rhs.m_handle);
 }
 
 auto operator<(const UniqueSubscriberId& lhs, const UniqueSubscriberId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_subscriber_id_h_ref(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_subscriber_id_h_ref(rhs.m_handle);
-    return iox2_unique_subscriber_id_less(lhs_ref, rhs_ref);
+    return iox2_unique_subscriber_id_less(&lhs.m_handle, &rhs.m_handle);
 }
 
 UniqueSubscriberId::UniqueSubscriberId(iox2_unique_subscriber_id_h handle)
@@ -115,15 +107,11 @@ UniqueNotifierId::~UniqueNotifierId() {
 }
 
 auto operator==(const UniqueNotifierId& lhs, const UniqueNotifierId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_notifier_id_h_ref(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_notifier_id_h_ref(rhs.m_handle);
-    return iox2_unique_notifier_id_eq(lhs_ref, rhs_ref);
+    return iox2_unique_notifier_id_eq(&lhs.m_handle, &rhs.m_handle);
 }
 
 auto operator<(const UniqueNotifierId& lhs, const UniqueNotifierId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_notifier_id_h_ref(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_notifier_id_h_ref(rhs.m_handle);
-    return iox2_unique_notifier_id_less(lhs_ref, rhs_ref);
+    return iox2_unique_notifier_id_less(&lhs.m_handle, &rhs.m_handle);
 }
 
 UniqueNotifierId::UniqueNotifierId(iox2_unique_notifier_id_h handle)
@@ -156,15 +144,11 @@ UniqueListenerId::~UniqueListenerId() {
 }
 
 auto operator==(const UniqueListenerId& lhs, const UniqueListenerId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_listener_id_h_ref(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_listener_id_h_ref(rhs.m_handle);
-    return iox2_unique_listener_id_eq(lhs_ref, rhs_ref);
+    return iox2_unique_listener_id_eq(&lhs.m_handle, &rhs.m_handle);
 }
 
 auto operator<(const UniqueListenerId& lhs, const UniqueListenerId& rhs) -> bool {
-    auto* lhs_ref = iox2_cast_unique_listener_id_h_ref(lhs.m_handle);
-    auto* rhs_ref = iox2_cast_unique_listener_id_h_ref(rhs.m_handle);
-    return iox2_unique_listener_id_less(lhs_ref, rhs_ref);
+    return iox2_unique_listener_id_less(&lhs.m_handle, &rhs.m_handle);
 }
 
 UniqueListenerId::UniqueListenerId(iox2_unique_listener_id_h handle)

--- a/iceoryx2-ffi/ffi-macros/src/lib.rs
+++ b/iceoryx2-ffi/ffi-macros/src/lib.rs
@@ -61,8 +61,7 @@ pub fn iceoryx2_ffi(args: TokenStream, input: TokenStream) -> TokenStream {
     let struct_storage_name = format_ident!("iox2_{}_storage_t", stripped_struct_name);
     let _struct_h_t_name = format_ident!("iox2_{}_h_t", stripped_struct_name);
     let struct_h_name = format_ident!("iox2_{}_h", stripped_struct_name);
-    let _struct_h_ref_t_name = format_ident!("iox2_{}_h_ref_t", stripped_struct_name);
-    let struct_h_ref_name = format_ident!("iox2_{}_h_ref", stripped_struct_name);
+    let _struct_h_ref_name = format_ident!("iox2_{}_h_ref", stripped_struct_name);
 
     // NOTE: cbindgen does not play well with adding new structs or fields to existing structs;
     // this code is kept for reference
@@ -129,9 +128,6 @@ pub fn iceoryx2_ffi(args: TokenStream, input: TokenStream) -> TokenStream {
 
         impl #struct_name {
             pub(super) fn as_handle(&mut self) -> #struct_h_name {
-                self as *mut _ as _
-            }
-            pub(super) fn as_h_refandle(&mut self) -> #struct_h_ref_name {
                 self as *mut _ as _
             }
 

--- a/iceoryx2-ffi/ffi-macros/src/lib.rs
+++ b/iceoryx2-ffi/ffi-macros/src/lib.rs
@@ -61,8 +61,8 @@ pub fn iceoryx2_ffi(args: TokenStream, input: TokenStream) -> TokenStream {
     let struct_storage_name = format_ident!("iox2_{}_storage_t", stripped_struct_name);
     let _struct_h_t_name = format_ident!("iox2_{}_h_t", stripped_struct_name);
     let struct_h_name = format_ident!("iox2_{}_h", stripped_struct_name);
-    let _struct_ref_h_t_name = format_ident!("iox2_{}_ref_h_t", stripped_struct_name);
-    let struct_ref_h_name = format_ident!("iox2_{}_ref_h", stripped_struct_name);
+    let _struct_h_ref_t_name = format_ident!("iox2_{}_h_ref_t", stripped_struct_name);
+    let struct_h_ref_name = format_ident!("iox2_{}_h_ref", stripped_struct_name);
 
     // NOTE: cbindgen does not play well with adding new structs or fields to existing structs;
     // this code is kept for reference
@@ -131,7 +131,7 @@ pub fn iceoryx2_ffi(args: TokenStream, input: TokenStream) -> TokenStream {
             pub(super) fn as_handle(&mut self) -> #struct_h_name {
                 self as *mut _ as _
             }
-            pub(super) fn as_ref_handle(&mut self) -> #struct_ref_h_name {
+            pub(super) fn as_h_refandle(&mut self) -> #struct_h_ref_name {
                 self as *mut _ as _
             }
 

--- a/iceoryx2-ffi/ffi/README.md
+++ b/iceoryx2-ffi/ffi/README.md
@@ -11,8 +11,8 @@
   `pub type iox2_foo_ref_h = *mut iox2_foo_ref_h_t`
 * immutable pointer to the Rust type end with a `_ptr` and are a type definition
   like `pub type iox2_foo_ptr = *const Foo`
-* mutable pointer to the Rust type end with a `_mut_ptr` and are a type
-  definition like `pub type iox2_foo_mut_ptr = *mut Foo`
+* mutable pointer to the Rust type end with a `_ptr_mut` and are a type
+  definition like `pub type iox2_foo_ptr_mut = *mut Foo`
 * `enums` ends with a `_e`
 
 ## Pattern for Type Erasure
@@ -59,7 +59,7 @@ When the owning handle is passed to a function, the ownership of the underlying
 data is moved to that specific function and the `*_h` handles as well as all the
 `*_ptr` related to that handle are invalid. Accessing the handles or pointer
 afterwards lead to undefined behavior. The only exception are the `iox2_cast_*`
-functions which can be used to get `_ptr` and `_mut_ptr` pointer the the Rust
+functions which can be used to get `_ptr` and `_ptr_mut` pointer the the Rust
 type or a non-owning `_ref_h` handle to the C struct.
 
 The corresponding handle and pointer are defined like this
@@ -73,7 +73,7 @@ pub type iox2_foo_ref_h = *mut iox2_foo_ref_h_t;
 
 pub type iox2_foo_ptr = *const Foo;
 
-pub type iox2_foo_mut_ptr = *mut Foo;
+pub type iox2_foo_ptr_mut = *mut Foo;
 ```
 
 The `_h` handle is in general created by a builder and the `_ptr` pointer are in

--- a/iceoryx2-ffi/ffi/README.md
+++ b/iceoryx2-ffi/ffi/README.md
@@ -6,9 +6,9 @@
 * `structs` end with a `_t`
 * owning handles end with a `_h` and are a type definition to a
   `struct iox2_foo_h_t;` as `pub type iox2_foo_h = *mut iox2_foo_h_t`
-* non-owning handles end with a `_ref_h` and are a type definition to a
-  `struct iox2_foo_ref_h_t;` as
-  `pub type iox2_foo_ref_h = *mut iox2_foo_ref_h_t`
+* non-owning handles end with a `_h_ref` and are a type definition to a
+  `struct iox2_foo_h_ref_t;` as
+  `pub type iox2_foo_h_ref = *mut iox2_foo_h_ref_t`
 * immutable pointer to the Rust type end with a `_ptr` and are a type definition
   like `pub type iox2_foo_ptr = *const Foo`
 * mutable pointer to the Rust type end with a `_ptr_mut` and are a type
@@ -60,7 +60,7 @@ data is moved to that specific function and the `*_h` handles as well as all the
 `*_ptr` related to that handle are invalid. Accessing the handles or pointer
 afterwards lead to undefined behavior. The only exception are the `iox2_cast_*`
 functions which can be used to get `_ptr` and `_ptr_mut` pointer the the Rust
-type or a non-owning `_ref_h` handle to the C struct.
+type or a non-owning `_h_ref` handle to the C struct.
 
 The corresponding handle and pointer are defined like this
 
@@ -68,8 +68,8 @@ The corresponding handle and pointer are defined like this
 pub struct iox2_foo_h_t;
 pub type iox2_foo_h = *mut iox2_foo_h_t;
 
-pub struct iox2_foo_ref_h_t;
-pub type iox2_foo_ref_h = *mut iox2_foo_ref_h_t;
+pub struct iox2_foo_h_ref_t;
+pub type iox2_foo_h_ref = *mut iox2_foo_h_ref_t;
 
 pub type iox2_foo_ptr = *const Foo;
 

--- a/iceoryx2-ffi/ffi/README.md
+++ b/iceoryx2-ffi/ffi/README.md
@@ -101,9 +101,9 @@ the following warning and eventually to build failures.
 <!-- markdownlint-disable -->
 
 > warning: output filename collision.
-> The lib target `iceoryx2_ffi` in package `iceoryx2-ffi v0.3.0 (C:\Users\ekxide\iceoryx2\iceoryx2-ffi\ffi)`
+> The lib target `iceoryx2_ffi` in package `iceoryx2-ffi vX.Y.Z (C:\Users\ekxide\iceoryx2\iceoryx2-ffi\ffi)`
 > has the same output filename as the lib target `iceoryx2_ffi` in package
-> `iceoryx2-ffi v0.3.0 (C:\Users\ekxide\iceoryx2\iceoryx2-ffi\ffi)`.
+> `iceoryx2-ffi vX.Y.Z (C:\Users\ekxide\iceoryx2\iceoryx2-ffi\ffi)`.
 > Colliding filename is: C:\Users\ekxide\iceoryx2\target\release\deps\iceoryx2_ffi.lib
 > The targets should have unique names.
 > Consider changing their names to be unique or compiling them separately.

--- a/iceoryx2-ffi/ffi/README.md
+++ b/iceoryx2-ffi/ffi/README.md
@@ -7,8 +7,8 @@
 * owning handles end with a `_h` and are a type definition to a
   `struct iox2_foo_h_t;` as `pub type iox2_foo_h = *mut iox2_foo_h_t`
 * non-owning handles end with a `_h_ref` and are a type definition to a
-  `struct iox2_foo_h_ref_t;` as
-  `pub type iox2_foo_h_ref = *mut iox2_foo_h_ref_t`
+  `iox2_foo_h` as
+  `pub type iox2_foo_h_ref = *const iox2_foo_h`
 * immutable pointer to the Rust type end with a `_ptr` and are a type definition
   like `pub type iox2_foo_ptr = *const Foo`
 * mutable pointer to the Rust type end with a `_ptr_mut` and are a type
@@ -67,9 +67,7 @@ The corresponding handle and pointer are defined like this
 ```rs
 pub struct iox2_foo_h_t;
 pub type iox2_foo_h = *mut iox2_foo_h_t;
-
-pub struct iox2_foo_h_ref_t;
-pub type iox2_foo_h_ref = *mut iox2_foo_h_ref_t;
+pub type iox2_foo_h_ref = *const iox2_foo_h;
 
 pub type iox2_foo_ptr = *const Foo;
 

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -12,7 +12,7 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::{c_size_t, iox2_unable_to_deliver_strategy_e};
+use crate::{api::AssertNonNullHandle, c_size_t, iox2_unable_to_deliver_strategy_e};
 use core::ffi::{c_char, c_int};
 use core::time::Duration;
 use iceoryx2::config::{Config, ConfigCreationError};
@@ -96,9 +96,23 @@ pub struct iox2_config_h_t;
 /// The owning handle for `iox2_config_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_config_h = *mut iox2_config_h_t;
 
-pub struct iox2_config_h_ref_t;
 /// The non-owning handle for `iox2_config_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_config_h_ref = *mut iox2_config_h_ref_t;
+pub type iox2_config_h_ref = *const iox2_config_h;
+
+impl AssertNonNullHandle for iox2_config_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_config_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_config_h {
     type Target = *mut iox2_config_t;
@@ -112,30 +126,13 @@ impl HandleToType for iox2_config_h_ref {
     type Target = *mut iox2_config_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
 // END type definition
 
 // BEGIN C API
-/// Cast an owning [`iox2_config_h`] into a non-owning [`iox2_config_h_ref`]
-///
-/// # Arguments
-///
-/// * `handle` obtained by [`iox2_config_from_file()`], [`iox2_config_default()`],
-///     [`iox2_config_clone()`] or [`iox2_config_from_ptr()`]
-///
-/// # Safety
-///
-/// * The `handle` must be a valid handle.
-/// * The `handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_config_h_ref(handle: iox2_config_h) -> iox2_config_h_ref {
-    debug_assert!(!handle.is_null());
-
-    (*handle.as_type()).as_h_refandle() as *mut _ as _
-}
 
 /// This function casts a [`iox2_config_h`] into a [`iox2_config_ptr`]
 ///
@@ -250,11 +247,11 @@ pub unsafe extern "C" fn iox2_config_from_file(
 ///                  by this function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_from_ptr(
-    handle: iox2_config_ptr,
+    config: iox2_config_ptr,
     struct_ptr: *mut iox2_config_t,
     handle_ptr: *mut iox2_config_h,
 ) {
-    debug_assert!(!handle.is_null());
+    debug_assert!(!config.is_null());
     debug_assert!(!handle_ptr.is_null());
 
     let mut struct_ptr = struct_ptr;
@@ -266,7 +263,7 @@ pub unsafe extern "C" fn iox2_config_from_ptr(
     }
     debug_assert!(!struct_ptr.is_null());
 
-    (*struct_ptr).init(ManuallyDrop::new((*handle).clone()), deleter);
+    (*struct_ptr).init(ManuallyDrop::new((*config).clone()), deleter);
     *handle_ptr = (*struct_ptr).as_handle();
 }
 
@@ -274,7 +271,7 @@ pub unsafe extern "C" fn iox2_config_from_ptr(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_config_t`].
 ///                  If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `handle_ptr` - An uninitialized or dangling [`iox2_config_h`] handle which will be initialized
@@ -285,7 +282,7 @@ pub unsafe extern "C" fn iox2_config_clone(
     struct_ptr: *mut iox2_config_t,
     handle_ptr: *mut iox2_config_h,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
     debug_assert!(!handle_ptr.is_null());
 
     let mut struct_ptr = struct_ptr;
@@ -310,7 +307,7 @@ pub unsafe extern "C" fn iox2_config_clone(
 ///                  after this function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_drop(handle: iox2_config_h) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     ManuallyDrop::drop(&mut config.value.as_mut().value);
@@ -325,10 +322,10 @@ pub unsafe extern "C" fn iox2_config_drop(handle: iox2_config_h) {
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_prefix(handle: iox2_config_h_ref) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config.value.as_ref().value.global.prefix.as_c_str()
@@ -341,14 +338,14 @@ pub unsafe extern "C" fn iox2_config_global_prefix(handle: iox2_config_h_ref) ->
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the prefix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_set_prefix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -364,10 +361,10 @@ pub unsafe extern "C" fn iox2_config_global_set_prefix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_root_path(handle: iox2_config_h_ref) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config.value.as_ref().value.global.root_path().as_c_str()
@@ -380,14 +377,14 @@ pub unsafe extern "C" fn iox2_config_global_root_path(handle: iox2_config_h_ref)
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid path
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_set_root_path(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match Path::from_c_str(value) {
@@ -409,12 +406,12 @@ pub unsafe extern "C" fn iox2_config_global_set_root_path(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_directory(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config.value.as_ref().value.global.node.directory.as_c_str()
@@ -427,14 +424,14 @@ pub unsafe extern "C" fn iox2_config_global_node_directory(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid path
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_directory(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match Path::from_c_str(value) {
@@ -450,12 +447,12 @@ pub unsafe extern "C" fn iox2_config_global_node_set_directory(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_monitor_suffix(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -475,14 +472,14 @@ pub unsafe extern "C" fn iox2_config_global_node_monitor_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_monitor_suffix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -498,12 +495,12 @@ pub unsafe extern "C" fn iox2_config_global_node_set_monitor_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_static_config_suffix(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -523,14 +520,14 @@ pub unsafe extern "C" fn iox2_config_global_node_static_config_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_static_config_suffix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -546,12 +543,12 @@ pub unsafe extern "C" fn iox2_config_global_node_set_static_config_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_service_tag_suffix(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -571,14 +568,14 @@ pub unsafe extern "C" fn iox2_config_global_node_service_tag_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_service_tag_suffix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -596,12 +593,12 @@ pub unsafe extern "C" fn iox2_config_global_node_set_service_tag_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_creation(
     handle: iox2_config_h_ref,
 ) -> bool {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -617,13 +614,13 @@ pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_creation(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_creation(
     handle: iox2_config_h_ref,
     value: bool,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -642,12 +639,12 @@ pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_creat
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_destruction(
     handle: iox2_config_h_ref,
 ) -> bool {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -663,13 +660,13 @@ pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_destructi
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_destruction(
     handle: iox2_config_h_ref,
     value: bool,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -693,12 +690,12 @@ pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_destr
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_directory(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -718,14 +715,14 @@ pub unsafe extern "C" fn iox2_config_global_service_directory(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid path
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_directory(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match Path::from_c_str(value) {
@@ -741,12 +738,12 @@ pub unsafe extern "C" fn iox2_config_global_service_set_directory(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_publisher_data_segment_suffix(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -766,14 +763,14 @@ pub unsafe extern "C" fn iox2_config_global_service_publisher_data_segment_suffi
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_publisher_data_segment_suffix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -795,12 +792,12 @@ pub unsafe extern "C" fn iox2_config_global_service_set_publisher_data_segment_s
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_static_config_storage_suffix(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -820,14 +817,14 @@ pub unsafe extern "C" fn iox2_config_global_service_static_config_storage_suffix
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_static_config_storage_suffix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -849,12 +846,12 @@ pub unsafe extern "C" fn iox2_config_global_service_set_static_config_storage_su
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_dynamic_config_storage_suffix(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -874,14 +871,14 @@ pub unsafe extern "C" fn iox2_config_global_service_dynamic_config_storage_suffi
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_dynamic_config_storage_suffix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -904,7 +901,7 @@ pub unsafe extern "C" fn iox2_config_global_service_set_dynamic_config_storage_s
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `secs` - A valid pointer pointing to a [`u64`].
 /// * `nsecs` - A valid pointer pointing to a [`u32`]
 #[no_mangle]
@@ -913,7 +910,7 @@ pub unsafe extern "C" fn iox2_config_global_service_creation_timeout(
     secs: *mut u64,
     nsecs: *mut u32,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
     debug_assert!(!secs.is_null());
     debug_assert!(!nsecs.is_null());
 
@@ -930,7 +927,7 @@ pub unsafe extern "C" fn iox2_config_global_service_creation_timeout(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_creation_timeout(
@@ -938,7 +935,7 @@ pub unsafe extern "C" fn iox2_config_global_service_set_creation_timeout(
     sec: u64,
     nsec: u32,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config.value.as_mut().value.global.service.creation_timeout =
@@ -949,12 +946,12 @@ pub unsafe extern "C" fn iox2_config_global_service_set_creation_timeout(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_connection_suffix(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -974,14 +971,14 @@ pub unsafe extern "C" fn iox2_config_global_service_connection_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_connection_suffix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -997,12 +994,12 @@ pub unsafe extern "C" fn iox2_config_global_service_set_connection_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_event_connection_suffix(
     handle: iox2_config_h_ref,
 ) -> *const c_char {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1022,14 +1019,14 @@ pub unsafe extern "C" fn iox2_config_global_service_event_connection_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_event_connection_suffix(
     handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     match FileName::from_c_str(value) {
@@ -1057,12 +1054,12 @@ pub unsafe extern "C" fn iox2_config_global_service_set_event_connection_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_subscribers(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1078,13 +1075,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_subscribers(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_subscribers(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1100,12 +1097,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_subscrib
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_publishers(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1121,13 +1118,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_publishers(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_publishers(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1144,12 +1141,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_publishe
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_nodes(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1165,13 +1162,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_nodes(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_nodes(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1187,12 +1184,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_nodes(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_buffer_size(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1208,13 +1205,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_b
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_max_buffer_size(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1231,12 +1228,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_m
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_borrowed_samples(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1253,13 +1250,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_b
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_max_borrowed_samples(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1276,12 +1273,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_m
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_max_loaned_samples(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1298,13 +1295,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_max_lo
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_max_loaned_samples(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1321,12 +1318,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_ma
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_history_size(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1343,13 +1340,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_histor
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_history_size(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1367,12 +1364,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_hi
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_enable_safe_overflow(
     handle: iox2_config_h_ref,
 ) -> bool {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1388,13 +1385,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_enable_safe_over
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_enable_safe_overflow(
     handle: iox2_config_h_ref,
     value: bool,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1414,12 +1411,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_enable_safe_
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_unable_to_deliver_strategy(
     handle: iox2_config_h_ref,
 ) -> c_int {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1436,13 +1433,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_unable_to_delive
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_unable_to_deliver_strategy(
     handle: iox2_config_h_ref,
     value: iox2_unable_to_deliver_strategy_e,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1462,12 +1459,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_unable_to_de
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_expired_connection_buffer(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1483,13 +1480,13 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_expir
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_expired_connection_buffer(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config
@@ -1511,12 +1508,12 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_e
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_max_listeners(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config.value.as_ref().value.defaults.event.max_listeners
@@ -1526,13 +1523,13 @@ pub unsafe extern "C" fn iox2_config_defaults_event_max_listeners(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_set_max_listeners(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config.value.as_mut().value.defaults.event.max_listeners = value;
@@ -1542,12 +1539,12 @@ pub unsafe extern "C" fn iox2_config_defaults_event_set_max_listeners(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_max_notifiers(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config.value.as_ref().value.defaults.event.max_notifiers
@@ -1557,13 +1554,13 @@ pub unsafe extern "C" fn iox2_config_defaults_event_max_notifiers(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_set_max_notifiers(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config.value.as_mut().value.defaults.event.max_notifiers = value;
@@ -1574,12 +1571,12 @@ pub unsafe extern "C" fn iox2_config_defaults_event_set_max_notifiers(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_max_nodes(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config.value.as_ref().value.defaults.event.max_nodes
@@ -1589,13 +1586,13 @@ pub unsafe extern "C" fn iox2_config_defaults_event_max_nodes(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_set_max_nodes(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config.value.as_mut().value.defaults.event.max_nodes = value;
@@ -1605,12 +1602,12 @@ pub unsafe extern "C" fn iox2_config_defaults_event_set_max_nodes(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_event_id_max_value(
     handle: iox2_config_h_ref,
 ) -> c_size_t {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &*handle.as_type();
     config
@@ -1626,13 +1623,13 @@ pub unsafe extern "C" fn iox2_config_defaults_event_event_id_max_value(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_set_event_id_max_value(
     handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let config = &mut *handle.as_type();
     config

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -64,7 +64,7 @@ impl IntoCInt for ConfigCreationError {
 /// The immutable pointer to the underlying `Config`
 pub type iox2_config_ptr = *const Config;
 /// The mutable pointer to the underlying `Config`
-pub type iox2_config_mut_ptr = *mut Config;
+pub type iox2_config_ptr_mut = *mut Config;
 
 pub(super) struct ConfigOwner {
     pub(crate) value: ManuallyDrop<Config>,

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -96,9 +96,9 @@ pub struct iox2_config_h_t;
 /// The owning handle for `iox2_config_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_config_h = *mut iox2_config_h_t;
 
-pub struct iox2_config_ref_h_t;
+pub struct iox2_config_h_ref_t;
 /// The non-owning handle for `iox2_config_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_config_ref_h = *mut iox2_config_ref_h_t;
+pub type iox2_config_h_ref = *mut iox2_config_h_ref_t;
 
 impl HandleToType for iox2_config_h {
     type Target = *mut iox2_config_t;
@@ -108,7 +108,7 @@ impl HandleToType for iox2_config_h {
     }
 }
 
-impl HandleToType for iox2_config_ref_h {
+impl HandleToType for iox2_config_h_ref {
     type Target = *mut iox2_config_t;
 
     fn as_type(self) -> Self::Target {
@@ -119,7 +119,7 @@ impl HandleToType for iox2_config_ref_h {
 // END type definition
 
 // BEGIN C API
-/// Cast an owning [`iox2_config_h`] into a non-owning [`iox2_config_ref_h`]
+/// Cast an owning [`iox2_config_h`] into a non-owning [`iox2_config_h_ref`]
 ///
 /// # Arguments
 ///
@@ -131,10 +131,10 @@ impl HandleToType for iox2_config_ref_h {
 /// * The `handle` must be a valid handle.
 /// * The `handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_config_ref_h(handle: iox2_config_h) -> iox2_config_ref_h {
+pub unsafe extern "C" fn iox2_cast_config_h_ref(handle: iox2_config_h) -> iox2_config_h_ref {
     debug_assert!(!handle.is_null());
 
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// This function casts a [`iox2_config_h`] into a [`iox2_config_ptr`]
@@ -270,18 +270,18 @@ pub unsafe extern "C" fn iox2_config_from_ptr(
     *handle_ptr = (*struct_ptr).as_handle();
 }
 
-/// Clones a config from a given non-owning [`iox2_config_ref_h`].
+/// Clones a config from a given non-owning [`iox2_config_h_ref`].
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_config_t`].
 ///                  If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `handle_ptr` - An uninitialized or dangling [`iox2_config_h`] handle which will be initialized
 ///                  by this function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_clone(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     struct_ptr: *mut iox2_config_t,
     handle_ptr: *mut iox2_config_h,
 ) {
@@ -325,9 +325,9 @@ pub unsafe extern "C" fn iox2_config_drop(handle: iox2_config_h) {
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
-pub unsafe extern "C" fn iox2_config_global_prefix(handle: iox2_config_ref_h) -> *const c_char {
+pub unsafe extern "C" fn iox2_config_global_prefix(handle: iox2_config_h_ref) -> *const c_char {
     debug_assert!(!handle.is_null());
 
     let config = &*handle.as_type();
@@ -341,11 +341,11 @@ pub unsafe extern "C" fn iox2_config_global_prefix(handle: iox2_config_ref_h) ->
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the prefix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_set_prefix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -364,9 +364,9 @@ pub unsafe extern "C" fn iox2_config_global_set_prefix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
-pub unsafe extern "C" fn iox2_config_global_root_path(handle: iox2_config_ref_h) -> *const c_char {
+pub unsafe extern "C" fn iox2_config_global_root_path(handle: iox2_config_h_ref) -> *const c_char {
     debug_assert!(!handle.is_null());
 
     let config = &*handle.as_type();
@@ -380,11 +380,11 @@ pub unsafe extern "C" fn iox2_config_global_root_path(handle: iox2_config_ref_h)
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid path
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_set_root_path(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -409,10 +409,10 @@ pub unsafe extern "C" fn iox2_config_global_set_root_path(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_directory(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -427,11 +427,11 @@ pub unsafe extern "C" fn iox2_config_global_node_directory(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid path
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_directory(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -450,10 +450,10 @@ pub unsafe extern "C" fn iox2_config_global_node_set_directory(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_monitor_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -475,11 +475,11 @@ pub unsafe extern "C" fn iox2_config_global_node_monitor_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_monitor_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -498,10 +498,10 @@ pub unsafe extern "C" fn iox2_config_global_node_set_monitor_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_static_config_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -523,11 +523,11 @@ pub unsafe extern "C" fn iox2_config_global_node_static_config_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_static_config_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -546,10 +546,10 @@ pub unsafe extern "C" fn iox2_config_global_node_set_static_config_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_service_tag_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -571,11 +571,11 @@ pub unsafe extern "C" fn iox2_config_global_node_service_tag_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_service_tag_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -596,10 +596,10 @@ pub unsafe extern "C" fn iox2_config_global_node_set_service_tag_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_creation(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> bool {
     debug_assert!(!handle.is_null());
 
@@ -617,10 +617,10 @@ pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_creation(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_creation(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: bool,
 ) {
     debug_assert!(!handle.is_null());
@@ -642,10 +642,10 @@ pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_creat
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_destruction(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> bool {
     debug_assert!(!handle.is_null());
 
@@ -663,10 +663,10 @@ pub unsafe extern "C" fn iox2_config_global_node_cleanup_dead_nodes_on_destructi
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_destruction(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: bool,
 ) {
     debug_assert!(!handle.is_null());
@@ -693,10 +693,10 @@ pub unsafe extern "C" fn iox2_config_global_node_set_cleanup_dead_nodes_on_destr
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_directory(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -718,11 +718,11 @@ pub unsafe extern "C" fn iox2_config_global_service_directory(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid path
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_directory(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -741,10 +741,10 @@ pub unsafe extern "C" fn iox2_config_global_service_set_directory(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_publisher_data_segment_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -766,11 +766,11 @@ pub unsafe extern "C" fn iox2_config_global_service_publisher_data_segment_suffi
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_publisher_data_segment_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -795,10 +795,10 @@ pub unsafe extern "C" fn iox2_config_global_service_set_publisher_data_segment_s
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_static_config_storage_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -820,11 +820,11 @@ pub unsafe extern "C" fn iox2_config_global_service_static_config_storage_suffix
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_static_config_storage_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -849,10 +849,10 @@ pub unsafe extern "C" fn iox2_config_global_service_set_static_config_storage_su
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_dynamic_config_storage_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -874,11 +874,11 @@ pub unsafe extern "C" fn iox2_config_global_service_dynamic_config_storage_suffi
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_dynamic_config_storage_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -904,12 +904,12 @@ pub unsafe extern "C" fn iox2_config_global_service_set_dynamic_config_storage_s
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `secs` - A valid pointer pointing to a [`u64`].
 /// * `nsecs` - A valid pointer pointing to a [`u32`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_creation_timeout(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     secs: *mut u64,
     nsecs: *mut u32,
 ) {
@@ -930,11 +930,11 @@ pub unsafe extern "C" fn iox2_config_global_service_creation_timeout(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_creation_timeout(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     sec: u64,
     nsec: u32,
 ) {
@@ -949,10 +949,10 @@ pub unsafe extern "C" fn iox2_config_global_service_set_creation_timeout(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_connection_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -974,11 +974,11 @@ pub unsafe extern "C" fn iox2_config_global_service_connection_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_connection_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -997,10 +997,10 @@ pub unsafe extern "C" fn iox2_config_global_service_set_connection_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_event_connection_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> *const c_char {
     debug_assert!(!handle.is_null());
 
@@ -1022,11 +1022,11 @@ pub unsafe extern "C" fn iox2_config_global_service_event_connection_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 /// * `value` - A valid file name containing the suffix
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_global_service_set_event_connection_suffix(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: *const c_char,
 ) -> c_int {
     debug_assert!(!handle.is_null());
@@ -1057,10 +1057,10 @@ pub unsafe extern "C" fn iox2_config_global_service_set_event_connection_suffix(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_subscribers(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1078,10 +1078,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_subscribers(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_subscribers(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1100,10 +1100,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_subscrib
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_publishers(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1121,10 +1121,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_publishers(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_publishers(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1144,10 +1144,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_publishe
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_nodes(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1165,10 +1165,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_max_nodes(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_nodes(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1187,10 +1187,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_max_nodes(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_buffer_size(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1208,10 +1208,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_b
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_max_buffer_size(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1231,10 +1231,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_m
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_borrowed_samples(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1253,10 +1253,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_max_b
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_max_borrowed_samples(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1276,10 +1276,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_m
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_max_loaned_samples(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1298,10 +1298,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_max_lo
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_max_loaned_samples(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1321,10 +1321,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_ma
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_history_size(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1343,10 +1343,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_publisher_histor
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_history_size(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1367,10 +1367,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_publisher_hi
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_enable_safe_overflow(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> bool {
     debug_assert!(!handle.is_null());
 
@@ -1388,10 +1388,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_enable_safe_over
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_enable_safe_overflow(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: bool,
 ) {
     debug_assert!(!handle.is_null());
@@ -1414,10 +1414,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_enable_safe_
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_unable_to_deliver_strategy(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_int {
     debug_assert!(!handle.is_null());
 
@@ -1436,10 +1436,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_unable_to_delive
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_unable_to_deliver_strategy(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: iox2_unable_to_deliver_strategy_e,
 ) {
     debug_assert!(!handle.is_null());
@@ -1462,10 +1462,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_unable_to_de
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_expired_connection_buffer(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1483,10 +1483,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_subscriber_expir
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_expired_connection_buffer(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1511,10 +1511,10 @@ pub unsafe extern "C" fn iox2_config_defaults_publish_subscribe_set_subscriber_e
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_max_listeners(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1526,10 +1526,10 @@ pub unsafe extern "C" fn iox2_config_defaults_event_max_listeners(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_set_max_listeners(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1542,10 +1542,10 @@ pub unsafe extern "C" fn iox2_config_defaults_event_set_max_listeners(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_max_notifiers(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1557,10 +1557,10 @@ pub unsafe extern "C" fn iox2_config_defaults_event_max_notifiers(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_set_max_notifiers(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1574,10 +1574,10 @@ pub unsafe extern "C" fn iox2_config_defaults_event_set_max_notifiers(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_max_nodes(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1589,10 +1589,10 @@ pub unsafe extern "C" fn iox2_config_defaults_event_max_nodes(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_set_max_nodes(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());
@@ -1605,10 +1605,10 @@ pub unsafe extern "C" fn iox2_config_defaults_event_set_max_nodes(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_event_id_max_value(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
 ) -> c_size_t {
     debug_assert!(!handle.is_null());
 
@@ -1626,10 +1626,10 @@ pub unsafe extern "C" fn iox2_config_defaults_event_event_id_max_value(
 ///
 /// # Safety
 ///
-/// * `handle` - A valid non-owning [`iox2_config_ref_h`] obtained by [`iox2_cast_config_ref_h`].
+/// * `handle` - A valid non-owning [`iox2_config_h_ref`] obtained by [`iox2_cast_config_h_ref`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_config_defaults_event_set_event_id_max_value(
-    handle: iox2_config_ref_h,
+    handle: iox2_config_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/listener.rs
+++ b/iceoryx2-ffi/ffi/src/api/listener.rs
@@ -97,9 +97,9 @@ pub struct iox2_listener_h_t;
 /// The owning handle for `iox2_listener_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_listener_h = *mut iox2_listener_h_t;
 
-pub struct iox2_listener_ref_h_t;
+pub struct iox2_listener_h_ref_t;
 /// The non-owning handle for `iox2_listener_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_listener_ref_h = *mut iox2_listener_ref_h_t;
+pub type iox2_listener_h_ref = *mut iox2_listener_h_ref_t;
 
 impl HandleToType for iox2_listener_h {
     type Target = *mut iox2_listener_t;
@@ -109,7 +109,7 @@ impl HandleToType for iox2_listener_h {
     }
 }
 
-impl HandleToType for iox2_listener_ref_h {
+impl HandleToType for iox2_listener_h_ref {
     type Target = *mut iox2_listener_t;
 
     fn as_type(self) -> Self::Target {
@@ -124,25 +124,25 @@ pub type iox2_listener_wait_all_callback =
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_listener_h`] into a non-owning [`iox2_listener_ref_h`]
+/// This function casts an owning [`iox2_listener_h`] into a non-owning [`iox2_listener_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `listener_handle` obtained by [`iox2_port_factory_listener_builder_create`](crate::iox2_port_factory_listener_builder_create)
 ///
-/// Returns a [`iox2_listener_ref_h`]
+/// Returns a [`iox2_listener_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `listener_handle` must be a valid handle.
 /// * The `listener_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_listener_ref_h(
+pub unsafe extern "C" fn iox2_cast_listener_h_ref(
     listener_handle: iox2_listener_h,
-) -> iox2_listener_ref_h {
+) -> iox2_listener_h_ref {
     debug_assert!(!listener_handle.is_null());
 
-    (*listener_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*listener_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// This function needs to be called to destroy the listener!
@@ -179,7 +179,7 @@ pub unsafe extern "C" fn iox2_listener_drop(listener_handle: iox2_listener_h) {
 ///
 /// # Arguments
 ///
-/// * `listener_handle` - A valid [`iox2_listener_ref_h`],
+/// * `listener_handle` - A valid [`iox2_listener_h_ref`],
 /// * `callback` - A valid callback with [`iox2_listener_wait_all_callback`} signature
 /// * `callback_ctx` - An optional callback context [`iox2_callback_context`} to e.g. store information across callback iterations
 ///
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn iox2_listener_drop(listener_handle: iox2_listener_h) {
 /// * The `callback` must be a valid function pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_listener_try_wait_all(
-    listener_handle: iox2_listener_ref_h,
+    listener_handle: iox2_listener_h_ref,
     callback: iox2_listener_wait_all_callback,
     callback_ctx: iox2_callback_context,
 ) -> c_int {
@@ -219,7 +219,7 @@ pub unsafe extern "C" fn iox2_listener_try_wait_all(
 ///
 /// # Arguments
 ///
-/// * `listener_handle` - A valid [`iox2_listener_ref_h`],
+/// * `listener_handle` - A valid [`iox2_listener_h_ref`],
 /// * `callback` - A valid callback with [`iox2_listener_wait_all_callback`} signature
 /// * `callback_ctx` - An optional callback context [`iox2_callback_context`} to e.g. store information across callback iterations
 ///
@@ -229,7 +229,7 @@ pub unsafe extern "C" fn iox2_listener_try_wait_all(
 /// * The `callback` must be a valid function pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_listener_timed_wait_all(
-    listener_handle: iox2_listener_ref_h,
+    listener_handle: iox2_listener_h_ref,
     callback: iox2_listener_wait_all_callback,
     callback_ctx: iox2_callback_context,
     seconds: u64,
@@ -272,11 +272,11 @@ pub unsafe extern "C" fn iox2_listener_timed_wait_all(
 ///
 /// # Safety
 ///
-/// * `listener_handle` is valid, non-null and was obtained via [`iox2_cast_listener_ref_h`]
+/// * `listener_handle` is valid, non-null and was obtained via [`iox2_cast_listener_h_ref`]
 /// * `id` is valid and non-null
 #[no_mangle]
 pub unsafe extern "C" fn iox2_listener_id(
-    listener_handle: iox2_listener_ref_h,
+    listener_handle: iox2_listener_h_ref,
     id_struct_ptr: *mut iox2_unique_listener_id_t,
     id_handle_ptr: *mut iox2_unique_listener_id_h,
 ) {
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn iox2_listener_id(
 ///
 /// # Arguments
 ///
-/// * `listener_handle` - A valid [`iox2_listener_ref_h`],
+/// * `listener_handle` - A valid [`iox2_listener_h_ref`],
 /// * `callback` - A valid callback with [`iox2_listener_wait_all_callback`} signature
 /// * `callback_ctx` - An optional callback context [`iox2_callback_context`} to e.g. store information across callback iterations
 ///
@@ -319,7 +319,7 @@ pub unsafe extern "C" fn iox2_listener_id(
 /// * The `callback` must be a valid function pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_listener_blocking_wait_all(
-    listener_handle: iox2_listener_ref_h,
+    listener_handle: iox2_listener_h_ref,
     callback: iox2_listener_wait_all_callback,
     callback_ctx: iox2_callback_context,
 ) -> c_int {
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn iox2_listener_blocking_wait_all(
 ///
 /// # Arguments
 ///
-/// * `listener_handle` - A valid [`iox2_listener_ref_h`],
+/// * `listener_handle` - A valid [`iox2_listener_h_ref`],
 /// * `event_id` - A pointer to an [`iox2_event_id_t`] to store the received id.
 /// * `has_received_one` - A pointer to a [`bool`] that signals if an event id was received or not
 ///
@@ -358,7 +358,7 @@ pub unsafe extern "C" fn iox2_listener_blocking_wait_all(
 /// * All input arguments must be non-null.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_listener_try_wait_one(
-    listener_handle: iox2_listener_ref_h,
+    listener_handle: iox2_listener_h_ref,
     event_id: *mut iox2_event_id_t,
     has_received_one: *mut bool,
 ) -> c_int {
@@ -397,7 +397,7 @@ pub unsafe extern "C" fn iox2_listener_try_wait_one(
 ///
 /// # Arguments
 ///
-/// * `listener_handle` - A valid [`iox2_listener_ref_h`],
+/// * `listener_handle` - A valid [`iox2_listener_h_ref`],
 /// * `event_id` - A pointer to an [`iox2_event_id_t`] to store the received id.
 /// * `has_received_one` - A pointer to a [`bool`] that signals if an event id was received or not
 /// * `seconds` - The timeout seconds part
@@ -408,7 +408,7 @@ pub unsafe extern "C" fn iox2_listener_try_wait_one(
 /// * All input arguments must be non-null.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_listener_timed_wait_one(
-    listener_handle: iox2_listener_ref_h,
+    listener_handle: iox2_listener_h_ref,
     event_id: *mut iox2_event_id_t,
     has_received_one: *mut bool,
     seconds: u64,
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn iox2_listener_timed_wait_one(
 ///
 /// # Arguments
 ///
-/// * `listener_handle` - A valid [`iox2_listener_ref_h`],
+/// * `listener_handle` - A valid [`iox2_listener_h_ref`],
 /// * `event_id` - A pointer to an [`iox2_event_id_t`] to store the received id.
 /// * `has_received_one` - A pointer to a [`bool`] that signals if an event id was received or not
 ///
@@ -458,7 +458,7 @@ pub unsafe extern "C" fn iox2_listener_timed_wait_one(
 /// * All input arguments must be non-null.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_listener_blocking_wait_one(
-    listener_handle: iox2_listener_ref_h,
+    listener_handle: iox2_listener_h_ref,
     event_id: *mut iox2_event_id_t,
     has_received_one: *mut bool,
 ) -> c_int {

--- a/iceoryx2-ffi/ffi/src/api/mod.rs
+++ b/iceoryx2-ffi/ffi/src/api/mod.rs
@@ -172,3 +172,7 @@ trait HandleToType {
     #[allow(clippy::wrong_self_convention)]
     fn as_type(self) -> Self::Target;
 }
+
+trait AssertNonNullHandle {
+    fn assert_non_null(self);
+}

--- a/iceoryx2-ffi/ffi/src/api/node.rs
+++ b/iceoryx2-ffi/ffi/src/api/node.rs
@@ -13,11 +13,10 @@
 #![allow(non_camel_case_types)]
 
 use crate::api::{
-    iox2_callback_progression_e, iox2_config_ptr, iox2_node_name_ptr, iox2_service_builder_h,
-    iox2_service_builder_t, iox2_service_name_ptr, iox2_service_type_e, HandleToType, IntoCInt,
-    ServiceBuilderUnion, IOX2_OK,
+    iox2_callback_context, iox2_callback_progression_e, iox2_config_ptr, iox2_node_name_ptr,
+    iox2_service_builder_h, iox2_service_builder_t, iox2_service_name_ptr, iox2_service_type_e,
+    AssertNonNullHandle, HandleToType, IntoCInt, ServiceBuilderUnion, IOX2_OK,
 };
-use crate::iox2_callback_context;
 
 use iceoryx2::node::{NodeId, NodeListFailure, NodeView};
 use iceoryx2::prelude::*;
@@ -116,10 +115,23 @@ impl iox2_node_t {
 pub struct iox2_name_h_t;
 /// The owning handle for `iox2_node_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_node_h = *mut iox2_name_h_t;
-
-pub struct iox2_node_h_ref_t;
 /// The non-owning handle for `iox2_node_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_node_h_ref = *mut iox2_node_h_ref_t;
+pub type iox2_node_h_ref = *const iox2_node_h;
+
+impl AssertNonNullHandle for iox2_node_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_node_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_node_h {
     type Target = *mut iox2_node_t;
@@ -133,7 +145,7 @@ impl HandleToType for iox2_node_h_ref {
     type Target = *mut iox2_node_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -175,25 +187,6 @@ pub type iox2_node_list_callback = extern "C" fn(
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_node_h`] into a non-owning [`iox2_node_h_ref`]
-///
-/// # Arguments
-///
-/// * `node_handle` obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)
-///
-/// Returns a [`iox2_node_h_ref`]
-///
-/// # Safety
-///
-/// * The `node_handle` must be a valid handle.
-/// * The `node_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_node_h_ref(node_handle: iox2_node_h) -> iox2_node_h_ref {
-    debug_assert!(!node_handle.is_null());
-
-    (*node_handle.as_type()).as_h_refandle()
-}
-
 /// Returns the [`iox2_node_name_ptr`](crate::iox2_node_name_ptr), an immutable pointer to the node name.
 ///
 /// # Safety
@@ -201,7 +194,7 @@ pub unsafe extern "C" fn iox2_cast_node_h_ref(node_handle: iox2_node_h) -> iox2_
 /// * The `node_handle` must be valid and obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)!
 #[no_mangle]
 pub unsafe extern "C" fn iox2_node_name(node_handle: iox2_node_h_ref) -> iox2_node_name_ptr {
-    debug_assert!(!node_handle.is_null());
+    node_handle.assert_non_null();
 
     let node = &mut *node_handle.as_type();
 
@@ -223,7 +216,7 @@ pub unsafe extern "C" fn iox2_node_wait(
     cycle_time_sec: u64,
     cycle_time_nsec: u32,
 ) -> c_int {
-    debug_assert!(!node_handle.is_null());
+    node_handle.assert_non_null();
 
     let node = &mut *node_handle.as_type();
     let cycle_time =
@@ -242,7 +235,7 @@ pub unsafe extern "C" fn iox2_node_wait(
 /// * The `node_handle` must be valid and obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)!
 #[no_mangle]
 pub unsafe extern "C" fn iox2_node_config(node_handle: iox2_node_h_ref) -> iox2_config_ptr {
-    debug_assert!(!node_handle.is_null());
+    node_handle.assert_non_null();
 
     let node = &mut *node_handle.as_type();
 
@@ -259,7 +252,7 @@ pub unsafe extern "C" fn iox2_node_config(node_handle: iox2_node_h_ref) -> iox2_
 /// * The `node_handle` must be valid and obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)!
 #[no_mangle]
 pub unsafe extern "C" fn iox2_node_id(node_handle: iox2_node_h_ref) -> iox2_node_id_ptr {
-    debug_assert!(!node_handle.is_null());
+    node_handle.assert_non_null();
     todo!() // TODO: [#210] implement
 }
 
@@ -364,7 +357,6 @@ pub unsafe extern "C" fn iox2_node_list(
 /// # Arguments
 ///
 /// * `node_handle` - Must be a valid [`iox2_node_h_ref`] obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)
-///   and casted by [`iox2_cast_node_h_ref`]
 /// * `service_builder_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_service_builder_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `service_name_ptr` - Must be a valid [`iox2_service_name_ptr`] obtained by [`iox2_service_name_new`](crate::iox2_service_name_new)
@@ -381,7 +373,7 @@ pub unsafe extern "C" fn iox2_node_service_builder(
     service_builder_struct_ptr: *mut iox2_service_builder_t,
     service_name_ptr: iox2_service_name_ptr,
 ) -> iox2_service_builder_h {
-    debug_assert!(!node_handle.is_null());
+    node_handle.assert_non_null();
     debug_assert!(!service_name_ptr.is_null());
 
     let mut service_builder_struct_ptr = service_builder_struct_ptr;
@@ -432,7 +424,7 @@ pub unsafe extern "C" fn iox2_node_service_builder(
 /// * The corresponding [`iox2_node_t`] can be re-used with a call to [`iox2_node_builder_create`](crate::iox2_node_builder_create)!
 #[no_mangle]
 pub unsafe extern "C" fn iox2_node_drop(node_handle: iox2_node_h) {
-    debug_assert!(!node_handle.is_null());
+    node_handle.assert_non_null();
 
     let node = &mut *node_handle.as_type();
 

--- a/iceoryx2-ffi/ffi/src/api/node.rs
+++ b/iceoryx2-ffi/ffi/src/api/node.rs
@@ -150,7 +150,7 @@ pub enum iox2_node_state_e {
 /// The immutable pointer to the underlying `NodeId`
 pub type iox2_node_id_ptr = *const NodeId;
 /// The mutable pointer to the underlying `NodeId`
-pub type iox2_node_id_mut_ptr = *mut NodeId;
+pub type iox2_node_id_ptr_mut = *mut NodeId;
 
 /// The callback for [`iox2_node_list`]
 ///

--- a/iceoryx2-ffi/ffi/src/api/node.rs
+++ b/iceoryx2-ffi/ffi/src/api/node.rs
@@ -117,9 +117,9 @@ pub struct iox2_name_h_t;
 /// The owning handle for `iox2_node_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_node_h = *mut iox2_name_h_t;
 
-pub struct iox2_node_ref_h_t;
+pub struct iox2_node_h_ref_t;
 /// The non-owning handle for `iox2_node_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_node_ref_h = *mut iox2_node_ref_h_t;
+pub type iox2_node_h_ref = *mut iox2_node_h_ref_t;
 
 impl HandleToType for iox2_node_h {
     type Target = *mut iox2_node_t;
@@ -129,7 +129,7 @@ impl HandleToType for iox2_node_h {
     }
 }
 
-impl HandleToType for iox2_node_ref_h {
+impl HandleToType for iox2_node_h_ref {
     type Target = *mut iox2_node_t;
 
     fn as_type(self) -> Self::Target {
@@ -175,23 +175,23 @@ pub type iox2_node_list_callback = extern "C" fn(
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_node_h`] into a non-owning [`iox2_node_ref_h`]
+/// This function casts an owning [`iox2_node_h`] into a non-owning [`iox2_node_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `node_handle` obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)
 ///
-/// Returns a [`iox2_node_ref_h`]
+/// Returns a [`iox2_node_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `node_handle` must be a valid handle.
 /// * The `node_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_node_ref_h(node_handle: iox2_node_h) -> iox2_node_ref_h {
+pub unsafe extern "C" fn iox2_cast_node_h_ref(node_handle: iox2_node_h) -> iox2_node_h_ref {
     debug_assert!(!node_handle.is_null());
 
-    (*node_handle.as_type()).as_ref_handle()
+    (*node_handle.as_type()).as_h_refandle()
 }
 
 /// Returns the [`iox2_node_name_ptr`](crate::iox2_node_name_ptr), an immutable pointer to the node name.
@@ -200,7 +200,7 @@ pub unsafe extern "C" fn iox2_cast_node_ref_h(node_handle: iox2_node_h) -> iox2_
 ///
 /// * The `node_handle` must be valid and obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)!
 #[no_mangle]
-pub unsafe extern "C" fn iox2_node_name(node_handle: iox2_node_ref_h) -> iox2_node_name_ptr {
+pub unsafe extern "C" fn iox2_node_name(node_handle: iox2_node_h_ref) -> iox2_node_name_ptr {
     debug_assert!(!node_handle.is_null());
 
     let node = &mut *node_handle.as_type();
@@ -219,7 +219,7 @@ pub unsafe extern "C" fn iox2_node_name(node_handle: iox2_node_ref_h) -> iox2_no
 /// * The `node_handle` must be valid and obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)!
 #[no_mangle]
 pub unsafe extern "C" fn iox2_node_wait(
-    node_handle: iox2_node_ref_h,
+    node_handle: iox2_node_h_ref,
     cycle_time_sec: u64,
     cycle_time_nsec: u32,
 ) -> c_int {
@@ -241,7 +241,7 @@ pub unsafe extern "C" fn iox2_node_wait(
 ///
 /// * The `node_handle` must be valid and obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)!
 #[no_mangle]
-pub unsafe extern "C" fn iox2_node_config(node_handle: iox2_node_ref_h) -> iox2_config_ptr {
+pub unsafe extern "C" fn iox2_node_config(node_handle: iox2_node_h_ref) -> iox2_config_ptr {
     debug_assert!(!node_handle.is_null());
 
     let node = &mut *node_handle.as_type();
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn iox2_node_config(node_handle: iox2_node_ref_h) -> iox2_
 ///
 /// * The `node_handle` must be valid and obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)!
 #[no_mangle]
-pub unsafe extern "C" fn iox2_node_id(node_handle: iox2_node_ref_h) -> iox2_node_id_ptr {
+pub unsafe extern "C" fn iox2_node_id(node_handle: iox2_node_h_ref) -> iox2_node_id_ptr {
     debug_assert!(!node_handle.is_null());
     todo!() // TODO: [#210] implement
 }
@@ -363,8 +363,8 @@ pub unsafe extern "C" fn iox2_node_list(
 ///
 /// # Arguments
 ///
-/// * `node_handle` - Must be a valid [`iox2_node_ref_h`] obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)
-///   and casted by [`iox2_cast_node_ref_h`]
+/// * `node_handle` - Must be a valid [`iox2_node_h_ref`] obtained by [`iox2_node_builder_create`](crate::iox2_node_builder_create)
+///   and casted by [`iox2_cast_node_h_ref`]
 /// * `service_builder_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_service_builder_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `service_name_ptr` - Must be a valid [`iox2_service_name_ptr`] obtained by [`iox2_service_name_new`](crate::iox2_service_name_new)
@@ -377,7 +377,7 @@ pub unsafe extern "C" fn iox2_node_list(
 /// * The `node_handle` is still valid after the return of this function and can be use in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_node_service_builder(
-    node_handle: iox2_node_ref_h,
+    node_handle: iox2_node_h_ref,
     service_builder_struct_ptr: *mut iox2_service_builder_t,
     service_name_ptr: iox2_service_name_ptr,
 ) -> iox2_service_builder_h {

--- a/iceoryx2-ffi/ffi/src/api/node_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/node_builder.rs
@@ -16,7 +16,7 @@ use crate::api::{
     iox2_node_h, iox2_node_name_ptr, iox2_node_t, iox2_service_type_e, HandleToType, IntoCInt,
     NodeUnion, IOX2_OK,
 };
-use crate::iox2_config_ref_h;
+use crate::iox2_config_h_ref;
 
 use iceoryx2::node::NodeCreationFailure;
 use iceoryx2::prelude::*;
@@ -63,9 +63,9 @@ pub struct iox2_node_builder_h_t;
 /// The owning handle for `iox2_node_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_node_builder_h = *mut iox2_node_builder_h_t;
 
-pub struct iox2_node_builder_ref_h_t;
+pub struct iox2_node_builder_h_ref_t;
 /// The non-owning handle for `iox2_node_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_node_builder_ref_h = *mut iox2_node_builder_ref_h_t;
+pub type iox2_node_builder_h_ref = *mut iox2_node_builder_h_ref_t;
 
 impl HandleToType for iox2_node_builder_h {
     type Target = *mut iox2_node_builder_t;
@@ -75,7 +75,7 @@ impl HandleToType for iox2_node_builder_h {
     }
 }
 
-impl HandleToType for iox2_node_builder_ref_h {
+impl HandleToType for iox2_node_builder_h_ref {
     type Target = *mut iox2_node_builder_t;
 
     fn as_type(self) -> Self::Target {
@@ -119,32 +119,32 @@ pub unsafe extern "C" fn iox2_node_builder_new(
     (*node_builder_struct_ptr).as_handle()
 }
 
-/// This function casts an owning [`iox2_node_builder_h`] into a non-owning [`iox2_node_builder_ref_h`]
+/// This function casts an owning [`iox2_node_builder_h`] into a non-owning [`iox2_node_builder_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `node_builder_handle` obtained by [`iox2_node_builder_new`]
 ///
-/// Returns a [`iox2_node_builder_ref_h`]
+/// Returns a [`iox2_node_builder_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `node_builder_handle` must be a valid handle.
 /// * The `node_builder_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_node_builder_ref_h(
+pub unsafe extern "C" fn iox2_cast_node_builder_h_ref(
     node_builder_handle: iox2_node_builder_h,
-) -> iox2_node_builder_ref_h {
+) -> iox2_node_builder_h_ref {
     debug_assert!(!node_builder_handle.is_null());
 
-    (*node_builder_handle.as_type()).as_ref_handle()
+    (*node_builder_handle.as_type()).as_h_refandle()
 }
 
 /// Sets the node name for the builder
 ///
 /// # Arguments
 ///
-/// * `node_builder_handle` - Must be a valid [`iox2_node_builder_ref_h`] obtained by [`iox2_node_builder_new`] and casted by [`iox2_cast_node_builder_ref_h`].
+/// * `node_builder_handle` - Must be a valid [`iox2_node_builder_h_ref`] obtained by [`iox2_node_builder_new`] and casted by [`iox2_cast_node_builder_h_ref`].
 /// * `node_name_ptr` - Must be a valid [`iox2_node_name_ptr`], e.g. obtained by [`iox2_node_name_new`](crate::iox2_node_name_new) and converted
 ///    by [`iox2_cast_node_name_ptr`](crate::iox2_cast_node_name_ptr)
 ///
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn iox2_cast_node_builder_ref_h(
 /// * `node_builder_handle` as well as `node_name_ptr` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_node_builder_set_name(
-    node_builder_handle: iox2_node_builder_ref_h,
+    node_builder_handle: iox2_node_builder_h_ref,
     node_name_ptr: iox2_node_name_ptr,
 ) -> c_int {
     debug_assert!(!node_builder_handle.is_null());
@@ -176,13 +176,13 @@ pub unsafe extern "C" fn iox2_node_builder_set_name(
 ///
 /// # Safety
 ///
-/// * `node_builder_handle` - Must be a valid [`iox2_node_builder_ref_h`] obtained by [`iox2_node_builder_new`] and casted by [`iox2_cast_node_builder_ref_h`].
-/// * `config_handle` - Must be a valid [`iox2_config_ref_h`]
+/// * `node_builder_handle` - Must be a valid [`iox2_node_builder_h_ref`] obtained by [`iox2_node_builder_new`] and casted by [`iox2_cast_node_builder_h_ref`].
+/// * `config_handle` - Must be a valid [`iox2_config_h_ref`]
 ///
 #[no_mangle]
 pub unsafe extern "C" fn iox2_node_builder_set_config(
-    node_builder_handle: iox2_node_builder_ref_h,
-    config_handle: iox2_config_ref_h,
+    node_builder_handle: iox2_node_builder_h_ref,
+    config_handle: iox2_config_h_ref,
 ) {
     debug_assert!(!node_builder_handle.is_null());
     debug_assert!(!config_handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/node_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/node_builder.rs
@@ -13,10 +13,9 @@
 #![allow(non_camel_case_types)]
 
 use crate::api::{
-    iox2_node_h, iox2_node_name_ptr, iox2_node_t, iox2_service_type_e, HandleToType, IntoCInt,
-    NodeUnion, IOX2_OK,
+    iox2_config_h_ref, iox2_node_h, iox2_node_name_ptr, iox2_node_t, iox2_service_type_e,
+    AssertNonNullHandle, HandleToType, IntoCInt, NodeUnion, IOX2_OK,
 };
-use crate::iox2_config_h_ref;
 
 use iceoryx2::node::NodeCreationFailure;
 use iceoryx2::prelude::*;
@@ -62,10 +61,23 @@ pub struct iox2_node_builder_t {
 pub struct iox2_node_builder_h_t;
 /// The owning handle for `iox2_node_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_node_builder_h = *mut iox2_node_builder_h_t;
-
-pub struct iox2_node_builder_h_ref_t;
 /// The non-owning handle for `iox2_node_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_node_builder_h_ref = *mut iox2_node_builder_h_ref_t;
+pub type iox2_node_builder_h_ref = *const iox2_node_builder_h;
+
+impl AssertNonNullHandle for iox2_node_builder_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_node_builder_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_node_builder_h {
     type Target = *mut iox2_node_builder_t;
@@ -79,7 +91,7 @@ impl HandleToType for iox2_node_builder_h_ref {
     type Target = *mut iox2_node_builder_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -119,32 +131,11 @@ pub unsafe extern "C" fn iox2_node_builder_new(
     (*node_builder_struct_ptr).as_handle()
 }
 
-/// This function casts an owning [`iox2_node_builder_h`] into a non-owning [`iox2_node_builder_h_ref`]
-///
-/// # Arguments
-///
-/// * `node_builder_handle` obtained by [`iox2_node_builder_new`]
-///
-/// Returns a [`iox2_node_builder_h_ref`]
-///
-/// # Safety
-///
-/// * The `node_builder_handle` must be a valid handle.
-/// * The `node_builder_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_node_builder_h_ref(
-    node_builder_handle: iox2_node_builder_h,
-) -> iox2_node_builder_h_ref {
-    debug_assert!(!node_builder_handle.is_null());
-
-    (*node_builder_handle.as_type()).as_h_refandle()
-}
-
 /// Sets the node name for the builder
 ///
 /// # Arguments
 ///
-/// * `node_builder_handle` - Must be a valid [`iox2_node_builder_h_ref`] obtained by [`iox2_node_builder_new`] and casted by [`iox2_cast_node_builder_h_ref`].
+/// * `node_builder_handle` - Must be a valid [`iox2_node_builder_h_ref`] obtained by [`iox2_node_builder_new`].
 /// * `node_name_ptr` - Must be a valid [`iox2_node_name_ptr`], e.g. obtained by [`iox2_node_name_new`](crate::iox2_node_name_new) and converted
 ///    by [`iox2_cast_node_name_ptr`](crate::iox2_cast_node_name_ptr)
 ///
@@ -158,7 +149,7 @@ pub unsafe extern "C" fn iox2_node_builder_set_name(
     node_builder_handle: iox2_node_builder_h_ref,
     node_name_ptr: iox2_node_name_ptr,
 ) -> c_int {
-    debug_assert!(!node_builder_handle.is_null());
+    node_builder_handle.assert_non_null();
     debug_assert!(!node_name_ptr.is_null());
 
     let node_builder_struct = &mut *node_builder_handle.as_type();
@@ -176,7 +167,7 @@ pub unsafe extern "C" fn iox2_node_builder_set_name(
 ///
 /// # Safety
 ///
-/// * `node_builder_handle` - Must be a valid [`iox2_node_builder_h_ref`] obtained by [`iox2_node_builder_new`] and casted by [`iox2_cast_node_builder_h_ref`].
+/// * `node_builder_handle` - Must be a valid [`iox2_node_builder_h_ref`] obtained by [`iox2_node_builder_new`].
 /// * `config_handle` - Must be a valid [`iox2_config_h_ref`]
 ///
 #[no_mangle]
@@ -184,8 +175,8 @@ pub unsafe extern "C" fn iox2_node_builder_set_config(
     node_builder_handle: iox2_node_builder_h_ref,
     config_handle: iox2_config_h_ref,
 ) {
-    debug_assert!(!node_builder_handle.is_null());
-    debug_assert!(!config_handle.is_null());
+    node_builder_handle.assert_non_null();
+    config_handle.assert_non_null();
 
     let node_builder_struct = &mut *node_builder_handle.as_type();
     let config = &*config_handle.as_type();

--- a/iceoryx2-ffi/ffi/src/api/node_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/node_name.rs
@@ -41,9 +41,9 @@ pub struct iox2_node_name_h_t;
 /// The owning handle for `iox2_node_name_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_node_name_h = *mut iox2_node_name_h_t;
 
-pub struct iox2_node_name_ref_h_t;
+pub struct iox2_node_name_h_ref_t;
 /// The non-owning handle for `iox2_node_name_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_node_name_ref_h = *mut iox2_node_name_ref_h_t;
+pub type iox2_node_name_h_ref = *mut iox2_node_name_h_ref_t;
 
 // NOTE check the README.md for using opaque types with renaming
 /// The immutable pointer to the underlying `NodeName`
@@ -59,7 +59,7 @@ impl HandleToType for iox2_node_name_h {
     }
 }
 
-impl HandleToType for iox2_node_name_ref_h {
+impl HandleToType for iox2_node_name_h_ref {
     type Target = *mut iox2_node_name_t;
 
     fn as_type(self) -> Self::Target {

--- a/iceoryx2-ffi/ffi/src/api/node_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/node_name.rs
@@ -49,7 +49,7 @@ pub type iox2_node_name_ref_h = *mut iox2_node_name_ref_h_t;
 /// The immutable pointer to the underlying `NodeName`
 pub type iox2_node_name_ptr = *const NodeName;
 /// The mutable pointer to the underlying `NodeName`
-pub type iox2_node_name_mut_ptr = *mut NodeName;
+pub type iox2_node_name_ptr_mut = *mut NodeName;
 
 impl HandleToType for iox2_node_name_h {
     type Target = *mut iox2_node_name_t;

--- a/iceoryx2-ffi/ffi/src/api/node_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/node_name.rs
@@ -12,8 +12,9 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::api::{iox2_semantic_string_error_e, HandleToType, IntoCInt, IOX2_OK};
-use crate::c_size_t;
+use crate::api::{
+    c_size_t, iox2_semantic_string_error_e, AssertNonNullHandle, HandleToType, IntoCInt, IOX2_OK,
+};
 
 use iceoryx2::prelude::*;
 use iceoryx2_bb_elementary::static_assert::*;
@@ -41,15 +42,29 @@ pub struct iox2_node_name_h_t;
 /// The owning handle for `iox2_node_name_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_node_name_h = *mut iox2_node_name_h_t;
 
-pub struct iox2_node_name_h_ref_t;
 /// The non-owning handle for `iox2_node_name_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_node_name_h_ref = *mut iox2_node_name_h_ref_t;
+pub type iox2_node_name_h_ref = *const iox2_node_name_h;
 
 // NOTE check the README.md for using opaque types with renaming
 /// The immutable pointer to the underlying `NodeName`
 pub type iox2_node_name_ptr = *const NodeName;
 /// The mutable pointer to the underlying `NodeName`
 pub type iox2_node_name_ptr_mut = *mut NodeName;
+
+impl AssertNonNullHandle for iox2_node_name_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_node_name_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_node_name_h {
     type Target = *mut iox2_node_name_t;
@@ -63,7 +78,7 @@ impl HandleToType for iox2_node_name_h_ref {
     type Target = *mut iox2_node_name_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 

--- a/iceoryx2-ffi/ffi/src/api/notifier.rs
+++ b/iceoryx2-ffi/ffi/src/api/notifier.rs
@@ -133,7 +133,7 @@ impl HandleToType for iox2_notifier_h_ref {
 ///
 /// # Safety
 ///
-/// * `notifier_handle` is valid, non-null and was obtained via [`iox2_port_factory_notifier_builder_create`]
+/// * `notifier_handle` is valid, non-null and was obtained via [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create).
 /// * `id_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_unique_notifier_id_t`].
 ///                         If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `id_handle_ptr` valid pointer to a [`iox2_unique_notifier_id_h`].

--- a/iceoryx2-ffi/ffi/src/api/notifier.rs
+++ b/iceoryx2-ffi/ffi/src/api/notifier.rs
@@ -12,8 +12,10 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::api::{iox2_service_type_e, HandleToType, IntoCInt, IOX2_OK};
-use crate::{c_size_t, iox2_event_id_t, iox2_unique_notifier_id_h, iox2_unique_notifier_id_t};
+use crate::api::{
+    c_size_t, iox2_event_id_t, iox2_service_type_e, iox2_unique_notifier_id_h,
+    iox2_unique_notifier_id_t, AssertNonNullHandle, HandleToType, IntoCInt, IOX2_OK,
+};
 
 use iceoryx2::port::notifier::{Notifier, NotifierNotifyError};
 use iceoryx2::prelude::*;
@@ -89,10 +91,23 @@ impl iox2_notifier_t {
 pub struct iox2_notifier_h_t;
 /// The owning handle for `iox2_notifier_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_notifier_h = *mut iox2_notifier_h_t;
-
-pub struct iox2_notifier_h_ref_t;
 /// The non-owning handle for `iox2_notifier_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_notifier_h_ref = *mut iox2_notifier_h_ref_t;
+pub type iox2_notifier_h_ref = *const iox2_notifier_h;
+
+impl AssertNonNullHandle for iox2_notifier_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_notifier_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_notifier_h {
     type Target = *mut iox2_notifier_t;
@@ -106,7 +121,7 @@ impl HandleToType for iox2_notifier_h_ref {
     type Target = *mut iox2_notifier_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -114,32 +129,11 @@ impl HandleToType for iox2_notifier_h_ref {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_notifier_h`] into a non-owning [`iox2_notifier_h_ref`]
-///
-/// # Arguments
-///
-/// * `notifier_handle` obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create)
-///
-/// Returns a [`iox2_notifier_h_ref`]
-///
-/// # Safety
-///
-/// * The `notifier_handle` must be a valid handle.
-/// * The `notifier_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_notifier_h_ref(
-    notifier_handle: iox2_notifier_h,
-) -> iox2_notifier_h_ref {
-    debug_assert!(!notifier_handle.is_null());
-
-    (*notifier_handle.as_type()).as_h_refandle() as *mut _ as _
-}
-
 /// Returns the unique port id of the notifier.
 ///
 /// # Safety
 ///
-/// * `notifier_handle` is valid, non-null and was obtained via [`iox2_cast_notifier_h_ref`]
+/// * `notifier_handle` is valid, non-null and was obtained via [`iox2_port_factory_notifier_builder_create`]
 /// * `id_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_unique_notifier_id_t`].
 ///                         If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `id_handle_ptr` valid pointer to a [`iox2_unique_notifier_id_h`].
@@ -149,7 +143,7 @@ pub unsafe extern "C" fn iox2_notifier_id(
     id_struct_ptr: *mut iox2_unique_notifier_id_t,
     id_handle_ptr: *mut iox2_unique_notifier_id_h,
 ) {
-    debug_assert!(!notifier_handle.is_null());
+    notifier_handle.assert_non_null();
     debug_assert!(!id_handle_ptr.is_null());
 
     fn no_op(_: *mut iox2_unique_notifier_id_t) {}
@@ -178,8 +172,7 @@ pub unsafe extern "C" fn iox2_notifier_id(
 /// # Arguments
 ///
 /// * notifier_handle -  Must be a valid [`iox2_notifier_h_ref`]
-///   obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create) and
-///   casted by [`iox2_cast_notifier_h_ref`]
+///   obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create)
 /// * number_of_notified_listener_ptr - Must be either a NULL pointer or a pointer to a `size_t` to store the number of notified listener
 ///
 /// Returns IOX2_OK on success, an [`iox2_notifier_notify_error_e`] otherwise.
@@ -192,7 +185,7 @@ pub unsafe extern "C" fn iox2_notifier_notify(
     notifier_handle: iox2_notifier_h_ref,
     number_of_notified_listener_ptr: *mut c_size_t,
 ) -> c_int {
-    debug_assert!(!notifier_handle.is_null());
+    notifier_handle.assert_non_null();
 
     let notifier = &mut *notifier_handle.as_type();
 
@@ -221,8 +214,7 @@ pub unsafe extern "C" fn iox2_notifier_notify(
 /// # Arguments
 ///
 /// * notifier_handle -  Must be a valid [`iox2_notifier_h_ref`]
-///   obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create) and
-///   casted by [`iox2_cast_notifier_h_ref`]
+///   obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create)
 /// * custom_event_id_ptr - Must be a pointer to an initialized [`iox2_event_id_t`](crate::iox2_event_id_t)
 /// * number_of_notified_listener_ptr - Must be either a NULL pointer or a pointer to a `size_t` to store the number of notified listener
 ///
@@ -238,7 +230,7 @@ pub unsafe extern "C" fn iox2_notifier_notify_with_custom_event_id(
     custom_event_id_ptr: *const iox2_event_id_t,
     number_of_notified_listener_ptr: *mut c_size_t,
 ) -> c_int {
-    debug_assert!(!notifier_handle.is_null());
+    notifier_handle.assert_non_null();
     debug_assert!(!custom_event_id_ptr.is_null());
 
     let event_id = (*custom_event_id_ptr).into();

--- a/iceoryx2-ffi/ffi/src/api/notifier.rs
+++ b/iceoryx2-ffi/ffi/src/api/notifier.rs
@@ -90,9 +90,9 @@ pub struct iox2_notifier_h_t;
 /// The owning handle for `iox2_notifier_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_notifier_h = *mut iox2_notifier_h_t;
 
-pub struct iox2_notifier_ref_h_t;
+pub struct iox2_notifier_h_ref_t;
 /// The non-owning handle for `iox2_notifier_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_notifier_ref_h = *mut iox2_notifier_ref_h_t;
+pub type iox2_notifier_h_ref = *mut iox2_notifier_h_ref_t;
 
 impl HandleToType for iox2_notifier_h {
     type Target = *mut iox2_notifier_t;
@@ -102,7 +102,7 @@ impl HandleToType for iox2_notifier_h {
     }
 }
 
-impl HandleToType for iox2_notifier_ref_h {
+impl HandleToType for iox2_notifier_h_ref {
     type Target = *mut iox2_notifier_t;
 
     fn as_type(self) -> Self::Target {
@@ -114,38 +114,38 @@ impl HandleToType for iox2_notifier_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_notifier_h`] into a non-owning [`iox2_notifier_ref_h`]
+/// This function casts an owning [`iox2_notifier_h`] into a non-owning [`iox2_notifier_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `notifier_handle` obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create)
 ///
-/// Returns a [`iox2_notifier_ref_h`]
+/// Returns a [`iox2_notifier_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `notifier_handle` must be a valid handle.
 /// * The `notifier_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_notifier_ref_h(
+pub unsafe extern "C" fn iox2_cast_notifier_h_ref(
     notifier_handle: iox2_notifier_h,
-) -> iox2_notifier_ref_h {
+) -> iox2_notifier_h_ref {
     debug_assert!(!notifier_handle.is_null());
 
-    (*notifier_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*notifier_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Returns the unique port id of the notifier.
 ///
 /// # Safety
 ///
-/// * `notifier_handle` is valid, non-null and was obtained via [`iox2_cast_notifier_ref_h`]
+/// * `notifier_handle` is valid, non-null and was obtained via [`iox2_cast_notifier_h_ref`]
 /// * `id_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_unique_notifier_id_t`].
 ///                         If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `id_handle_ptr` valid pointer to a [`iox2_unique_notifier_id_h`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_notifier_id(
-    notifier_handle: iox2_notifier_ref_h,
+    notifier_handle: iox2_notifier_h_ref,
     id_struct_ptr: *mut iox2_unique_notifier_id_t,
     id_handle_ptr: *mut iox2_unique_notifier_id_h,
 ) {
@@ -177,9 +177,9 @@ pub unsafe extern "C" fn iox2_notifier_id(
 ///
 /// # Arguments
 ///
-/// * notifier_handle -  Must be a valid [`iox2_notifier_ref_h`]
+/// * notifier_handle -  Must be a valid [`iox2_notifier_h_ref`]
 ///   obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create) and
-///   casted by [`iox2_cast_notifier_ref_h`]
+///   casted by [`iox2_cast_notifier_h_ref`]
 /// * number_of_notified_listener_ptr - Must be either a NULL pointer or a pointer to a `size_t` to store the number of notified listener
 ///
 /// Returns IOX2_OK on success, an [`iox2_notifier_notify_error_e`] otherwise.
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn iox2_notifier_id(
 /// `notifier_handle` must be a valid handle and is still valid after the return of this function and can be use in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_notifier_notify(
-    notifier_handle: iox2_notifier_ref_h,
+    notifier_handle: iox2_notifier_h_ref,
     number_of_notified_listener_ptr: *mut c_size_t,
 ) -> c_int {
     debug_assert!(!notifier_handle.is_null());
@@ -220,9 +220,9 @@ pub unsafe extern "C" fn iox2_notifier_notify(
 ///
 /// # Arguments
 ///
-/// * notifier_handle -  Must be a valid [`iox2_notifier_ref_h`]
+/// * notifier_handle -  Must be a valid [`iox2_notifier_h_ref`]
 ///   obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create) and
-///   casted by [`iox2_cast_notifier_ref_h`]
+///   casted by [`iox2_cast_notifier_h_ref`]
 /// * custom_event_id_ptr - Must be a pointer to an initialized [`iox2_event_id_t`](crate::iox2_event_id_t)
 /// * number_of_notified_listener_ptr - Must be either a NULL pointer or a pointer to a `size_t` to store the number of notified listener
 ///
@@ -234,7 +234,7 @@ pub unsafe extern "C" fn iox2_notifier_notify(
 /// `custom_event_id_ptr` must not be a NULL pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_notifier_notify_with_custom_event_id(
-    notifier_handle: iox2_notifier_ref_h,
+    notifier_handle: iox2_notifier_h_ref,
     custom_event_id_ptr: *const iox2_event_id_t,
     number_of_notified_listener_ptr: *mut c_size_t,
 ) -> c_int {

--- a/iceoryx2-ffi/ffi/src/api/port_factory_event.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_event.rs
@@ -15,8 +15,8 @@
 use crate::api::{
     iox2_port_factory_listener_builder_h, iox2_port_factory_listener_builder_t,
     iox2_port_factory_notifier_builder_h, iox2_port_factory_notifier_builder_t,
-    iox2_service_name_ptr, iox2_service_type_e, HandleToType, PortFactoryListenerBuilderUnion,
-    PortFactoryNotifierBuilderUnion,
+    iox2_service_name_ptr, iox2_service_type_e, AssertNonNullHandle, HandleToType,
+    PortFactoryListenerBuilderUnion, PortFactoryNotifierBuilderUnion,
 };
 
 use iceoryx2::prelude::*;
@@ -78,10 +78,23 @@ impl iox2_port_factory_event_t {
 pub struct iox2_port_factory_event_h_t;
 /// The owning handle for `iox2_port_factory_event_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_event_h = *mut iox2_port_factory_event_h_t;
-
-pub struct iox2_port_factory_event_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_event_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_event_h_ref = *mut iox2_port_factory_event_h_ref_t;
+pub type iox2_port_factory_event_h_ref = *const iox2_port_factory_event_h;
+
+impl AssertNonNullHandle for iox2_port_factory_event_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_port_factory_event_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_port_factory_event_h {
     type Target = *mut iox2_port_factory_event_t;
@@ -95,35 +108,13 @@ impl HandleToType for iox2_port_factory_event_h_ref {
     type Target = *mut iox2_port_factory_event_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
 // END type definition
 
 // BEGIN C API
-
-/// This function casts an owning [`iox2_port_factory_event_h`] into a non-owning [`iox2_port_factory_event_h_ref`]
-///
-/// # Arguments
-///
-/// * `port_factory_handle` obtained by [`iox2_service_builder_event_open`](crate::iox2_service_builder_event_open) or
-///   [`iox2_service_builder_event_open_or_create`](crate::iox2_service_builder_event_open_or_create)
-///
-/// Returns a [`iox2_port_factory_event_h_ref`]
-///
-/// # Safety
-///
-/// * The `port_factory_handle` must be a valid handle.
-/// * The `port_factory_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_event_h_ref(
-    port_factory_handle: iox2_port_factory_event_h,
-) -> iox2_port_factory_event_h_ref {
-    debug_assert!(!port_factory_handle.is_null());
-
-    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
-}
 
 /// Returns the [`iox2_service_name_ptr`], an immutable pointer to the service name.
 ///
@@ -135,7 +126,7 @@ pub unsafe extern "C" fn iox2_cast_port_factory_event_h_ref(
 pub unsafe extern "C" fn iox2_port_factory_event_service_name(
     port_factory_handle: iox2_port_factory_event_h_ref,
 ) -> iox2_service_name_ptr {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
 
     let port_factory = &mut *port_factory_handle.as_type();
 
@@ -157,7 +148,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_static_config(
     port_factory_handle: iox2_port_factory_event_h_ref,
     static_config: *mut iox2_static_config_event_t,
 ) {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
     debug_assert!(!static_config.is_null());
 
     let port_factory = &mut *port_factory_handle.as_type();
@@ -178,7 +169,6 @@ pub unsafe extern "C" fn iox2_port_factory_event_static_config(
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_event_h_ref`] obtained
 ///   by e.g. [`iox2_service_builder_event_open_or_create`](crate::iox2_service_builder_event_open_or_create)
-///   and casted by [`iox2_cast_port_factory_event_h_ref`]
 /// * `notifier_builder_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_port_factory_notifier_builder_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 ///
@@ -192,7 +182,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_notifier_builder(
     port_factory_handle: iox2_port_factory_event_h_ref,
     notifier_builder_struct_ptr: *mut iox2_port_factory_notifier_builder_t,
 ) -> iox2_port_factory_notifier_builder_h {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
 
     let mut notifier_builder_struct_ptr = notifier_builder_struct_ptr;
     fn no_op(_: *mut iox2_port_factory_notifier_builder_t) {}
@@ -232,7 +222,6 @@ pub unsafe extern "C" fn iox2_port_factory_event_notifier_builder(
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_event_h_ref`] obtained
 ///   by e.g. [`iox2_service_builder_event_open_or_create`](crate::iox2_service_builder_event_open_or_create)
-///   and casted by [`iox2_cast_port_factory_event_h_ref`]
 /// * `listener_builder_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_port_factory_listener_builder_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 ///
@@ -246,7 +235,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_listener_builder(
     port_factory_handle: iox2_port_factory_event_h_ref,
     listener_builder_struct_ptr: *mut iox2_port_factory_listener_builder_t,
 ) -> iox2_port_factory_listener_builder_h {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
 
     let mut listener_builder_struct_ptr = listener_builder_struct_ptr;
     fn no_op(_: *mut iox2_port_factory_listener_builder_t) {}
@@ -296,7 +285,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_listener_builder(
 pub unsafe extern "C" fn iox2_port_factory_event_drop(
     port_factory_handle: iox2_port_factory_event_h,
 ) {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
 
     let port_factory = &mut *port_factory_handle.as_type();
 

--- a/iceoryx2-ffi/ffi/src/api/port_factory_event.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_event.rs
@@ -79,9 +79,9 @@ pub struct iox2_port_factory_event_h_t;
 /// The owning handle for `iox2_port_factory_event_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_event_h = *mut iox2_port_factory_event_h_t;
 
-pub struct iox2_port_factory_event_ref_h_t;
+pub struct iox2_port_factory_event_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_event_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_event_ref_h = *mut iox2_port_factory_event_ref_h_t;
+pub type iox2_port_factory_event_h_ref = *mut iox2_port_factory_event_h_ref_t;
 
 impl HandleToType for iox2_port_factory_event_h {
     type Target = *mut iox2_port_factory_event_t;
@@ -91,7 +91,7 @@ impl HandleToType for iox2_port_factory_event_h {
     }
 }
 
-impl HandleToType for iox2_port_factory_event_ref_h {
+impl HandleToType for iox2_port_factory_event_h_ref {
     type Target = *mut iox2_port_factory_event_t;
 
     fn as_type(self) -> Self::Target {
@@ -103,26 +103,26 @@ impl HandleToType for iox2_port_factory_event_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_port_factory_event_h`] into a non-owning [`iox2_port_factory_event_ref_h`]
+/// This function casts an owning [`iox2_port_factory_event_h`] into a non-owning [`iox2_port_factory_event_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `port_factory_handle` obtained by [`iox2_service_builder_event_open`](crate::iox2_service_builder_event_open) or
 ///   [`iox2_service_builder_event_open_or_create`](crate::iox2_service_builder_event_open_or_create)
 ///
-/// Returns a [`iox2_port_factory_event_ref_h`]
+/// Returns a [`iox2_port_factory_event_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `port_factory_handle` must be a valid handle.
 /// * The `port_factory_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_event_ref_h(
+pub unsafe extern "C" fn iox2_cast_port_factory_event_h_ref(
     port_factory_handle: iox2_port_factory_event_h,
-) -> iox2_port_factory_event_ref_h {
+) -> iox2_port_factory_event_h_ref {
     debug_assert!(!port_factory_handle.is_null());
 
-    (*port_factory_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Returns the [`iox2_service_name_ptr`], an immutable pointer to the service name.
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn iox2_cast_port_factory_event_ref_h(
 ///   [`iox2_service_builder_event_open_or_create`](crate::iox2_service_builder_event_open_or_create)!
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_event_service_name(
-    port_factory_handle: iox2_port_factory_event_ref_h,
+    port_factory_handle: iox2_port_factory_event_h_ref,
 ) -> iox2_service_name_ptr {
     debug_assert!(!port_factory_handle.is_null());
 
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_service_name(
 /// * The `static_config` must be a valid pointer and non-null.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_event_static_config(
-    port_factory_handle: iox2_port_factory_event_ref_h,
+    port_factory_handle: iox2_port_factory_event_h_ref,
     static_config: *mut iox2_static_config_event_t,
 ) {
     debug_assert!(!port_factory_handle.is_null());
@@ -176,9 +176,9 @@ pub unsafe extern "C" fn iox2_port_factory_event_static_config(
 ///
 /// # Arguments
 ///
-/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_event_ref_h`] obtained
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_event_h_ref`] obtained
 ///   by e.g. [`iox2_service_builder_event_open_or_create`](crate::iox2_service_builder_event_open_or_create)
-///   and casted by [`iox2_cast_port_factory_event_ref_h`]
+///   and casted by [`iox2_cast_port_factory_event_h_ref`]
 /// * `notifier_builder_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_port_factory_notifier_builder_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 ///
@@ -189,7 +189,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_static_config(
 /// * The `port_factory_handle` is still valid after the return of this function and can be use in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_event_notifier_builder(
-    port_factory_handle: iox2_port_factory_event_ref_h,
+    port_factory_handle: iox2_port_factory_event_h_ref,
     notifier_builder_struct_ptr: *mut iox2_port_factory_notifier_builder_t,
 ) -> iox2_port_factory_notifier_builder_h {
     debug_assert!(!port_factory_handle.is_null());
@@ -230,9 +230,9 @@ pub unsafe extern "C" fn iox2_port_factory_event_notifier_builder(
 ///
 /// # Arguments
 ///
-/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_event_ref_h`] obtained
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_event_h_ref`] obtained
 ///   by e.g. [`iox2_service_builder_event_open_or_create`](crate::iox2_service_builder_event_open_or_create)
-///   and casted by [`iox2_cast_port_factory_event_ref_h`]
+///   and casted by [`iox2_cast_port_factory_event_h_ref`]
 /// * `listener_builder_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_port_factory_listener_builder_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 ///
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_notifier_builder(
 /// * The `port_factory_handle` is still valid after the return of this function and can be use in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_event_listener_builder(
-    port_factory_handle: iox2_port_factory_event_ref_h,
+    port_factory_handle: iox2_port_factory_event_h_ref,
     listener_builder_struct_ptr: *mut iox2_port_factory_listener_builder_t,
 ) -> iox2_port_factory_listener_builder_h {
     debug_assert!(!port_factory_handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/port_factory_listener_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_listener_builder.rs
@@ -97,9 +97,9 @@ pub struct iox2_port_factory_listener_builder_h_t;
 /// The owning handle for `iox2_port_factory_listener_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_listener_builder_h = *mut iox2_port_factory_listener_builder_h_t;
 
-pub struct iox2_port_factory_listener_builder_ref_h_t;
+pub struct iox2_port_factory_listener_builder_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_listener_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_listener_builder_ref_h = *mut iox2_port_factory_listener_builder_ref_h_t;
+pub type iox2_port_factory_listener_builder_h_ref = *mut iox2_port_factory_listener_builder_h_ref_t;
 
 impl HandleToType for iox2_port_factory_listener_builder_h {
     type Target = *mut iox2_port_factory_listener_builder_t;
@@ -109,7 +109,7 @@ impl HandleToType for iox2_port_factory_listener_builder_h {
     }
 }
 
-impl HandleToType for iox2_port_factory_listener_builder_ref_h {
+impl HandleToType for iox2_port_factory_listener_builder_h_ref {
     type Target = *mut iox2_port_factory_listener_builder_t;
 
     fn as_type(self) -> Self::Target {

--- a/iceoryx2-ffi/ffi/src/api/port_factory_listener_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_listener_builder.rs
@@ -13,8 +13,8 @@
 #![allow(non_camel_case_types)]
 
 use crate::api::{
-    iox2_listener_h, iox2_listener_t, iox2_service_type_e, HandleToType, IntoCInt, ListenerUnion,
-    IOX2_OK,
+    iox2_listener_h, iox2_listener_t, iox2_service_type_e, AssertNonNullHandle, HandleToType,
+    IntoCInt, ListenerUnion, IOX2_OK,
 };
 
 use iceoryx2::port::listener::ListenerCreateError;
@@ -96,10 +96,23 @@ impl iox2_port_factory_listener_builder_t {
 pub struct iox2_port_factory_listener_builder_h_t;
 /// The owning handle for `iox2_port_factory_listener_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_listener_builder_h = *mut iox2_port_factory_listener_builder_h_t;
-
-pub struct iox2_port_factory_listener_builder_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_listener_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_listener_builder_h_ref = *mut iox2_port_factory_listener_builder_h_ref_t;
+pub type iox2_port_factory_listener_builder_h_ref = *const iox2_port_factory_listener_builder_h;
+
+impl AssertNonNullHandle for iox2_port_factory_listener_builder_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_port_factory_listener_builder_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_port_factory_listener_builder_h {
     type Target = *mut iox2_port_factory_listener_builder_t;
@@ -113,7 +126,7 @@ impl HandleToType for iox2_port_factory_listener_builder_h_ref {
     type Target = *mut iox2_port_factory_listener_builder_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 

--- a/iceoryx2-ffi/ffi/src/api/port_factory_notifier_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_notifier_builder.rs
@@ -13,8 +13,8 @@
 #![allow(non_camel_case_types)]
 
 use crate::api::{
-    iox2_event_id_t, iox2_notifier_h, iox2_notifier_t, iox2_service_type_e, HandleToType, IntoCInt,
-    NotifierUnion, IOX2_OK,
+    iox2_event_id_t, iox2_notifier_h, iox2_notifier_t, iox2_service_type_e, AssertNonNullHandle,
+    HandleToType, IntoCInt, NotifierUnion, IOX2_OK,
 };
 
 use iceoryx2::port::notifier::NotifierCreateError;
@@ -92,10 +92,23 @@ impl iox2_port_factory_notifier_builder_t {
 pub struct iox2_port_factory_notifier_builder_h_t;
 /// The owning handle for `iox2_port_factory_notifier_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_notifier_builder_h = *mut iox2_port_factory_notifier_builder_h_t;
-
-pub struct iox2_port_factory_notifier_builder_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_notifier_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_notifier_builder_h_ref = *mut iox2_port_factory_notifier_builder_h_ref_t;
+pub type iox2_port_factory_notifier_builder_h_ref = *const iox2_port_factory_notifier_builder_h;
+
+impl AssertNonNullHandle for iox2_port_factory_notifier_builder_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_port_factory_notifier_builder_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_port_factory_notifier_builder_h {
     type Target = *mut iox2_port_factory_notifier_builder_t;
@@ -109,7 +122,7 @@ impl HandleToType for iox2_port_factory_notifier_builder_h_ref {
     type Target = *mut iox2_port_factory_notifier_builder_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -117,34 +130,12 @@ impl HandleToType for iox2_port_factory_notifier_builder_h_ref {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_port_factory_notifier_builder_h`] into a non-owning [`iox2_port_factory_notifier_builder_h_ref`]
-///
-/// # Arguments
-///
-/// * `port_factory_handle` obtained by [`iox2_port_factory_event_notifier_builder`](crate::iox2_port_factory_event_notifier_builder)
-///
-/// Returns a [`iox2_port_factory_notifier_builder_h_ref`]
-///
-/// # Safety
-///
-/// * The `port_factory_handle` must be a valid handle.
-/// * The `port_factory_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_notifier_builder_h_ref(
-    port_factory_handle: iox2_port_factory_notifier_builder_h,
-) -> iox2_port_factory_notifier_builder_h_ref {
-    debug_assert!(!port_factory_handle.is_null());
-
-    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
-}
-
 /// Sets the default event id for the builder
 ///
 /// # Arguments
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_notifier_builder_h_ref`]
-///   obtained by [`iox2_port_factory_event_notifier_builder`](crate::iox2_port_factory_event_notifier_builder) and
-///   casted by [`iox2_cast_port_factory_notifier_builder_h_ref`].
+///   obtained by [`iox2_port_factory_event_notifier_builder`](crate::iox2_port_factory_event_notifier_builder).
 /// * `value` - The value to set the default event id to
 ///
 /// # Safety
@@ -156,7 +147,7 @@ pub unsafe extern "C" fn iox2_port_factory_notifier_builder_set_default_event_id
     port_factory_handle: iox2_port_factory_notifier_builder_h_ref,
     value: *const iox2_event_id_t,
 ) {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
 
     let value = (*value).into();
 

--- a/iceoryx2-ffi/ffi/src/api/port_factory_notifier_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_notifier_builder.rs
@@ -93,9 +93,9 @@ pub struct iox2_port_factory_notifier_builder_h_t;
 /// The owning handle for `iox2_port_factory_notifier_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_notifier_builder_h = *mut iox2_port_factory_notifier_builder_h_t;
 
-pub struct iox2_port_factory_notifier_builder_ref_h_t;
+pub struct iox2_port_factory_notifier_builder_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_notifier_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_notifier_builder_ref_h = *mut iox2_port_factory_notifier_builder_ref_h_t;
+pub type iox2_port_factory_notifier_builder_h_ref = *mut iox2_port_factory_notifier_builder_h_ref_t;
 
 impl HandleToType for iox2_port_factory_notifier_builder_h {
     type Target = *mut iox2_port_factory_notifier_builder_t;
@@ -105,7 +105,7 @@ impl HandleToType for iox2_port_factory_notifier_builder_h {
     }
 }
 
-impl HandleToType for iox2_port_factory_notifier_builder_ref_h {
+impl HandleToType for iox2_port_factory_notifier_builder_h_ref {
     type Target = *mut iox2_port_factory_notifier_builder_t;
 
     fn as_type(self) -> Self::Target {
@@ -117,34 +117,34 @@ impl HandleToType for iox2_port_factory_notifier_builder_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_port_factory_notifier_builder_h`] into a non-owning [`iox2_port_factory_notifier_builder_ref_h`]
+/// This function casts an owning [`iox2_port_factory_notifier_builder_h`] into a non-owning [`iox2_port_factory_notifier_builder_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `port_factory_handle` obtained by [`iox2_port_factory_event_notifier_builder`](crate::iox2_port_factory_event_notifier_builder)
 ///
-/// Returns a [`iox2_port_factory_notifier_builder_ref_h`]
+/// Returns a [`iox2_port_factory_notifier_builder_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `port_factory_handle` must be a valid handle.
 /// * The `port_factory_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_notifier_builder_ref_h(
+pub unsafe extern "C" fn iox2_cast_port_factory_notifier_builder_h_ref(
     port_factory_handle: iox2_port_factory_notifier_builder_h,
-) -> iox2_port_factory_notifier_builder_ref_h {
+) -> iox2_port_factory_notifier_builder_h_ref {
     debug_assert!(!port_factory_handle.is_null());
 
-    (*port_factory_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Sets the default event id for the builder
 ///
 /// # Arguments
 ///
-/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_notifier_builder_ref_h`]
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_notifier_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_event_notifier_builder`](crate::iox2_port_factory_event_notifier_builder) and
-///   casted by [`iox2_cast_port_factory_notifier_builder_ref_h`].
+///   casted by [`iox2_cast_port_factory_notifier_builder_h_ref`].
 /// * `value` - The value to set the default event id to
 ///
 /// # Safety
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn iox2_cast_port_factory_notifier_builder_ref_h(
 /// * `value` must not be a NULL pointer but a pointer to an initialized `iox2_event_id_t`
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_notifier_builder_set_default_event_id(
-    port_factory_handle: iox2_port_factory_notifier_builder_ref_h,
+    port_factory_handle: iox2_port_factory_notifier_builder_h_ref,
     value: *const iox2_event_id_t,
 ) {
     debug_assert!(!port_factory_handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/port_factory_pub_sub.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_pub_sub.rs
@@ -82,9 +82,9 @@ pub struct iox2_port_factory_pub_sub_h_t;
 /// The owning handle for `iox2_port_factory_pub_sub_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_pub_sub_h = *mut iox2_port_factory_pub_sub_h_t;
 
-pub struct iox2_port_factory_pub_sub_ref_h_t;
+pub struct iox2_port_factory_pub_sub_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_pub_sub_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_pub_sub_ref_h = *mut iox2_port_factory_pub_sub_ref_h_t;
+pub type iox2_port_factory_pub_sub_h_ref = *mut iox2_port_factory_pub_sub_h_ref_t;
 
 impl HandleToType for iox2_port_factory_pub_sub_h {
     type Target = *mut iox2_port_factory_pub_sub_t;
@@ -94,7 +94,7 @@ impl HandleToType for iox2_port_factory_pub_sub_h {
     }
 }
 
-impl HandleToType for iox2_port_factory_pub_sub_ref_h {
+impl HandleToType for iox2_port_factory_pub_sub_h_ref {
     type Target = *mut iox2_port_factory_pub_sub_t;
 
     fn as_type(self) -> Self::Target {
@@ -106,35 +106,35 @@ impl HandleToType for iox2_port_factory_pub_sub_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_port_factory_pub_sub_h`] into a non-owning [`iox2_port_factory_pub_sub_ref_h`]
+/// This function casts an owning [`iox2_port_factory_pub_sub_h`] into a non-owning [`iox2_port_factory_pub_sub_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `port_factory_handle` obtained by [`iox2_service_builder_pub_sub_open`](crate::iox2_service_builder_pub_sub_open) or
 ///   [`iox2_service_builder_pub_sub_open_or_create`](crate::iox2_service_builder_pub_sub_open_or_create)
 ///
-/// Returns a [`iox2_port_factory_pub_sub_ref_h`]
+/// Returns a [`iox2_port_factory_pub_sub_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `port_factory_handle` must be a valid handle.
 /// * The `port_factory_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_pub_sub_ref_h(
+pub unsafe extern "C" fn iox2_cast_port_factory_pub_sub_h_ref(
     port_factory_handle: iox2_port_factory_pub_sub_h,
-) -> iox2_port_factory_pub_sub_ref_h {
+) -> iox2_port_factory_pub_sub_h_ref {
     debug_assert!(!port_factory_handle.is_null());
 
-    (*port_factory_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Instantiates a [`iox2_port_factory_publisher_builder_h`] to build a publisher.
 ///
 /// # Arguments
 ///
-/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_pub_sub_ref_h`] obtained
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_pub_sub_h_ref`] obtained
 ///   by e.g. [`iox2_service_builder_pub_sub_open_or_create`](crate::iox2_service_builder_pub_sub_open_or_create)
-///   and casted by [`iox2_cast_port_factory_pub_sub_ref_h`]
+///   and casted by [`iox2_cast_port_factory_pub_sub_h_ref`]
 /// * `publisher_builder_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_port_factory_publisher_builder_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 ///
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn iox2_cast_port_factory_pub_sub_ref_h(
 /// * The `port_factory_handle` is still valid after the return of this function and can be use in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_pub_sub_publisher_builder(
-    port_factory_handle: iox2_port_factory_pub_sub_ref_h,
+    port_factory_handle: iox2_port_factory_pub_sub_h_ref,
     publisher_builder_struct_ptr: *mut iox2_port_factory_publisher_builder_t,
 ) -> iox2_port_factory_publisher_builder_h {
     debug_assert!(!port_factory_handle.is_null());
@@ -186,9 +186,9 @@ pub unsafe extern "C" fn iox2_port_factory_pub_sub_publisher_builder(
 ///
 /// # Arguments
 ///
-/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_pub_sub_ref_h`] obtained
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_pub_sub_h_ref`] obtained
 ///   by e.g. [`iox2_service_builder_pub_sub_open_or_create`](crate::iox2_service_builder_pub_sub_open_or_create)
-///   and casted by [`iox2_cast_port_factory_pub_sub_ref_h`]
+///   and casted by [`iox2_cast_port_factory_pub_sub_h_ref`]
 /// * `subscriber_builder_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_port_factory_subscriber_builder_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 ///
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn iox2_port_factory_pub_sub_publisher_builder(
 /// * The `port_factory_handle` is still valid after the return of this function and can be use in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_pub_sub_subscriber_builder(
-    port_factory_handle: iox2_port_factory_pub_sub_ref_h,
+    port_factory_handle: iox2_port_factory_pub_sub_h_ref,
     subscriber_builder_struct_ptr: *mut iox2_port_factory_subscriber_builder_t,
 ) -> iox2_port_factory_subscriber_builder_h {
     debug_assert!(!port_factory_handle.is_null());
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn iox2_port_factory_pub_sub_subscriber_builder(
 /// * The `static_config` must be a valid pointer and non-null.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_pub_sub_static_config(
-    port_factory_handle: iox2_port_factory_pub_sub_ref_h,
+    port_factory_handle: iox2_port_factory_pub_sub_h_ref,
     static_config: *mut iox2_static_config_publish_subscribe_t,
 ) {
     debug_assert!(!port_factory_handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
@@ -13,8 +13,8 @@
 #![allow(non_camel_case_types)]
 
 use crate::api::{
-    c_size_t, iox2_publisher_h, iox2_publisher_t, iox2_service_type_e, HandleToType, IntoCInt,
-    PayloadFfi, PublisherUnion, UserHeaderFfi, IOX2_OK,
+    c_size_t, iox2_publisher_h, iox2_publisher_t, iox2_service_type_e, AssertNonNullHandle,
+    HandleToType, IntoCInt, PayloadFfi, PublisherUnion, UserHeaderFfi, IOX2_OK,
 };
 
 use iceoryx2::port::publisher::PublisherCreateError;
@@ -135,11 +135,23 @@ impl iox2_port_factory_publisher_builder_t {
 pub struct iox2_port_factory_publisher_builder_h_t;
 /// The owning handle for `iox2_port_factory_publisher_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_publisher_builder_h = *mut iox2_port_factory_publisher_builder_h_t;
-
-pub struct iox2_port_factory_publisher_builder_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_publisher_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_publisher_builder_h_ref =
-    *mut iox2_port_factory_publisher_builder_h_ref_t;
+pub type iox2_port_factory_publisher_builder_h_ref = *const iox2_port_factory_publisher_builder_h;
+
+impl AssertNonNullHandle for iox2_port_factory_publisher_builder_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_port_factory_publisher_builder_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_port_factory_publisher_builder_h {
     type Target = *mut iox2_port_factory_publisher_builder_t;
@@ -153,7 +165,7 @@ impl HandleToType for iox2_port_factory_publisher_builder_h_ref {
     type Target = *mut iox2_port_factory_publisher_builder_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -161,34 +173,12 @@ impl HandleToType for iox2_port_factory_publisher_builder_h_ref {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_port_factory_publisher_builder_h`] into a non-owning [`iox2_port_factory_publisher_builder_h_ref`]
-///
-/// # Arguments
-///
-/// * `port_factory_handle` obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder)
-///
-/// Returns a [`iox2_port_factory_publisher_builder_h_ref`]
-///
-/// # Safety
-///
-/// * The `port_factory_handle` must be a valid handle.
-/// * The `port_factory_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_publisher_builder_h_ref(
-    port_factory_handle: iox2_port_factory_publisher_builder_h,
-) -> iox2_port_factory_publisher_builder_h_ref {
-    debug_assert!(!port_factory_handle.is_null());
-
-    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
-}
-
 /// Sets the max loaned samples for the publisher
 ///
 /// # Arguments
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_h_ref`]
-///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder) and
-///   casted by [`iox2_cast_port_factory_publisher_builder_h_ref`].
+///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder).
 /// * `value` - The value to set max loaned samples to
 ///
 /// # Safety
@@ -199,7 +189,7 @@ pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_max_loaned_samp
     port_factory_handle: iox2_port_factory_publisher_builder_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
 
     let port_factory_struct = unsafe { &mut *port_factory_handle.as_type() };
     match port_factory_struct.service_type {
@@ -227,8 +217,7 @@ pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_max_loaned_samp
 /// # Arguments
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_h_ref`]
-///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder) and
-///   casted by [`iox2_cast_port_factory_publisher_builder_h_ref`](crate::iox2_cast_port_factory_publisher_builder_h_ref).
+///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder).
 /// * `value` - The value to set the strategy to
 ///
 /// # Safety
@@ -239,7 +228,7 @@ pub unsafe extern "C" fn iox2_port_factory_publisher_builder_unable_to_deliver_s
     port_factory_handle: iox2_port_factory_publisher_builder_h_ref,
     value: iox2_unable_to_deliver_strategy_e,
 ) {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
 
     let handle = unsafe { &mut *port_factory_handle.as_type() };
     match handle.service_type {

--- a/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
@@ -136,10 +136,10 @@ pub struct iox2_port_factory_publisher_builder_h_t;
 /// The owning handle for `iox2_port_factory_publisher_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_publisher_builder_h = *mut iox2_port_factory_publisher_builder_h_t;
 
-pub struct iox2_port_factory_publisher_builder_ref_h_t;
+pub struct iox2_port_factory_publisher_builder_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_publisher_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_publisher_builder_ref_h =
-    *mut iox2_port_factory_publisher_builder_ref_h_t;
+pub type iox2_port_factory_publisher_builder_h_ref =
+    *mut iox2_port_factory_publisher_builder_h_ref_t;
 
 impl HandleToType for iox2_port_factory_publisher_builder_h {
     type Target = *mut iox2_port_factory_publisher_builder_t;
@@ -149,7 +149,7 @@ impl HandleToType for iox2_port_factory_publisher_builder_h {
     }
 }
 
-impl HandleToType for iox2_port_factory_publisher_builder_ref_h {
+impl HandleToType for iox2_port_factory_publisher_builder_h_ref {
     type Target = *mut iox2_port_factory_publisher_builder_t;
 
     fn as_type(self) -> Self::Target {
@@ -161,34 +161,34 @@ impl HandleToType for iox2_port_factory_publisher_builder_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_port_factory_publisher_builder_h`] into a non-owning [`iox2_port_factory_publisher_builder_ref_h`]
+/// This function casts an owning [`iox2_port_factory_publisher_builder_h`] into a non-owning [`iox2_port_factory_publisher_builder_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `port_factory_handle` obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder)
 ///
-/// Returns a [`iox2_port_factory_publisher_builder_ref_h`]
+/// Returns a [`iox2_port_factory_publisher_builder_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `port_factory_handle` must be a valid handle.
 /// * The `port_factory_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_publisher_builder_ref_h(
+pub unsafe extern "C" fn iox2_cast_port_factory_publisher_builder_h_ref(
     port_factory_handle: iox2_port_factory_publisher_builder_h,
-) -> iox2_port_factory_publisher_builder_ref_h {
+) -> iox2_port_factory_publisher_builder_h_ref {
     debug_assert!(!port_factory_handle.is_null());
 
-    (*port_factory_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Sets the max loaned samples for the publisher
 ///
 /// # Arguments
 ///
-/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_ref_h`]
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder) and
-///   casted by [`iox2_cast_port_factory_publisher_builder_ref_h`].
+///   casted by [`iox2_cast_port_factory_publisher_builder_h_ref`].
 /// * `value` - The value to set max loaned samples to
 ///
 /// # Safety
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn iox2_cast_port_factory_publisher_builder_ref_h(
 /// * `port_factory_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_max_loaned_samples(
-    port_factory_handle: iox2_port_factory_publisher_builder_ref_h,
+    port_factory_handle: iox2_port_factory_publisher_builder_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!port_factory_handle.is_null());
@@ -226,9 +226,9 @@ pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_max_loaned_samp
 ///
 /// # Arguments
 ///
-/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_ref_h`]
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder) and
-///   casted by [`iox2_cast_port_factory_publisher_builder_ref_h`](crate::iox2_cast_port_factory_publisher_builder_ref_h).
+///   casted by [`iox2_cast_port_factory_publisher_builder_h_ref`](crate::iox2_cast_port_factory_publisher_builder_h_ref).
 /// * `value` - The value to set the strategy to
 ///
 /// # Safety
@@ -236,7 +236,7 @@ pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_max_loaned_samp
 /// * `port_factory_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_publisher_builder_unable_to_deliver_strategy(
-    port_factory_handle: iox2_port_factory_publisher_builder_ref_h,
+    port_factory_handle: iox2_port_factory_publisher_builder_h_ref,
     value: iox2_unable_to_deliver_strategy_e,
 ) {
     debug_assert!(!port_factory_handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/port_factory_subscriber_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_subscriber_builder.rs
@@ -101,10 +101,10 @@ pub struct iox2_port_factory_subscriber_builder_h_t;
 /// The owning handle for `iox2_port_factory_subscriber_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_subscriber_builder_h = *mut iox2_port_factory_subscriber_builder_h_t;
 
-pub struct iox2_port_factory_subscriber_builder_ref_h_t;
+pub struct iox2_port_factory_subscriber_builder_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_subscriber_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_subscriber_builder_ref_h =
-    *mut iox2_port_factory_subscriber_builder_ref_h_t;
+pub type iox2_port_factory_subscriber_builder_h_ref =
+    *mut iox2_port_factory_subscriber_builder_h_ref_t;
 
 impl HandleToType for iox2_port_factory_subscriber_builder_h {
     type Target = *mut iox2_port_factory_subscriber_builder_t;
@@ -114,7 +114,7 @@ impl HandleToType for iox2_port_factory_subscriber_builder_h {
     }
 }
 
-impl HandleToType for iox2_port_factory_subscriber_builder_ref_h {
+impl HandleToType for iox2_port_factory_subscriber_builder_h_ref {
     type Target = *mut iox2_port_factory_subscriber_builder_t;
 
     fn as_type(self) -> Self::Target {
@@ -126,34 +126,34 @@ impl HandleToType for iox2_port_factory_subscriber_builder_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_port_factory_subscriber_builder_h`] into a non-owning [`iox2_port_factory_subscriber_builder_ref_h`]
+/// This function casts an owning [`iox2_port_factory_subscriber_builder_h`] into a non-owning [`iox2_port_factory_subscriber_builder_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `port_factory_handle` obtained by [`iox2_port_factory_pub_sub_subscriber_builder`](crate::iox2_port_factory_pub_sub_subscriber_builder)
 ///
-/// Returns a [`iox2_port_factory_subscriber_builder_ref_h`]
+/// Returns a [`iox2_port_factory_subscriber_builder_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `port_factory_handle` must be a valid handle.
 /// * The `port_factory_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_subscriber_builder_ref_h(
+pub unsafe extern "C" fn iox2_cast_port_factory_subscriber_builder_h_ref(
     port_factory_handle: iox2_port_factory_subscriber_builder_h,
-) -> iox2_port_factory_subscriber_builder_ref_h {
+) -> iox2_port_factory_subscriber_builder_h_ref {
     debug_assert!(!port_factory_handle.is_null());
 
-    (*port_factory_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Sets the buffer size for the subscriber
 ///
 /// # Arguments
 ///
-/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_subscriber_builder_ref_h`]
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_subscriber_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_pub_sub_subscriber_builder`](crate::iox2_port_factory_pub_sub_subscriber_builder) and
-///   casted by [`iox2_cast_port_factory_subscriber_builder_ref_h`].
+///   casted by [`iox2_cast_port_factory_subscriber_builder_h_ref`].
 /// * `value` - The value to set buffer size to
 ///
 /// # Safety
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn iox2_cast_port_factory_subscriber_builder_ref_h(
 /// * `port_factory_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_subscriber_builder_set_buffer_size(
-    port_factory_handle: iox2_port_factory_subscriber_builder_ref_h,
+    port_factory_handle: iox2_port_factory_subscriber_builder_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!port_factory_handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/port_factory_subscriber_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_subscriber_builder.rs
@@ -13,8 +13,8 @@
 #![allow(non_camel_case_types)]
 
 use crate::api::{
-    c_size_t, iox2_service_type_e, iox2_subscriber_h, iox2_subscriber_t, HandleToType, IntoCInt,
-    PayloadFfi, SubscriberUnion, UserHeaderFfi, IOX2_OK,
+    c_size_t, iox2_service_type_e, iox2_subscriber_h, iox2_subscriber_t, AssertNonNullHandle,
+    HandleToType, IntoCInt, PayloadFfi, SubscriberUnion, UserHeaderFfi, IOX2_OK,
 };
 
 use iceoryx2::port::subscriber::SubscriberCreateError;
@@ -100,11 +100,23 @@ impl iox2_port_factory_subscriber_builder_t {
 pub struct iox2_port_factory_subscriber_builder_h_t;
 /// The owning handle for `iox2_port_factory_subscriber_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_port_factory_subscriber_builder_h = *mut iox2_port_factory_subscriber_builder_h_t;
-
-pub struct iox2_port_factory_subscriber_builder_h_ref_t;
 /// The non-owning handle for `iox2_port_factory_subscriber_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_port_factory_subscriber_builder_h_ref =
-    *mut iox2_port_factory_subscriber_builder_h_ref_t;
+pub type iox2_port_factory_subscriber_builder_h_ref = *const iox2_port_factory_subscriber_builder_h;
+
+impl AssertNonNullHandle for iox2_port_factory_subscriber_builder_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_port_factory_subscriber_builder_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_port_factory_subscriber_builder_h {
     type Target = *mut iox2_port_factory_subscriber_builder_t;
@@ -118,7 +130,7 @@ impl HandleToType for iox2_port_factory_subscriber_builder_h_ref {
     type Target = *mut iox2_port_factory_subscriber_builder_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -126,34 +138,12 @@ impl HandleToType for iox2_port_factory_subscriber_builder_h_ref {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_port_factory_subscriber_builder_h`] into a non-owning [`iox2_port_factory_subscriber_builder_h_ref`]
-///
-/// # Arguments
-///
-/// * `port_factory_handle` obtained by [`iox2_port_factory_pub_sub_subscriber_builder`](crate::iox2_port_factory_pub_sub_subscriber_builder)
-///
-/// Returns a [`iox2_port_factory_subscriber_builder_h_ref`]
-///
-/// # Safety
-///
-/// * The `port_factory_handle` must be a valid handle.
-/// * The `port_factory_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_port_factory_subscriber_builder_h_ref(
-    port_factory_handle: iox2_port_factory_subscriber_builder_h,
-) -> iox2_port_factory_subscriber_builder_h_ref {
-    debug_assert!(!port_factory_handle.is_null());
-
-    (*port_factory_handle.as_type()).as_h_refandle() as *mut _ as _
-}
-
 /// Sets the buffer size for the subscriber
 ///
 /// # Arguments
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_subscriber_builder_h_ref`]
-///   obtained by [`iox2_port_factory_pub_sub_subscriber_builder`](crate::iox2_port_factory_pub_sub_subscriber_builder) and
-///   casted by [`iox2_cast_port_factory_subscriber_builder_h_ref`].
+///   obtained by [`iox2_port_factory_pub_sub_subscriber_builder`](crate::iox2_port_factory_pub_sub_subscriber_builder).
 /// * `value` - The value to set buffer size to
 ///
 /// # Safety
@@ -164,7 +154,7 @@ pub unsafe extern "C" fn iox2_port_factory_subscriber_builder_set_buffer_size(
     port_factory_handle: iox2_port_factory_subscriber_builder_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!port_factory_handle.is_null());
+    port_factory_handle.assert_non_null();
 
     let port_factory_struct = unsafe { &mut *port_factory_handle.as_type() };
     match port_factory_struct.service_type {

--- a/iceoryx2-ffi/ffi/src/api/publish_subscribe_header.rs
+++ b/iceoryx2-ffi/ffi/src/api/publish_subscribe_header.rs
@@ -59,7 +59,7 @@ pub type iox2_publish_subscribe_header_ref_h = *mut iox2_publish_subscribe_heade
 /// The immutable pointer to the underlying `publish_subscribe::Header`
 pub type iox2_publish_subscribe_header_ptr = *const Header;
 /// The mutable pointer to the underlying `publish_subscribe::Header`
-pub type iox2_publish_subscribe_header_mut_ptr = *mut Header;
+pub type iox2_publish_subscribe_header_ptr_mut = *mut Header;
 
 impl HandleToType for iox2_publish_subscribe_header_h {
     type Target = *mut iox2_publish_subscribe_header_t;

--- a/iceoryx2-ffi/ffi/src/api/publish_subscribe_header.rs
+++ b/iceoryx2-ffi/ffi/src/api/publish_subscribe_header.rs
@@ -16,9 +16,10 @@ use iceoryx2::service::header::publish_subscribe::Header;
 use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
-use crate::{iox2_unique_publisher_id_h, iox2_unique_publisher_id_t};
-
-use super::HandleToType;
+use crate::{
+    api::AssertNonNullHandle, api::HandleToType, iox2_unique_publisher_id_h,
+    iox2_unique_publisher_id_t,
+};
 
 // BEGIN types definition
 
@@ -50,16 +51,29 @@ impl iox2_publish_subscribe_header_t {
 pub struct iox2_publish_subscribe_header_h_t;
 /// The owning handle for [`iox2_publish_subscribe_header_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_publish_subscribe_header_h = *mut iox2_publish_subscribe_header_h_t;
-
-pub struct iox2_publish_subscribe_header_h_ref_t;
 /// The non-owning handle for [`iox2_publish_subscribe_header_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_publish_subscribe_header_h_ref = *mut iox2_publish_subscribe_header_h_ref_t;
+pub type iox2_publish_subscribe_header_h_ref = *const iox2_publish_subscribe_header_h;
 
 // NOTE check the README.md for using opaque types with renaming
 /// The immutable pointer to the underlying `publish_subscribe::Header`
 pub type iox2_publish_subscribe_header_ptr = *const Header;
 /// The mutable pointer to the underlying `publish_subscribe::Header`
 pub type iox2_publish_subscribe_header_ptr_mut = *mut Header;
+
+impl AssertNonNullHandle for iox2_publish_subscribe_header_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_publish_subscribe_header_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_publish_subscribe_header_h {
     type Target = *mut iox2_publish_subscribe_header_t;
@@ -73,30 +87,13 @@ impl HandleToType for iox2_publish_subscribe_header_h_ref {
     type Target = *mut iox2_publish_subscribe_header_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
 // END types definition
 
 // BEGIN C API
-
-/// This function casts an owning [`iox2_publish_subscribe_header_h`] into a non-owning [`iox2_publish_subscribe_header_h_ref`]
-///
-/// Returns a [`iox2_publish_subscribe_header_h_ref`]
-///
-/// # Safety
-///
-/// * The `handle` must be a valid handle.
-/// * The `handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_publish_subscribe_header_h_ref(
-    handle: iox2_publish_subscribe_header_h,
-) -> iox2_publish_subscribe_header_h_ref {
-    debug_assert!(!handle.is_null());
-
-    (*handle.as_type()).as_h_refandle() as *mut _ as _
-}
 
 /// This function needs to be called to destroy the publish_subscribe_header!
 ///
@@ -128,7 +125,7 @@ pub unsafe extern "C" fn iox2_publish_subscribe_header_drop(
 ///
 /// # Safety
 ///
-/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_h_ref`]
+/// * `header_handle` is valid and non-null
 /// * `id_struct_ptr` is either null or valid and non-null
 /// * `id_handle_ptr` is valid and non-null
 #[no_mangle]
@@ -137,7 +134,7 @@ pub unsafe extern "C" fn iox2_publish_subscribe_header_publisher_id(
     id_struct_ptr: *mut iox2_unique_publisher_id_t,
     id_handle_ptr: *mut iox2_unique_publisher_id_h,
 ) {
-    debug_assert!(!header_handle.is_null());
+    header_handle.assert_non_null();
     debug_assert!(!id_handle_ptr.is_null());
 
     fn no_op(_: *mut iox2_unique_publisher_id_t) {}
@@ -166,12 +163,12 @@ pub unsafe extern "C" fn iox2_publish_subscribe_header_publisher_id(
 ///
 /// # Safety
 ///
-/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_h_ref`]
+/// * `header_handle` is valid and non-null
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publish_subscribe_header_payload_type_size(
     header_handle: iox2_publish_subscribe_header_h_ref,
 ) -> usize {
-    debug_assert!(!header_handle.is_null());
+    header_handle.assert_non_null();
 
     let header = &mut *header_handle.as_type();
 
@@ -187,12 +184,12 @@ pub unsafe extern "C" fn iox2_publish_subscribe_header_payload_type_size(
 ///
 /// # Safety
 ///
-/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_h_ref`]
+/// * `header_handle` is valid and non-null
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publish_subscribe_header_payload_type_alignment(
     header_handle: iox2_publish_subscribe_header_h_ref,
 ) -> usize {
-    debug_assert!(!header_handle.is_null());
+    header_handle.assert_non_null();
 
     let header = &mut *header_handle.as_type();
 

--- a/iceoryx2-ffi/ffi/src/api/publish_subscribe_header.rs
+++ b/iceoryx2-ffi/ffi/src/api/publish_subscribe_header.rs
@@ -51,9 +51,9 @@ pub struct iox2_publish_subscribe_header_h_t;
 /// The owning handle for [`iox2_publish_subscribe_header_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_publish_subscribe_header_h = *mut iox2_publish_subscribe_header_h_t;
 
-pub struct iox2_publish_subscribe_header_ref_h_t;
+pub struct iox2_publish_subscribe_header_h_ref_t;
 /// The non-owning handle for [`iox2_publish_subscribe_header_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_publish_subscribe_header_ref_h = *mut iox2_publish_subscribe_header_ref_h_t;
+pub type iox2_publish_subscribe_header_h_ref = *mut iox2_publish_subscribe_header_h_ref_t;
 
 // NOTE check the README.md for using opaque types with renaming
 /// The immutable pointer to the underlying `publish_subscribe::Header`
@@ -69,7 +69,7 @@ impl HandleToType for iox2_publish_subscribe_header_h {
     }
 }
 
-impl HandleToType for iox2_publish_subscribe_header_ref_h {
+impl HandleToType for iox2_publish_subscribe_header_h_ref {
     type Target = *mut iox2_publish_subscribe_header_t;
 
     fn as_type(self) -> Self::Target {
@@ -81,21 +81,21 @@ impl HandleToType for iox2_publish_subscribe_header_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_publish_subscribe_header_h`] into a non-owning [`iox2_publish_subscribe_header_ref_h`]
+/// This function casts an owning [`iox2_publish_subscribe_header_h`] into a non-owning [`iox2_publish_subscribe_header_h_ref`]
 ///
-/// Returns a [`iox2_publish_subscribe_header_ref_h`]
+/// Returns a [`iox2_publish_subscribe_header_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `handle` must be a valid handle.
 /// * The `handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_publish_subscribe_header_ref_h(
+pub unsafe extern "C" fn iox2_cast_publish_subscribe_header_h_ref(
     handle: iox2_publish_subscribe_header_h,
-) -> iox2_publish_subscribe_header_ref_h {
+) -> iox2_publish_subscribe_header_h_ref {
     debug_assert!(!handle.is_null());
 
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// This function needs to be called to destroy the publish_subscribe_header!
@@ -128,12 +128,12 @@ pub unsafe extern "C" fn iox2_publish_subscribe_header_drop(
 ///
 /// # Safety
 ///
-/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_ref_h`]
+/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_h_ref`]
 /// * `id_struct_ptr` is either null or valid and non-null
 /// * `id_handle_ptr` is valid and non-null
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publish_subscribe_header_publisher_id(
-    header_handle: iox2_publish_subscribe_header_ref_h,
+    header_handle: iox2_publish_subscribe_header_h_ref,
     id_struct_ptr: *mut iox2_unique_publisher_id_t,
     id_handle_ptr: *mut iox2_unique_publisher_id_h,
 ) {
@@ -166,10 +166,10 @@ pub unsafe extern "C" fn iox2_publish_subscribe_header_publisher_id(
 ///
 /// # Safety
 ///
-/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_ref_h`]
+/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publish_subscribe_header_payload_type_size(
-    header_handle: iox2_publish_subscribe_header_ref_h,
+    header_handle: iox2_publish_subscribe_header_h_ref,
 ) -> usize {
     debug_assert!(!header_handle.is_null());
 
@@ -187,10 +187,10 @@ pub unsafe extern "C" fn iox2_publish_subscribe_header_payload_type_size(
 ///
 /// # Safety
 ///
-/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_ref_h`]
+/// * `header_handle` is valid, non-null and was obtained via [`iox2_cast_publish_subscribe_header_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publish_subscribe_header_payload_type_alignment(
-    header_handle: iox2_publish_subscribe_header_ref_h,
+    header_handle: iox2_publish_subscribe_header_h_ref,
 ) -> usize {
     debug_assert!(!header_handle.is_null());
 

--- a/iceoryx2-ffi/ffi/src/api/publisher.rs
+++ b/iceoryx2-ffi/ffi/src/api/publisher.rs
@@ -150,9 +150,9 @@ pub struct iox2_publisher_h_t;
 /// The owning handle for `iox2_publisher_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_publisher_h = *mut iox2_publisher_h_t;
 
-pub struct iox2_publisher_ref_h_t;
+pub struct iox2_publisher_h_ref_t;
 /// The non-owning handle for `iox2_publisher_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_publisher_ref_h = *mut iox2_publisher_ref_h_t;
+pub type iox2_publisher_h_ref = *mut iox2_publisher_h_ref_t;
 
 impl HandleToType for iox2_publisher_h {
     type Target = *mut iox2_publisher_t;
@@ -162,7 +162,7 @@ impl HandleToType for iox2_publisher_h {
     }
 }
 
-impl HandleToType for iox2_publisher_ref_h {
+impl HandleToType for iox2_publisher_h_ref {
     type Target = *mut iox2_publisher_t;
 
     fn as_type(self) -> Self::Target {
@@ -206,25 +206,25 @@ unsafe fn send_copy<S: Service>(
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_publisher_h`] into a non-owning [`iox2_publisher_ref_h`]
+/// This function casts an owning [`iox2_publisher_h`] into a non-owning [`iox2_publisher_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `handle` obtained by [`iox2_port_factory_publisher_builder_create`](crate::iox2_port_factory_publisher_builder_create)
 ///
-/// Returns a [`iox2_publisher_ref_h`]
+/// Returns a [`iox2_publisher_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `handle` must be a valid handle.
 /// * The `handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_publisher_ref_h(
+pub unsafe extern "C" fn iox2_cast_publisher_h_ref(
     handle: iox2_publisher_h,
-) -> iox2_publisher_ref_h {
+) -> iox2_publisher_h_ref {
     debug_assert!(!handle.is_null());
 
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Returns the strategy the publisher follows when a sample cannot be delivered
@@ -238,10 +238,10 @@ pub unsafe extern "C" fn iox2_cast_publisher_ref_h(
 ///
 /// # Safety
 ///
-/// * `publisher_handle` is valid, non-null and was obtained via [`iox2_cast_publisher_ref_h`]
+/// * `publisher_handle` is valid, non-null and was obtained via [`iox2_cast_publisher_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publisher_unable_to_deliver_strategy(
-    publisher_handle: iox2_publisher_ref_h,
+    publisher_handle: iox2_publisher_h_ref,
 ) -> iox2_unable_to_deliver_strategy_e {
     debug_assert!(!publisher_handle.is_null());
 
@@ -274,11 +274,11 @@ pub unsafe extern "C" fn iox2_publisher_unable_to_deliver_strategy(
 ///
 /// # Safety
 ///
-/// * `publisher_handle` is valid, non-null and was obtained via [`iox2_cast_publisher_ref_h`]
+/// * `publisher_handle` is valid, non-null and was obtained via [`iox2_cast_publisher_h_ref`]
 /// * `id` is valid and non-null
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publisher_id(
-    publisher_handle: iox2_publisher_ref_h,
+    publisher_handle: iox2_publisher_h_ref,
     id_struct_ptr: *mut iox2_unique_publisher_id_t,
     id_handle_ptr: *mut iox2_unique_publisher_id_h,
 ) {
@@ -318,13 +318,13 @@ pub unsafe extern "C" fn iox2_publisher_id(
 ///
 /// # Safety
 ///
-/// * `publisher_handle` is valid, non-null and was obtained via [`iox2_cast_publisher_ref_h`]
+/// * `publisher_handle` is valid, non-null and was obtained via [`iox2_cast_publisher_h_ref`]
 /// * `data_ptr` non-null pointer to a valid position in memory
 /// * `data_len` the size of the payload memory
 /// * `number_of_recipients` can be null, otherwise a valid pointer to an [`usize`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publisher_send_copy(
-    publisher_handle: iox2_publisher_ref_h,
+    publisher_handle: iox2_publisher_h_ref,
     data_ptr: *const c_void,
     data_len: usize,
     number_of_recipients: *mut usize,
@@ -364,11 +364,11 @@ pub unsafe extern "C" fn iox2_publisher_send_copy(
 ///
 /// # Safety
 ///
-/// * `publisher_handle` is valid, non-null and was obtained via [`iox2_cast_publisher_ref_h`]
+/// * `publisher_handle` is valid, non-null and was obtained via [`iox2_cast_publisher_h_ref`]
 /// * The `sample_handle_ptr` is pointing to a valid [`iox2_sample_mut_h`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publisher_loan(
-    publisher_handle: iox2_publisher_ref_h,
+    publisher_handle: iox2_publisher_h_ref,
     sample_struct_ptr: *mut iox2_sample_mut_t,
     sample_handle_ptr: *mut iox2_sample_mut_h,
 ) -> c_int {
@@ -427,16 +427,16 @@ pub unsafe extern "C" fn iox2_publisher_loan(
 ///
 /// # Arguments
 ///
-/// * `publisher_handle` - Must be a valid [`iox2_publisher_ref_h`]
+/// * `publisher_handle` - Must be a valid [`iox2_publisher_h_ref`]
 ///   obtained by [`iox2_port_factory_publisher_builder_create`](crate::iox2_port_factory_publisher_builder_create) and
-///   casted by [`iox2_cast_publisher_ref_h`].
+///   casted by [`iox2_cast_publisher_h_ref`].
 ///
 /// # Safety
 ///
 /// * The `publisher_handle` is still valid after the return of this function and can be use in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publisher_update_connections(
-    publisher_handle: iox2_publisher_ref_h,
+    publisher_handle: iox2_publisher_h_ref,
 ) -> c_int {
     debug_assert!(!publisher_handle.is_null());
 

--- a/iceoryx2-ffi/ffi/src/api/sample.rs
+++ b/iceoryx2-ffi/ffi/src/api/sample.rs
@@ -74,9 +74,9 @@ pub struct iox2_sample_h_t;
 /// The owning handle for `iox2_sample_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_sample_h = *mut iox2_sample_h_t;
 
-pub struct iox2_sample_ref_h_t;
+pub struct iox2_sample_h_ref_t;
 /// The non-owning handle for `iox2_sample_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_sample_ref_h = *mut iox2_sample_ref_h_t;
+pub type iox2_sample_h_ref = *mut iox2_sample_h_ref_t;
 
 impl HandleToType for iox2_sample_h {
     type Target = *mut iox2_sample_t;
@@ -86,7 +86,7 @@ impl HandleToType for iox2_sample_h {
     }
 }
 
-impl HandleToType for iox2_sample_ref_h {
+impl HandleToType for iox2_sample_h_ref {
     type Target = *mut iox2_sample_t;
 
     fn as_type(self) -> Self::Target {
@@ -98,22 +98,22 @@ impl HandleToType for iox2_sample_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_sample_h`] into a non-owning [`iox2_sample_ref_h`]
+/// This function casts an owning [`iox2_sample_h`] into a non-owning [`iox2_sample_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `handle` obtained by [`iox2_subscriber_receive()`](crate::iox2_subscriber_receive())
 ///
-/// Returns a [`iox2_sample_ref_h`]
+/// Returns a [`iox2_sample_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `handle` must be a valid handle.
 /// * The `handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_sample_ref_h(handle: iox2_sample_h) -> iox2_sample_ref_h {
+pub unsafe extern "C" fn iox2_cast_sample_h_ref(handle: iox2_sample_h) -> iox2_sample_h_ref {
     debug_assert!(!handle.is_null());
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// cbindgen:ignore
@@ -160,7 +160,7 @@ pub unsafe extern "C" fn iox2_sample_move(
 /// * `header_handle_ptr` valid pointer to a [`iox2_publish_subscribe_header_h`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_header(
-    handle: iox2_sample_ref_h,
+    handle: iox2_sample_h_ref,
     header_struct_ptr: *mut iox2_publish_subscribe_header_t,
     header_handle_ptr: *mut iox2_publish_subscribe_header_h,
 ) {
@@ -195,7 +195,7 @@ pub unsafe extern "C" fn iox2_sample_header(
 /// * `header_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_user_header(
-    sample_handle: iox2_sample_ref_h,
+    sample_handle: iox2_sample_h_ref,
     header_ptr: *mut *const c_void,
 ) {
     debug_assert!(!sample_handle.is_null());
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn iox2_sample_user_header(
 /// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_payload(
-    sample_handle: iox2_sample_ref_h,
+    sample_handle: iox2_sample_h_ref,
     payload_ptr: *mut *const c_void,
     payload_len: *mut c_size_t,
 ) {

--- a/iceoryx2-ffi/ffi/src/api/sample.rs
+++ b/iceoryx2-ffi/ffi/src/api/sample.rs
@@ -12,8 +12,10 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::api::{iox2_service_type_e, HandleToType, PayloadFfi, UserHeaderFfi};
-use crate::{c_size_t, iox2_publish_subscribe_header_h, iox2_publish_subscribe_header_t};
+use crate::api::{
+    c_size_t, iox2_publish_subscribe_header_h, iox2_publish_subscribe_header_t,
+    iox2_service_type_e, AssertNonNullHandle, HandleToType, PayloadFfi, UserHeaderFfi,
+};
 
 use iceoryx2::prelude::*;
 use iceoryx2::sample::Sample;
@@ -73,10 +75,23 @@ impl iox2_sample_t {
 pub struct iox2_sample_h_t;
 /// The owning handle for `iox2_sample_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_sample_h = *mut iox2_sample_h_t;
-
-pub struct iox2_sample_h_ref_t;
 /// The non-owning handle for `iox2_sample_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_sample_h_ref = *mut iox2_sample_h_ref_t;
+pub type iox2_sample_h_ref = *const iox2_sample_h;
+
+impl AssertNonNullHandle for iox2_sample_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_sample_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_sample_h {
     type Target = *mut iox2_sample_t;
@@ -90,31 +105,13 @@ impl HandleToType for iox2_sample_h_ref {
     type Target = *mut iox2_sample_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
 // END type definition
 
 // BEGIN C API
-
-/// This function casts an owning [`iox2_sample_h`] into a non-owning [`iox2_sample_h_ref`]
-///
-/// # Arguments
-///
-/// * `handle` obtained by [`iox2_subscriber_receive()`](crate::iox2_subscriber_receive())
-///
-/// Returns a [`iox2_sample_h_ref`]
-///
-/// # Safety
-///
-/// * The `handle` must be a valid handle.
-/// * The `handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_sample_h_ref(handle: iox2_sample_h) -> iox2_sample_h_ref {
-    debug_assert!(!handle.is_null());
-    (*handle.as_type()).as_h_refandle() as *mut _ as _
-}
 
 /// cbindgen:ignore
 /// Internal API - do not use
@@ -164,7 +161,7 @@ pub unsafe extern "C" fn iox2_sample_header(
     header_struct_ptr: *mut iox2_publish_subscribe_header_t,
     header_handle_ptr: *mut iox2_publish_subscribe_header_h,
 ) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
     debug_assert!(!header_handle_ptr.is_null());
 
     fn no_op(_: *mut iox2_publish_subscribe_header_t) {}
@@ -195,13 +192,13 @@ pub unsafe extern "C" fn iox2_sample_header(
 /// * `header_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_user_header(
-    sample_handle: iox2_sample_h_ref,
+    handle: iox2_sample_h_ref,
     header_ptr: *mut *const c_void,
 ) {
-    debug_assert!(!sample_handle.is_null());
+    handle.assert_non_null();
     debug_assert!(!header_ptr.is_null());
 
-    let sample = &mut *sample_handle.as_type();
+    let sample = &mut *handle.as_type();
 
     let header = match sample.service_type {
         iox2_service_type_e::IPC => sample.value.as_mut().ipc.user_header(),
@@ -220,14 +217,14 @@ pub unsafe extern "C" fn iox2_sample_user_header(
 /// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_payload(
-    sample_handle: iox2_sample_h_ref,
+    handle: iox2_sample_h_ref,
     payload_ptr: *mut *const c_void,
     payload_len: *mut c_size_t,
 ) {
-    debug_assert!(!sample_handle.is_null());
+    handle.assert_non_null();
     debug_assert!(!payload_ptr.is_null());
 
-    let sample = &mut *sample_handle.as_type();
+    let sample = &mut *handle.as_type();
 
     let payload = match sample.service_type {
         iox2_service_type_e::IPC => sample.value.as_mut().ipc.payload(),

--- a/iceoryx2-ffi/ffi/src/api/sample_mut.rs
+++ b/iceoryx2-ffi/ffi/src/api/sample_mut.rs
@@ -80,9 +80,9 @@ pub struct iox2_sample_mut_h_t;
 /// The owning handle for `iox2_sample_mut_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_sample_mut_h = *mut iox2_sample_mut_h_t;
 
-pub struct iox2_sample_mut_ref_h_t;
+pub struct iox2_sample_mut_h_ref_t;
 /// The non-owning handle for `iox2_sample_mut_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_sample_mut_ref_h = *mut iox2_sample_mut_ref_h_t;
+pub type iox2_sample_mut_h_ref = *mut iox2_sample_mut_h_ref_t;
 
 impl HandleToType for iox2_sample_mut_h {
     type Target = *mut iox2_sample_mut_t;
@@ -92,7 +92,7 @@ impl HandleToType for iox2_sample_mut_h {
     }
 }
 
-impl HandleToType for iox2_sample_mut_ref_h {
+impl HandleToType for iox2_sample_mut_h_ref {
     type Target = *mut iox2_sample_mut_t;
 
     fn as_type(self) -> Self::Target {
@@ -104,24 +104,24 @@ impl HandleToType for iox2_sample_mut_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_sample_mut_h`] into a non-owning [`iox2_sample_mut_ref_h`]
+/// This function casts an owning [`iox2_sample_mut_h`] into a non-owning [`iox2_sample_mut_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `handle` obtained by [`iox2_publisher_loan()`](crate::iox2_publisher_loan())
 ///
-/// Returns a [`iox2_sample_mut_ref_h`]
+/// Returns a [`iox2_sample_mut_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `handle` must be a valid handle.
 /// * The `handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_sample_mut_ref_h(
+pub unsafe extern "C" fn iox2_cast_sample_mut_h_ref(
     handle: iox2_sample_mut_h,
-) -> iox2_sample_mut_ref_h {
+) -> iox2_sample_mut_h_ref {
     debug_assert!(!handle.is_null());
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// cbindgen:ignore
@@ -166,7 +166,7 @@ pub unsafe extern "C" fn iox2_sample_mut_move(
 /// * `header_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_user_header(
-    sample_handle: iox2_sample_mut_ref_h,
+    sample_handle: iox2_sample_mut_h_ref,
     header_ptr: *mut *const c_void,
 ) {
     debug_assert!(!sample_handle.is_null());
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn iox2_sample_mut_user_header(
 /// * `header_handle_ptr` valid pointer to a [`iox2_publish_subscribe_header_h`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_header(
-    handle: iox2_sample_mut_ref_h,
+    handle: iox2_sample_mut_h_ref,
     header_struct_ptr: *mut iox2_publish_subscribe_header_t,
     header_handle_ptr: *mut iox2_publish_subscribe_header_h,
 ) {
@@ -227,7 +227,7 @@ pub unsafe extern "C" fn iox2_sample_mut_header(
 /// * `header_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_user_header_mut(
-    sample_handle: iox2_sample_mut_ref_h,
+    sample_handle: iox2_sample_mut_h_ref,
     header_ptr: *mut *mut c_void,
 ) {
     debug_assert!(!sample_handle.is_null());
@@ -252,7 +252,7 @@ pub unsafe extern "C" fn iox2_sample_mut_user_header_mut(
 /// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_payload_mut(
-    sample_handle: iox2_sample_mut_ref_h,
+    sample_handle: iox2_sample_mut_h_ref,
     payload_ptr: *mut *mut c_void,
     payload_len: *mut c_size_t,
 ) {
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn iox2_sample_mut_payload_mut(
 /// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_payload(
-    sample_handle: iox2_sample_mut_ref_h,
+    sample_handle: iox2_sample_mut_h_ref,
     payload_ptr: *mut *const c_void,
     payload_len: *mut c_size_t,
 ) {

--- a/iceoryx2-ffi/ffi/src/api/service_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder.rs
@@ -12,7 +12,7 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::api::{iox2_service_type_e, HandleToType};
+use crate::api::{iox2_service_type_e, AssertNonNullHandle, HandleToType};
 
 use iceoryx2::prelude::*;
 use iceoryx2::service::builder::publish_subscribe::CustomHeaderMarker;
@@ -127,26 +127,50 @@ impl iox2_service_builder_t {
 pub struct iox2_service_builder_h_t;
 /// The owning handle for `iox2_service_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_service_builder_h = *mut iox2_service_builder_h_t;
-
-pub struct iox2_service_builder_h_ref_t;
 /// The non-owning handle for `iox2_service_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_service_builder_h_ref = *mut iox2_service_builder_h_ref_t;
+pub type iox2_service_builder_h_ref = *const iox2_service_builder_h;
 
 pub struct iox2_service_builder_event_h_t;
 /// The owning handle for `iox2_service_builder_t` which is already configured as event. Passing the handle to an function transfers the ownership.
 pub type iox2_service_builder_event_h = *mut iox2_service_builder_event_h_t;
-
-pub struct iox2_service_builder_event_h_ref_t;
 /// The non-owning handle for `iox2_service_builder_t` which is already configured as event. Passing the handle to an function does not transfers the ownership.
-pub type iox2_service_builder_event_h_ref = *mut iox2_service_builder_event_h_ref_t;
+pub type iox2_service_builder_event_h_ref = *const iox2_service_builder_event_h;
 
 pub struct iox2_service_builder_pub_sub_h_t;
 /// The owning handle for `iox2_service_builder_t` which is already configured as event. Passing the handle to an function transfers the ownership.
 pub type iox2_service_builder_pub_sub_h = *mut iox2_service_builder_pub_sub_h_t;
-
-pub struct iox2_service_builder_pub_sub_h_ref_t;
 /// The non-owning handle for `iox2_service_builder_t` which is already configured as event. Passing the handle to an function does not transfers the ownership.
-pub type iox2_service_builder_pub_sub_h_ref = *mut iox2_service_builder_pub_sub_h_ref_t;
+pub type iox2_service_builder_pub_sub_h_ref = *const iox2_service_builder_pub_sub_h;
+
+impl AssertNonNullHandle for iox2_service_builder_event_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_service_builder_event_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
+
+impl AssertNonNullHandle for iox2_service_builder_pub_sub_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_service_builder_pub_sub_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_service_builder_h {
     type Target = *mut iox2_service_builder_t;
@@ -160,7 +184,7 @@ impl HandleToType for iox2_service_builder_h_ref {
     type Target = *mut iox2_service_builder_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -176,7 +200,7 @@ impl HandleToType for iox2_service_builder_event_h_ref {
     type Target = *mut iox2_service_builder_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -192,55 +216,13 @@ impl HandleToType for iox2_service_builder_pub_sub_h_ref {
     type Target = *mut iox2_service_builder_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
 // END type definition
 
 // BEGIN C API
-
-/// This function casts an owning [`iox2_service_builder_event_h`] into a non-owning [`iox2_service_builder_event_h_ref`]
-///
-/// # Arguments
-///
-/// * `service_builder_handle` obtained by `iox2_service_builder_event`
-///
-/// Returns a [`iox2_service_builder_event_h_ref`]
-///
-/// # Safety
-///
-/// * The `service_builder_handle` must be a valid handle.
-/// * The `service_builder_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_service_builder_event_h_ref(
-    service_builder_handle: iox2_service_builder_event_h,
-) -> iox2_service_builder_event_h_ref {
-    debug_assert!(!service_builder_handle.is_null());
-
-    (*service_builder_handle.as_type()).as_h_refandle() as *mut _ as _
-}
-
-/// This function casts an owning [`iox2_service_builder_pub_sub_h`] into a non-owning [`iox2_service_builder_pub_sub_h_ref`]
-///
-/// # Arguments
-///
-/// * `service_builder_handle` obtained by `iox2_service_builder_pub_sub`
-///
-/// Returns a [`iox2_service_builder_pub_sub_h_ref`]
-///
-/// # Safety
-///
-/// * The `service_builder_handle` must be a valid handle.
-/// * The `service_builder_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_service_builder_pub_sub_h_ref(
-    service_builder_handle: iox2_service_builder_pub_sub_h,
-) -> iox2_service_builder_pub_sub_h_ref {
-    debug_assert!(!service_builder_handle.is_null());
-
-    (*service_builder_handle.as_type()).as_h_refandle() as *mut _ as _
-}
 
 /// This function transform the [`iox2_service_builder_h`] to an event service builder.
 ///

--- a/iceoryx2-ffi/ffi/src/api/service_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder.rs
@@ -128,25 +128,25 @@ pub struct iox2_service_builder_h_t;
 /// The owning handle for `iox2_service_builder_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_service_builder_h = *mut iox2_service_builder_h_t;
 
-pub struct iox2_service_builder_ref_h_t;
+pub struct iox2_service_builder_h_ref_t;
 /// The non-owning handle for `iox2_service_builder_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_service_builder_ref_h = *mut iox2_service_builder_ref_h_t;
+pub type iox2_service_builder_h_ref = *mut iox2_service_builder_h_ref_t;
 
 pub struct iox2_service_builder_event_h_t;
 /// The owning handle for `iox2_service_builder_t` which is already configured as event. Passing the handle to an function transfers the ownership.
 pub type iox2_service_builder_event_h = *mut iox2_service_builder_event_h_t;
 
-pub struct iox2_service_builder_event_ref_h_t;
+pub struct iox2_service_builder_event_h_ref_t;
 /// The non-owning handle for `iox2_service_builder_t` which is already configured as event. Passing the handle to an function does not transfers the ownership.
-pub type iox2_service_builder_event_ref_h = *mut iox2_service_builder_event_ref_h_t;
+pub type iox2_service_builder_event_h_ref = *mut iox2_service_builder_event_h_ref_t;
 
 pub struct iox2_service_builder_pub_sub_h_t;
 /// The owning handle for `iox2_service_builder_t` which is already configured as event. Passing the handle to an function transfers the ownership.
 pub type iox2_service_builder_pub_sub_h = *mut iox2_service_builder_pub_sub_h_t;
 
-pub struct iox2_service_builder_pub_sub_ref_h_t;
+pub struct iox2_service_builder_pub_sub_h_ref_t;
 /// The non-owning handle for `iox2_service_builder_t` which is already configured as event. Passing the handle to an function does not transfers the ownership.
-pub type iox2_service_builder_pub_sub_ref_h = *mut iox2_service_builder_pub_sub_ref_h_t;
+pub type iox2_service_builder_pub_sub_h_ref = *mut iox2_service_builder_pub_sub_h_ref_t;
 
 impl HandleToType for iox2_service_builder_h {
     type Target = *mut iox2_service_builder_t;
@@ -156,7 +156,7 @@ impl HandleToType for iox2_service_builder_h {
     }
 }
 
-impl HandleToType for iox2_service_builder_ref_h {
+impl HandleToType for iox2_service_builder_h_ref {
     type Target = *mut iox2_service_builder_t;
 
     fn as_type(self) -> Self::Target {
@@ -172,7 +172,7 @@ impl HandleToType for iox2_service_builder_event_h {
     }
 }
 
-impl HandleToType for iox2_service_builder_event_ref_h {
+impl HandleToType for iox2_service_builder_event_h_ref {
     type Target = *mut iox2_service_builder_t;
 
     fn as_type(self) -> Self::Target {
@@ -188,7 +188,7 @@ impl HandleToType for iox2_service_builder_pub_sub_h {
     }
 }
 
-impl HandleToType for iox2_service_builder_pub_sub_ref_h {
+impl HandleToType for iox2_service_builder_pub_sub_h_ref {
     type Target = *mut iox2_service_builder_t;
 
     fn as_type(self) -> Self::Target {
@@ -200,46 +200,46 @@ impl HandleToType for iox2_service_builder_pub_sub_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_service_builder_event_h`] into a non-owning [`iox2_service_builder_event_ref_h`]
+/// This function casts an owning [`iox2_service_builder_event_h`] into a non-owning [`iox2_service_builder_event_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `service_builder_handle` obtained by `iox2_service_builder_event`
 ///
-/// Returns a [`iox2_service_builder_event_ref_h`]
+/// Returns a [`iox2_service_builder_event_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `service_builder_handle` must be a valid handle.
 /// * The `service_builder_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_service_builder_event_ref_h(
+pub unsafe extern "C" fn iox2_cast_service_builder_event_h_ref(
     service_builder_handle: iox2_service_builder_event_h,
-) -> iox2_service_builder_event_ref_h {
+) -> iox2_service_builder_event_h_ref {
     debug_assert!(!service_builder_handle.is_null());
 
-    (*service_builder_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*service_builder_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
-/// This function casts an owning [`iox2_service_builder_pub_sub_h`] into a non-owning [`iox2_service_builder_pub_sub_ref_h`]
+/// This function casts an owning [`iox2_service_builder_pub_sub_h`] into a non-owning [`iox2_service_builder_pub_sub_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `service_builder_handle` obtained by `iox2_service_builder_pub_sub`
 ///
-/// Returns a [`iox2_service_builder_pub_sub_ref_h`]
+/// Returns a [`iox2_service_builder_pub_sub_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `service_builder_handle` must be a valid handle.
 /// * The `service_builder_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_service_builder_pub_sub_ref_h(
+pub unsafe extern "C" fn iox2_cast_service_builder_pub_sub_h_ref(
     service_builder_handle: iox2_service_builder_pub_sub_h,
-) -> iox2_service_builder_pub_sub_ref_h {
+) -> iox2_service_builder_pub_sub_h_ref {
     debug_assert!(!service_builder_handle.is_null());
 
-    (*service_builder_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*service_builder_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// This function transform the [`iox2_service_builder_h`] to an event service builder.

--- a/iceoryx2-ffi/ffi/src/api/service_builder_event.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder_event.rs
@@ -14,7 +14,7 @@
 
 use crate::api::{
     c_size_t, iox2_port_factory_event_h, iox2_port_factory_event_t, iox2_service_builder_event_h,
-    iox2_service_builder_event_ref_h, iox2_service_type_e, HandleToType, IntoCInt,
+    iox2_service_builder_event_h_ref, iox2_service_type_e, HandleToType, IntoCInt,
     PortFactoryEventUnion, ServiceBuilderUnion, IOX2_OK,
 };
 
@@ -139,9 +139,9 @@ impl IntoCInt for EventOpenOrCreateError {
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_event_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_event_h_ref`]
 ///   obtained by [`iox2_service_builder_event`](crate::iox2_service_builder_event) and
-///   casted by [`iox2_cast_service_builder_event_ref_h`](crate::iox2_cast_service_builder_event_ref_h).
+///   casted by [`iox2_cast_service_builder_event_h_ref`](crate::iox2_cast_service_builder_event_h_ref).
 /// * `value` - The value to set the max notifiers to
 ///
 /// # Safety
@@ -149,7 +149,7 @@ impl IntoCInt for EventOpenOrCreateError {
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_event_set_max_notifiers(
-    service_builder_handle: iox2_service_builder_event_ref_h,
+    service_builder_handle: iox2_service_builder_event_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!service_builder_handle.is_null());
@@ -182,9 +182,9 @@ pub unsafe extern "C" fn iox2_service_builder_event_set_max_notifiers(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_event_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_event_h_ref`]
 ///   obtained by [`iox2_service_builder_event`](crate::iox2_service_builder_event) and
-///   casted by [`iox2_cast_service_builder_event_ref_h`](crate::iox2_cast_service_builder_event_ref_h).
+///   casted by [`iox2_cast_service_builder_event_h_ref`](crate::iox2_cast_service_builder_event_h_ref).
 /// * `value` - The value to set the max listeners to
 ///
 /// # Safety
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn iox2_service_builder_event_set_max_notifiers(
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_event_set_max_listeners(
-    service_builder_handle: iox2_service_builder_event_ref_h,
+    service_builder_handle: iox2_service_builder_event_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!service_builder_handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/service_builder_event.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder_event.rs
@@ -14,8 +14,8 @@
 
 use crate::api::{
     c_size_t, iox2_port_factory_event_h, iox2_port_factory_event_t, iox2_service_builder_event_h,
-    iox2_service_builder_event_h_ref, iox2_service_type_e, HandleToType, IntoCInt,
-    PortFactoryEventUnion, ServiceBuilderUnion, IOX2_OK,
+    iox2_service_builder_event_h_ref, iox2_service_type_e, AssertNonNullHandle, HandleToType,
+    IntoCInt, PortFactoryEventUnion, ServiceBuilderUnion, IOX2_OK,
 };
 
 use iceoryx2::prelude::*;
@@ -140,8 +140,7 @@ impl IntoCInt for EventOpenOrCreateError {
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_event_h_ref`]
-///   obtained by [`iox2_service_builder_event`](crate::iox2_service_builder_event) and
-///   casted by [`iox2_cast_service_builder_event_h_ref`](crate::iox2_cast_service_builder_event_h_ref).
+///   obtained by [`iox2_service_builder_event`](crate::iox2_service_builder_event).
 /// * `value` - The value to set the max notifiers to
 ///
 /// # Safety
@@ -152,7 +151,7 @@ pub unsafe extern "C" fn iox2_service_builder_event_set_max_notifiers(
     service_builder_handle: iox2_service_builder_event_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 
@@ -183,8 +182,7 @@ pub unsafe extern "C" fn iox2_service_builder_event_set_max_notifiers(
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_event_h_ref`]
-///   obtained by [`iox2_service_builder_event`](crate::iox2_service_builder_event) and
-///   casted by [`iox2_cast_service_builder_event_h_ref`](crate::iox2_cast_service_builder_event_h_ref).
+///   obtained by [`iox2_service_builder_event`](crate::iox2_service_builder_event).
 /// * `value` - The value to set the max listeners to
 ///
 /// # Safety
@@ -195,7 +193,7 @@ pub unsafe extern "C" fn iox2_service_builder_event_set_max_listeners(
     service_builder_handle: iox2_service_builder_event_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 

--- a/iceoryx2-ffi/ffi/src/api/service_builder_pub_sub.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder_pub_sub.rs
@@ -15,8 +15,8 @@
 use crate::api::{
     c_size_t, iox2_port_factory_pub_sub_h, iox2_port_factory_pub_sub_t,
     iox2_service_builder_pub_sub_h, iox2_service_builder_pub_sub_h_ref, iox2_service_type_e,
-    HandleToType, IntoCInt, PayloadFfi, PortFactoryPubSubUnion, ServiceBuilderUnion, UserHeaderFfi,
-    IOX2_OK,
+    AssertNonNullHandle, HandleToType, IntoCInt, PayloadFfi, PortFactoryPubSubUnion,
+    ServiceBuilderUnion, UserHeaderFfi, IOX2_OK,
 };
 
 use iceoryx2::prelude::*;
@@ -205,8 +205,7 @@ pub enum iox2_type_detail_error_e {
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `type_variant` - The [`iox2_type_variant_e`] for the payload
 /// * `type_name_str` - Must string for the type name.
 /// * `type_name_len` - The length of the type name string, not including a null
@@ -229,7 +228,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_user_header_type_detai
     size: c_size_t,
     alignment: c_size_t,
 ) -> c_int {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
     debug_assert!(!type_name_str.is_null());
 
     let type_name = slice::from_raw_parts(type_name_str as _, type_name_len as _);
@@ -283,8 +282,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_user_header_type_detai
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `type_variant` - The [`iox2_type_variant_e`] for the payload
 /// * `type_name_str` - Must string for the type name.
 /// * `type_name_len` - The length of the type name string, not including a null
@@ -307,7 +305,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_payload_type_details(
     size: c_size_t,
     alignment: c_size_t,
 ) -> c_int {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
     debug_assert!(!type_name_str.is_null());
 
     let type_name = slice::from_raw_parts(type_name_str as _, type_name_len as _);
@@ -361,8 +359,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_payload_type_details(
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `value` - The value to set the max nodes to
 ///
 /// # Safety
@@ -373,7 +370,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_nodes(
     service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 
@@ -404,8 +401,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_nodes(
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `value` - The value to set the max publishers to
 ///
 /// # Safety
@@ -416,7 +412,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_publishers(
     service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 
@@ -447,8 +443,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_publishers(
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `value` - The value to set the max subscribers to
 ///
 /// # Safety
@@ -459,7 +454,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_subscribers(
     service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 
@@ -490,8 +485,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_subscribers(
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `value` - The value to set the history size to
 ///
 /// # Safety
@@ -502,7 +496,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_history_size(
     service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 
@@ -533,8 +527,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_history_size(
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `value` - The value to set the subscriber max buffer size to
 ///
 /// # Safety
@@ -545,7 +538,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_buffer_
     service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 
@@ -576,8 +569,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_buffer_
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `value` - The value to set the subscriber max borrowed samples to
 ///
 /// # Safety
@@ -588,7 +580,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_borrowe
     service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 
@@ -619,8 +611,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_borrowe
 /// # Arguments
 ///
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
-///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
 /// * `value` - defines if safe overflow shall be enabled (true) or not (false)
 ///
 /// # Safety
@@ -631,7 +622,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_enable_safe_overflow(
     service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: bool,
 ) {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
 
     let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
 
@@ -766,7 +757,7 @@ unsafe fn iox2_service_builder_pub_sub_open_create_impl<E: IntoCInt>(
         Builder<PayloadFfi, UserHeaderFfi, local::Service>,
     ) -> Result<PortFactory<local::Service, PayloadFfi, UserHeaderFfi>, E>,
 ) -> c_int {
-    debug_assert!(!service_builder_handle.is_null());
+    service_builder_handle.assert_non_null();
     debug_assert!(!port_factory_handle_ptr.is_null());
 
     let init_port_factory_struct_ptr =

--- a/iceoryx2-ffi/ffi/src/api/service_builder_pub_sub.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder_pub_sub.rs
@@ -14,7 +14,7 @@
 
 use crate::api::{
     c_size_t, iox2_port_factory_pub_sub_h, iox2_port_factory_pub_sub_t,
-    iox2_service_builder_pub_sub_h, iox2_service_builder_pub_sub_ref_h, iox2_service_type_e,
+    iox2_service_builder_pub_sub_h, iox2_service_builder_pub_sub_h_ref, iox2_service_type_e,
     HandleToType, IntoCInt, PayloadFfi, PortFactoryPubSubUnion, ServiceBuilderUnion, UserHeaderFfi,
     IOX2_OK,
 };
@@ -204,9 +204,9 @@ pub enum iox2_type_detail_error_e {
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `type_variant` - The [`iox2_type_variant_e`] for the payload
 /// * `type_name_str` - Must string for the type name.
 /// * `type_name_len` - The length of the type name string, not including a null
@@ -222,7 +222,7 @@ pub enum iox2_type_detail_error_e {
 /// * `size` and `alignment` must satisfy the Rust `Layout` type requirements
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_user_header_type_details(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     type_variant: iox2_type_variant_e,
     type_name_str: *const c_char,
     type_name_len: c_size_t,
@@ -282,9 +282,9 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_user_header_type_detai
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `type_variant` - The [`iox2_type_variant_e`] for the payload
 /// * `type_name_str` - Must string for the type name.
 /// * `type_name_len` - The length of the type name string, not including a null
@@ -300,7 +300,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_user_header_type_detai
 /// * `size` and `alignment` must satisfy the Rust `Layout` type requirements
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_payload_type_details(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     type_variant: iox2_type_variant_e,
     type_name_str: *const c_char,
     type_name_len: c_size_t,
@@ -360,9 +360,9 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_payload_type_details(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `value` - The value to set the max nodes to
 ///
 /// # Safety
@@ -370,7 +370,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_payload_type_details(
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_nodes(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!service_builder_handle.is_null());
@@ -403,9 +403,9 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_nodes(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `value` - The value to set the max publishers to
 ///
 /// # Safety
@@ -413,7 +413,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_nodes(
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_publishers(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!service_builder_handle.is_null());
@@ -446,9 +446,9 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_publishers(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `value` - The value to set the max subscribers to
 ///
 /// # Safety
@@ -456,7 +456,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_publishers(
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_subscribers(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!service_builder_handle.is_null());
@@ -489,9 +489,9 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_subscribers(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `value` - The value to set the history size to
 ///
 /// # Safety
@@ -499,7 +499,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_subscribers(
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_history_size(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!service_builder_handle.is_null());
@@ -532,9 +532,9 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_history_size(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `value` - The value to set the subscriber max buffer size to
 ///
 /// # Safety
@@ -542,7 +542,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_history_size(
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_buffer_size(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!service_builder_handle.is_null());
@@ -575,9 +575,9 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_buffer_
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `value` - The value to set the subscriber max borrowed samples to
 ///
 /// # Safety
@@ -585,7 +585,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_buffer_
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_borrowed_samples(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: c_size_t,
 ) {
     debug_assert!(!service_builder_handle.is_null());
@@ -618,9 +618,9 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_borrowe
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_ref_h`]
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
 ///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub) and
-///   casted by [`iox2_cast_service_builder_pub_sub_ref_h`](crate::iox2_cast_service_builder_pub_sub_ref_h).
+///   casted by [`iox2_cast_service_builder_pub_sub_h_ref`](crate::iox2_cast_service_builder_pub_sub_h_ref).
 /// * `value` - defines if safe overflow shall be enabled (true) or not (false)
 ///
 /// # Safety
@@ -628,7 +628,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_subscriber_max_borrowe
 /// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_enable_safe_overflow(
-    service_builder_handle: iox2_service_builder_pub_sub_ref_h,
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
     value: bool,
 ) {
     debug_assert!(!service_builder_handle.is_null());

--- a/iceoryx2-ffi/ffi/src/api/service_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_name.rs
@@ -49,7 +49,7 @@ pub type iox2_service_name_ref_h = *mut iox2_service_name_ref_h_t;
 /// The immutable pointer to the underlying `ServiceName`
 pub type iox2_service_name_ptr = *const ServiceName;
 /// The mutable pointer to the underlying `ServiceName`
-pub type iox2_service_name_mut_ptr = *mut ServiceName;
+pub type iox2_service_name_ptr_mut = *mut ServiceName;
 
 impl HandleToType for iox2_service_name_h {
     type Target = *mut iox2_service_name_t;

--- a/iceoryx2-ffi/ffi/src/api/service_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_name.rs
@@ -41,9 +41,9 @@ pub struct iox2_service_name_h_t;
 /// The owning handle for `iox2_service_name_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_service_name_h = *mut iox2_service_name_h_t;
 
-pub struct iox2_service_name_ref_h_t;
+pub struct iox2_service_name_h_ref_t;
 /// The non-owning handle for `iox2_service_name_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_service_name_ref_h = *mut iox2_service_name_ref_h_t;
+pub type iox2_service_name_h_ref = *mut iox2_service_name_h_ref_t;
 
 // NOTE check the README.md for using opaque types with renaming
 /// The immutable pointer to the underlying `ServiceName`
@@ -59,7 +59,7 @@ impl HandleToType for iox2_service_name_h {
     }
 }
 
-impl HandleToType for iox2_service_name_ref_h {
+impl HandleToType for iox2_service_name_h_ref {
     type Target = *mut iox2_service_name_t;
 
     fn as_type(self) -> Self::Target {

--- a/iceoryx2-ffi/ffi/src/api/service_name.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_name.rs
@@ -12,7 +12,9 @@
 
 #![allow(non_camel_case_types)]
 
-use crate::api::{iox2_semantic_string_error_e, HandleToType, IntoCInt, IOX2_OK};
+use crate::api::{
+    iox2_semantic_string_error_e, AssertNonNullHandle, HandleToType, IntoCInt, IOX2_OK,
+};
 use crate::c_size_t;
 
 use iceoryx2::prelude::*;
@@ -41,15 +43,29 @@ pub struct iox2_service_name_h_t;
 /// The owning handle for `iox2_service_name_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_service_name_h = *mut iox2_service_name_h_t;
 
-pub struct iox2_service_name_h_ref_t;
 /// The non-owning handle for `iox2_service_name_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_service_name_h_ref = *mut iox2_service_name_h_ref_t;
+pub type iox2_service_name_h_ref = *const iox2_service_name_h;
 
 // NOTE check the README.md for using opaque types with renaming
 /// The immutable pointer to the underlying `ServiceName`
 pub type iox2_service_name_ptr = *const ServiceName;
 /// The mutable pointer to the underlying `ServiceName`
 pub type iox2_service_name_ptr_mut = *mut ServiceName;
+
+impl AssertNonNullHandle for iox2_service_name_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_service_name_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_service_name_h {
     type Target = *mut iox2_service_name_t;
@@ -63,7 +79,7 @@ impl HandleToType for iox2_service_name_h_ref {
     type Target = *mut iox2_service_name_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 

--- a/iceoryx2-ffi/ffi/src/api/subscriber.rs
+++ b/iceoryx2-ffi/ffi/src/api/subscriber.rs
@@ -124,9 +124,9 @@ pub struct iox2_subscriber_h_t;
 /// The owning handle for `iox2_subscriber_t`. Passing the handle to an function transfers the ownership.
 pub type iox2_subscriber_h = *mut iox2_subscriber_h_t;
 
-pub struct iox2_subscriber_ref_h_t;
+pub struct iox2_subscriber_h_ref_t;
 /// The non-owning handle for `iox2_subscriber_t`. Passing the handle to an function does not transfers the ownership.
-pub type iox2_subscriber_ref_h = *mut iox2_subscriber_ref_h_t;
+pub type iox2_subscriber_h_ref = *mut iox2_subscriber_h_ref_t;
 
 impl HandleToType for iox2_subscriber_h {
     type Target = *mut iox2_subscriber_t;
@@ -136,7 +136,7 @@ impl HandleToType for iox2_subscriber_h {
     }
 }
 
-impl HandleToType for iox2_subscriber_ref_h {
+impl HandleToType for iox2_subscriber_h_ref {
     type Target = *mut iox2_subscriber_t;
 
     fn as_type(self) -> Self::Target {
@@ -148,41 +148,41 @@ impl HandleToType for iox2_subscriber_ref_h {
 
 // BEGIN C API
 
-/// This function casts an owning [`iox2_subscriber_h`] into a non-owning [`iox2_subscriber_ref_h`]
+/// This function casts an owning [`iox2_subscriber_h`] into a non-owning [`iox2_subscriber_h_ref`]
 ///
 /// # Arguments
 ///
 /// * `subscriber_handle` obtained by [`iox2_port_factory_subscriber_builder_create`](crate::iox2_port_factory_subscriber_builder_create)
 ///
-/// Returns a [`iox2_subscriber_ref_h`]
+/// Returns a [`iox2_subscriber_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `subscriber_handle` must be a valid handle.
 /// * The `subscriber_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_subscriber_ref_h(
+pub unsafe extern "C" fn iox2_cast_subscriber_h_ref(
     subscriber_handle: iox2_subscriber_h,
-) -> iox2_subscriber_ref_h {
+) -> iox2_subscriber_h_ref {
     debug_assert!(!subscriber_handle.is_null());
 
-    (*subscriber_handle.as_type()).as_ref_handle() as *mut _ as _
+    (*subscriber_handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Returns the buffer size of the subscriber
 ///
 /// # Arguments
 ///
-/// * `subscriber_handle` - Must be a valid [`iox2_subscriber_ref_h`]
+/// * `subscriber_handle` - Must be a valid [`iox2_subscriber_h_ref`]
 ///   obtained by [`iox2_port_factory_subscriber_builder_create`](crate::iox2_port_factory_subscriber_builder_create) and
-///   casted by [`iox2_cast_subscriber_ref_h`].
+///   casted by [`iox2_cast_subscriber_h_ref`].
 ///
 /// # Safety
 ///
 /// * `subscriber_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_subscriber_buffer_size(
-    subscriber_handle: iox2_subscriber_ref_h,
+    subscriber_handle: iox2_subscriber_h_ref,
 ) -> c_size_t {
     debug_assert!(!subscriber_handle.is_null());
 
@@ -205,11 +205,11 @@ pub unsafe extern "C" fn iox2_subscriber_buffer_size(
 ///
 /// # Safety
 ///
-/// * `subscriber_handle` is valid, non-null and was obtained via [`iox2_cast_subscriber_ref_h`]
+/// * `subscriber_handle` is valid, non-null and was obtained via [`iox2_cast_subscriber_h_ref`]
 /// * `id` is valid and non-null
 #[no_mangle]
 pub unsafe extern "C" fn iox2_subscriber_id(
-    subscriber_handle: iox2_subscriber_ref_h,
+    subscriber_handle: iox2_subscriber_h_ref,
     id_struct_ptr: *mut iox2_unique_subscriber_id_t,
     id_handle_ptr: *mut iox2_unique_subscriber_id_h,
 ) {
@@ -242,9 +242,9 @@ pub unsafe extern "C" fn iox2_subscriber_id(
 ///
 /// # Arguments
 ///
-/// * `subscriber_handle` - Must be a valid [`iox2_subscriber_ref_h`]
+/// * `subscriber_handle` - Must be a valid [`iox2_subscriber_h_ref`]
 ///   obtained by [`iox2_port_factory_subscriber_builder_create`](crate::iox2_port_factory_subscriber_builder_create) and
-///   casted by [`iox2_cast_subscriber_ref_h`].
+///   casted by [`iox2_cast_subscriber_h_ref`].
 /// * `sample_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_sample_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `sample_handle_ptr` - An uninitialized or dangling [`iox2_sample_h`] handle which will be initialized by this function call if a sample is obtained, otherwise it will be set to NULL.
@@ -258,7 +258,7 @@ pub unsafe extern "C" fn iox2_subscriber_id(
 /// * The `sample_handle_ptr` is pointing to a valid [`iox2_sample_h`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_subscriber_receive(
-    subscriber_handle: iox2_subscriber_ref_h,
+    subscriber_handle: iox2_subscriber_h_ref,
     sample_struct_ptr: *mut iox2_sample_t,
     sample_handle_ptr: *mut iox2_sample_h,
 ) -> c_int {
@@ -318,9 +318,9 @@ pub unsafe extern "C" fn iox2_subscriber_receive(
 ///
 /// # Arguments
 ///
-/// * `subscriber_handle` - Must be a valid [`iox2_subscriber_ref_h`]
+/// * `subscriber_handle` - Must be a valid [`iox2_subscriber_h_ref`]
 ///   obtained by [`iox2_port_factory_subscriber_builder_create`](crate::iox2_port_factory_subscriber_builder_create) and
-///   casted by [`iox2_cast_subscriber_ref_h`].
+///   casted by [`iox2_cast_subscriber_h_ref`].
 /// * `result_ptr` - A non-null pointer to a bool that will contain the result.
 ///
 /// Returns IOX2_OK on success, an [`iox2_connection_failure_e`] otherwise.
@@ -332,7 +332,7 @@ pub unsafe extern "C" fn iox2_subscriber_receive(
 /// * The `result_ptr` is pointing to a valid bool.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_subscriber_has_samples(
-    subscriber_handle: iox2_subscriber_ref_h,
+    subscriber_handle: iox2_subscriber_h_ref,
     result_ptr: *mut bool,
 ) -> c_int {
     debug_assert!(!subscriber_handle.is_null());
@@ -362,16 +362,16 @@ pub unsafe extern "C" fn iox2_subscriber_has_samples(
 ///
 /// # Arguments
 ///
-/// * `subscriber_handle` - Must be a valid [`iox2_subscriber_ref_h`]
+/// * `subscriber_handle` - Must be a valid [`iox2_subscriber_h_ref`]
 ///   obtained by [`iox2_port_factory_subscriber_builder_create`](crate::iox2_port_factory_subscriber_builder_create) and
-///   casted by [`iox2_cast_subscriber_ref_h`].
+///   casted by [`iox2_cast_subscriber_h_ref`].
 ///
 /// # Safety
 ///
 /// * The `subscriber_handle` is still valid after the return of this function and can be use in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_subscriber_update_connections(
-    subscriber_handle: iox2_subscriber_ref_h,
+    subscriber_handle: iox2_subscriber_h_ref,
 ) -> c_int {
     debug_assert!(!subscriber_handle.is_null());
 

--- a/iceoryx2-ffi/ffi/src/api/unique_listener_id.rs
+++ b/iceoryx2-ffi/ffi/src/api/unique_listener_id.rs
@@ -16,7 +16,7 @@ use iceoryx2::port::port_identifiers::UniqueListenerId;
 use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
-use super::HandleToType;
+use crate::api::{AssertNonNullHandle, HandleToType};
 
 // BEGIN types definition
 
@@ -48,10 +48,23 @@ impl iox2_unique_listener_id_t {
 pub struct iox2_unique_listener_id_h_t;
 /// The owning handle for [`iox2_unique_listener_id_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_unique_listener_id_h = *mut iox2_unique_listener_id_h_t;
-
-pub struct iox2_unique_listener_id_h_ref_t;
 /// The non-owning handle for [`iox2_unique_listener_id_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_unique_listener_id_h_ref = *mut iox2_unique_listener_id_h_ref_t;
+pub type iox2_unique_listener_id_h_ref = *const iox2_unique_listener_id_h;
+
+impl AssertNonNullHandle for iox2_unique_listener_id_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_unique_listener_id_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_unique_listener_id_h {
     type Target = *mut iox2_unique_listener_id_t;
@@ -65,7 +78,7 @@ impl HandleToType for iox2_unique_listener_id_h_ref {
     type Target = *mut iox2_unique_listener_id_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -84,29 +97,11 @@ impl HandleToType for iox2_unique_listener_id_h_ref {
 /// * The `handle` is invalid after the return of this function and leads to undefined behavior if used in another function call!
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_listener_id_drop(handle: iox2_unique_listener_id_h) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let h = &mut *handle.as_type();
     core::ptr::drop_in_place(h.value.as_option_mut());
     (h.deleter)(h);
-}
-
-/// This function casts an owning [`iox2_unique_listener_id_h`] into a non-owning
-/// [`iox2_unique_listener_id_h_ref`]
-///
-/// Returns a [`iox2_unique_listener_id_h_ref`]
-///
-/// # Safety
-///
-/// * The `listener_handle` must be a valid handle.
-/// * The `listener_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_unique_listener_id_h_ref(
-    handle: iox2_unique_listener_id_h,
-) -> iox2_unique_listener_id_h_ref {
-    debug_assert!(!handle.is_null());
-
-    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Checks two [`iox2_unique_listener_id_t`] for equality.
@@ -120,8 +115,8 @@ pub unsafe extern "C" fn iox2_unique_listener_id_eq(
     lhs: iox2_unique_listener_id_h_ref,
     rhs: iox2_unique_listener_id_h_ref,
 ) -> bool {
-    debug_assert!(!lhs.is_null());
-    debug_assert!(!rhs.is_null());
+    lhs.assert_non_null();
+    rhs.assert_non_null();
 
     let lhs = &mut *lhs.as_type();
     let rhs = &mut *rhs.as_type();
@@ -140,8 +135,8 @@ pub unsafe extern "C" fn iox2_unique_listener_id_less(
     lhs: iox2_unique_listener_id_h_ref,
     rhs: iox2_unique_listener_id_h_ref,
 ) -> bool {
-    debug_assert!(!lhs.is_null());
-    debug_assert!(!rhs.is_null());
+    lhs.assert_non_null();
+    rhs.assert_non_null();
 
     let lhs = &mut *lhs.as_type();
     let rhs = &mut *rhs.as_type();

--- a/iceoryx2-ffi/ffi/src/api/unique_listener_id.rs
+++ b/iceoryx2-ffi/ffi/src/api/unique_listener_id.rs
@@ -49,9 +49,9 @@ pub struct iox2_unique_listener_id_h_t;
 /// The owning handle for [`iox2_unique_listener_id_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_unique_listener_id_h = *mut iox2_unique_listener_id_h_t;
 
-pub struct iox2_unique_listener_id_ref_h_t;
+pub struct iox2_unique_listener_id_h_ref_t;
 /// The non-owning handle for [`iox2_unique_listener_id_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_unique_listener_id_ref_h = *mut iox2_unique_listener_id_ref_h_t;
+pub type iox2_unique_listener_id_h_ref = *mut iox2_unique_listener_id_h_ref_t;
 
 impl HandleToType for iox2_unique_listener_id_h {
     type Target = *mut iox2_unique_listener_id_t;
@@ -61,7 +61,7 @@ impl HandleToType for iox2_unique_listener_id_h {
     }
 }
 
-impl HandleToType for iox2_unique_listener_id_ref_h {
+impl HandleToType for iox2_unique_listener_id_h_ref {
     type Target = *mut iox2_unique_listener_id_t;
 
     fn as_type(self) -> Self::Target {
@@ -92,33 +92,33 @@ pub unsafe extern "C" fn iox2_unique_listener_id_drop(handle: iox2_unique_listen
 }
 
 /// This function casts an owning [`iox2_unique_listener_id_h`] into a non-owning
-/// [`iox2_unique_listener_id_ref_h`]
+/// [`iox2_unique_listener_id_h_ref`]
 ///
-/// Returns a [`iox2_unique_listener_id_ref_h`]
+/// Returns a [`iox2_unique_listener_id_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `listener_handle` must be a valid handle.
 /// * The `listener_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_unique_listener_id_ref_h(
+pub unsafe extern "C" fn iox2_cast_unique_listener_id_h_ref(
     handle: iox2_unique_listener_id_h,
-) -> iox2_unique_listener_id_ref_h {
+) -> iox2_unique_listener_id_h_ref {
     debug_assert!(!handle.is_null());
 
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Checks two [`iox2_unique_listener_id_t`] for equality.
 ///
 /// # Safety
 ///
-/// * `lhs` - Must be a valid [`iox2_unique_listener_id_ref_h`]
-/// * `rhs` - Must be a valid [`iox2_unique_listener_id_ref_h`]
+/// * `lhs` - Must be a valid [`iox2_unique_listener_id_h_ref`]
+/// * `rhs` - Must be a valid [`iox2_unique_listener_id_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_listener_id_eq(
-    lhs: iox2_unique_listener_id_ref_h,
-    rhs: iox2_unique_listener_id_ref_h,
+    lhs: iox2_unique_listener_id_h_ref,
+    rhs: iox2_unique_listener_id_h_ref,
 ) -> bool {
     debug_assert!(!lhs.is_null());
     debug_assert!(!rhs.is_null());
@@ -133,12 +133,12 @@ pub unsafe extern "C" fn iox2_unique_listener_id_eq(
 ///
 /// # Safety
 ///
-/// * `lhs` - Must be a valid [`iox2_unique_listener_id_ref_h`]
-/// * `rhs` - Must be a valid [`iox2_unique_listener_id_ref_h`]
+/// * `lhs` - Must be a valid [`iox2_unique_listener_id_h_ref`]
+/// * `rhs` - Must be a valid [`iox2_unique_listener_id_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_listener_id_less(
-    lhs: iox2_unique_listener_id_ref_h,
-    rhs: iox2_unique_listener_id_ref_h,
+    lhs: iox2_unique_listener_id_h_ref,
+    rhs: iox2_unique_listener_id_h_ref,
 ) -> bool {
     debug_assert!(!lhs.is_null());
     debug_assert!(!rhs.is_null());

--- a/iceoryx2-ffi/ffi/src/api/unique_notifier_id.rs
+++ b/iceoryx2-ffi/ffi/src/api/unique_notifier_id.rs
@@ -16,7 +16,7 @@ use iceoryx2::port::port_identifiers::UniqueNotifierId;
 use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
-use super::HandleToType;
+use crate::api::{AssertNonNullHandle, HandleToType};
 
 // BEGIN types definition
 
@@ -48,10 +48,23 @@ impl iox2_unique_notifier_id_t {
 pub struct iox2_unique_notifier_id_h_t;
 /// The owning handle for [`iox2_unique_notifier_id_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_unique_notifier_id_h = *mut iox2_unique_notifier_id_h_t;
-
-pub struct iox2_unique_notifier_id_h_ref_t;
 /// The non-owning handle for [`iox2_unique_notifier_id_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_unique_notifier_id_h_ref = *mut iox2_unique_notifier_id_h_ref_t;
+pub type iox2_unique_notifier_id_h_ref = *const iox2_unique_notifier_id_h;
+
+impl AssertNonNullHandle for iox2_unique_notifier_id_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_unique_notifier_id_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_unique_notifier_id_h {
     type Target = *mut iox2_unique_notifier_id_t;
@@ -65,7 +78,7 @@ impl HandleToType for iox2_unique_notifier_id_h_ref {
     type Target = *mut iox2_unique_notifier_id_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -91,24 +104,6 @@ pub unsafe extern "C" fn iox2_unique_notifier_id_drop(handle: iox2_unique_notifi
     (h.deleter)(h);
 }
 
-/// This function casts an owning [`iox2_unique_notifier_id_h`] into a non-owning
-/// [`iox2_unique_notifier_id_h_ref`]
-///
-/// Returns a [`iox2_unique_notifier_id_h_ref`]
-///
-/// # Safety
-///
-/// * The `notifier_handle` must be a valid handle.
-/// * The `notifier_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_unique_notifier_id_h_ref(
-    handle: iox2_unique_notifier_id_h,
-) -> iox2_unique_notifier_id_h_ref {
-    debug_assert!(!handle.is_null());
-
-    (*handle.as_type()).as_h_refandle() as *mut _ as _
-}
-
 /// Checks two [`iox2_unique_notifier_id_t`] for equality.
 ///
 /// # Safety
@@ -120,8 +115,8 @@ pub unsafe extern "C" fn iox2_unique_notifier_id_eq(
     lhs: iox2_unique_notifier_id_h_ref,
     rhs: iox2_unique_notifier_id_h_ref,
 ) -> bool {
-    debug_assert!(!lhs.is_null());
-    debug_assert!(!rhs.is_null());
+    lhs.assert_non_null();
+    rhs.assert_non_null();
 
     let lhs = &mut *lhs.as_type();
     let rhs = &mut *rhs.as_type();
@@ -140,8 +135,8 @@ pub unsafe extern "C" fn iox2_unique_notifier_id_less(
     lhs: iox2_unique_notifier_id_h_ref,
     rhs: iox2_unique_notifier_id_h_ref,
 ) -> bool {
-    debug_assert!(!lhs.is_null());
-    debug_assert!(!rhs.is_null());
+    lhs.assert_non_null();
+    rhs.assert_non_null();
 
     let lhs = &mut *lhs.as_type();
     let rhs = &mut *rhs.as_type();

--- a/iceoryx2-ffi/ffi/src/api/unique_notifier_id.rs
+++ b/iceoryx2-ffi/ffi/src/api/unique_notifier_id.rs
@@ -49,9 +49,9 @@ pub struct iox2_unique_notifier_id_h_t;
 /// The owning handle for [`iox2_unique_notifier_id_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_unique_notifier_id_h = *mut iox2_unique_notifier_id_h_t;
 
-pub struct iox2_unique_notifier_id_ref_h_t;
+pub struct iox2_unique_notifier_id_h_ref_t;
 /// The non-owning handle for [`iox2_unique_notifier_id_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_unique_notifier_id_ref_h = *mut iox2_unique_notifier_id_ref_h_t;
+pub type iox2_unique_notifier_id_h_ref = *mut iox2_unique_notifier_id_h_ref_t;
 
 impl HandleToType for iox2_unique_notifier_id_h {
     type Target = *mut iox2_unique_notifier_id_t;
@@ -61,7 +61,7 @@ impl HandleToType for iox2_unique_notifier_id_h {
     }
 }
 
-impl HandleToType for iox2_unique_notifier_id_ref_h {
+impl HandleToType for iox2_unique_notifier_id_h_ref {
     type Target = *mut iox2_unique_notifier_id_t;
 
     fn as_type(self) -> Self::Target {
@@ -92,33 +92,33 @@ pub unsafe extern "C" fn iox2_unique_notifier_id_drop(handle: iox2_unique_notifi
 }
 
 /// This function casts an owning [`iox2_unique_notifier_id_h`] into a non-owning
-/// [`iox2_unique_notifier_id_ref_h`]
+/// [`iox2_unique_notifier_id_h_ref`]
 ///
-/// Returns a [`iox2_unique_notifier_id_ref_h`]
+/// Returns a [`iox2_unique_notifier_id_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `notifier_handle` must be a valid handle.
 /// * The `notifier_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_unique_notifier_id_ref_h(
+pub unsafe extern "C" fn iox2_cast_unique_notifier_id_h_ref(
     handle: iox2_unique_notifier_id_h,
-) -> iox2_unique_notifier_id_ref_h {
+) -> iox2_unique_notifier_id_h_ref {
     debug_assert!(!handle.is_null());
 
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Checks two [`iox2_unique_notifier_id_t`] for equality.
 ///
 /// # Safety
 ///
-/// * `lhs` - Must be a valid [`iox2_unique_notifier_id_ref_h`]
-/// * `rhs` - Must be a valid [`iox2_unique_notifier_id_ref_h`]
+/// * `lhs` - Must be a valid [`iox2_unique_notifier_id_h_ref`]
+/// * `rhs` - Must be a valid [`iox2_unique_notifier_id_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_notifier_id_eq(
-    lhs: iox2_unique_notifier_id_ref_h,
-    rhs: iox2_unique_notifier_id_ref_h,
+    lhs: iox2_unique_notifier_id_h_ref,
+    rhs: iox2_unique_notifier_id_h_ref,
 ) -> bool {
     debug_assert!(!lhs.is_null());
     debug_assert!(!rhs.is_null());
@@ -133,12 +133,12 @@ pub unsafe extern "C" fn iox2_unique_notifier_id_eq(
 ///
 /// # Safety
 ///
-/// * `lhs` - Must be a valid [`iox2_unique_notifier_id_ref_h`]
-/// * `rhs` - Must be a valid [`iox2_unique_notifier_id_ref_h`]
+/// * `lhs` - Must be a valid [`iox2_unique_notifier_id_h_ref`]
+/// * `rhs` - Must be a valid [`iox2_unique_notifier_id_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_notifier_id_less(
-    lhs: iox2_unique_notifier_id_ref_h,
-    rhs: iox2_unique_notifier_id_ref_h,
+    lhs: iox2_unique_notifier_id_h_ref,
+    rhs: iox2_unique_notifier_id_h_ref,
 ) -> bool {
     debug_assert!(!lhs.is_null());
     debug_assert!(!rhs.is_null());

--- a/iceoryx2-ffi/ffi/src/api/unique_publisher_id.rs
+++ b/iceoryx2-ffi/ffi/src/api/unique_publisher_id.rs
@@ -49,9 +49,9 @@ pub struct iox2_unique_publisher_id_h_t;
 /// The owning handle for [`iox2_unique_publisher_id_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_unique_publisher_id_h = *mut iox2_unique_publisher_id_h_t;
 
-pub struct iox2_unique_publisher_id_ref_h_t;
+pub struct iox2_unique_publisher_id_h_ref_t;
 /// The non-owning handle for [`iox2_unique_publisher_id_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_unique_publisher_id_ref_h = *mut iox2_unique_publisher_id_ref_h_t;
+pub type iox2_unique_publisher_id_h_ref = *mut iox2_unique_publisher_id_h_ref_t;
 
 impl HandleToType for iox2_unique_publisher_id_h {
     type Target = *mut iox2_unique_publisher_id_t;
@@ -61,7 +61,7 @@ impl HandleToType for iox2_unique_publisher_id_h {
     }
 }
 
-impl HandleToType for iox2_unique_publisher_id_ref_h {
+impl HandleToType for iox2_unique_publisher_id_h_ref {
     type Target = *mut iox2_unique_publisher_id_t;
 
     fn as_type(self) -> Self::Target {
@@ -92,33 +92,33 @@ pub unsafe extern "C" fn iox2_unique_publisher_id_drop(handle: iox2_unique_publi
 }
 
 /// This function casts an owning [`iox2_unique_publisher_id_h`] into a non-owning
-/// [`iox2_unique_publisher_id_ref_h`]
+/// [`iox2_unique_publisher_id_h_ref`]
 ///
-/// Returns a [`iox2_unique_publisher_id_ref_h`]
+/// Returns a [`iox2_unique_publisher_id_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `publisher_handle` must be a valid handle.
 /// * The `publisher_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_unique_publisher_id_ref_h(
+pub unsafe extern "C" fn iox2_cast_unique_publisher_id_h_ref(
     handle: iox2_unique_publisher_id_h,
-) -> iox2_unique_publisher_id_ref_h {
+) -> iox2_unique_publisher_id_h_ref {
     debug_assert!(!handle.is_null());
 
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Checks two [`iox2_unique_publisher_id_t`] for equality.
 ///
 /// # Safety
 ///
-/// * `lhs` - Must be a valid [`iox2_unique_publisher_id_ref_h`]
-/// * `rhs` - Must be a valid [`iox2_unique_publisher_id_ref_h`]
+/// * `lhs` - Must be a valid [`iox2_unique_publisher_id_h_ref`]
+/// * `rhs` - Must be a valid [`iox2_unique_publisher_id_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_publisher_id_eq(
-    lhs: iox2_unique_publisher_id_ref_h,
-    rhs: iox2_unique_publisher_id_ref_h,
+    lhs: iox2_unique_publisher_id_h_ref,
+    rhs: iox2_unique_publisher_id_h_ref,
 ) -> bool {
     debug_assert!(!lhs.is_null());
     debug_assert!(!rhs.is_null());
@@ -133,12 +133,12 @@ pub unsafe extern "C" fn iox2_unique_publisher_id_eq(
 ///
 /// # Safety
 ///
-/// * `lhs` - Must be a valid [`iox2_unique_publisher_id_ref_h`]
-/// * `rhs` - Must be a valid [`iox2_unique_publisher_id_ref_h`]
+/// * `lhs` - Must be a valid [`iox2_unique_publisher_id_h_ref`]
+/// * `rhs` - Must be a valid [`iox2_unique_publisher_id_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_publisher_id_less(
-    lhs: iox2_unique_publisher_id_ref_h,
-    rhs: iox2_unique_publisher_id_ref_h,
+    lhs: iox2_unique_publisher_id_h_ref,
+    rhs: iox2_unique_publisher_id_h_ref,
 ) -> bool {
     debug_assert!(!lhs.is_null());
     debug_assert!(!rhs.is_null());

--- a/iceoryx2-ffi/ffi/src/api/unique_publisher_id.rs
+++ b/iceoryx2-ffi/ffi/src/api/unique_publisher_id.rs
@@ -16,7 +16,7 @@ use iceoryx2::port::port_identifiers::UniquePublisherId;
 use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
-use super::HandleToType;
+use crate::api::{AssertNonNullHandle, HandleToType};
 
 // BEGIN types definition
 
@@ -48,10 +48,23 @@ impl iox2_unique_publisher_id_t {
 pub struct iox2_unique_publisher_id_h_t;
 /// The owning handle for [`iox2_unique_publisher_id_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_unique_publisher_id_h = *mut iox2_unique_publisher_id_h_t;
-
-pub struct iox2_unique_publisher_id_h_ref_t;
 /// The non-owning handle for [`iox2_unique_publisher_id_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_unique_publisher_id_h_ref = *mut iox2_unique_publisher_id_h_ref_t;
+pub type iox2_unique_publisher_id_h_ref = *const iox2_unique_publisher_id_h;
+
+impl AssertNonNullHandle for iox2_unique_publisher_id_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_unique_publisher_id_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_unique_publisher_id_h {
     type Target = *mut iox2_unique_publisher_id_t;
@@ -65,7 +78,7 @@ impl HandleToType for iox2_unique_publisher_id_h_ref {
     type Target = *mut iox2_unique_publisher_id_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -84,29 +97,11 @@ impl HandleToType for iox2_unique_publisher_id_h_ref {
 /// * The `handle` is invalid after the return of this function and leads to undefined behavior if used in another function call!
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_publisher_id_drop(handle: iox2_unique_publisher_id_h) {
-    debug_assert!(!handle.is_null());
+    handle.assert_non_null();
 
     let h = &mut *handle.as_type();
     core::ptr::drop_in_place(h.value.as_option_mut());
     (h.deleter)(h);
-}
-
-/// This function casts an owning [`iox2_unique_publisher_id_h`] into a non-owning
-/// [`iox2_unique_publisher_id_h_ref`]
-///
-/// Returns a [`iox2_unique_publisher_id_h_ref`]
-///
-/// # Safety
-///
-/// * The `publisher_handle` must be a valid handle.
-/// * The `publisher_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_unique_publisher_id_h_ref(
-    handle: iox2_unique_publisher_id_h,
-) -> iox2_unique_publisher_id_h_ref {
-    debug_assert!(!handle.is_null());
-
-    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Checks two [`iox2_unique_publisher_id_t`] for equality.
@@ -120,8 +115,8 @@ pub unsafe extern "C" fn iox2_unique_publisher_id_eq(
     lhs: iox2_unique_publisher_id_h_ref,
     rhs: iox2_unique_publisher_id_h_ref,
 ) -> bool {
-    debug_assert!(!lhs.is_null());
-    debug_assert!(!rhs.is_null());
+    lhs.assert_non_null();
+    rhs.assert_non_null();
 
     let lhs = &mut *lhs.as_type();
     let rhs = &mut *rhs.as_type();
@@ -140,8 +135,8 @@ pub unsafe extern "C" fn iox2_unique_publisher_id_less(
     lhs: iox2_unique_publisher_id_h_ref,
     rhs: iox2_unique_publisher_id_h_ref,
 ) -> bool {
-    debug_assert!(!lhs.is_null());
-    debug_assert!(!rhs.is_null());
+    lhs.assert_non_null();
+    rhs.assert_non_null();
 
     let lhs = &mut *lhs.as_type();
     let rhs = &mut *rhs.as_type();

--- a/iceoryx2-ffi/ffi/src/api/unique_subscriber_id.rs
+++ b/iceoryx2-ffi/ffi/src/api/unique_subscriber_id.rs
@@ -16,7 +16,7 @@ use iceoryx2::port::port_identifiers::UniqueSubscriberId;
 use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
-use super::HandleToType;
+use crate::api::{AssertNonNullHandle, HandleToType};
 
 // BEGIN types definition
 
@@ -48,10 +48,23 @@ impl iox2_unique_subscriber_id_t {
 pub struct iox2_unique_subscriber_id_h_t;
 /// The owning handle for [`iox2_unique_subscriber_id_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_unique_subscriber_id_h = *mut iox2_unique_subscriber_id_h_t;
-
-pub struct iox2_unique_subscriber_id_h_ref_t;
 /// The non-owning handle for [`iox2_unique_subscriber_id_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_unique_subscriber_id_h_ref = *mut iox2_unique_subscriber_id_h_ref_t;
+pub type iox2_unique_subscriber_id_h_ref = *const iox2_unique_subscriber_id_h;
+
+impl AssertNonNullHandle for iox2_unique_subscriber_id_h {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+    }
+}
+
+impl AssertNonNullHandle for iox2_unique_subscriber_id_h_ref {
+    fn assert_non_null(self) {
+        debug_assert!(!self.is_null());
+        unsafe {
+            debug_assert!(!(*self).is_null());
+        }
+    }
+}
 
 impl HandleToType for iox2_unique_subscriber_id_h {
     type Target = *mut iox2_unique_subscriber_id_t;
@@ -65,7 +78,7 @@ impl HandleToType for iox2_unique_subscriber_id_h_ref {
     type Target = *mut iox2_unique_subscriber_id_t;
 
     fn as_type(self) -> Self::Target {
-        self as *mut _ as _
+        unsafe { *self as *mut _ as _ }
     }
 }
 
@@ -91,24 +104,6 @@ pub unsafe extern "C" fn iox2_unique_subscriber_id_drop(handle: iox2_unique_subs
     (h.deleter)(h);
 }
 
-/// This function casts an owning [`iox2_unique_subscriber_id_h`] into a non-owning
-/// [`iox2_unique_subscriber_id_h_ref`]
-///
-/// Returns a [`iox2_unique_subscriber_id_h_ref`]
-///
-/// # Safety
-///
-/// * The `subscriber_handle` must be a valid handle.
-/// * The `subscriber_handle` is still valid after the call to this function.
-#[no_mangle]
-pub unsafe extern "C" fn iox2_cast_unique_subscriber_id_h_ref(
-    handle: iox2_unique_subscriber_id_h,
-) -> iox2_unique_subscriber_id_h_ref {
-    debug_assert!(!handle.is_null());
-
-    (*handle.as_type()).as_h_refandle() as *mut _ as _
-}
-
 /// Checks two [`iox2_unique_subscriber_id_t`] for equality.
 ///
 /// # Safety
@@ -120,8 +115,8 @@ pub unsafe extern "C" fn iox2_unique_subscriber_id_eq(
     lhs: iox2_unique_subscriber_id_h_ref,
     rhs: iox2_unique_subscriber_id_h_ref,
 ) -> bool {
-    debug_assert!(!lhs.is_null());
-    debug_assert!(!rhs.is_null());
+    lhs.assert_non_null();
+    rhs.assert_non_null();
 
     let lhs = &mut *lhs.as_type();
     let rhs = &mut *rhs.as_type();
@@ -140,8 +135,8 @@ pub unsafe extern "C" fn iox2_unique_subscriber_id_less(
     lhs: iox2_unique_subscriber_id_h_ref,
     rhs: iox2_unique_subscriber_id_h_ref,
 ) -> bool {
-    debug_assert!(!lhs.is_null());
-    debug_assert!(!rhs.is_null());
+    lhs.assert_non_null();
+    rhs.assert_non_null();
 
     let lhs = &mut *lhs.as_type();
     let rhs = &mut *rhs.as_type();

--- a/iceoryx2-ffi/ffi/src/api/unique_subscriber_id.rs
+++ b/iceoryx2-ffi/ffi/src/api/unique_subscriber_id.rs
@@ -49,9 +49,9 @@ pub struct iox2_unique_subscriber_id_h_t;
 /// The owning handle for [`iox2_unique_subscriber_id_t`]. Passing the handle to an function transfers the ownership.
 pub type iox2_unique_subscriber_id_h = *mut iox2_unique_subscriber_id_h_t;
 
-pub struct iox2_unique_subscriber_id_ref_h_t;
+pub struct iox2_unique_subscriber_id_h_ref_t;
 /// The non-owning handle for [`iox2_unique_subscriber_id_t`]. Passing the handle to an function does not transfers the ownership.
-pub type iox2_unique_subscriber_id_ref_h = *mut iox2_unique_subscriber_id_ref_h_t;
+pub type iox2_unique_subscriber_id_h_ref = *mut iox2_unique_subscriber_id_h_ref_t;
 
 impl HandleToType for iox2_unique_subscriber_id_h {
     type Target = *mut iox2_unique_subscriber_id_t;
@@ -61,7 +61,7 @@ impl HandleToType for iox2_unique_subscriber_id_h {
     }
 }
 
-impl HandleToType for iox2_unique_subscriber_id_ref_h {
+impl HandleToType for iox2_unique_subscriber_id_h_ref {
     type Target = *mut iox2_unique_subscriber_id_t;
 
     fn as_type(self) -> Self::Target {
@@ -92,33 +92,33 @@ pub unsafe extern "C" fn iox2_unique_subscriber_id_drop(handle: iox2_unique_subs
 }
 
 /// This function casts an owning [`iox2_unique_subscriber_id_h`] into a non-owning
-/// [`iox2_unique_subscriber_id_ref_h`]
+/// [`iox2_unique_subscriber_id_h_ref`]
 ///
-/// Returns a [`iox2_unique_subscriber_id_ref_h`]
+/// Returns a [`iox2_unique_subscriber_id_h_ref`]
 ///
 /// # Safety
 ///
 /// * The `subscriber_handle` must be a valid handle.
 /// * The `subscriber_handle` is still valid after the call to this function.
 #[no_mangle]
-pub unsafe extern "C" fn iox2_cast_unique_subscriber_id_ref_h(
+pub unsafe extern "C" fn iox2_cast_unique_subscriber_id_h_ref(
     handle: iox2_unique_subscriber_id_h,
-) -> iox2_unique_subscriber_id_ref_h {
+) -> iox2_unique_subscriber_id_h_ref {
     debug_assert!(!handle.is_null());
 
-    (*handle.as_type()).as_ref_handle() as *mut _ as _
+    (*handle.as_type()).as_h_refandle() as *mut _ as _
 }
 
 /// Checks two [`iox2_unique_subscriber_id_t`] for equality.
 ///
 /// # Safety
 ///
-/// * `lhs` - Must be a valid [`iox2_unique_subscriber_id_ref_h`]
-/// * `rhs` - Must be a valid [`iox2_unique_subscriber_id_ref_h`]
+/// * `lhs` - Must be a valid [`iox2_unique_subscriber_id_h_ref`]
+/// * `rhs` - Must be a valid [`iox2_unique_subscriber_id_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_subscriber_id_eq(
-    lhs: iox2_unique_subscriber_id_ref_h,
-    rhs: iox2_unique_subscriber_id_ref_h,
+    lhs: iox2_unique_subscriber_id_h_ref,
+    rhs: iox2_unique_subscriber_id_h_ref,
 ) -> bool {
     debug_assert!(!lhs.is_null());
     debug_assert!(!rhs.is_null());
@@ -133,12 +133,12 @@ pub unsafe extern "C" fn iox2_unique_subscriber_id_eq(
 ///
 /// # Safety
 ///
-/// * `lhs` - Must be a valid [`iox2_unique_subscriber_id_ref_h`]
-/// * `rhs` - Must be a valid [`iox2_unique_subscriber_id_ref_h`]
+/// * `lhs` - Must be a valid [`iox2_unique_subscriber_id_h_ref`]
+/// * `rhs` - Must be a valid [`iox2_unique_subscriber_id_h_ref`]
 #[no_mangle]
 pub unsafe extern "C" fn iox2_unique_subscriber_id_less(
-    lhs: iox2_unique_subscriber_id_ref_h,
-    rhs: iox2_unique_subscriber_id_ref_h,
+    lhs: iox2_unique_subscriber_id_h_ref,
+    rhs: iox2_unique_subscriber_id_h_ref,
 ) -> bool {
     debug_assert!(!lhs.is_null());
     debug_assert!(!rhs.is_null());

--- a/iceoryx2-ffi/ffi/src/tests/listener_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/listener_tests.rs
@@ -19,11 +19,10 @@ mod service_builder {
         unsafe {
             let node_handle = create_node::<S>("bar");
 
-            let event_service_handle =
-                create_event_service(iox2_cast_node_h_ref(node_handle), "all/glory/to/hypnotaod");
+            let event_service_handle = create_event_service(&node_handle, "all/glory/to/hypnotaod");
 
             let listener_builder_handle = iox2_port_factory_event_listener_builder(
-                iox2_cast_port_factory_event_h_ref(event_service_handle),
+                &event_service_handle,
                 std::ptr::null_mut(),
             );
 

--- a/iceoryx2-ffi/ffi/src/tests/listener_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/listener_tests.rs
@@ -20,10 +20,10 @@ mod service_builder {
             let node_handle = create_node::<S>("bar");
 
             let event_service_handle =
-                create_event_service(iox2_cast_node_ref_h(node_handle), "all/glory/to/hypnotaod");
+                create_event_service(iox2_cast_node_h_ref(node_handle), "all/glory/to/hypnotaod");
 
             let listener_builder_handle = iox2_port_factory_event_listener_builder(
-                iox2_cast_port_factory_event_ref_h(event_service_handle),
+                iox2_cast_port_factory_event_h_ref(event_service_handle),
                 std::ptr::null_mut(),
             );
 

--- a/iceoryx2-ffi/ffi/src/tests/mod.rs
+++ b/iceoryx2-ffi/ffi/src/tests/mod.rs
@@ -53,7 +53,7 @@ fn create_node<S: Service + ServiceTypeMapping>(node_name: &str) -> iox2_node_h 
         );
         assert_that!(ret_val, eq(IOX2_OK));
         iox2_node_builder_set_name(
-            iox2_cast_node_builder_h_ref(node_builder_handle),
+            &node_builder_handle,
             iox2_cast_node_name_ptr(node_name_handle),
         );
         iox2_node_name_drop(node_name_handle);
@@ -94,14 +94,8 @@ fn create_event_service(
         iox2_service_name_drop(service_name_handle);
 
         let service_builder_handle = iox2_service_builder_event(service_builder_handle);
-        iox2_service_builder_event_set_max_notifiers(
-            iox2_cast_service_builder_event_h_ref(service_builder_handle),
-            10,
-        );
-        iox2_service_builder_event_set_max_listeners(
-            iox2_cast_service_builder_event_h_ref(service_builder_handle),
-            10,
-        );
+        iox2_service_builder_event_set_max_notifiers(&service_builder_handle, 10);
+        iox2_service_builder_event_set_max_listeners(&service_builder_handle, 10);
 
         let mut event_factory: iox2_port_factory_event_h = std::ptr::null_mut();
         let ret_val = iox2_service_builder_event_open_or_create(

--- a/iceoryx2-ffi/ffi/src/tests/mod.rs
+++ b/iceoryx2-ffi/ffi/src/tests/mod.rs
@@ -53,7 +53,7 @@ fn create_node<S: Service + ServiceTypeMapping>(node_name: &str) -> iox2_node_h 
         );
         assert_that!(ret_val, eq(IOX2_OK));
         iox2_node_builder_set_name(
-            iox2_cast_node_builder_ref_h(node_builder_handle),
+            iox2_cast_node_builder_h_ref(node_builder_handle),
             iox2_cast_node_name_ptr(node_name_handle),
         );
         iox2_node_name_drop(node_name_handle);
@@ -73,7 +73,7 @@ fn create_node<S: Service + ServiceTypeMapping>(node_name: &str) -> iox2_node_h 
 }
 
 fn create_event_service(
-    node_handle: iox2_node_ref_h,
+    node_handle: iox2_node_h_ref,
     service_name: &str,
 ) -> iox2_port_factory_event_h {
     unsafe {
@@ -95,11 +95,11 @@ fn create_event_service(
 
         let service_builder_handle = iox2_service_builder_event(service_builder_handle);
         iox2_service_builder_event_set_max_notifiers(
-            iox2_cast_service_builder_event_ref_h(service_builder_handle),
+            iox2_cast_service_builder_event_h_ref(service_builder_handle),
             10,
         );
         iox2_service_builder_event_set_max_listeners(
-            iox2_cast_service_builder_event_ref_h(service_builder_handle),
+            iox2_cast_service_builder_event_h_ref(service_builder_handle),
             10,
         );
 

--- a/iceoryx2-ffi/ffi/src/tests/node_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/node_tests.rs
@@ -12,7 +12,7 @@
 
 #[generic_tests::define]
 mod node {
-    use crate::{iox2_cast_node_ref_h, tests::*};
+    use crate::{iox2_cast_node_h_ref, tests::*};
 
     use core::{slice, str};
 
@@ -34,7 +34,7 @@ mod node {
 
             let expected_config = Config::global_config();
 
-            let config = iox2_node_config(iox2_cast_node_ref_h(node_handle));
+            let config = iox2_node_config(iox2_cast_node_h_ref(node_handle));
 
             assert_that!(*(config as *const Config), eq(*expected_config));
 
@@ -48,7 +48,7 @@ mod node {
         unsafe {
             let node_handle = create_node::<S>("hypnotoad");
 
-            let node_name = iox2_node_name(iox2_cast_node_ref_h(node_handle));
+            let node_name = iox2_node_name(iox2_cast_node_h_ref(node_handle));
 
             let mut node_name_len = 0;
             let node_name_chars = iox2_node_name_as_chars(node_name, &mut node_name_len);
@@ -104,7 +104,7 @@ mod node {
         unsafe {
             let mut ctx = NodeListCtx::default();
             let node_handle = create_node::<S>("");
-            let config = iox2_node_config(iox2_cast_node_ref_h(node_handle));
+            let config = iox2_node_config(iox2_cast_node_h_ref(node_handle));
 
             let ret_val = iox2_node_list(
                 S::service_type(),

--- a/iceoryx2-ffi/ffi/src/tests/node_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/node_tests.rs
@@ -12,7 +12,7 @@
 
 #[generic_tests::define]
 mod node {
-    use crate::{iox2_cast_node_h_ref, tests::*};
+    use crate::tests::*;
 
     use core::{slice, str};
 
@@ -34,7 +34,7 @@ mod node {
 
             let expected_config = Config::global_config();
 
-            let config = iox2_node_config(iox2_cast_node_h_ref(node_handle));
+            let config = iox2_node_config(&node_handle);
 
             assert_that!(*(config as *const Config), eq(*expected_config));
 
@@ -48,7 +48,7 @@ mod node {
         unsafe {
             let node_handle = create_node::<S>("hypnotoad");
 
-            let node_name = iox2_node_name(iox2_cast_node_h_ref(node_handle));
+            let node_name = iox2_node_name(&node_handle);
 
             let mut node_name_len = 0;
             let node_name_chars = iox2_node_name_as_chars(node_name, &mut node_name_len);
@@ -104,7 +104,7 @@ mod node {
         unsafe {
             let mut ctx = NodeListCtx::default();
             let node_handle = create_node::<S>("");
-            let config = iox2_node_config(iox2_cast_node_h_ref(node_handle));
+            let config = iox2_node_config(&node_handle);
 
             let ret_val = iox2_node_list(
                 S::service_type(),

--- a/iceoryx2-ffi/ffi/src/tests/notifier_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/notifier_tests.rs
@@ -20,10 +20,10 @@ mod service_builder {
             let node_handle = create_node::<S>("bar");
 
             let event_service_handle =
-                create_event_service(iox2_cast_node_ref_h(node_handle), "all/glory/to/hypnotaod");
+                create_event_service(iox2_cast_node_h_ref(node_handle), "all/glory/to/hypnotaod");
 
             let notifier_builder_handle = iox2_port_factory_event_notifier_builder(
-                iox2_cast_port_factory_event_ref_h(event_service_handle),
+                iox2_cast_port_factory_event_h_ref(event_service_handle),
                 std::ptr::null_mut(),
             );
 

--- a/iceoryx2-ffi/ffi/src/tests/notifier_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/notifier_tests.rs
@@ -19,11 +19,10 @@ mod service_builder {
         unsafe {
             let node_handle = create_node::<S>("bar");
 
-            let event_service_handle =
-                create_event_service(iox2_cast_node_h_ref(node_handle), "all/glory/to/hypnotaod");
+            let event_service_handle = create_event_service(&node_handle, "all/glory/to/hypnotaod");
 
             let notifier_builder_handle = iox2_port_factory_event_notifier_builder(
-                iox2_cast_port_factory_event_h_ref(event_service_handle),
+                &event_service_handle,
                 std::ptr::null_mut(),
             );
 

--- a/iceoryx2-ffi/ffi/src/tests/service_builder_event_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/service_builder_event_tests.rs
@@ -31,7 +31,7 @@ mod service_builder {
             assert_that!(ret_val, eq(IOX2_OK));
 
             let service_builder_handle = iox2_node_service_builder(
-                iox2_cast_node_ref_h(node_handle),
+                iox2_cast_node_h_ref(node_handle),
                 std::ptr::null_mut(),
                 iox2_cast_service_name_ptr(service_name_handle),
             );
@@ -39,11 +39,11 @@ mod service_builder {
 
             let service_builder_handle = iox2_service_builder_event(service_builder_handle);
             iox2_service_builder_event_set_max_notifiers(
-                iox2_cast_service_builder_event_ref_h(service_builder_handle),
+                iox2_cast_service_builder_event_h_ref(service_builder_handle),
                 10,
             );
             iox2_service_builder_event_set_max_listeners(
-                iox2_cast_service_builder_event_ref_h(service_builder_handle),
+                iox2_cast_service_builder_event_h_ref(service_builder_handle),
                 10,
             );
 

--- a/iceoryx2-ffi/ffi/src/tests/service_builder_event_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/service_builder_event_tests.rs
@@ -31,21 +31,15 @@ mod service_builder {
             assert_that!(ret_val, eq(IOX2_OK));
 
             let service_builder_handle = iox2_node_service_builder(
-                iox2_cast_node_h_ref(node_handle),
+                &node_handle,
                 std::ptr::null_mut(),
                 iox2_cast_service_name_ptr(service_name_handle),
             );
             iox2_service_name_drop(service_name_handle);
 
             let service_builder_handle = iox2_service_builder_event(service_builder_handle);
-            iox2_service_builder_event_set_max_notifiers(
-                iox2_cast_service_builder_event_h_ref(service_builder_handle),
-                10,
-            );
-            iox2_service_builder_event_set_max_listeners(
-                iox2_cast_service_builder_event_h_ref(service_builder_handle),
-                10,
-            );
+            iox2_service_builder_event_set_max_notifiers(&service_builder_handle, 10);
+            iox2_service_builder_event_set_max_listeners(&service_builder_handle, 10);
 
             let mut event_factory: iox2_port_factory_event_h = std::ptr::null_mut();
             let ret_val = iox2_service_builder_event_open_or_create(

--- a/iceoryx2-ffi/ffi/src/tests/service_builder_pub_sub_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/service_builder_pub_sub_tests.rs
@@ -31,21 +31,15 @@ mod service_builder {
             assert_that!(ret_val, eq(IOX2_OK));
 
             let service_builder_handle = iox2_node_service_builder(
-                iox2_cast_node_h_ref(node_handle),
+                &node_handle,
                 std::ptr::null_mut(),
                 iox2_cast_service_name_ptr(service_name_handle),
             );
             iox2_service_name_drop(service_name_handle);
 
             let service_builder_handle = iox2_service_builder_pub_sub(service_builder_handle);
-            iox2_service_builder_pub_sub_set_max_publishers(
-                iox2_cast_service_builder_pub_sub_h_ref(service_builder_handle),
-                10,
-            );
-            iox2_service_builder_pub_sub_set_max_subscribers(
-                iox2_cast_service_builder_pub_sub_h_ref(service_builder_handle),
-                10,
-            );
+            iox2_service_builder_pub_sub_set_max_publishers(&service_builder_handle, 10);
+            iox2_service_builder_pub_sub_set_max_subscribers(&service_builder_handle, 10);
 
             let mut pub_sub_factory: iox2_port_factory_pub_sub_h = std::ptr::null_mut();
             iox2_service_builder_pub_sub_open_or_create(

--- a/iceoryx2-ffi/ffi/src/tests/service_builder_pub_sub_tests.rs
+++ b/iceoryx2-ffi/ffi/src/tests/service_builder_pub_sub_tests.rs
@@ -31,7 +31,7 @@ mod service_builder {
             assert_that!(ret_val, eq(IOX2_OK));
 
             let service_builder_handle = iox2_node_service_builder(
-                iox2_cast_node_ref_h(node_handle),
+                iox2_cast_node_h_ref(node_handle),
                 std::ptr::null_mut(),
                 iox2_cast_service_name_ptr(service_name_handle),
             );
@@ -39,11 +39,11 @@ mod service_builder {
 
             let service_builder_handle = iox2_service_builder_pub_sub(service_builder_handle);
             iox2_service_builder_pub_sub_set_max_publishers(
-                iox2_cast_service_builder_pub_sub_ref_h(service_builder_handle),
+                iox2_cast_service_builder_pub_sub_h_ref(service_builder_handle),
                 10,
             );
             iox2_service_builder_pub_sub_set_max_subscribers(
-                iox2_cast_service_builder_pub_sub_ref_h(service_builder_handle),
+                iox2_cast_service_builder_pub_sub_h_ref(service_builder_handle),
                 10,
             );
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
     <name>iceoryx2_cxx</name>
-    <version>0.3.0</version>
+    <version>0.4.0</version>
     <description>iceoryx2 with c/c++ bindings</description>
     <maintainer email="iceoryx-oss-support@ekxide.io">ekxide developers</maintainer>
     <license>Apache 2.0</license>


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR adjust the naming convention for handle and pointer aliases for the C bindings

- `_ref_h` becomes `_h_ref`
- `_mut_ptr` becomes `_ptr_mut`

This makes is easier to find all occurrences of e.g. `foo_ptr`, independent of the mutability.

Additionally, the `_h_ref` types are now just an alias to `*const _h`. This makes quite a few casts obsolet.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #210 
