### PR TITLE
[#409] Fix bug in iox2 when called outside of cargo workspace

### DIFF
--- a/doc/release-notes/iceoryx2-v0.4.1.md
+++ b/doc/release-notes/iceoryx2-v0.4.1.md
@@ -1,0 +1,14 @@
+# iceoryx2 v0.4.1
+
+## [v0.4.1](https://github.com/eclipse-iceoryx/iceoryx2/tree/v0.4.1)
+
+[Full Changelog](https://github.com/eclipse-iceoryx/iceoryx2/compare/v0.4.0...v0.4.1)
+
+### Bugfixes
+
+* Fix bug preventing `iox2` from being executed from any location
+  [#409](https://github.com/eclipse-iceoryx/iceoryx2/issues/409)
+
+## Thanks To All Contributors Of This Version
+
+* [»orecham«](https://github.com/orecham)

--- a/iceoryx2-cli/iox2/src/commands.rs
+++ b/iceoryx2-cli/iox2/src/commands.rs
@@ -175,8 +175,8 @@ where
     E: Environment,
 {
     fn paths() -> Result<PathsList> {
-        let build = E::build_paths().context("Failed to retrieve build paths")?;
-        let install = E::install_paths().context("Failed to retrieve install paths")?;
+        let build = E::build_paths().unwrap_or_default();
+        let install = E::install_paths().unwrap_or_default();
 
         Ok(PathsList { build, install })
     }
@@ -225,13 +225,18 @@ where
 {
     let paths = IceoryxCommandFinder::<E>::paths().context("Failed to list search paths")?;
 
-    println!("{}", "Build Paths:".bright_green().bold());
-    for dir in paths.build {
-        println!("  {}", dir.display().to_string().bold());
+    if !paths.build.is_empty() {
+        println!("{}", "Build Paths:".bright_green().bold());
+        for dir in &paths.build {
+            println!("  {}", dir.display().to_string().bold());
+        }
+        println!();
     }
-    println!("\n{}", "Install Paths:".bright_green().bold());
-    for dir in paths.install {
-        println!("  {}", dir.display().to_string().bold());
+    if !paths.install.is_empty() {
+        println!("{}", "Install Paths:".bright_green().bold());
+        for dir in &paths.install {
+            println!("  {}", dir.display().to_string().bold());
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

1. The CLI was incorrectly assuming it would always be called from a cargo workspace
2. With this change, the CLI will ignore build paths and only try to find commands in the install path

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] ~~Tests follow the [best practice for testing][testing]~~
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #410
