### PR TITLE
[#60] integrate miri in ci with an allow list

### DIFF
--- a/.github/workflows/miri-check.yml
+++ b/.github/workflows/miri-check.yml
@@ -1,0 +1,26 @@
+name: Miri
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main, release* ]
+
+jobs:
+  miri:
+    name: "Miri"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+      - name: List all changed files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: ./internal/scripts/ci_run_miri.sh  

--- a/.miri_allowlist
+++ b/.miri_allowlist
@@ -1,0 +1,8 @@
+# .miri_allowlist use hash character to lead a comment
+# each line will be treated as a valid relative path to enter and run 'cargo miri test',
+# if it contains some changed files(added, copied and modified, deletion is excluded) in the PR.
+#
+# note that each line should end up with a newline character,
+# otherwise the ci shell will skip the last line
+iceoryx2-bb/testing
+# this line is put here to ensure each file path contains a newline char, don't remove it 

--- a/internal/scripts/ci_run_miri.sh
+++ b/internal/scripts/ci_run_miri.sh
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+filename=".miri_allowlist"
+while IFS= read -r line; do
+if [[ "$line" == \#* ]]; then
+    continue
+fi          
+
+if echo "$ALL_CHANGED_FILES" | grep -q "$line"; then
+    cd "$line" || { echo "Failed to change directory to $line"; exit 1; }
+    echo "Run cargo miri test under: $(pwd)"
+    cargo miri test
+    if [ $? -ne 0 ]; then
+        echo "Error: cargo miri test failed."
+        exit 1
+    fi
+    cd -
+else
+    echo "skip $line because the PR doesn't touch its files"
+fi
+done < "$filename"     


### PR DESCRIPTION
Allow CI failures for now

## Notes for Reviewer

I have integrated miri in github action while supporting a shell-style `.miri_allowlist` file for all sub-folders to run `cargo miri test`. 

## Pre-Review Checklist for the PR Author

1. [X] Add sensible notes for the reviewer
1. [X] PR title is short, expressive and meaningful
1. [X] Relevant issues are linked in the [References](#references) section
1. [X] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [X] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [X] Commits messages are according to this [guideline][commit-guidelines]
    - [X] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [X] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [X] Tests follow the [best practice for testing][testing]
1. [X] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [X] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [ ] ~~Unit tests have been written for new behavior~~
- [ ] ~~Public API is documented~~
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #60