### PR TITLE
[#464] c api

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -257,7 +257,8 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        toolchain: [stable, stable-gnu, 1.75.0]
+        # toolchain: [stable, stable-gnu, 1.75.0]
+        toolchain: [stable, 1.75.0]
         mode:
           - name: "release"
             arg: "--release"

--- a/iceoryx2-bb/log/src/logger/buffer.rs
+++ b/iceoryx2-bb/log/src/logger/buffer.rs
@@ -84,7 +84,7 @@ impl Logger {
     }
 }
 
-impl crate::logger::Logger for Logger {
+impl crate::Log for Logger {
     fn log(
         &self,
         log_level: LogLevel,

--- a/iceoryx2-bb/log/src/logger/console.rs
+++ b/iceoryx2-bb/log/src/logger/console.rs
@@ -171,7 +171,7 @@ impl Logger {
     }
 }
 
-impl crate::logger::Logger for Logger {
+impl crate::Log for Logger {
     fn log(
         &self,
         log_level: crate::LogLevel,

--- a/iceoryx2-bb/log/src/logger/file.rs
+++ b/iceoryx2-bb/log/src/logger/file.rs
@@ -118,7 +118,7 @@ impl Drop for Logger {
     }
 }
 
-impl crate::Logger for Logger {
+impl crate::Log for Logger {
     fn log(
         &self,
         log_level: LogLevel,

--- a/iceoryx2-bb/log/src/logger/log.rs
+++ b/iceoryx2-bb/log/src/logger/log.rs
@@ -22,7 +22,7 @@ impl Logger {
     }
 }
 
-impl crate::logger::Logger for Logger {
+impl crate::Log for Logger {
     fn log(
         &self,
         log_level: crate::LogLevel,

--- a/iceoryx2-bb/log/src/logger/mod.rs
+++ b/iceoryx2-bb/log/src/logger/mod.rs
@@ -20,3 +20,20 @@ pub mod file;
 pub mod log;
 #[cfg(feature = "logger_tracing")]
 pub mod tracing;
+
+/// Sets the [`console::Logger`] as default logger
+pub fn use_console_logger() -> bool {
+    // LazyLock is only available from 1.80 but currently iceoryx2 has the minimum version 1.75.
+    // But since static values are never dropped in Rust, we can also use Box::leak
+    let logger = Box::leak(Box::new(console::Logger::new()));
+    crate::set_logger(&*logger)
+}
+
+/// Sets the [`file::Logger`] as default logger
+pub fn use_file_logger(log_file_name: &str) -> bool {
+    // we cannot capture non const parameters in a LazyLock and since static values are not
+    // dropped in Rust we can also use Box::leak
+    let logger = Box::leak(Box::new(file::Logger::new(log_file_name)));
+
+    crate::set_logger(logger)
+}

--- a/iceoryx2-bb/log/src/logger/mod.rs
+++ b/iceoryx2-bb/log/src/logger/mod.rs
@@ -20,12 +20,3 @@ pub mod file;
 pub mod log;
 #[cfg(feature = "logger_tracing")]
 pub mod tracing;
-
-use std::fmt::Arguments;
-
-use crate::LogLevel;
-
-pub trait Logger: Send + Sync {
-    /// logs a message
-    fn log(&self, log_level: LogLevel, origin: Arguments, formatted_message: Arguments);
-}

--- a/iceoryx2-bb/log/src/logger/tracing.rs
+++ b/iceoryx2-bb/log/src/logger/tracing.rs
@@ -22,7 +22,7 @@ impl Logger {
     }
 }
 
-impl crate::logger::Logger for Logger {
+impl crate::Log for Logger {
     fn log(
         &self,
         log_level: crate::LogLevel,

--- a/iceoryx2-ffi/cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/enum_translation.hpp
@@ -646,20 +646,41 @@ constexpr auto from<int, iox2::ConfigCreationError>(const int value) noexcept ->
 template <>
 constexpr auto from<iox2::LogLevel, iox2_log_level_e>(iox2::LogLevel value) noexcept -> iox2_log_level_e {
     switch (value) {
-    case iox2::LogLevel::TRACE:
+    case iox2::LogLevel::Trace:
         return iox2_log_level_e_TRACE;
-    case iox2::LogLevel::DEBUG:
+    case iox2::LogLevel::Debug:
         return iox2_log_level_e_DEBUG;
-    case iox2::LogLevel::INFO:
+    case iox2::LogLevel::Info:
         return iox2_log_level_e_INFO;
-    case iox2::LogLevel::WARN:
+    case iox2::LogLevel::Warn:
         return iox2_log_level_e_WARN;
-    case iox2::LogLevel::ERROR:
+    case iox2::LogLevel::Error:
         return iox2_log_level_e_ERROR;
-    case iox2::LogLevel::FATAL:
+    case iox2::LogLevel::Fatal:
         return iox2_log_level_e_FATAL;
     }
     IOX_UNREACHABLE();
+}
+
+template <>
+constexpr auto from<int, iox2::LogLevel>(int value) noexcept -> iox2::LogLevel {
+    const auto variant = static_cast<iox2_log_level_e>(value);
+    switch (value) {
+    case iox2_log_level_e_TRACE:
+        return iox2::LogLevel::Trace;
+    case iox2_log_level_e_DEBUG:
+        return iox2::LogLevel::Debug;
+    case iox2_log_level_e_INFO:
+        return iox2::LogLevel::Info;
+    case iox2_log_level_e_WARN:
+        return iox2::LogLevel::Warn;
+    case iox2_log_level_e_ERROR:
+        return iox2::LogLevel::Error;
+    case iox2_log_level_e_FATAL:
+        return iox2::LogLevel::Fatal;
+    default:
+        IOX_UNREACHABLE();
+    }
 }
 
 template <>

--- a/iceoryx2-ffi/cxx/include/iox2/log.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/log.hpp
@@ -22,7 +22,7 @@ namespace iox2 {
 /// # Example
 ///
 /// @code
-/// class ConsoleLogger : public LoggerInterface {
+/// class ConsoleLogger : public Log {
 ///   public:
 ///     void log(LogLevel log_level, const char* origin, const char* message) override {
 ///         std::cout << "origin = " << origin << ", message = " << message << std::endl;
@@ -33,14 +33,14 @@ namespace iox2 {
 ///
 /// set_logger(CUSTOM_LOGGER);
 /// @endcode
-class LoggerInterface {
+class Log {
   public:
-    LoggerInterface() = default;
-    LoggerInterface(const LoggerInterface&) = default;
-    LoggerInterface(LoggerInterface&&) = default;
-    auto operator=(const LoggerInterface&) -> LoggerInterface& = default;
-    auto operator=(LoggerInterface&&) -> LoggerInterface& = default;
-    virtual ~LoggerInterface() = default;
+    Log() = default;
+    Log(const Log&) = default;
+    Log(Log&&) = default;
+    auto operator=(const Log&) -> Log& = default;
+    auto operator=(Log&&) -> Log& = default;
+    virtual ~Log() = default;
 
     /// The actual log method. The system provides the log level, the origin of the message and
     /// the actual message.
@@ -53,7 +53,7 @@ void log(LogLevel log_level, const char* origin, const char* message);
 /// Sets the logger that shall be used. This function can only be called once and must be called
 /// before any log message was created.
 /// It returns true if the logger was set, otherwise false.
-auto set_logger(LoggerInterface& logger) -> bool;
+auto set_logger(Log& logger) -> bool;
 
 /// Sets the global log level for the application
 auto set_log_level(LogLevel level) -> void;

--- a/iceoryx2-ffi/cxx/include/iox2/log.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/log.hpp
@@ -50,6 +50,12 @@ class Log {
 /// Adds a log message to the logger.
 void log(LogLevel log_level, const char* origin, const char* message);
 
+/// Sets the console logger as default logger. Returns true if the logger was set, otherwise false.
+auto use_console_logger() -> bool;
+
+/// Sets the file logger as default logger. Returns true if the logger was set, otherwise false.
+auto use_file_logger(const char* log_file) -> bool;
+
 /// Sets the logger that shall be used. This function can only be called once and must be called
 /// before any log message was created.
 /// It returns true if the logger was set, otherwise false.

--- a/iceoryx2-ffi/cxx/include/iox2/log.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/log.hpp
@@ -35,6 +35,7 @@ namespace iox2 {
 /// @endcode
 class LoggerInterface {
   public:
+    LoggerInterface() = default;
     LoggerInterface(const LoggerInterface&) = default;
     LoggerInterface(LoggerInterface&&) = default;
     auto operator=(const LoggerInterface&) -> LoggerInterface& = default;

--- a/iceoryx2-ffi/cxx/include/iox2/log.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/log.hpp
@@ -17,6 +17,43 @@
 
 namespace iox2 {
 
+/// The abstract base class every custom logger has to implement.
+///
+/// # Example
+///
+/// @code
+/// class ConsoleLogger : public LoggerInterface {
+///   public:
+///     void log(LogLevel log_level, const char* origin, const char* message) override {
+///         std::cout << "origin = " << origin << ", message = " << message << std::endl;
+///     }
+/// };
+///
+/// static ConsoleLogger CUSTOM_LOGGER = ConsoleLogger();
+///
+/// set_logger(CUSTOM_LOGGER);
+/// @endcode
+class LoggerInterface {
+  public:
+    LoggerInterface(const LoggerInterface&) = default;
+    LoggerInterface(LoggerInterface&&) = default;
+    auto operator=(const LoggerInterface&) -> LoggerInterface& = default;
+    auto operator=(LoggerInterface&&) -> LoggerInterface& = default;
+    virtual ~LoggerInterface() = default;
+
+    /// The actual log method. The system provides the log level, the origin of the message and
+    /// the actual message.
+    virtual void log(LogLevel log_level, const char* origin, const char* message) = 0;
+};
+
+/// Adds a log message to the logger.
+void log(LogLevel log_level, const char* origin, const char* message);
+
+/// Sets the logger that shall be used. This function can only be called once and must be called
+/// before any log message was created.
+/// It returns true if the logger was set, otherwise false.
+auto set_logger(LoggerInterface& logger) -> bool;
+
 /// Sets the global log level for the application
 auto set_log_level(LogLevel level) -> void;
 

--- a/iceoryx2-ffi/cxx/include/iox2/log_level.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/log_level.hpp
@@ -18,12 +18,12 @@
 namespace iox2 {
 
 enum class LogLevel : uint8_t {
-    TRACE = 0,
-    DEBUG = 1,
-    INFO = 2,
-    WARN = 3,
-    ERROR = 4,
-    FATAL = 5,
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+    Fatal = 5,
 };
 
 } // namespace iox2

--- a/iceoryx2-ffi/cxx/src/log.cpp
+++ b/iceoryx2-ffi/cxx/src/log.cpp
@@ -18,14 +18,14 @@
 namespace iox2 {
 namespace {
 //NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): it is in an anonymous namespace and therefore only accessible in this compilation unit
-iox::optional<LoggerInterface*> global_logger = iox::nullopt;
+iox::optional<Log*> global_logger = iox::nullopt;
 } // namespace
 
 void internal_log_callback(iox2_log_level_e log_level, const char* origin, const char* message) {
     (*global_logger)->log(iox::into<LogLevel>(static_cast<int>(log_level)), origin, message);
 }
 
-auto set_logger(LoggerInterface& logger) -> bool {
+auto set_logger(Log& logger) -> bool {
     auto success = iox2_set_logger(internal_log_callback);
     if (success) {
         global_logger.emplace(&logger);

--- a/iceoryx2-ffi/cxx/src/log.cpp
+++ b/iceoryx2-ffi/cxx/src/log.cpp
@@ -11,9 +11,28 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #include "iox2/log.hpp"
+#include "iox/into.hpp"
+#include "iox/optional.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 
 namespace iox2 {
+static iox::optional<LoggerInterface*> LOGGER = iox::nullopt;
+
+void internal_log_callback(iox2_log_level_e log_level, const char* origin, const char* message) {
+    (*LOGGER)->log(iox::into<LogLevel>(static_cast<int>(log_level)), origin, message);
+}
+
+auto set_logger(LoggerInterface& logger) -> bool {
+    auto success = iox2_set_logger(internal_log_callback);
+    if (success) {
+        LOGGER.emplace(&logger);
+    }
+    return success;
+}
+
+void log(LogLevel log_level, const char* origin, const char* message) {
+    iox2_log(iox::into<iox2_log_level_e>(log_level), origin, message);
+}
 
 auto set_log_level(LogLevel level) -> void {
     iox2_set_log_level(iox::into<iox2_log_level_e>(level));

--- a/iceoryx2-ffi/cxx/src/log.cpp
+++ b/iceoryx2-ffi/cxx/src/log.cpp
@@ -16,9 +16,10 @@
 #include "iox2/internal/iceoryx2.hpp"
 
 namespace iox2 {
-
-//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): the static keyword prevents it from being accessible in any other compilation unit, therefore it is not a global variable - false positive
-static iox::optional<LoggerInterface*> global_logger = iox::nullopt;
+namespace {
+//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): it is in an anonymous namespace and therefore only accessible in this compilation unit
+iox::optional<LoggerInterface*> global_logger = iox::nullopt;
+} // namespace
 
 void internal_log_callback(iox2_log_level_e log_level, const char* origin, const char* message) {
     (*global_logger)->log(iox::into<LogLevel>(static_cast<int>(log_level)), origin, message);

--- a/iceoryx2-ffi/cxx/src/log.cpp
+++ b/iceoryx2-ffi/cxx/src/log.cpp
@@ -45,4 +45,11 @@ auto get_log_level() -> LogLevel {
     return LogLevel(iox2_get_log_level());
 }
 
+auto use_console_logger() -> bool {
+    return iox2_use_console_logger();
+}
+
+auto use_file_logger(const char* log_file) -> bool {
+    return iox2_use_file_logger(log_file);
+}
 } // namespace iox2

--- a/iceoryx2-ffi/cxx/src/log.cpp
+++ b/iceoryx2-ffi/cxx/src/log.cpp
@@ -16,16 +16,18 @@
 #include "iox2/internal/iceoryx2.hpp"
 
 namespace iox2 {
-static iox::optional<LoggerInterface*> LOGGER = iox::nullopt;
+
+//NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables): the static keyword prevents it from being accessible in any other compilation unit, therefore it is not a global variable - false positive
+static iox::optional<LoggerInterface*> global_logger = iox::nullopt;
 
 void internal_log_callback(iox2_log_level_e log_level, const char* origin, const char* message) {
-    (*LOGGER)->log(iox::into<LogLevel>(static_cast<int>(log_level)), origin, message);
+    (*global_logger)->log(iox::into<LogLevel>(static_cast<int>(log_level)), origin, message);
 }
 
 auto set_logger(LoggerInterface& logger) -> bool {
     auto success = iox2_set_logger(internal_log_callback);
     if (success) {
-        LOGGER.emplace(&logger);
+        global_logger.emplace(&logger);
     }
     return success;
 }

--- a/iceoryx2-ffi/cxx/tests/src/log.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/log.cpp
@@ -19,20 +19,23 @@ namespace {
 using namespace iox2;
 
 TEST(LogLevel, can_set_and_get_log_level) {
-    set_log_level(LogLevel::INFO);
-    EXPECT_EQ(get_log_level(), LogLevel::INFO);
+    set_log_level(LogLevel::Trace);
+    EXPECT_EQ(get_log_level(), LogLevel::Trace);
 
-    set_log_level(LogLevel::DEBUG);
-    EXPECT_EQ(get_log_level(), LogLevel::DEBUG);
+    set_log_level(LogLevel::Debug);
+    EXPECT_EQ(get_log_level(), LogLevel::Debug);
 
-    set_log_level(LogLevel::WARN);
-    EXPECT_EQ(get_log_level(), LogLevel::WARN);
+    set_log_level(LogLevel::Info);
+    EXPECT_EQ(get_log_level(), LogLevel::Info);
 
-    set_log_level(LogLevel::ERROR);
-    EXPECT_EQ(get_log_level(), LogLevel::ERROR);
+    set_log_level(LogLevel::Warn);
+    EXPECT_EQ(get_log_level(), LogLevel::Warn);
 
-    set_log_level(LogLevel::FATAL);
-    EXPECT_EQ(get_log_level(), LogLevel::FATAL);
+    set_log_level(LogLevel::Error);
+    EXPECT_EQ(get_log_level(), LogLevel::Error);
+
+    set_log_level(LogLevel::Fatal);
+    EXPECT_EQ(get_log_level(), LogLevel::Fatal);
 }
 
 } // namespace

--- a/iceoryx2-ffi/cxx/tests/src/log.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/log.cpp
@@ -10,6 +10,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#include <string>
+#include <vector>
+
 #include "iox2/log.hpp"
 #include "iox2/log_level.hpp"
 
@@ -17,8 +20,75 @@
 
 namespace {
 using namespace iox2;
+class Entry {
+  private:
+    LogLevel m_log_level;
+    std::string m_origin;
+    std::string m_message;
 
-TEST(LogLevel, can_set_and_get_log_level) {
+  public:
+    Entry(LogLevel log_level, const char* origin, const char* message)
+        : m_log_level { log_level }
+        , m_origin { origin }
+        , m_message { message } {
+    }
+
+    auto is_equal(LogLevel log_level, const char* origin, const char* message) -> bool {
+        return m_log_level == log_level && m_origin == origin && m_message == message;
+    }
+};
+
+class TestLogger : public LoggerInterface {
+  public:
+    static auto set_global_logger() {
+        auto& instance = get_instance();
+        set_logger(instance);
+        instance.m_log_buffer.clear();
+    }
+
+    static auto get_instance() -> TestLogger& {
+        static TestLogger INSTANCE;
+        return INSTANCE;
+    }
+
+    void log(LogLevel log_level, const char* origin, const char* message) override {
+        m_log_buffer.emplace_back(log_level, origin, message);
+    }
+
+    auto get_log_buffer() -> std::vector<Entry> {
+        auto buffer = m_log_buffer;
+        m_log_buffer.clear();
+        return buffer;
+    }
+
+  private:
+    std::vector<Entry> m_log_buffer;
+};
+
+TEST(Log, custom_logger_works) {
+    TestLogger::set_global_logger();
+
+    log(LogLevel::Trace, "hello", "world");
+    log(LogLevel::Debug, "goodbye", "hypnotoad");
+    log(LogLevel::Info, "Who is looking for freedom?", "The Hoff!");
+    log(LogLevel::Warn, "Blümchen", "Bassface");
+    log(LogLevel::Error, "Blümchen should record a single with", "The almighty Hypnotoad");
+    log(LogLevel::Fatal, "It is the end", "my beloved toad.");
+
+    auto log_buffer = TestLogger::get_instance().get_log_buffer();
+
+    ASSERT_THAT(log_buffer.size(), Eq(6));
+
+    ASSERT_TRUE(log_buffer[0].is_equal(LogLevel::Trace, "hello", "world"));
+    ASSERT_TRUE(log_buffer[1].is_equal(LogLevel::Debug, "goodbye", "hypnotoad"));
+    ASSERT_TRUE(log_buffer[2].is_equal(LogLevel::Info, "Who is looking for freedom?", "The Hoff!"));
+    ASSERT_TRUE(log_buffer[3].is_equal(LogLevel::Warn, "Blümchen", "Bassface"));
+    ASSERT_TRUE(
+        log_buffer[4].is_equal(LogLevel::Error, "Blümchen should record a single with", "The almighty Hypnotoad"));
+    ASSERT_TRUE(log_buffer[5].is_equal(LogLevel::Fatal, "It is the end", "my beloved toad."));
+}
+
+TEST(Log, can_set_and_get_log_level) {
     set_log_level(LogLevel::Trace);
     EXPECT_EQ(get_log_level(), LogLevel::Trace);
 

--- a/iceoryx2-ffi/cxx/tests/src/log_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/log_tests.cpp
@@ -38,7 +38,7 @@ class Entry {
     }
 };
 
-class TestLogger : public LoggerInterface {
+class TestLogger : public Log {
   public:
     static auto set_global_logger() {
         auto& instance = get_instance();

--- a/iceoryx2-ffi/cxx/tests/src/log_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/log_tests.cpp
@@ -42,10 +42,6 @@ class Entry {
 
 class TestLogger : public Log {
   public:
-    TestLogger()
-        : Log() {
-    }
-
     static auto set_global_logger() {
         auto& instance = get_instance();
         set_logger(instance);

--- a/iceoryx2-ffi/ffi/src/api/log.rs
+++ b/iceoryx2-ffi/ffi/src/api/log.rs
@@ -17,6 +17,7 @@
 
 use iceoryx2_bb_log::{
     get_log_level, set_log_level, set_logger, Log, LogLevel, __internal_print_log_msg,
+    logger::{use_console_logger, use_file_logger},
 };
 use std::{
     ffi::{c_char, CStr},
@@ -131,6 +132,8 @@ pub unsafe extern "C" fn iox2_log(
     origin: *const c_char,
     message: *const c_char,
 ) {
+    debug_assert!(!message.is_null());
+
     let empty_origin = b"\0";
     let origin = if origin.is_null() {
         CStr::from_bytes_with_nul(empty_origin).unwrap()
@@ -144,6 +147,25 @@ pub unsafe extern "C" fn iox2_log(
         format_args!("{}", origin.to_string_lossy()),
         format_args!("{}", message.to_string_lossy()),
     );
+}
+
+/// Sets the console logger as default logger. Returns true if the logger was set, otherwise false.
+#[no_mangle]
+pub extern "C" fn iox2_use_console_logger() -> bool {
+    use_console_logger()
+}
+
+/// Sets the file logger as default logger. Returns true if the logger was set, otherwise false.
+///
+/// # Safety
+///
+///  * log_file must be a valid pointer to a string
+#[no_mangle]
+pub unsafe extern "C" fn iox2_use_file_logger(log_file: *const c_char) -> bool {
+    debug_assert!(!log_file.is_null());
+
+    let log_file = CStr::from_ptr(log_file).to_string_lossy();
+    use_file_logger(&log_file)
 }
 
 /// Sets the log level.

--- a/iceoryx2-ffi/ffi/src/api/log.rs
+++ b/iceoryx2-ffi/ffi/src/api/log.rs
@@ -16,7 +16,7 @@
 // BEGIN type definition
 
 use iceoryx2_bb_log::{
-    get_log_level, logger::Logger, set_log_level, set_logger, LogLevel, __internal_print_log_msg,
+    get_log_level, set_log_level, set_logger, Log, LogLevel, __internal_print_log_msg,
 };
 use std::{
     ffi::{c_char, CStr},
@@ -87,7 +87,7 @@ impl CLogger {
     }
 }
 
-impl Logger for CLogger {
+impl Log for CLogger {
     fn log(
         &self,
         log_level: LogLevel,


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

* Implements the C and C++ binding for `log`.
* It renames the `Logger` trait for custom loggers to `Log` to be more in line with the Rust naming scheme - traits are verbs
* provides user convenience functions to set the file logger as default logger

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #464 