### PR TITLE
[#349] Add all remaining tests to bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,6 +14,7 @@ build --action_env=CARGO_BAZEL_REPIN=true
 # build --strategy=Genrule=standalone
 
 test --test_output=streamed
+test --nocache_test_results
 
 #
 # feature flags

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,7 +7,11 @@ build:mingw --cxxopt="-std=c++17"
 
 build --action_env=CARGO_BAZEL_REPIN=true
 
-#test --local_test_jobs=1
+# test --local_test_jobs=1
+# test --test_strategy=standalone
+
+# test --spawn_strategy=standalone
+# build --strategy=Genrule=standalone
 
 test --test_output=streamed
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,7 @@ build --action_env=CARGO_BAZEL_REPIN=true
 
 test --test_output=streamed
 test --nocache_test_results
+test --action_env=RUST_TEST_THREADS=1
 
 #
 # feature flags

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,10 +7,9 @@ build:mingw --cxxopt="-std=c++17"
 
 build --action_env=CARGO_BAZEL_REPIN=true
 
-# test --local_test_jobs=1
-# test --test_strategy=standalone
-
-# test --spawn_strategy=standalone
+test --local_test_jobs=1
+test --test_strategy=standalone
+test --spawn_strategy=standalone
 # build --strategy=Genrule=standalone
 
 test --test_output=streamed

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,8 @@ build:mingw --cxxopt="-std=c++17"
 
 build --action_env=CARGO_BAZEL_REPIN=true
 
+#test --local_test_jobs=1
+
 #
 # feature flags
 #

--- a/.bazelrc
+++ b/.bazelrc
@@ -7,9 +7,9 @@ build:mingw --cxxopt="-std=c++17"
 
 build --action_env=CARGO_BAZEL_REPIN=true
 
-test --local_test_jobs=1
-test --test_strategy=standalone
-test --spawn_strategy=standalone
+# test --local_test_jobs=1
+# test --test_strategy=standalone
+# test --spawn_strategy=standalone
 # build --strategy=Genrule=standalone
 
 test --test_output=streamed

--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,8 @@ build --action_env=CARGO_BAZEL_REPIN=true
 
 #test --local_test_jobs=1
 
+test --test_output=streamed
+
 #
 # feature flags
 #

--- a/iceoryx2-bb/container/BUILD.bazel
+++ b/iceoryx2-bb/container/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -33,4 +33,13 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-bb-container-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2-bb-container",
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+        "@crate_index//:serde_test",
+    ],
+)

--- a/iceoryx2-bb/container/tests/queue_tests.rs
+++ b/iceoryx2-bb/container/tests/queue_tests.rs
@@ -203,35 +203,35 @@ mod queue {
 
     #[test]
     fn drops_all_objects_when_out_of_scope() {
-        LifetimeTracker::start_tracking();
+        let state = LifetimeTracker::start_tracking();
         let mut sut = FixedSizeQueue::<LifetimeTracker, SUT_CAPACITY>::new();
 
         for _ in 0..sut.capacity() {
             sut.push(LifetimeTracker::new());
         }
 
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq SUT_CAPACITY);
+        assert_that!(state.number_of_living_instances(), eq SUT_CAPACITY);
         drop(sut);
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq 0);
+        assert_that!(state.number_of_living_instances(), eq 0);
     }
 
     #[test]
     fn drops_all_objects_with_clear() {
-        LifetimeTracker::start_tracking();
+        let state = LifetimeTracker::start_tracking();
         let mut sut = FixedSizeQueue::<LifetimeTracker, SUT_CAPACITY>::new();
 
         for _ in 0..sut.capacity() {
             sut.push(LifetimeTracker::new());
         }
 
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq SUT_CAPACITY);
+        assert_that!(state.number_of_living_instances(), eq SUT_CAPACITY);
         sut.clear();
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq 0);
+        assert_that!(state.number_of_living_instances(), eq 0);
     }
 
     #[test]
     fn pop_releases_object() {
-        LifetimeTracker::start_tracking();
+        let state = LifetimeTracker::start_tracking();
         let mut sut = FixedSizeQueue::<LifetimeTracker, SUT_CAPACITY>::new();
 
         for _ in 0..sut.capacity() {
@@ -242,13 +242,13 @@ mod queue {
             let result = sut.pop();
             assert_that!(result, is_some);
             drop(result);
-            assert_that!(LifetimeTracker::number_of_living_instances(), eq i);
+            assert_that!(state.number_of_living_instances(), eq i);
         }
     }
 
     #[test]
     fn queue_clear_drops_all_objects() {
-        LifetimeTracker::start_tracking();
+        let state = LifetimeTracker::start_tracking();
         let mut sut = Queue::<LifetimeTracker>::new(SUT_CAPACITY);
 
         for _ in 0..sut.capacity() {
@@ -256,12 +256,12 @@ mod queue {
         }
 
         sut.clear();
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq 0);
+        assert_that!(state.number_of_living_instances(), eq 0);
     }
 
     #[test]
     fn fixed_size_queue_clear_drops_all_objects() {
-        LifetimeTracker::start_tracking();
+        let state = LifetimeTracker::start_tracking();
         let mut sut = FixedSizeQueue::<LifetimeTracker, SUT_CAPACITY>::new();
 
         for _ in 0..sut.capacity() {
@@ -269,7 +269,7 @@ mod queue {
         }
 
         sut.clear();
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq 0);
+        assert_that!(state.number_of_living_instances(), eq 0);
     }
 
     #[test]

--- a/iceoryx2-bb/container/tests/vec_tests.rs
+++ b/iceoryx2-bb/container/tests/vec_tests.rs
@@ -205,35 +205,35 @@ mod fixed_size_vec {
 
     #[test]
     fn drops_all_objects_when_out_of_scope() {
-        LifetimeTracker::start_tracking();
+        let state = LifetimeTracker::start_tracking();
         let mut sut = FixedSizeVec::<LifetimeTracker, SUT_CAPACITY>::new();
 
         for _ in 0..SUT_CAPACITY {
             assert_that!(sut.push(LifetimeTracker::new()), eq true);
         }
 
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq SUT_CAPACITY);
+        assert_that!(state.number_of_living_instances(), eq SUT_CAPACITY);
         drop(sut);
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq 0);
+        assert_that!(state.number_of_living_instances(), eq 0);
     }
 
     #[test]
     fn drops_all_objects_with_clear() {
-        LifetimeTracker::start_tracking();
+        let state = LifetimeTracker::start_tracking();
         let mut sut = FixedSizeVec::<LifetimeTracker, SUT_CAPACITY>::new();
 
         for _ in 0..SUT_CAPACITY {
             assert_that!(sut.push(LifetimeTracker::new()), eq true);
         }
 
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq SUT_CAPACITY);
+        assert_that!(state.number_of_living_instances(), eq SUT_CAPACITY);
         sut.clear();
-        assert_that!(LifetimeTracker::number_of_living_instances(), eq 0);
+        assert_that!(state.number_of_living_instances(), eq 0);
     }
 
     #[test]
     fn pop_releases_ownership() {
-        LifetimeTracker::start_tracking();
+        let state = LifetimeTracker::start_tracking();
         let mut sut = FixedSizeVec::<LifetimeTracker, SUT_CAPACITY>::new();
 
         for _ in 0..SUT_CAPACITY {
@@ -244,7 +244,7 @@ mod fixed_size_vec {
             let result = sut.pop();
             assert_that!(result, is_some);
             drop(result);
-            assert_that!(LifetimeTracker::number_of_living_instances(), eq i);
+            assert_that!(state.number_of_living_instances(), eq i);
         }
     }
 

--- a/iceoryx2-bb/derive-macros/BUILD.bazel
+++ b/iceoryx2-bb/derive-macros/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_proc_macro")
+load("@rules_rust//rust:defs.bzl", "rust_proc_macro", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -30,4 +30,15 @@ rust_proc_macro(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-bb-derive-macros-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+    ],
+    proc_macro_deps = [
+        ":iceoryx2-bb-derive-macros",
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2-bb/elementary/BUILD.bazel
+++ b/iceoryx2-bb/elementary/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -27,4 +27,14 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-bb-elementary-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2-bb-elementary",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+    ],
+    proc_macro_deps = [
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2-bb/elementary/tests/package_version_tests.rs
+++ b/iceoryx2-bb/elementary/tests/package_version_tests.rs
@@ -15,6 +15,13 @@ use iceoryx2_bb_testing::assert_that;
 
 #[test]
 fn package_version_works() {
+    // NOTE: The test is skipped when not run with cargo but with bazel
+    //       The CI which runs with cargo ensures that the constants defined
+    //       in PackageVersion::get equal the package version.
+    if option_env!("CARGO").is_none() {
+        return;
+    }
+
     let major = option_env!("CARGO_PKG_VERSION_MAJOR")
         .and_then(|s| s.parse::<u16>().ok())
         .expect("Contains a valid major version number.");

--- a/iceoryx2-bb/elementary/tests/package_version_tests.rs
+++ b/iceoryx2-bb/elementary/tests/package_version_tests.rs
@@ -11,16 +11,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use iceoryx2_bb_elementary::package_version::PackageVersion;
-use iceoryx2_bb_testing::assert_that;
+use iceoryx2_bb_testing::{assert_that, test_requires};
 
 #[test]
 fn package_version_works() {
     // NOTE: The test is skipped when not run with cargo but with bazel
     //       The CI which runs with cargo ensures that the constants defined
     //       in PackageVersion::get equal the package version.
-    if option_env!("CARGO").is_none() {
-        return;
-    }
+    test_requires!(option_env!("CARGO").is_some());
 
     let major = option_env!("CARGO_PKG_VERSION_MAJOR")
         .and_then(|s| s.parse::<u16>().ok())

--- a/iceoryx2-bb/lock-free/BUILD.bazel
+++ b/iceoryx2-bb/lock-free/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -30,4 +30,16 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-bb-lock-free-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2-bb-lock-free",
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/posix:iceoryx2-bb-posix",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+    ],
+    proc_macro_deps = [
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2-bb/memory/BUILD.bazel
+++ b/iceoryx2-bb/memory/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -33,4 +33,15 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-bb-memory-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        "iceoryx2-bb-memory",
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+    ],
+    proc_macro_deps = [
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2-bb/posix/BUILD.bazel
+++ b/iceoryx2-bb/posix/BUILD.bazel
@@ -51,6 +51,7 @@ rust_test_suite(
         "//iceoryx2-pal/posix:iceoryx2-pal-posix",
         "//iceoryx2-pal/configuration:iceoryx2-pal-configuration",
     ],
+    tags = ["exclusive"],
     proc_macro_deps = [
         "@crate_index//:generic-tests",
     ],

--- a/iceoryx2-bb/posix/BUILD.bazel
+++ b/iceoryx2-bb/posix/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -38,4 +38,19 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-bb-posix-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2-bb-posix",
+        "//iceoryx2-bb/container:iceoryx2-bb-container",
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/system-types:iceoryx2-bb-system-types",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+        "//iceoryx2-pal/posix:iceoryx2-pal-posix",
+        "//iceoryx2-pal/configuration:iceoryx2-pal-configuration",
+    ],
+    proc_macro_deps = [
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2-bb/posix/BUILD.bazel
+++ b/iceoryx2-bb/posix/BUILD.bazel
@@ -45,6 +45,7 @@ rust_test_suite(
         ":iceoryx2-bb-posix",
         "//iceoryx2-bb/container:iceoryx2-bb-container",
         "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/log:iceoryx2-bb-log",
         "//iceoryx2-bb/system-types:iceoryx2-bb-system-types",
         "//iceoryx2-bb/testing:iceoryx2-bb-testing",
         "//iceoryx2-pal/posix:iceoryx2-pal-posix",

--- a/iceoryx2-bb/posix/src/testing.rs
+++ b/iceoryx2-bb/posix/src/testing.rs
@@ -10,8 +10,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::config::test_directory;
+use crate::directory::{Directory, DirectoryCreateError};
+use crate::permission::Permission;
 use crate::process_state::ProcessGuard;
+use iceoryx2_bb_log::fatal_panic;
 
 pub fn __internal_process_guard_staged_death(state: ProcessGuard) {
     state.staged_death();
+}
+
+pub fn create_test_directory() {
+    match Directory::create(&test_directory(), Permission::OWNER_ALL) {
+        Ok(_) | Err(DirectoryCreateError::DirectoryAlreadyExists) => (),
+        Err(e) => fatal_panic!(
+            "Failed to create test directory {} due to {:?}.",
+            test_directory(),
+            e
+        ),
+    };
 }

--- a/iceoryx2-bb/posix/tests/directory_tests.rs
+++ b/iceoryx2-bb/posix/tests/directory_tests.rs
@@ -16,6 +16,7 @@ use iceoryx2_bb_posix::directory::*;
 use iceoryx2_bb_posix::file::*;
 use iceoryx2_bb_posix::file_descriptor::FileDescriptorBased;
 use iceoryx2_bb_posix::file_type::*;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
@@ -108,16 +109,19 @@ impl TestFixture {
 
 #[test]
 fn directory_temp_directory_does_exist() {
+    create_test_directory();
     assert_that!(Directory::does_exist(&test_directory()).unwrap(), eq true);
 }
 
 #[test]
 fn directory_non_existing_directory_does_not_exist() {
+    create_test_directory();
     assert_that!(!Directory::does_exist(&Path::new(b"i_do_not_exist").unwrap()).unwrap(), eq true);
 }
 
 #[test]
 fn directory_file_is_not_a_directory() {
+    create_test_directory();
     FileBuilder::new(&FilePath::new(b"no_directory").unwrap())
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
@@ -130,6 +134,7 @@ fn directory_file_is_not_a_directory() {
 fn directory_create_from_path_works() {
     let mut test = TestFixture::new();
 
+    create_test_directory();
     let sut_name = test.generate_directory_name();
 
     assert_that!(Directory::does_exist(&sut_name).unwrap(), eq false);
@@ -143,6 +148,7 @@ fn directory_create_from_path_works() {
 fn directory_create_from_path_works_recursively() {
     let mut test = TestFixture::new();
 
+    create_test_directory();
     let mut sut_name = test.generate_directory_name();
     sut_name
         .add_path_entry(&Path::new(b"all").unwrap())
@@ -168,6 +174,7 @@ fn directory_create_from_path_works_recursively() {
 fn directory_open_from_path_works() {
     let mut test = TestFixture::new();
 
+    create_test_directory();
     let sut_name = test.generate_directory_name();
 
     Directory::create(&sut_name, Permission::OWNER_ALL).unwrap();
@@ -180,6 +187,7 @@ fn directory_open_from_path_works() {
 fn directory_list_contents_works() {
     let mut test = TestFixture::new();
 
+    create_test_directory();
     let sut_name = test.generate_directory_name();
 
     let sut = Directory::create(&sut_name, Permission::OWNER_ALL);

--- a/iceoryx2-bb/posix/tests/file_descriptor_set_tests.rs
+++ b/iceoryx2-bb/posix/tests/file_descriptor_set_tests.rs
@@ -14,6 +14,7 @@ use iceoryx2_bb_container::semantic_string::SemanticString;
 use iceoryx2_bb_posix::config::*;
 use iceoryx2_bb_posix::file_descriptor::FileDescriptorBased;
 use iceoryx2_bb_posix::file_descriptor_set::*;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_bb_posix::unix_datagram_socket::*;
 use iceoryx2_bb_system_types::file_name::FileName;
@@ -41,6 +42,7 @@ fn generate_socket_name() -> FilePath {
 
 #[test]
 fn file_descriptor_set_timed_wait_blocks_at_least_timeout() {
+    create_test_directory();
     let socket_name = generate_socket_name();
 
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
@@ -77,6 +79,7 @@ fn file_descriptor_set_add_and_remove_works() {
     let mut sockets = vec![];
     let number_of_fds: usize = core::cmp::min(128, posix::FD_SETSIZE);
 
+    create_test_directory();
     for _ in 0..number_of_fds {
         let socket_name = generate_socket_name();
         sockets.push(
@@ -113,6 +116,7 @@ fn file_descriptor_set_add_and_remove_works() {
 fn file_descriptor_set_add_same_fd_twice_fails() {
     let fd_set = FileDescriptorSet::new();
 
+    create_test_directory();
     let socket_name = generate_socket_name();
     let socket = UnixDatagramReceiverBuilder::new(&socket_name)
         .creation_mode(CreationMode::PurgeAndCreate)
@@ -127,6 +131,7 @@ fn file_descriptor_set_add_same_fd_twice_fails() {
 
 #[test]
 fn file_descriptor_set_timed_wait_works() {
+    create_test_directory();
     let socket_name = generate_socket_name();
 
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
@@ -157,6 +162,7 @@ fn file_descriptor_set_timed_wait_works() {
 
 #[test]
 fn file_descriptor_set_blocking_wait_immediately_returns_notifications() {
+    create_test_directory();
     let socket_name = generate_socket_name();
 
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
@@ -187,6 +193,7 @@ fn file_descriptor_set_blocking_wait_immediately_returns_notifications() {
 
 #[test]
 fn file_descriptor_guard_has_access_to_underlying_fd() {
+    create_test_directory();
     let socket_name = generate_socket_name();
 
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
@@ -215,6 +222,7 @@ fn file_descriptor_triggering_many_returns_correct_number_of_notifications() {
     let mut senders = vec![];
     let number_of_fds: usize = core::cmp::min(128, posix::FD_SETSIZE);
 
+    create_test_directory();
     for _ in 0..number_of_fds {
         let socket_name = generate_socket_name();
         sockets.push(

--- a/iceoryx2-bb/posix/tests/file_descriptor_tests.rs
+++ b/iceoryx2-bb/posix/tests/file_descriptor_tests.rs
@@ -17,6 +17,7 @@ use iceoryx2_bb_posix::file::*;
 use iceoryx2_bb_posix::file_descriptor::*;
 use iceoryx2_bb_posix::ownership::*;
 use iceoryx2_bb_posix::shared_memory::*;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_bb_posix::user::*;
 use iceoryx2_bb_system_types::file_name::FileName;
@@ -53,6 +54,7 @@ impl GenericTestBuilder for File {
 
         let file_content = [170u8; 2048];
 
+        create_test_directory();
         let mut file = FileBuilder::new(&name)
             .creation_mode(CreationMode::PurgeAndCreate)
             .create()
@@ -82,6 +84,8 @@ mod file_descriptor_management {
     fn owner_handling_works<Sut: GenericTestBuilder + FileDescriptorManagement>() {
         test_requires!(POSIX_SUPPORT_USERS_AND_GROUPS);
 
+        create_test_directory();
+
         let mut sut = Sut::sut();
 
         let uid = User::from_self().unwrap().uid();
@@ -101,6 +105,8 @@ mod file_descriptor_management {
     fn permission_handling_works<Sut: GenericTestBuilder + FileDescriptorManagement>() {
         test_requires!(POSIX_SUPPORT_PERMISSIONS);
 
+        create_test_directory();
+
         let mut sut = Sut::sut();
 
         assert_that!(sut.set_permission(Permission::ALL), is_ok);
@@ -111,6 +117,8 @@ mod file_descriptor_management {
     #[test]
     fn metadata_handling_works<Sut: GenericTestBuilder + FileDescriptorManagement>() {
         test_requires!(POSIX_SUPPORT_PERMISSIONS);
+
+        create_test_directory();
 
         let mut sut = Sut::sut();
 

--- a/iceoryx2-bb/posix/tests/file_lock_tests.rs
+++ b/iceoryx2-bb/posix/tests/file_lock_tests.rs
@@ -15,6 +15,7 @@ use iceoryx2_bb_posix::config;
 use iceoryx2_bb_posix::file::*;
 use iceoryx2_bb_posix::file_lock::*;
 use iceoryx2_bb_posix::process::*;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
@@ -49,6 +50,7 @@ struct TestFixture<'a> {
 
 impl<'a> TestFixture<'a> {
     fn new(handle: &'a ReadWriteMutexHandle<File>) -> TestFixture {
+        create_test_directory();
         let file_name = generate_file_name();
         let file = FileBuilder::new(&file_name)
             .creation_mode(CreationMode::PurgeAndCreate)

--- a/iceoryx2-bb/posix/tests/file_tests.rs
+++ b/iceoryx2-bb/posix/tests/file_tests.rs
@@ -34,8 +34,6 @@ fn generate_file_name() -> FilePath {
     )
     .unwrap();
 
-    println!("#### {}", file);
-
     FilePath::from_path_and_file(&test_directory(), &file).unwrap()
 }
 

--- a/iceoryx2-bb/posix/tests/file_tests.rs
+++ b/iceoryx2-bb/posix/tests/file_tests.rs
@@ -14,6 +14,7 @@ use iceoryx2_bb_container::semantic_string::SemanticString;
 use iceoryx2_bb_posix::config::*;
 use iceoryx2_bb_posix::file::*;
 use iceoryx2_bb_posix::file_descriptor::*;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
@@ -33,6 +34,8 @@ fn generate_file_name() -> FilePath {
     )
     .unwrap();
 
+    println!("#### {}", file);
+
     FilePath::from_path_and_file(&test_directory(), &file).unwrap()
 }
 
@@ -42,6 +45,7 @@ struct TestFixture {
 
 impl TestFixture {
     fn new() -> TestFixture {
+        create_test_directory();
         let file = generate_file_name();
         File::remove(&file).ok();
         TestFixture { file }
@@ -265,6 +269,7 @@ fn file_remove_returns_false_when_file_not_exists() -> Result<(), FileError> {
 
 #[test]
 fn file_newly_created_file_is_removed_when_it_has_ownership() -> Result<(), FileError> {
+    create_test_directory();
     let file_name = generate_file_name();
 
     let file = FileBuilder::new(&file_name)
@@ -282,6 +287,7 @@ fn file_newly_created_file_is_removed_when_it_has_ownership() -> Result<(), File
 
 #[test]
 fn file_newly_created_file_has_not_ownership_by_default() -> Result<(), FileError> {
+    create_test_directory();
     let file_name = generate_file_name();
 
     let file = FileBuilder::new(&file_name)
@@ -300,6 +306,7 @@ fn file_newly_created_file_has_not_ownership_by_default() -> Result<(), FileErro
 
 #[test]
 fn file_opened_file_is_removed_when_it_has_ownership() -> Result<(), FileError> {
+    create_test_directory();
     let file_name = generate_file_name();
 
     FileBuilder::new(&file_name)
@@ -321,6 +328,7 @@ fn file_opened_file_is_removed_when_it_has_ownership() -> Result<(), FileError> 
 
 #[test]
 fn file_opened_file_has_not_ownership_by_default() -> Result<(), FileError> {
+    create_test_directory();
     let file_name = generate_file_name();
 
     FileBuilder::new(&file_name)
@@ -343,6 +351,7 @@ fn file_opened_file_has_not_ownership_by_default() -> Result<(), FileError> {
 
 #[test]
 fn file_acquire_ownership_works() -> Result<(), FileError> {
+    create_test_directory();
     let file_name = generate_file_name();
 
     let mut file = FileBuilder::new(&file_name)
@@ -361,6 +370,7 @@ fn file_acquire_ownership_works() -> Result<(), FileError> {
 
 #[test]
 fn file_release_ownership_works() -> Result<(), FileError> {
+    create_test_directory();
     let file_name = generate_file_name();
 
     let mut file = FileBuilder::new(&file_name)

--- a/iceoryx2-bb/posix/tests/metadata_tests.rs
+++ b/iceoryx2-bb/posix/tests/metadata_tests.rs
@@ -17,6 +17,7 @@ use iceoryx2_bb_posix::file::*;
 use iceoryx2_bb_posix::file_descriptor::*;
 use iceoryx2_bb_posix::file_type::*;
 use iceoryx2_bb_posix::group::*;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_posix::user::*;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
@@ -27,6 +28,7 @@ use iceoryx2_pal_posix::posix::POSIX_SUPPORT_USERS_AND_GROUPS;
 
 #[test]
 fn metadata_reads_basic_stats_correctly() {
+    create_test_directory();
     let file_name =
         FilePath::from_path_and_file(&test_directory(), &FileName::new(b"meta_test").unwrap())
             .unwrap();
@@ -49,6 +51,7 @@ fn metadata_reads_basic_stats_correctly() {
 fn metadata_reads_owner_and_permission_stats_correctly() {
     test_requires!(POSIX_SUPPORT_USERS_AND_GROUPS && POSIX_SUPPORT_PERMISSIONS);
 
+    create_test_directory();
     let file_name =
         FilePath::from_path_and_file(&test_directory(), &FileName::new(b"meta_test_123").unwrap())
             .unwrap();

--- a/iceoryx2-bb/posix/tests/process_state_tests.rs
+++ b/iceoryx2-bb/posix/tests/process_state_tests.rs
@@ -19,6 +19,7 @@ use iceoryx2_bb_posix::file::{File, FileBuilder};
 use iceoryx2_bb_posix::file_descriptor::FileDescriptorManagement;
 use iceoryx2_bb_posix::shared_memory::Permission;
 use iceoryx2_bb_posix::testing::__internal_process_guard_staged_death;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_posix::unix_datagram_socket::CreationMode;
 use iceoryx2_bb_posix::{process_state::*, unique_system_id::UniqueSystemId};
 use iceoryx2_bb_system_types::{file_name::FileName, file_path::FilePath};
@@ -41,6 +42,7 @@ fn generate_file_path() -> FilePath {
 
 #[test]
 pub fn process_state_guard_can_be_created() {
+    create_test_directory();
     let path = generate_file_path();
 
     let guard = ProcessGuard::new(&path).unwrap();
@@ -51,6 +53,7 @@ pub fn process_state_guard_can_be_created() {
 
 #[test]
 pub fn process_state_guard_removes_file_when_dropped() {
+    create_test_directory();
     let path = generate_file_path();
 
     let guard = ProcessGuard::new(&path).unwrap();
@@ -61,6 +64,7 @@ pub fn process_state_guard_removes_file_when_dropped() {
 
 #[test]
 pub fn process_state_guard_cannot_use_already_existing_file() {
+    create_test_directory();
     let path = generate_file_path();
 
     let file = FileBuilder::new(&path)
@@ -77,6 +81,7 @@ pub fn process_state_guard_cannot_use_already_existing_file() {
 
 #[test]
 pub fn process_state_monitor_detects_dead_state() {
+    create_test_directory();
     let path = generate_file_path();
     let mut cleaner_path = path.clone();
     cleaner_path.push_bytes(b"_owner_lock").unwrap();
@@ -92,6 +97,7 @@ pub fn process_state_monitor_detects_dead_state() {
 
 #[test]
 pub fn process_state_monitor_detects_non_existing_state() {
+    create_test_directory();
     let path = generate_file_path();
 
     let monitor = ProcessMonitor::new(&path).unwrap();
@@ -100,6 +106,7 @@ pub fn process_state_monitor_detects_non_existing_state() {
 
 #[test]
 pub fn process_state_monitor_transitions_work_starting_from_non_existing_process() {
+    create_test_directory();
     let path = generate_file_path();
     let mut cleaner_path = path.clone();
     cleaner_path.push_bytes(b"_owner_lock").unwrap();
@@ -125,6 +132,7 @@ pub fn process_state_monitor_transitions_work_starting_from_non_existing_process
 
 #[test]
 pub fn process_state_monitor_transitions_work_starting_from_existing_process() {
+    create_test_directory();
     let path = generate_file_path();
     let mut owner_lock_path = path.clone();
     owner_lock_path.push_bytes(b"_owner_lock").unwrap();
@@ -155,6 +163,7 @@ pub fn process_state_monitor_transitions_work_starting_from_existing_process() {
 
 #[test]
 pub fn process_state_monitor_detects_initialized_state() {
+    create_test_directory();
     let path = generate_file_path();
 
     let mut file = FileBuilder::new(&path)
@@ -172,6 +181,7 @@ pub fn process_state_monitor_detects_initialized_state() {
 
 #[test]
 pub fn process_state_owner_lock_cannot_be_created_when_process_does_not_exist() {
+    create_test_directory();
     let path = generate_file_path();
     let mut owner_lock_path = path.clone();
     owner_lock_path.push_bytes(b"_owner_lock").unwrap();
@@ -214,6 +224,7 @@ pub fn process_state_owner_lock_cannot_be_created_when_process_does_not_exist() 
 
 #[test]
 pub fn process_state_cleaner_removes_state_files_on_drop() {
+    create_test_directory();
     let path = generate_file_path();
     let mut owner_lock_path = path.clone();
     owner_lock_path.push_bytes(b"_owner_lock").unwrap();
@@ -241,6 +252,7 @@ pub fn process_state_cleaner_removes_state_files_on_drop() {
 
 #[test]
 pub fn process_state_cleaner_keeps_state_files_when_abandoned() {
+    create_test_directory();
     let path = generate_file_path();
     let mut owner_lock_path = path.clone();
     owner_lock_path.push_bytes(b"_owner_lock").unwrap();
@@ -273,6 +285,7 @@ pub fn process_state_cleaner_keeps_state_files_when_abandoned() {
 #[test]
 #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
 pub fn process_state_monitor_detects_alive_state_from_existing_process() {
+    create_test_directory();
     let path = generate_file_path();
 
     let guard = ProcessGuard::new(&path).unwrap();
@@ -286,6 +299,7 @@ pub fn process_state_monitor_detects_alive_state_from_existing_process() {
 #[test]
 #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
 pub fn process_state_owner_lock_cannot_be_acquired_from_living_process() {
+    create_test_directory();
     let path = generate_file_path();
 
     let _guard = ProcessGuard::new(&path).unwrap();
@@ -300,6 +314,7 @@ pub fn process_state_owner_lock_cannot_be_acquired_from_living_process() {
 #[test]
 #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
 pub fn process_state_owner_lock_cannot_be_acquired_twice() {
+    create_test_directory();
     let path = generate_file_path();
     let mut owner_lock_path = path.clone();
     owner_lock_path.push_bytes(b"_owner_lock").unwrap();

--- a/iceoryx2-bb/posix/tests/socket_ancillary_tests.rs
+++ b/iceoryx2-bb/posix/tests/socket_ancillary_tests.rs
@@ -17,6 +17,7 @@ use iceoryx2_bb_posix::file::*;
 use iceoryx2_bb_posix::file_descriptor::*;
 use iceoryx2_bb_posix::process::ProcessId;
 use iceoryx2_bb_posix::socket_ancillary::*;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
 use iceoryx2_bb_testing::assert_that;
@@ -102,6 +103,7 @@ fn socket_ancillary_add_file_descriptors_work() {
     let mut test = TestFixture::new();
     let mut sut = SocketAncillary::new();
 
+    create_test_directory();
     for _i in 0..MAX_FILE_DESCRIPTORS_PER_MESSAGE - 1 {
         assert_that!(sut.add_fd(test.create_file().file_descriptor().clone()), eq true);
         assert_that!(sut, is_not_empty);

--- a/iceoryx2-bb/posix/tests/unix_datagram_socket_tests.rs
+++ b/iceoryx2-bb/posix/tests/unix_datagram_socket_tests.rs
@@ -14,9 +14,11 @@ use iceoryx2_bb_container::semantic_string::SemanticString;
 use iceoryx2_bb_posix::barrier::*;
 use iceoryx2_bb_posix::config::*;
 use iceoryx2_bb_posix::creation_mode::*;
+use iceoryx2_bb_posix::directory::Directory;
 use iceoryx2_bb_posix::file::*;
 use iceoryx2_bb_posix::file_descriptor::*;
 use iceoryx2_bb_posix::socket_ancillary::*;
+use iceoryx2_bb_posix::testing::create_test_directory;
 use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_bb_posix::unix_datagram_socket::*;
 use iceoryx2_bb_system_types::file_name::FileName;
@@ -91,6 +93,7 @@ impl Drop for TestFixture {
 
 #[test]
 fn unix_datagram_socket_send_receive_works() {
+    create_test_directory();
     let socket_name = generate_socket_name();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
         .permission(Permission::OWNER_ALL)
@@ -116,6 +119,7 @@ fn unix_datagram_socket_send_receive_works() {
 
 #[test]
 fn unix_datagram_socket_adjust_buffer_size_works() {
+    create_test_directory();
     let socket_name = generate_socket_name();
     let mut sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
         .permission(Permission::OWNER_ALL)
@@ -136,6 +140,7 @@ fn unix_datagram_socket_adjust_buffer_size_works() {
 
 #[test]
 fn unix_datagram_socket_non_blocking_mode_returns_zero_when_nothing_was_received() {
+    create_test_directory();
     let socket_name = generate_socket_name();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
         .permission(Permission::OWNER_ALL)
@@ -155,6 +160,7 @@ fn unix_datagram_socket_non_blocking_mode_returns_zero_when_nothing_was_received
 
 #[test]
 fn unix_datagram_socket_blocking_mode_blocks() {
+    create_test_directory();
     let socket_name = generate_socket_name();
     let received_message = AtomicBool::new(false);
     let handle = BarrierHandle::new();
@@ -194,6 +200,7 @@ fn unix_datagram_socket_blocking_mode_blocks() {
 
 #[test]
 fn unix_datagram_socket_timeout_blocks_at_least() {
+    create_test_directory();
     let socket_name = generate_socket_name();
     let handle = BarrierHandle::new();
     let handle_2 = BarrierHandle::new();
@@ -234,6 +241,7 @@ fn unix_datagram_socket_sending_receiving_with_single_fd_works() {
 
     let mut test = TestFixture::new();
 
+    create_test_directory();
     let socket_name = generate_socket_name();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
         .permission(Permission::OWNER_ALL)
@@ -281,6 +289,7 @@ fn unix_datagram_socket_sending_receiving_with_single_fd_works() {
 fn unix_datagram_socket_sending_receiving_credentials_works() {
     test_requires!(POSIX_SUPPORT_UNIX_DATAGRAM_SOCKETS_ANCILLARY_DATA);
 
+    create_test_directory();
     let socket_name = generate_socket_name();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
         .permission(Permission::OWNER_ALL)
@@ -313,6 +322,7 @@ fn unix_datagram_socket_sending_receiving_with_max_supported_fd_and_credentials_
 
     let mut test = TestFixture::new();
 
+    create_test_directory();
     let socket_name = generate_socket_name();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
         .permission(Permission::OWNER_ALL)

--- a/iceoryx2-bb/system-types/BUILD.bazel
+++ b/iceoryx2-bb/system-types/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -31,4 +31,12 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-bb-system-types-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2-bb-system-types",
+        "//iceoryx2-bb/container:iceoryx2-bb-container",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+    ],
+)

--- a/iceoryx2-bb/threadsafe/BUILD.bazel
+++ b/iceoryx2-bb/threadsafe/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -29,4 +29,15 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-bb-threadsafe-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2-bb-threadsafe",
+        "//iceoryx2-bb/posix:iceoryx2-bb-posix",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+    ],
+    proc_macro_deps = [
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2-cal/BUILD.bazel
+++ b/iceoryx2-cal/BUILD.bazel
@@ -63,7 +63,6 @@ rust_test_suite(
         "@crate_index//:lazy_static",
         "@crate_index//:serde",
     ],
-    tags = ["external", "no-sandbox", "requires-fakeroot", "no-remote"],
     proc_macro_deps = [
         "@crate_index//:generic-tests",
     ],

--- a/iceoryx2-cal/BUILD.bazel
+++ b/iceoryx2-cal/BUILD.bazel
@@ -63,6 +63,7 @@ rust_test_suite(
         "@crate_index//:lazy_static",
         "@crate_index//:serde",
     ],
+    tags = ["external", "no-sandbox", "requires-fakeroot", "no-remote"],
     proc_macro_deps = [
         "@crate_index//:generic-tests",
     ],

--- a/iceoryx2-cal/BUILD.bazel
+++ b/iceoryx2-cal/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -48,4 +48,22 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-cal-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2-cal",
+        "//iceoryx2-bb/container:iceoryx2-bb-container",
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/lock-free:iceoryx2-bb-lock-free",
+        "//iceoryx2-bb/memory:iceoryx2-bb-memory",
+        "//iceoryx2-bb/posix:iceoryx2-bb-posix",
+        "//iceoryx2-bb/system-types:iceoryx2-bb-system-types",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+        "@crate_index//:lazy_static",
+        "@crate_index//:serde",
+    ],
+    proc_macro_deps = [
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2-cal/src/communication_channel/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/communication_channel/posix_shared_memory.rs
@@ -94,6 +94,7 @@ impl Default for Configuration {
 impl From<Configuration> for dynamic_storage::posix_shared_memory::Configuration<Management> {
     fn from(value: Configuration) -> Self {
         Self::default()
+            .prefix(&value.prefix)
             .suffix(&value.suffix)
             .path_hint(&value.path_hint)
     }

--- a/iceoryx2-cal/src/event/unix_datagram_socket.rs
+++ b/iceoryx2-cal/src/event/unix_datagram_socket.rs
@@ -71,7 +71,10 @@ impl NamedConceptConfiguration for Configuration {
 
 impl From<Configuration> for crate::communication_channel::unix_datagram::Configuration {
     fn from(value: Configuration) -> Self {
-        Self::default().suffix(&value.suffix).path_hint(&value.path)
+        Self::default()
+            .prefix(&value.prefix)
+            .suffix(&value.suffix)
+            .path_hint(&value.path)
     }
 }
 

--- a/iceoryx2-cal/src/lib.rs
+++ b/iceoryx2-cal/src/lib.rs
@@ -23,3 +23,6 @@ pub mod shared_memory_directory;
 pub mod shm_allocator;
 pub mod static_storage;
 pub mod zero_copy_connection;
+
+#[doc(hidden)]
+pub mod testing;

--- a/iceoryx2-cal/src/named_concept.rs
+++ b/iceoryx2-cal/src/named_concept.rs
@@ -49,7 +49,7 @@ pub enum NamedConceptPathHintRemoveError {
 /// a custom [`NamedConceptConfiguration::suffix()`] for all file names that are transparent during
 /// usage as well as a [`NamedConceptConfiguration::path_hint()`] that can be ignored if the
 /// underlying resource does not support it.
-pub trait NamedConceptConfiguration: Default + Clone + Debug {
+pub trait NamedConceptConfiguration: Default + Clone + Debug + Send {
     /// Defines the prefix that the concept will use.
     fn prefix(self, value: &FileName) -> Self;
 

--- a/iceoryx2-cal/src/testing.rs
+++ b/iceoryx2-cal/src/testing.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::named_concept::*;
+use iceoryx2_bb_container::semantic_string::*;
+use iceoryx2_bb_elementary::math::ToB64;
+use iceoryx2_bb_log::fatal_panic;
+use iceoryx2_bb_posix::{
+    config::test_directory,
+    directory::{Directory, DirectoryCreateError},
+    file::Permission,
+    unique_system_id::UniqueSystemId,
+};
+use iceoryx2_bb_system_types::file_name::FileName;
+
+pub fn generate_name() -> FileName {
+    let mut file = FileName::new(b"test_").unwrap();
+    file.push_bytes(
+        UniqueSystemId::new()
+            .unwrap()
+            .value()
+            .to_b64()
+            .to_lowercase()
+            .as_bytes(),
+    )
+    .unwrap();
+    file
+}
+
+fn generate_prefix() -> FileName {
+    let mut prefix = FileName::new(b"test_prefix_").unwrap();
+    prefix
+        .push_bytes(
+            UniqueSystemId::new()
+                .unwrap()
+                .value()
+                .to_b64()
+                .to_lowercase()
+                .as_bytes(),
+        )
+        .unwrap();
+
+    prefix
+}
+
+pub fn generate_isolated_config<T: NamedConceptMgmt>() -> T::Configuration {
+    match Directory::create(&test_directory(), Permission::OWNER_ALL) {
+        Ok(_) | Err(DirectoryCreateError::DirectoryAlreadyExists) => (),
+        Err(e) => fatal_panic!(
+            "Failed to create test directory {} due to {:?}.",
+            test_directory(),
+            e
+        ),
+    };
+
+    T::Configuration::default()
+        .prefix(&generate_prefix())
+        .path_hint(&test_directory())
+}

--- a/iceoryx2-cal/tests/dynamic_storage_trait_tests.rs
+++ b/iceoryx2-cal/tests/dynamic_storage_trait_tests.rs
@@ -14,28 +14,20 @@
 mod dynamic_storage {
     use iceoryx2_bb_container::semantic_string::*;
     use iceoryx2_bb_elementary::allocator::*;
-    use iceoryx2_bb_elementary::math::ToB64;
-    use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_system_types::file_name::FileName;
     use iceoryx2_bb_testing::lifetime_tracker::LifetimeTracker;
     use iceoryx2_bb_testing::{assert_that, test_requires};
     use iceoryx2_cal::dynamic_storage::*;
     use iceoryx2_cal::named_concept::*;
+    use iceoryx2_cal::testing::*;
     use std::sync::atomic::{AtomicI64, Ordering};
-
-    fn generate_name() -> FileName {
-        let mut file = FileName::new(b"test_").unwrap();
-        file.push_bytes(UniqueSystemId::new().unwrap().value().to_b64().as_bytes())
-            .unwrap();
-        file
-    }
 
     #[derive(Debug)]
     struct TestData {
         value: AtomicI64,
         supplementary_ptr: *mut u8,
         supplementary_len: usize,
-        _lifetime_tracker: LifetimeTracker,
+        _lifetime_tracker: Option<LifetimeTracker>,
     }
 
     impl TestData {
@@ -44,7 +36,16 @@ mod dynamic_storage {
                 value: AtomicI64::new(value),
                 supplementary_ptr: std::ptr::null_mut::<u8>(),
                 supplementary_len: 0,
-                _lifetime_tracker: LifetimeTracker::new(),
+                _lifetime_tracker: None,
+            }
+        }
+
+        fn new_with_lifetime_tracking(value: i64) -> Self {
+            Self {
+                value: AtomicI64::new(value),
+                supplementary_ptr: std::ptr::null_mut::<u8>(),
+                supplementary_len: 0,
+                _lifetime_tracker: Some(LifetimeTracker::new()),
             }
         }
     }
@@ -55,14 +56,19 @@ mod dynamic_storage {
     #[test]
     fn create_and_read_works<Sut: DynamicStorage<TestData>, WrongTypeSut: DynamicStorage<u64>>() {
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
+            .config(&config)
             .create(TestData::new(123))
             .unwrap();
 
         assert_that!(*sut.name(), eq storage_name);
 
-        let sut2 = Sut::Builder::new(&storage_name).open().unwrap();
+        let sut2 = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .open()
+            .unwrap();
 
         assert_that!(*sut2.name(), eq storage_name);
 
@@ -78,7 +84,9 @@ mod dynamic_storage {
     #[test]
     fn open_non_existing_fails<Sut: DynamicStorage<TestData>, WrongTypeSut: DynamicStorage<u64>>() {
         let storage_name = generate_name();
-        let sut = Sut::Builder::new(&storage_name).open();
+        let config = generate_isolated_config::<Sut>();
+
+        let sut = Sut::Builder::new(&storage_name).config(&config).open();
 
         assert_that!(sut, is_err);
         assert_that!(sut.err().unwrap(), eq DynamicStorageOpenError::DoesNotExist);
@@ -90,11 +98,14 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        let sut = Sut::Builder::new(&storage_name).create(TestData::new(123));
+        let sut = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .create(TestData::new(123));
         drop(sut);
 
-        let sut = Sut::Builder::new(&storage_name).open();
+        let sut = Sut::Builder::new(&storage_name).config(&config).open();
 
         assert_that!(sut, is_err);
         assert_that!(sut.err().unwrap(), eq DynamicStorageOpenError::DoesNotExist);
@@ -106,9 +117,14 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        let _sut1 = Sut::Builder::new(&storage_name).create(TestData::new(123));
-        let sut2 = Sut::Builder::new(&storage_name).create(TestData::new(123));
+        let _sut1 = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .create(TestData::new(123));
+        let sut2 = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .create(TestData::new(123));
 
         assert_that!(sut2, is_err);
         assert_that!(
@@ -125,12 +141,17 @@ mod dynamic_storage {
         test_requires!(Sut::does_support_persistency());
 
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
+            .config(&config)
             .create(TestData::new(123))
             .unwrap();
 
-        let sut2 = Sut::Builder::new(&storage_name).open().unwrap();
+        let sut2 = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .open()
+            .unwrap();
 
         drop(sut);
 
@@ -157,14 +178,21 @@ mod dynamic_storage {
     >() {
         const NUMBER_OF_OPENERS: u64 = 64;
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
+            .config(&config)
             .create(TestData::new(789))
             .unwrap();
 
         let mut sut_vec = vec![];
         for _i in 0..NUMBER_OF_OPENERS {
-            sut_vec.push(Sut::Builder::new(&storage_name).open().unwrap());
+            sut_vec.push(
+                Sut::Builder::new(&storage_name)
+                    .config(&config)
+                    .open()
+                    .unwrap(),
+            );
         }
 
         for i in 0..NUMBER_OF_OPENERS {
@@ -186,8 +214,10 @@ mod dynamic_storage {
     fn release_ownership_works<Sut: DynamicStorage<TestData>, WrongTypeSut: DynamicStorage<u64>>() {
         test_requires!(Sut::does_support_persistency());
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
+            .config(&config)
             .create(TestData::new(9887))
             .unwrap();
 
@@ -196,10 +226,13 @@ mod dynamic_storage {
         assert_that!(sut.has_ownership(), eq false);
         drop(sut);
 
-        let sut2 = Sut::Builder::new(&storage_name).open().unwrap();
+        let sut2 = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .open()
+            .unwrap();
         assert_that!(sut2.get().value.load(Ordering::Relaxed), eq 9887);
 
-        assert_that!(unsafe { Sut::remove(&storage_name) }, eq Ok(true));
+        assert_that!(unsafe { Sut::remove_cfg(&storage_name, &config) }, eq Ok(true));
         drop(sut2);
 
         let sut2 = Sut::Builder::new(&storage_name).open();
@@ -214,9 +247,11 @@ mod dynamic_storage {
     >() {
         test_requires!(Sut::does_support_persistency());
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
             .has_ownership(false)
+            .config(&config)
             .create(TestData::new(9887))
             .unwrap();
 
@@ -224,13 +259,16 @@ mod dynamic_storage {
 
         drop(sut);
 
-        let sut2 = Sut::Builder::new(&storage_name).open().unwrap();
+        let sut2 = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .open()
+            .unwrap();
         assert_that!(sut2.get().value.load(Ordering::Relaxed), eq 9887);
 
-        assert_that!(unsafe { Sut::remove(&storage_name) }, eq Ok(true));
+        assert_that!(unsafe { Sut::remove_cfg(&storage_name, &config) }, eq Ok(true));
         drop(sut2);
 
-        let sut2 = Sut::Builder::new(&storage_name).open();
+        let sut2 = Sut::Builder::new(&storage_name).config(&config).open();
         assert_that!(sut2, is_err);
         assert_that!(sut2.err().unwrap(), eq DynamicStorageOpenError::DoesNotExist);
     }
@@ -239,9 +277,11 @@ mod dynamic_storage {
     fn acquire_ownership_works<Sut: DynamicStorage<TestData>, WrongTypeSut: DynamicStorage<u64>>() {
         test_requires!(Sut::does_support_persistency());
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
             .has_ownership(false)
+            .config(&config)
             .create(TestData::new(9887))
             .unwrap();
 
@@ -249,28 +289,31 @@ mod dynamic_storage {
 
         assert_that!(sut.has_ownership(), eq true);
         drop(sut);
-        assert_that!(Sut::does_exist(&storage_name).unwrap(), eq false);
+        assert_that!(Sut::does_exist_cfg(&storage_name, &config).unwrap(), eq false);
     }
 
     #[test]
     fn does_exist_works<Sut: DynamicStorage<TestData>, WrongTypeSut: DynamicStorage<u64>>() {
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        assert_that!(Sut::does_exist(&storage_name), eq Ok(false));
+        assert_that!(Sut::does_exist_cfg(&storage_name, &config), eq Ok(false));
 
         let additional_size: usize = 256;
         let sut = Sut::Builder::new(&storage_name)
             .supplementary_size(additional_size)
+            .config(&config)
             .create(TestData::new(9887))
             .unwrap();
         let _sut2 = Sut::Builder::new(&storage_name)
             .supplementary_size(additional_size)
+            .config(&config)
             .open()
             .unwrap();
 
-        assert_that!(Sut::does_exist(&storage_name), eq Ok(true));
+        assert_that!(Sut::does_exist_cfg(&storage_name, &config), eq Ok(true));
         drop(sut);
-        assert_that!(Sut::does_exist(&storage_name), eq Ok(false));
+        assert_that!(Sut::does_exist_cfg(&storage_name, &config), eq Ok(false));
     }
 
     #[test]
@@ -278,12 +321,17 @@ mod dynamic_storage {
         test_requires!(Sut::does_support_persistency());
 
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
+            .config(&config)
             .create(TestData::new(123))
             .unwrap();
 
-        let sut2 = Sut::Builder::new(&storage_name).open().unwrap();
+        let sut2 = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .open()
+            .unwrap();
 
         assert_that!(sut.has_ownership(), eq true);
         assert_that!(sut2.has_ownership(), eq false);
@@ -292,7 +340,7 @@ mod dynamic_storage {
         assert_that!(sut.has_ownership(), eq false);
         drop(sut);
         drop(sut2);
-        assert_that!(unsafe { Sut::remove(&storage_name) }, eq Ok(true));
+        assert_that!(unsafe { Sut::remove_cfg(&storage_name, &config) }, eq Ok(true));
     }
 
     #[test]
@@ -301,8 +349,10 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
+            .config(&config)
             .supplementary_size(134)
             .initializer(|value, allocator| {
                 let layout = Layout::from_size_align(134, 1).unwrap();
@@ -334,7 +384,10 @@ mod dynamic_storage {
             );
         }
 
-        let sut2 = Sut::Builder::new(&storage_name).open().unwrap();
+        let sut2 = Sut::Builder::new(&storage_name)
+            .config(&config)
+            .open()
+            .unwrap();
         assert_that!(sut2.get().value.load(Ordering::Relaxed), eq 8912);
         assert_that!(sut2.get().supplementary_len, eq 134);
         for i in 0..134 {
@@ -351,10 +404,12 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
             .supplementary_size(134)
             .initializer(|_, _| false)
+            .config(&config)
             .create(TestData::new(123));
 
         assert_that!(sut, is_err);
@@ -363,8 +418,8 @@ mod dynamic_storage {
             DynamicStorageCreateError::InitializationFailed
         );
 
-        assert_that!(<Sut as NamedConceptMgmt>::does_exist(&storage_name), eq Ok(false));
-        assert_that!(unsafe { <Sut as NamedConceptMgmt>::remove(&storage_name) }, eq Ok(false));
+        assert_that!(<Sut as NamedConceptMgmt>::does_exist_cfg(&storage_name, &config), eq Ok(false));
+        assert_that!(unsafe { <Sut as NamedConceptMgmt>::remove_cfg(&storage_name, &config) }, eq Ok(false));
     }
 
     #[test]
@@ -372,20 +427,22 @@ mod dynamic_storage {
         let mut sut_names = vec![];
         let mut suts = vec![];
         const LIMIT: usize = 5;
+        let config = generate_isolated_config::<Sut>();
 
         for i in 0..LIMIT {
-            assert_that!(<Sut as NamedConceptMgmt>::list().unwrap(), len i );
+            assert_that!(<Sut as NamedConceptMgmt>::list_cfg(&config).unwrap(), len i );
             sut_names.push(generate_name());
-            assert_that!(<Sut as NamedConceptMgmt>::does_exist(&sut_names[i]), eq Ok(false));
+            assert_that!(<Sut as NamedConceptMgmt>::does_exist_cfg(&sut_names[i], &config), eq Ok(false));
             suts.push(
                 Sut::Builder::new(&sut_names[i])
                     .supplementary_size(134)
+                    .config(&config)
                     .create(TestData::new(123)),
             );
-            assert_that!(<Sut as NamedConceptMgmt>::does_exist(&sut_names[i]), eq Ok(true));
+            assert_that!(<Sut as NamedConceptMgmt>::does_exist_cfg(&sut_names[i], &config), eq Ok(true));
 
-            let list = <Sut as NamedConceptMgmt>::list().unwrap();
-            assert_that!(<Sut as NamedConceptMgmt>::list().unwrap(), len i + 1);
+            let list = <Sut as NamedConceptMgmt>::list_cfg(&config).unwrap();
+            assert_that!(list, len i + 1);
             let does_exist_in_list = |value| {
                 for e in &list {
                     if e == value {
@@ -400,16 +457,16 @@ mod dynamic_storage {
             }
         }
 
-        assert_that!(<Sut as NamedConceptMgmt>::list().unwrap(), len LIMIT);
+        assert_that!(<Sut as NamedConceptMgmt>::list_cfg(&config).unwrap(), len LIMIT);
 
         for i in 0..LIMIT {
-            assert_that!(unsafe{<Sut as NamedConceptMgmt>::remove(&sut_names[i])}, eq Ok(true));
-            assert_that!(unsafe{<Sut as NamedConceptMgmt>::remove(&sut_names[i])}, eq Ok(false));
+            assert_that!(unsafe{<Sut as NamedConceptMgmt>::remove_cfg(&sut_names[i], &config)}, eq Ok(true));
+            assert_that!(unsafe{<Sut as NamedConceptMgmt>::remove_cfg(&sut_names[i], &config)}, eq Ok(false));
         }
 
         std::mem::forget(suts);
 
-        assert_that!(<Sut as NamedConceptMgmt>::list().unwrap(), len 0);
+        assert_that!(<Sut as NamedConceptMgmt>::list_cfg(&config).unwrap(), len 0);
     }
 
     #[test]
@@ -417,10 +474,11 @@ mod dynamic_storage {
         Sut: DynamicStorage<TestData>,
         WrongTypeSut: DynamicStorage<u64>,
     >() {
-        let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
+        let config = generate_isolated_config::<Sut>();
+        let config_1 = config
+            .clone()
             .suffix(unsafe { &FileName::new_unchecked(b".s1") });
-        let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { &FileName::new_unchecked(b".s2") });
+        let config_2 = config.suffix(unsafe { &FileName::new_unchecked(b".s2") });
 
         let sut_name = generate_name();
 
@@ -480,18 +538,23 @@ mod dynamic_storage {
     #[test]
     fn open_or_create_works<Sut: DynamicStorage<TestData>, WrongTypeSut: DynamicStorage<u64>>() {
         let sut_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        assert_that!(Sut::does_exist(&sut_name), eq Ok(false));
-        let sut_1 = Sut::Builder::new(&sut_name).open_or_create(TestData::new(123));
+        assert_that!(Sut::does_exist_cfg(&sut_name, &config), eq Ok(false));
+        let sut_1 = Sut::Builder::new(&sut_name)
+            .config(&config)
+            .open_or_create(TestData::new(123));
         assert_that!(sut_1, is_ok);
-        assert_that!(Sut::does_exist(&sut_name), eq Ok(true));
+        assert_that!(Sut::does_exist_cfg(&sut_name, &config), eq Ok(true));
 
-        let sut_2 = Sut::Builder::new(&sut_name).open_or_create(TestData::new(123));
+        let sut_2 = Sut::Builder::new(&sut_name)
+            .config(&config)
+            .open_or_create(TestData::new(123));
         assert_that!(sut_2, is_ok);
 
         drop(sut_2);
         drop(sut_1);
-        assert_that!(Sut::does_exist(&sut_name), eq Ok(false));
+        assert_that!(Sut::does_exist_cfg(&sut_name, &config), eq Ok(false));
     }
 
     #[test]
@@ -502,9 +565,11 @@ mod dynamic_storage {
         let state = LifetimeTracker::start_tracking();
 
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
-            .create(TestData::new(123))
+            .config(&config)
+            .create(TestData::new_with_lifetime_tracking(123))
             .unwrap();
 
         assert_that!(sut.has_ownership(), eq true);
@@ -523,15 +588,17 @@ mod dynamic_storage {
         test_requires!(Sut::does_support_persistency());
 
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
-            .create(TestData::new(123))
+            .config(&config)
+            .create(TestData::new_with_lifetime_tracking(123))
             .unwrap();
         sut.release_ownership();
         drop(sut);
 
         assert_that!(state.number_of_living_instances(), eq 1);
-        assert_that!(unsafe { Sut::remove(&storage_name) }, eq Ok(true));
+        assert_that!(unsafe { Sut::remove_cfg(&storage_name, &config) }, eq Ok(true));
     }
 
     #[test]
@@ -542,16 +609,18 @@ mod dynamic_storage {
         let state = LifetimeTracker::start_tracking();
 
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
         let sut = Sut::Builder::new(&storage_name)
-            .create(TestData::new(123))
+            .config(&config)
+            .create(TestData::new_with_lifetime_tracking(123))
             .unwrap();
         sut.release_ownership();
         // it leaks a memory mapping here but this we want explicitly to test remove also
         // for platforms that do not support persistent dynamic storage
         std::mem::forget(sut);
 
-        assert_that!(unsafe { Sut::remove(&storage_name) }, eq Ok(true));
+        assert_that!(unsafe { Sut::remove_cfg(&storage_name, &config) }, eq Ok(true));
         assert_that!(state.number_of_living_instances(), eq 0);
     }
 
@@ -561,6 +630,7 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let state = LifetimeTracker::start_tracking();
+        let config = generate_isolated_config::<Sut>();
 
         if std::any::TypeId::of::<Sut>()
             // skip process local test since the process locality ensures that an initializer
@@ -572,11 +642,12 @@ mod dynamic_storage {
 
             let _ = Sut::Builder::new(&storage_name)
                 .has_ownership(false)
+                .config(&config)
                 .initializer(|_, _| {
-                    assert_that!(unsafe { Sut::remove(&storage_name) }, eq Ok(true));
+                    assert_that!(unsafe { Sut::remove_cfg(&storage_name, &config) }, eq Ok(true));
                     false
                 })
-                .create(TestData::new(0));
+                .create(TestData::new_with_lifetime_tracking(0));
 
             assert_that!(state.number_of_living_instances(), eq 1);
         }
@@ -588,9 +659,16 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let storage_name = generate_name();
-        let sut = WrongTypeSut::Builder::new(&storage_name).create(123);
+        let config = generate_isolated_config::<Sut>();
+        let wrong_type_config = WrongTypeSut::Configuration::default()
+            .prefix(config.get_prefix())
+            .suffix(config.get_suffix())
+            .path_hint(config.get_path_hint());
+        let sut = WrongTypeSut::Builder::new(&storage_name)
+            .config(&wrong_type_config)
+            .create(123);
         assert_that!(sut, is_ok);
-        assert_that!(Sut::does_exist(&storage_name), eq Ok(false));
+        assert_that!(Sut::does_exist_cfg(&storage_name, &config), eq Ok(false));
     }
 
     #[test]
@@ -606,10 +684,16 @@ mod dynamic_storage {
         let mut u64_storages = vec![];
         let mut u64_storages_names = vec![];
 
+        let config = generate_isolated_config::<Sut>();
+        let wrong_type_config = WrongTypeSut::Configuration::default()
+            .prefix(config.get_prefix())
+            .suffix(config.get_suffix())
+            .path_hint(config.get_path_hint());
         for _ in 0..NUMBER_OF_TESTDATA_STORAGES {
             let storage_name = generate_name();
             testdata_storages.push(
                 Sut::Builder::new(&storage_name)
+                    .config(&config)
                     .create(TestData::new(123))
                     .unwrap(),
             );
@@ -617,6 +701,7 @@ mod dynamic_storage {
 
             u64_storages.push(
                 WrongTypeSut::Builder::new(&storage_name)
+                    .config(&wrong_type_config)
                     .create(34)
                     .unwrap(),
             );
@@ -628,14 +713,15 @@ mod dynamic_storage {
             let storage_name = generate_name();
             u64_storages.push(
                 WrongTypeSut::Builder::new(&storage_name)
+                    .config(&wrong_type_config)
                     .create(21)
                     .unwrap(),
             );
             u64_storages_names.push(storage_name);
         }
 
-        let testdata_list = Sut::list().unwrap();
-        let u64_list = WrongTypeSut::list().unwrap();
+        let testdata_list = Sut::list_cfg(&config).unwrap();
+        let u64_list = WrongTypeSut::list_cfg(&wrong_type_config).unwrap();
 
         assert_that!(testdata_list, len testdata_storages.len());
         assert_that!(u64_list, len u64_storages.len());
@@ -655,10 +741,19 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
+        let wrong_type_config = WrongTypeSut::Configuration::default()
+            .prefix(config.get_prefix())
+            .suffix(config.get_suffix())
+            .path_hint(config.get_path_hint());
+
         let _sut = Sut::Builder::new(&storage_name)
+            .config(&config)
             .create(TestData::new(1234))
             .unwrap();
-        let sut = WrongTypeSut::Builder::new(&storage_name).open();
+        let sut = WrongTypeSut::Builder::new(&storage_name)
+            .config(&wrong_type_config)
+            .open();
         assert_that!(sut.err().unwrap(), eq DynamicStorageOpenError::DoesNotExist);
     }
 
@@ -668,10 +763,16 @@ mod dynamic_storage {
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         let storage_name = generate_name();
+        let config = generate_isolated_config::<Sut>();
+        let wrong_type_config = WrongTypeSut::Configuration::default()
+            .prefix(config.get_prefix())
+            .suffix(config.get_suffix())
+            .path_hint(config.get_path_hint());
         let _sut = Sut::Builder::new(&storage_name)
+            .config(&config)
             .create(TestData::new(1234))
             .unwrap();
-        assert_that!(unsafe { WrongTypeSut::remove(&storage_name) }, eq Ok(false));
+        assert_that!(unsafe { WrongTypeSut::remove_cfg(&storage_name, &wrong_type_config) }, eq Ok(false));
     }
 
     #[instantiate_tests(<iceoryx2_cal::dynamic_storage::posix_shared_memory::Storage<TestData>,

--- a/iceoryx2-cal/tests/monitoring_tests.rs
+++ b/iceoryx2-cal/tests/monitoring_tests.rs
@@ -12,30 +12,18 @@
 
 #[generic_tests::define]
 mod monitoring {
-    use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_system_types::file_name::*;
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_cal::monitoring::*;
     use iceoryx2_cal::named_concept::*;
-
-    fn generate_name() -> FileName {
-        let mut file = FileName::new(b"monitoring_tests_").unwrap();
-        file.push_bytes(
-            UniqueSystemId::new()
-                .unwrap()
-                .value()
-                .to_string()
-                .as_bytes(),
-        )
-        .unwrap();
-        file
-    }
+    use iceoryx2_cal::testing::*;
 
     #[test]
     fn create_works<Sut: Monitoring>() {
         let name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        let sut_token = Sut::Builder::new(&name).token();
+        let sut_token = Sut::Builder::new(&name).config(&config).token();
         assert_that!(sut_token, is_ok);
         assert_that!(*sut_token.as_ref().unwrap().name(), eq name);
     }
@@ -43,11 +31,12 @@ mod monitoring {
     #[test]
     fn create_same_token_twice_fails<Sut: Monitoring>() {
         let name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        let sut_token_1 = Sut::Builder::new(&name).token();
+        let sut_token_1 = Sut::Builder::new(&name).config(&config).token();
         assert_that!(sut_token_1, is_ok);
 
-        let sut_token_2 = Sut::Builder::new(&name).token();
+        let sut_token_2 = Sut::Builder::new(&name).config(&config).token();
         assert_that!(sut_token_2, is_err);
         assert_that!(
             sut_token_2.err().unwrap(), eq
@@ -58,20 +47,22 @@ mod monitoring {
     #[test]
     fn token_removes_resources_when_going_out_of_scope<Sut: Monitoring>() {
         let name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        let sut_token_1 = Sut::Builder::new(&name).token();
+        let sut_token_1 = Sut::Builder::new(&name).config(&config).token();
         assert_that!(sut_token_1, is_ok);
         drop(sut_token_1);
 
-        let sut_token_2 = Sut::Builder::new(&name).token();
+        let sut_token_2 = Sut::Builder::new(&name).config(&config).token();
         assert_that!(sut_token_2, is_ok);
     }
 
     #[test]
     fn create_cleaner_fails_when_token_does_not_exist<Sut: Monitoring>() {
         let name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        let sut_cleaner = Sut::Builder::new(&name).cleaner();
+        let sut_cleaner = Sut::Builder::new(&name).config(&config).cleaner();
         assert_that!(sut_cleaner, is_err);
         assert_that!(sut_cleaner.err().unwrap(), eq MonitoringCreateCleanerError::DoesNotExist);
     }
@@ -80,12 +71,13 @@ mod monitoring {
     #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
     fn monitor_works<Sut: Monitoring>() {
         let name = generate_name();
+        let config = generate_isolated_config::<Sut>();
 
-        let sut_monitor = Sut::Builder::new(&name).monitor().unwrap();
+        let sut_monitor = Sut::Builder::new(&name).config(&config).monitor().unwrap();
         assert_that!(*sut_monitor.name(), eq name);
         assert_that!(sut_monitor.state().unwrap(), eq State::DoesNotExist);
 
-        let sut_token = Sut::Builder::new(&name).token();
+        let sut_token = Sut::Builder::new(&name).config(&config).token();
         assert_that!(sut_monitor.state().unwrap(), eq State::Alive);
 
         drop(sut_token);
@@ -96,15 +88,16 @@ mod monitoring {
     fn list_monitoring_token_works<Sut: Monitoring>() {
         let mut sut_names = vec![];
         const LIMIT: usize = 10;
+        let config = generate_isolated_config::<Sut>();
 
-        assert_that!(<Sut as NamedConceptMgmt>::list().unwrap(), len 0);
+        assert_that!(<Sut as NamedConceptMgmt>::list_cfg(&config).unwrap(), len 0);
         for i in 0..LIMIT {
             sut_names.push(generate_name());
-            assert_that!(<Sut as NamedConceptMgmt>::does_exist(&sut_names[i]), eq Ok(false));
-            std::mem::forget(Sut::Builder::new(&sut_names[i]).token());
-            assert_that!(<Sut as NamedConceptMgmt>::does_exist(&sut_names[i]), eq Ok(true));
+            assert_that!(<Sut as NamedConceptMgmt>::does_exist_cfg(&sut_names[i], &config), eq Ok(false));
+            std::mem::forget(Sut::Builder::new(&sut_names[i]).config(&config).token());
+            assert_that!(<Sut as NamedConceptMgmt>::does_exist_cfg(&sut_names[i], &config), eq Ok(true));
 
-            let list = <Sut as NamedConceptMgmt>::list().unwrap();
+            let list = <Sut as NamedConceptMgmt>::list_cfg(&config).unwrap();
             assert_that!(list, len i + 1);
             let does_exist_in_list = |value| {
                 for e in &list {
@@ -121,19 +114,20 @@ mod monitoring {
         }
 
         for i in 0..LIMIT {
-            assert_that!(unsafe{<Sut as NamedConceptMgmt>::remove(&sut_names[i])}, eq Ok(true));
-            assert_that!(unsafe{<Sut as NamedConceptMgmt>::remove(&sut_names[i])}, eq Ok(false));
+            assert_that!(unsafe{<Sut as NamedConceptMgmt>::remove_cfg(&sut_names[i], &config)}, eq Ok(true));
+            assert_that!(unsafe{<Sut as NamedConceptMgmt>::remove_cfg(&sut_names[i], &config)}, eq Ok(false));
         }
 
-        assert_that!(<Sut as NamedConceptMgmt>::list().unwrap(), len 0);
+        assert_that!(<Sut as NamedConceptMgmt>::list_cfg(&config).unwrap(), len 0);
     }
 
     #[test]
     fn custom_suffix_keeps_monitoring_token_separated<Sut: Monitoring>() {
-        let config_1 = <Sut as NamedConceptMgmt>::Configuration::default()
+        let config = generate_isolated_config::<Sut>();
+        let config_1 = config
+            .clone()
             .suffix(unsafe { &FileName::new_unchecked(b".suffix_1") });
-        let config_2 = <Sut as NamedConceptMgmt>::Configuration::default()
-            .suffix(unsafe { &FileName::new_unchecked(b".suffix_2") });
+        let config_2 = config.suffix(unsafe { &FileName::new_unchecked(b".suffix_2") });
 
         let sut_name = generate_name();
 

--- a/iceoryx2-cal/tests/reactor_tests.rs
+++ b/iceoryx2-cal/tests/reactor_tests.rs
@@ -12,16 +12,14 @@
 
 #[generic_tests::define]
 mod reactor {
-    use iceoryx2_bb_container::semantic_string::*;
     use iceoryx2_bb_posix::file_descriptor::FileDescriptorBased;
-    use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
-    use iceoryx2_bb_system_types::file_name::FileName;
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_cal::event::unix_datagram_socket::*;
     use iceoryx2_cal::event::{Listener, ListenerBuilder, Notifier, NotifierBuilder};
     use iceoryx2_cal::reactor::{Reactor, *};
+    use iceoryx2_cal::testing::{generate_isolated_config, generate_name};
     use std::sync::atomic::{AtomicU64, Ordering};
-    use std::sync::Barrier;
+    use std::sync::{Barrier, Mutex};
     use std::time::{Duration, Instant};
 
     const TIMEOUT: Duration = Duration::from_millis(50);
@@ -36,10 +34,13 @@ mod reactor {
     impl NotifierListenerPair {
         fn new() -> Self {
             let name = generate_name();
+            let config = generate_isolated_config::<unix_datagram_socket::EventImpl>();
             let listener = unix_datagram_socket::ListenerBuilder::new(&name)
+                .config(&config)
                 .create()
                 .unwrap();
             let notifier = unix_datagram_socket::NotifierBuilder::new(&name)
+                .config(&config)
                 .open()
                 .unwrap();
 
@@ -47,22 +48,10 @@ mod reactor {
         }
     }
 
-    fn generate_name() -> FileName {
-        let mut file = FileName::new(b"reactor_tests_").unwrap();
-        file.push_bytes(
-            UniqueSystemId::new()
-                .unwrap()
-                .value()
-                .to_string()
-                .as_bytes(),
-        )
-        .unwrap();
-        file
-    }
-
     #[test]
     fn attach_and_detach_works<Sut: Reactor>() {
         let sut = <<Sut as Reactor>::Builder>::new().create().unwrap();
+        let config = generate_isolated_config::<unix_datagram_socket::EventImpl>();
 
         let mut listeners = vec![];
         let mut guards = vec![];
@@ -70,6 +59,7 @@ mod reactor {
             let name = generate_name();
             listeners.push(
                 unix_datagram_socket::ListenerBuilder::new(&name)
+                    .config(&config)
                     .create()
                     .unwrap(),
             );
@@ -94,9 +84,11 @@ mod reactor {
     #[test]
     fn attach_the_same_attachment_twice_fails<Sut: Reactor>() {
         let sut = <<Sut as Reactor>::Builder>::new().create().unwrap();
+        let config = generate_isolated_config::<unix_datagram_socket::EventImpl>();
 
         let name = generate_name();
         let listener = unix_datagram_socket::ListenerBuilder::new(&name)
+            .config(&config)
             .create()
             .unwrap();
 
@@ -496,11 +488,13 @@ mod reactor {
         let name = generate_name();
         let barrier = Barrier::new(2);
         let counter = AtomicU64::new(0);
+        let config = Mutex::new(generate_isolated_config::<unix_datagram_socket::EventImpl>());
 
         std::thread::scope(|s| {
             let t = s.spawn(|| {
                 let sut = <<Sut as Reactor>::Builder>::new().create().unwrap();
                 let listener = unix_datagram_socket::ListenerBuilder::new(&name)
+                    .config(&config.lock().unwrap())
                     .create()
                     .unwrap();
                 let _guard = sut.attach(&listener);
@@ -523,6 +517,7 @@ mod reactor {
             let counter_old = counter.load(Ordering::Relaxed);
 
             let notifier = unix_datagram_socket::NotifierBuilder::new(&name)
+                .config(&config.lock().unwrap())
                 .open()
                 .unwrap();
             notifier.notify(TriggerId::new(123)).unwrap();
@@ -537,11 +532,13 @@ mod reactor {
         let name = generate_name();
         let barrier = Barrier::new(2);
         let counter = AtomicU64::new(0);
+        let config = Mutex::new(generate_isolated_config::<unix_datagram_socket::EventImpl>());
 
         std::thread::scope(|s| {
             let t = s.spawn(|| {
                 let sut = <<Sut as Reactor>::Builder>::new().create().unwrap();
                 let listener = unix_datagram_socket::ListenerBuilder::new(&name)
+                    .config(&config.lock().unwrap())
                     .create()
                     .unwrap();
                 let _guard = sut.attach(&listener);
@@ -562,6 +559,7 @@ mod reactor {
             let counter_old = counter.load(Ordering::Relaxed);
 
             let notifier = unix_datagram_socket::NotifierBuilder::new(&name)
+                .config(&config.lock().unwrap())
                 .open()
                 .unwrap();
             notifier.notify(TriggerId::new(123)).unwrap();

--- a/iceoryx2-cal/tests/shared_memory_directory_tests.rs
+++ b/iceoryx2-cal/tests/shared_memory_directory_tests.rs
@@ -14,25 +14,15 @@ mod shared_memory_directory {
     use std::alloc::Layout;
     use std::sync::Barrier;
 
-    use iceoryx2_bb_container::semantic_string::*;
-    use iceoryx2_bb_elementary::math::ToB64;
-    use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
-    use iceoryx2_bb_system_types::file_name::FileName;
     use iceoryx2_bb_testing::{assert_that, test_requires};
     use iceoryx2_cal::shared_memory::SharedMemoryCreateError;
     use iceoryx2_cal::shared_memory_directory::SharedMemoryDirectory;
     use iceoryx2_cal::shm_allocator::ShmAllocator;
+    use iceoryx2_cal::testing::generate_name;
     use iceoryx2_cal::{
         shared_memory, shared_memory_directory::SharedMemoryDirectoryCreateFileError,
         shared_memory_directory::SharedMemoryDirectoryCreator, shm_allocator,
     };
-
-    fn generate_name() -> FileName {
-        let mut file = FileName::new(b"test_").unwrap();
-        file.push_bytes(UniqueSystemId::new().unwrap().value().to_b64().as_bytes())
-            .unwrap();
-        file
-    }
 
     type MgmtShm = shared_memory::posix::Memory<shm_allocator::bump_allocator::BumpAllocator>;
     type Allocator = shm_allocator::pool_allocator::PoolAllocator;

--- a/iceoryx2-cal/tests/shared_memory_posix_shared_memory_tests.rs
+++ b/iceoryx2-cal/tests/shared_memory_posix_shared_memory_tests.rs
@@ -11,25 +11,16 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 mod shared_memory_posix_shared_memory_tests {
-    use iceoryx2_bb_elementary::math::ToB64;
     use iceoryx2_bb_posix::creation_mode::CreationMode;
     use iceoryx2_bb_posix::permission::Permission;
-    use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
-    use iceoryx2_bb_system_types::file_name::*;
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_cal::named_concept::*;
     use iceoryx2_cal::shared_memory::*;
     use iceoryx2_cal::shm_allocator::pool_allocator::PoolAllocator;
+    use iceoryx2_cal::testing::generate_name;
     use std::time::Duration;
 
     const TIMEOUT: Duration = Duration::from_millis(100);
-
-    fn generate_name() -> FileName {
-        let mut file = FileName::new(b"test_").unwrap();
-        file.push_bytes(UniqueSystemId::new().unwrap().value().to_b64().as_bytes())
-            .unwrap();
-        file
-    }
 
     #[test]
     fn waiting_for_initialization_works() {

--- a/iceoryx2-cal/tests/static_storage_file_tests.rs
+++ b/iceoryx2-cal/tests/static_storage_file_tests.rs
@@ -14,7 +14,6 @@ use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_posix::config::*;
 use iceoryx2_bb_posix::directory::Directory;
 use iceoryx2_bb_posix::file::*;
-use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-cal/tests/static_storage_file_tests.rs
+++ b/iceoryx2-cal/tests/static_storage_file_tests.rs
@@ -19,29 +19,16 @@ use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_cal::static_storage::file::*;
+use iceoryx2_cal::testing::*;
 use std::time::Duration;
 
-fn generate_name() -> FileName {
-    let mut file = FileName::new(b"communication_channel_tests_").unwrap();
-    file.push_bytes(
-        UniqueSystemId::new()
-            .unwrap()
-            .value()
-            .to_string()
-            .as_bytes(),
-    )
-    .unwrap();
-    file
-}
-
 #[test]
-fn static_storage_file_custom_path_and_suffix_works() {
+fn static_storage_file_custom_suffix_works() {
     let storage_name = generate_name();
+    let config = generate_isolated_config::<Storage>()
+        .suffix(unsafe { &FileName::new_unchecked(b".blubbme") });
 
     let content = "some storage content".to_string();
-    let config = Configuration::default()
-        .suffix(unsafe { &FileName::new_unchecked(b".blubbme") })
-        .path_hint(&test_directory());
 
     let storage_guard = Builder::new(&storage_name)
         .config(&config)
@@ -68,14 +55,13 @@ fn static_storage_file_custom_path_and_suffix_works() {
 #[test]
 fn static_storage_file_path_is_created_when_it_does_not_exist() {
     let storage_name = generate_name();
+    let config = generate_isolated_config::<Storage>();
     let content = "some more funky content".to_string();
     let non_existing_path =
         FilePath::from_path_and_file(&test_directory(), &generate_name()).unwrap();
 
     Directory::remove(&non_existing_path.into()).ok();
-    let config = Configuration::default()
-        .suffix(unsafe { &FileName::new_unchecked(b".blubbme") })
-        .path_hint(&non_existing_path.into());
+    let config = config.path_hint(&non_existing_path.into());
 
     let storage_guard = Builder::new(&storage_name)
         .config(&config)
@@ -101,7 +87,7 @@ fn static_storage_file_path_is_created_when_it_does_not_exist() {
 #[test]
 fn static_storage_file_custom_path_and_suffix_list_storage_works() {
     const NUMBER_OF_STORAGES: u64 = 12;
-    let config = Configuration::default()
+    let config = generate_isolated_config::<Storage>()
         .suffix(unsafe { &FileName::new_unchecked(b".blubbme") })
         .path_hint(
             &FilePath::from_path_and_file(

--- a/iceoryx2-ffi/c/tests/BUILD.bazel
+++ b/iceoryx2-ffi/c/tests/BUILD.bazel
@@ -10,28 +10,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
-package(default_visibility = ["//visibility:public"])
-
-load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
+load("@rules_cc//cc:defs.bzl", "cc_test")
 
 filegroup(
     name = "all_srcs",
     srcs = glob(["**"]),
 )
 
-rust_library(
-    name = "iceoryx2-pal-concurrency-sync",
-    srcs = glob(["src/**/*.rs"]),
-)
-
-rust_test_suite(
-    name = "iceoryx2-pal-concurrency-sync-tests",
-    srcs = glob(["tests/**/*.rs"]),
-    deps = [
-        ":iceoryx2-pal-concurrency-sync",
-        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+cc_test(
+    name = "iceoryx2-c-tests",
+    srcs = glob([
+        "src/*.cpp",
+        "src/*.hpp",
+    ]),
+    includes = [
+        "src",
     ],
-    proc_macro_deps = [
-        "@crate_index//:generic-tests",
+    linkopts = select({
+        "//:win-gcc": [],
+        "//:win-msvc": [],
+        "//conditions:default": ["-ldl"],
+    }),
+    tags = ["exclusive"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "@iceoryx//:iceoryx_hoofs",
+        "//:iceoryx2-cxx-static",
+        "@googletest//:gtest",
     ],
 )

--- a/iceoryx2-ffi/ffi/BUILD.bazel
+++ b/iceoryx2-ffi/ffi/BUILD.bazel
@@ -13,7 +13,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_rust//rust:defs.bzl", "rust_shared_library", "rust_static_library")
+load("@rules_rust//rust:defs.bzl", "rust_shared_library", "rust_static_library", "rust_test")
 
 filegroup(
     name = "all_srcs",
@@ -98,4 +98,21 @@ cc_library(
     linkstatic = True,
 )
 
-# TODO: [349] add tests
+rust_test(
+    name = "iceoryx2-ffi-tests",
+    srcs = glob(["src/**/*.rs"]),
+    deps = [
+        "//iceoryx2:iceoryx2",
+        "//iceoryx2-bb/container:iceoryx2-bb-container",
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/log:iceoryx2-bb-log",
+        "//iceoryx2-bb/posix:iceoryx2-bb-posix",
+        "//iceoryx2-bb/system-types:iceoryx2-bb-system-types",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+        "//iceoryx2-cal:iceoryx2-cal",
+    ],
+    proc_macro_deps = [
+        "//iceoryx2-ffi/ffi-macros:iceoryx2-ffi-macros",
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2-ffi/ffi/BUILD.bazel
+++ b/iceoryx2-ffi/ffi/BUILD.bazel
@@ -51,6 +51,7 @@ rust_shared_library(
         "//iceoryx2-cal:iceoryx2-cal",
         "@crate_index//:serde",
     ],
+    tags = ["exclusive"],
     proc_macro_deps = [
         "//iceoryx2-ffi/ffi-macros:iceoryx2-ffi-macros",
     ],

--- a/iceoryx2-pal/posix/BUILD.bazel
+++ b/iceoryx2-pal/posix/BUILD.bazel
@@ -14,7 +14,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_rust//cargo:defs.bzl", "cargo_build_script")
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -72,4 +72,20 @@ rust_library(
     },
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-pal-posix-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2-pal-posix",
+        "//iceoryx2-bb/container:iceoryx2-bb-container",
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/lock-free:iceoryx2-bb-lock-free",
+        "//iceoryx2-bb/memory:iceoryx2-bb-memory",
+        "//iceoryx2-bb/system-types:iceoryx2-bb-system-types",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+        "//iceoryx2-cal:iceoryx2-cal",
+    ],
+    proc_macro_deps = [
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2/BUILD.bazel
+++ b/iceoryx2/BUILD.bazel
@@ -12,7 +12,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test_suite")
 
 filegroup(
     name = "all_srcs",
@@ -60,4 +60,19 @@ rust_library(
     ],
 )
 
-# TODO: [349] add tests
+rust_test_suite(
+    name = "iceoryx2-tests",
+    srcs = glob(["tests/**/*.rs"]),
+    deps = [
+        ":iceoryx2",
+        "//iceoryx2-bb/elementary:iceoryx2-bb-elementary",
+        "//iceoryx2-bb/log:iceoryx2-bb-log",
+        "//iceoryx2-bb/system-types:iceoryx2-bb-system-types",
+        "//iceoryx2-bb/posix:iceoryx2-bb-posix",
+        "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+        "//iceoryx2-cal:iceoryx2-cal",
+    ],
+    proc_macro_deps = [
+        "@crate_index//:generic-tests",
+    ],
+)

--- a/iceoryx2/src/lib.rs
+++ b/iceoryx2/src/lib.rs
@@ -310,3 +310,6 @@ pub mod service;
 
 /// Loads a meaninful subset to cover 90% of the iceoryx2 communication use cases.
 pub mod prelude;
+
+#[doc(hidden)]
+pub mod testing;

--- a/iceoryx2/src/testing.rs
+++ b/iceoryx2/src/testing.rs
@@ -11,7 +11,13 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use iceoryx2_bb_elementary::math::ToB64;
-use iceoryx2_bb_posix::{config::test_directory, unique_system_id::UniqueSystemId};
+use iceoryx2_bb_log::fatal_panic;
+use iceoryx2_bb_posix::{
+    config::test_directory,
+    directory::{Directory, DirectoryCreateError},
+    file::Permission,
+    unique_system_id::UniqueSystemId,
+};
 use iceoryx2_bb_system_types::file_name::*;
 
 use crate::{
@@ -28,6 +34,15 @@ pub fn generate_node_name() -> NodeName {
 }
 
 pub fn generate_isolated_config() -> Config {
+    match Directory::create(&test_directory(), Permission::OWNER_ALL) {
+        Ok(_) | Err(DirectoryCreateError::DirectoryAlreadyExists) => (),
+        Err(e) => fatal_panic!(
+            "Failed to create test directory {} due to {:?}.",
+            test_directory(),
+            e
+        ),
+    };
+
     let mut prefix = FileName::new(b"test_prefix_").unwrap();
     prefix
         .push_bytes(

--- a/iceoryx2/src/testing.rs
+++ b/iceoryx2/src/testing.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2_bb_elementary::math::ToB64;
+use iceoryx2_bb_posix::{config::test_directory, unique_system_id::UniqueSystemId};
+use iceoryx2_bb_system_types::file_name::*;
+
+use crate::{
+    config::Config,
+    prelude::{NodeName, ServiceName},
+};
+
+pub fn generate_service_name() -> ServiceName {
+    ServiceName::new(&format!("tests_{}", UniqueSystemId::new().unwrap().value())).unwrap()
+}
+
+pub fn generate_node_name() -> NodeName {
+    NodeName::new(&format!("tests_{}", UniqueSystemId::new().unwrap().value())).unwrap()
+}
+
+pub fn generate_isolated_config() -> Config {
+    let mut prefix = FileName::new(b"test_prefix_").unwrap();
+    prefix
+        .push_bytes(
+            UniqueSystemId::new()
+                .unwrap()
+                .value()
+                .to_b64()
+                .to_lowercase()
+                .as_bytes(),
+        )
+        .unwrap();
+
+    let mut config = Config::default();
+    config.global.set_root_path(&test_directory());
+    config.global.prefix = prefix;
+
+    config
+}

--- a/iceoryx2/tests/config_tests.rs
+++ b/iceoryx2/tests/config_tests.rs
@@ -14,16 +14,14 @@ mod node_name {
     use iceoryx2::{config::DEFAULT_CONFIG_FILE, prelude::*};
     use iceoryx2_bb_system_types::file_path::*;
     use iceoryx2_bb_system_types::path::*;
-    use iceoryx2_bb_testing::assert_that;
+    use iceoryx2_bb_testing::{assert_that, test_requires};
 
     #[test]
     fn config_file_settings_and_default_config_are_equal() {
         // NOTE: The test is skipped when not run with cargo but with bazel,
         //       since it does not work with the sandbox.
         //       The CI which runs with cargo ensures that the settings are equal.
-        if option_env!("CARGO").is_none() {
-            return;
-        }
+        test_requires!(option_env!("CARGO").is_some());
 
         let default_config = Config::default();
         let top_level_dir = std::process::Command::new("git")

--- a/iceoryx2/tests/config_tests.rs
+++ b/iceoryx2/tests/config_tests.rs
@@ -18,6 +18,13 @@ mod node_name {
 
     #[test]
     fn config_file_settings_and_default_config_are_equal() {
+        // NOTE: The test is skipped when not run with cargo but with bazel,
+        //       since it does not work with the sandbox.
+        //       The CI which runs with cargo ensures that the settings are equal.
+        if option_env!("CARGO").is_none() {
+            return;
+        }
+
         let default_config = Config::default();
         let top_level_dir = std::process::Command::new("git")
             .args(["rev-parse", "--show-toplevel"])

--- a/iceoryx2/tests/listener_tests.rs
+++ b/iceoryx2/tests/listener_tests.rs
@@ -14,21 +14,9 @@
 mod listener {
     use std::collections::HashSet;
 
-    use iceoryx2::{
-        node::NodeBuilder,
-        port::listener::ListenerCreateError,
-        service::{service_name::ServiceName, Service},
-    };
-    use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
+    use iceoryx2::testing::*;
+    use iceoryx2::{node::NodeBuilder, port::listener::ListenerCreateError, service::Service};
     use iceoryx2_bb_testing::assert_that;
-
-    fn generate_name() -> ServiceName {
-        ServiceName::new(&format!(
-            "listener_tests_{}",
-            UniqueSystemId::new().unwrap().value()
-        ))
-        .unwrap()
-    }
 
     #[test]
     fn create_error_display_works<S: Service>() {
@@ -40,8 +28,9 @@ mod listener {
 
     #[test]
     fn id_is_unique<Sut: Service>() {
-        let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let service_name = generate_service_name();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX_LISTENERS: usize = 8;
 
         let sut = node

--- a/iceoryx2/tests/node_tests.rs
+++ b/iceoryx2/tests/node_tests.rs
@@ -22,6 +22,7 @@ mod node {
     };
     use iceoryx2::prelude::*;
     use iceoryx2::service::Service;
+    use iceoryx2::testing::*;
     use iceoryx2_bb_posix::directory::Directory;
     use iceoryx2_bb_posix::system_configuration::SystemInfo;
     use iceoryx2_bb_system_types::path::*;
@@ -84,15 +85,21 @@ mod node {
 
     #[test]
     fn node_without_name_can_be_created<S: Service>() {
-        let sut = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let sut = NodeBuilder::new().config(&config).create::<S>().unwrap();
 
         assert_that!(*sut.name(), eq NodeName::new("").unwrap());
     }
 
     #[test]
     fn node_with_name_can_be_created<S: Service>() {
+        let config = generate_isolated_config();
         let node_name = NodeName::new("photons taste like chicken").unwrap();
-        let sut = NodeBuilder::new().name(&node_name).create::<S>().unwrap();
+        let sut = NodeBuilder::new()
+            .config(&config)
+            .name(&node_name)
+            .create::<S>()
+            .unwrap();
 
         assert_that!(*sut.name(), eq node_name);
     }
@@ -100,11 +107,18 @@ mod node {
     #[test]
     fn multiple_nodes_with_the_same_name_can_be_created<S: Service>() {
         const NUMBER_OF_NODES: usize = 16;
+        let config = generate_isolated_config();
         let node_name = NodeName::new("but what does an electron taste like?").unwrap();
 
         let mut nodes = vec![];
         for _ in 0..NUMBER_OF_NODES {
-            nodes.push(NodeBuilder::new().name(&node_name).create::<S>().unwrap());
+            nodes.push(
+                NodeBuilder::new()
+                    .config(&config)
+                    .name(&node_name)
+                    .create::<S>()
+                    .unwrap(),
+            );
         }
 
         for node in nodes {
@@ -122,28 +136,38 @@ mod node {
     #[test]
     fn nodes_can_be_listed<S: Service>() {
         const NUMBER_OF_NODES: usize = 16;
+        let config = generate_isolated_config();
 
         let mut nodes = vec![];
         let mut node_details = VecDeque::new();
         for i in 0..NUMBER_OF_NODES {
             let node_name = generate_node_name(i, "give me a bit");
-            let node = NodeBuilder::new().name(&node_name).create::<S>().unwrap();
+            let node = NodeBuilder::new()
+                .config(&config)
+                .name(&node_name)
+                .create::<S>()
+                .unwrap();
             node_details.push_back(Details::from_node(&node));
             nodes.push(node);
         }
 
-        assert_node_presence::<S>(&node_details, Config::global_config());
+        assert_node_presence::<S>(&node_details, &config);
     }
 
     #[test]
     fn when_node_goes_out_of_scope_it_cleans_up<S: Service>() {
         const NUMBER_OF_NODES: usize = 16;
+        let config = generate_isolated_config();
 
         let mut nodes = vec![];
         let mut node_details = VecDeque::new();
         for i in 0..NUMBER_OF_NODES {
             let node_name = generate_node_name(i, "gravity should be illegal");
-            let node = NodeBuilder::new().name(&node_name).create::<S>().unwrap();
+            let node = NodeBuilder::new()
+                .config(&config)
+                .name(&node_name)
+                .create::<S>()
+                .unwrap();
             node_details.push_back(Details::from_node(&node));
             nodes.push(node);
         }
@@ -151,13 +175,14 @@ mod node {
         for _ in 0..NUMBER_OF_NODES {
             nodes.pop();
             node_details.pop_back();
-            assert_node_presence::<S>(&node_details, Config::global_config());
+            assert_node_presence::<S>(&node_details, &config);
         }
     }
 
     #[test]
     fn id_is_unique<S: Service>() {
         const NUMBER_OF_NODES: usize = 16;
+        let config = generate_isolated_config();
 
         let mut nodes = vec![];
         let mut node_ids = HashSet::new();
@@ -166,7 +191,13 @@ mod node {
                 i,
                 "its a bird, its a plane, no its the mountain goat jumping through the code",
             );
-            nodes.push(NodeBuilder::new().name(&node_name).create::<S>().unwrap());
+            nodes.push(
+                NodeBuilder::new()
+                    .config(&config)
+                    .name(&node_name)
+                    .create::<S>()
+                    .unwrap(),
+            );
             assert_that!(node_ids.insert(nodes.last().unwrap().id().clone()), eq true);
         }
     }
@@ -180,15 +211,22 @@ mod node {
         let mut nodes_2 = VecDeque::new();
         let mut node_details_2 = VecDeque::new();
 
-        let mut config = Config::default();
-        config.global.node.directory = Path::new(b"node2").unwrap();
+        let config = generate_isolated_config();
+        let mut config_1 = config.clone();
+        config_1.global.node.directory = Path::new(b"node2").unwrap();
+        let mut config_2 = config.clone();
+        config_2.global.node.directory = Path::new(b"bud_spencer").unwrap();
 
         for i in 0..NUMBER_OF_NODES {
             let node_name_1 = generate_node_name(i, "gravity should be illegal");
             let node_name_2 = generate_node_name(i, "i like to name it name it");
-            let node_1 = NodeBuilder::new().name(&node_name_1).create::<S>().unwrap();
+            let node_1 = NodeBuilder::new()
+                .config(&config_1)
+                .name(&node_name_1)
+                .create::<S>()
+                .unwrap();
             let node_2 = NodeBuilder::new()
-                .config(&config)
+                .config(&config_2)
                 .name(&node_name_2)
                 .create::<S>()
                 .unwrap();
@@ -205,8 +243,8 @@ mod node {
             node_details_1.pop_back();
             node_details_2.pop_front();
 
-            assert_node_presence::<S>(&node_details_1, Config::global_config());
-            assert_node_presence::<S>(&node_details_2, &config);
+            assert_node_presence::<S>(&node_details_1, &config_1);
+            assert_node_presence::<S>(&node_details_2, &config_2);
         }
 
         let mut path = *config.global.root_path();
@@ -248,7 +286,7 @@ mod node {
         let number_of_creators = (SystemInfo::NumberOfCpuCores.value()).clamp(2, 1024);
         const NUMBER_OF_ITERATIONS: usize = 100;
         let barrier = Barrier::new(number_of_creators);
-        let mut config = Config::global_config().clone();
+        let mut config = generate_isolated_config();
         config.global.node.cleanup_dead_nodes_on_creation = false;
         config.global.node.cleanup_dead_nodes_on_destruction = false;
 
@@ -300,8 +338,9 @@ mod node {
 
     #[test]
     fn node_listing_stops_when_callback_progression_signals_stop<S: Service>() {
-        let node_1 = NodeBuilder::new().create::<S>().unwrap();
-        let _node_2 = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<S>().unwrap();
+        let _node_2 = NodeBuilder::new().config(&config).create::<S>().unwrap();
 
         let mut node_counter = 0;
         let result = Node::<S>::list(node_1.config(), |_| {
@@ -315,7 +354,8 @@ mod node {
 
     #[test]
     fn i_am_not_dead<S: Service>() {
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
 
         let mut nodes = vec![];
         let result = Node::<S>::list(node.config(), |node_state| {

--- a/iceoryx2/tests/node_tests.rs
+++ b/iceoryx2/tests/node_tests.rs
@@ -23,7 +23,6 @@ mod node {
     use iceoryx2::prelude::*;
     use iceoryx2::service::Service;
     use iceoryx2::testing::*;
-    use iceoryx2_bb_posix::directory::Directory;
     use iceoryx2_bb_posix::system_configuration::SystemInfo;
     use iceoryx2_bb_system_types::path::*;
     use iceoryx2_bb_testing::watchdog::Watchdog;
@@ -246,10 +245,6 @@ mod node {
             assert_node_presence::<S>(&node_details_1, &config_1);
             assert_node_presence::<S>(&node_details_2, &config_2);
         }
-
-        let mut path = *config.global.root_path();
-        path.add_path_entry(&config.global.node.directory).unwrap();
-        let _ = Directory::remove(&path);
     }
 
     #[test]

--- a/iceoryx2/tests/notifier_tests.rs
+++ b/iceoryx2/tests/notifier_tests.rs
@@ -14,21 +14,13 @@
 mod notifier {
     use std::collections::HashSet;
 
+    use iceoryx2::testing::*;
     use iceoryx2::{
         node::NodeBuilder,
         port::notifier::{NotifierCreateError, NotifierNotifyError},
-        service::{service_name::ServiceName, Service},
+        service::Service,
     };
-    use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_testing::assert_that;
-
-    fn generate_name() -> ServiceName {
-        ServiceName::new(&format!(
-            "listener_tests_{}",
-            UniqueSystemId::new().unwrap().value()
-        ))
-        .unwrap()
-    }
 
     #[test]
     fn create_error_display_works<S: Service>() {
@@ -44,8 +36,9 @@ mod notifier {
 
     #[test]
     fn id_is_unique<Sut: Service>() {
-        let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let service_name = generate_service_name();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX_LISTENERS: usize = 8;
 
         let sut = node

--- a/iceoryx2/tests/publisher_tests.rs
+++ b/iceoryx2/tests/publisher_tests.rs
@@ -21,6 +21,7 @@ mod publisher {
     use iceoryx2::service::port_factory::publisher::UnableToDeliverStrategy;
     use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
     use iceoryx2::service::{service_name::ServiceName, Service};
+    use iceoryx2::testing::*;
     use iceoryx2_bb_posix::barrier::*;
     use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_testing::assert_that;
@@ -56,7 +57,8 @@ mod publisher {
     #[test]
     fn publisher_loan_and_send_sample_works<Sut: Service>() -> TestResult<()> {
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -74,7 +76,8 @@ mod publisher {
     #[test]
     fn publisher_loan_initializes_sample_with_default<Sut: Service>() -> TestResult<()> {
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<ComplexType>()
@@ -92,7 +95,8 @@ mod publisher {
     fn publisher_loan_slice_initializes_sample_with_default<Sut: Service>() -> TestResult<()> {
         const NUMBER_OF_ELEMENTS: usize = 120;
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<[ComplexType]>()
@@ -115,7 +119,8 @@ mod publisher {
     fn publisher_loan_slice_up_to_max_elements_works<Sut: Service>() -> TestResult<()> {
         const NUMBER_OF_ELEMENTS: usize = 125;
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<[ComplexType]>()
@@ -138,7 +143,8 @@ mod publisher {
     fn publisher_loan_slice_more_than_max_elements_fails<Sut: Service>() -> TestResult<()> {
         const NUMBER_OF_ELEMENTS: usize = 125;
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<[ComplexType]>()
@@ -159,7 +165,8 @@ mod publisher {
     #[test]
     fn publisher_loan_unit_and_send_sample_works<Sut: Service>() -> TestResult<()> {
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -177,7 +184,8 @@ mod publisher {
     #[test]
     fn publisher_can_borrow_multiple_sample_at_once<Sut: Service>() -> TestResult<()> {
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -209,7 +217,8 @@ mod publisher {
     #[test]
     fn publisher_max_loaned_samples_works<Sut: Service>() -> TestResult<()> {
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -230,7 +239,8 @@ mod publisher {
     #[test]
     fn publisher_sending_sample_reduces_loan_counter<Sut: Service>() -> TestResult<()> {
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -254,7 +264,8 @@ mod publisher {
     #[test]
     fn publisher_dropping_sample_reduces_loan_counter<Sut: Service>() -> TestResult<()> {
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -279,7 +290,8 @@ mod publisher {
     fn publisher_block_when_unable_to_deliver_blocks<Sut: Service>() -> TestResult<()> {
         let _watchdog = Watchdog::new();
         let service_name = generate_name()?;
-        let node = Mutex::new(NodeBuilder::new().create::<Sut>().unwrap());
+        let config = generate_isolated_config();
+        let node = Mutex::new(NodeBuilder::new().config(&config).create::<Sut>().unwrap());
         let service = node
             .lock()
             .unwrap()
@@ -359,7 +371,8 @@ mod publisher {
     #[test]
     fn id_is_unique<Sut: Service>() {
         let service_name = generate_name().unwrap();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX_PUBLISHERS: usize = 8;
 
         let sut = node
@@ -384,7 +397,8 @@ mod publisher {
     {
         const TYPE_SIZE_OVERRIDE: usize = 128;
         let service_name = generate_name()?;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let mut type_detail = TypeDetail::__internal_new::<u8>(TypeVariant::FixedSize);
         type_detail.size = TYPE_SIZE_OVERRIDE;
 

--- a/iceoryx2/tests/sample_tests.rs
+++ b/iceoryx2/tests/sample_tests.rs
@@ -17,6 +17,7 @@ mod sample {
     use iceoryx2::prelude::*;
     use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
     use iceoryx2::service::Service;
+    use iceoryx2::testing::*;
     use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_testing::assert_that;
 
@@ -38,8 +39,8 @@ mod sample {
     }
 
     impl<Sut: Service> TestContext<Sut> {
-        fn new() -> Self {
-            let node = NodeBuilder::new().create::<Sut>().unwrap();
+        fn new(config: &Config) -> Self {
+            let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
             let service_name = generate_name();
             let service = node
                 .service_builder(&service_name)
@@ -68,7 +69,8 @@ mod sample {
 
     #[test]
     fn origin_is_tracked_correctly<Sut: Service>() {
-        let test_context = TestContext::<Sut>::new();
+        let config = generate_isolated_config();
+        let test_context = TestContext::<Sut>::new(&config);
 
         assert_that!(test_context.publisher_1.send_copy(123), eq Ok(1));
         let sample = test_context.subscriber.receive().unwrap().unwrap();
@@ -81,7 +83,8 @@ mod sample {
 
     #[test]
     fn sample_of_dropped_service_does_not_block_new_service_creation<Sut: Service>() {
-        let test_context = TestContext::<Sut>::new();
+        let config = generate_isolated_config();
+        let test_context = TestContext::<Sut>::new(&config);
 
         let service_name = test_context.service_name.clone();
 
@@ -91,7 +94,7 @@ mod sample {
 
         drop(test_context);
 
-        let test_context = TestContext::<Sut>::new();
+        let test_context = TestContext::<Sut>::new(&config);
 
         let result = test_context
             .node
@@ -103,7 +106,8 @@ mod sample {
 
     #[test]
     fn when_everything_is_dropped_the_sample_can_still_be_consumed<Sut: Service>() {
-        let test_context = TestContext::<Sut>::new();
+        let config = generate_isolated_config();
+        let test_context = TestContext::<Sut>::new(&config);
 
         let sut = test_context.service;
         let publisher_1 = test_context.publisher_1;
@@ -126,7 +130,8 @@ mod sample {
 
     #[test]
     fn sample_received_from_dropped_publisher_does_not_block_new_publishers<Sut: Service>() {
-        let test_context = TestContext::<Sut>::new();
+        let config = generate_isolated_config();
+        let test_context = TestContext::<Sut>::new(&config);
         const PAYLOAD_1: u64 = 123554;
 
         let publisher = test_context.publisher_1;
@@ -147,7 +152,8 @@ mod sample {
 
     #[test]
     fn sample_from_dropped_subscriber_does_not_block_new_subscribers<Sut: Service>() {
-        let test_context = TestContext::<Sut>::new();
+        let config = generate_isolated_config();
+        let test_context = TestContext::<Sut>::new(&config);
         const PAYLOAD_1: u64 = 7781123554;
 
         let subscriber = test_context.subscriber;

--- a/iceoryx2/tests/service_event_tests.rs
+++ b/iceoryx2/tests/service_event_tests.rs
@@ -17,11 +17,11 @@ mod service_event {
     use std::sync::Barrier;
     use std::time::{Duration, Instant};
 
-    use iceoryx2::config::Config;
     use iceoryx2::port::listener::{Listener, ListenerCreateError};
     use iceoryx2::port::notifier::{NotifierCreateError, NotifierNotifyError};
     use iceoryx2::prelude::*;
     use iceoryx2::service::builder::event::{EventCreateError, EventOpenError};
+    use iceoryx2::testing::*;
     use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_bb_testing::watchdog::Watchdog;
@@ -39,7 +39,8 @@ mod service_event {
     #[test]
     fn creating_non_existing_service_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node.service_builder(&service_name).event().create();
 
         assert_that!(sut, is_ok);
@@ -50,7 +51,8 @@ mod service_event {
     #[test]
     fn creating_same_service_twice_fails<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node.service_builder(&service_name).event().create();
         assert_that!(sut, is_ok);
 
@@ -65,7 +67,8 @@ mod service_event {
     #[test]
     fn recreate_after_drop_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node.service_builder(&service_name).event().create();
         assert_that!(sut, is_ok);
 
@@ -78,7 +81,8 @@ mod service_event {
     #[test]
     fn open_fails_when_service_does_not_exist<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node.service_builder(&service_name).event().open();
         assert_that!(sut, is_err);
         assert_that!(sut.err().unwrap(), eq EventOpenError::DoesNotExist);
@@ -87,7 +91,8 @@ mod service_event {
     #[test]
     fn open_succeeds_when_service_does_exist<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node.service_builder(&service_name).event().create();
         assert_that!(sut, is_ok);
 
@@ -98,7 +103,8 @@ mod service_event {
     #[test]
     fn open_fails_when_service_does_not_satisfy_opener_notifier_requirements<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .event()
@@ -129,7 +135,8 @@ mod service_event {
     #[test]
     fn open_fails_when_service_does_not_satisfy_opener_listener_requirements<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .event()
@@ -160,7 +167,8 @@ mod service_event {
     #[test]
     fn set_max_nodes_to_zero_adjusts_it_to_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .event()
@@ -174,7 +182,8 @@ mod service_event {
     #[test]
     fn set_max_listeners_to_zero_adjusts_it_to_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .event()
@@ -188,7 +197,8 @@ mod service_event {
     #[test]
     fn set_max_notifiers_to_zero_adjusts_it_to_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .event()
@@ -202,7 +212,8 @@ mod service_event {
     #[test]
     fn open_fails_when_service_does_not_satisfy_opener_node_requirements<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .event()
@@ -234,7 +245,8 @@ mod service_event {
     fn open_fails_when_service_does_not_satisfy_event_id_requirements<Sut: Service>() {
         let service_name = generate_name();
         const EVENT_ID_MAX_VALUE: usize = 78;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let _sut = node
             .service_builder(&service_name)
@@ -263,7 +275,8 @@ mod service_event {
     #[test]
     fn open_uses_predefined_settings_when_nothing_is_specified<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .event()
@@ -285,7 +298,7 @@ mod service_event {
     #[test]
     fn settings_can_be_modified_via_custom_config<Sut: Service>() {
         let service_name = generate_name();
-        let mut custom_config = Config::default();
+        let mut custom_config = generate_isolated_config();
         custom_config.defaults.event.max_nodes = 13;
         custom_config.defaults.event.max_notifiers = 9;
         custom_config.defaults.event.max_listeners = 10;
@@ -312,7 +325,8 @@ mod service_event {
     #[test]
     fn simple_communication_works_listener_created_first<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let event_id = EventId::new(32);
 
         let sut = node
@@ -343,7 +357,8 @@ mod service_event {
     #[test]
     fn simple_communication_works_notifier_created_first<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let event_id = EventId::new(23);
 
         let sut = node
@@ -377,7 +392,8 @@ mod service_event {
         const MAX_NOTIFIERS: usize = 6;
         const NUMBER_OF_ITERATIONS: u64 = 128;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -425,7 +441,8 @@ mod service_event {
         const MAX_NOTIFIERS: usize = 7;
         const NUMBER_OF_ITERATIONS: u64 = 128;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -474,7 +491,8 @@ mod service_event {
     fn number_of_notifiers_works<Sut: Service>() {
         let service_name = generate_name();
         const MAX_NOTIFIERS: usize = 8;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -515,7 +533,8 @@ mod service_event {
     #[test]
     fn number_of_listeners_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX_LISTENERS: usize = 8;
 
         let sut = node
@@ -557,7 +576,8 @@ mod service_event {
     #[test]
     fn number_of_nodes_works<Sut: Service>() {
         let service_name = generate_name();
-        let main_node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let main_node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX_NODES: usize = 8;
 
         let _sut = main_node
@@ -571,14 +591,14 @@ mod service_event {
         let mut services = vec![];
 
         for _ in 1..MAX_NODES {
-            let node = NodeBuilder::new().create::<Sut>().unwrap();
+            let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
             let service = node.service_builder(&service_name).event().open();
             assert_that!(service, is_ok);
             nodes.push(node);
             services.push(service);
         }
 
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node.service_builder(&service_name).event().open();
         assert_that!(service, is_err);
         assert_that!(service.err().unwrap(), eq EventOpenError::ExceedsMaxNumberOfNodes);
@@ -586,7 +606,7 @@ mod service_event {
         nodes.pop();
         services.pop();
 
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service = node.service_builder(&service_name).event().open();
         assert_that!(service, is_ok);
     }
@@ -594,7 +614,8 @@ mod service_event {
     #[test]
     fn max_event_id_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const EVENT_ID_MAX_VALUE: usize = 78;
 
         let sut = node
@@ -632,7 +653,8 @@ mod service_event {
 
         let keep_running = AtomicBool::new(true);
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let barrier = Barrier::new(number_of_notifier_threads + number_of_listener_threads);
 
         let sut = node
@@ -691,7 +713,8 @@ mod service_event {
 
         let keep_running = AtomicBool::new(true);
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let barrier = Barrier::new(number_of_listener_threads + number_of_notifier_threads);
 
         let sut = node
@@ -745,7 +768,8 @@ mod service_event {
         Sut: Service,
     >() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let event_id = EventId::new(12);
 
         let sut = node
@@ -761,9 +785,9 @@ mod service_event {
             .unwrap();
         let listener = sut.listener_builder().create().unwrap();
 
-        assert_that!(Sut::does_exist(&service_name, Config::global_config(), MessagingPattern::Event), eq Ok(true));
+        assert_that!(Sut::does_exist(&service_name, &config, MessagingPattern::Event), eq Ok(true));
         drop(sut);
-        assert_that!(Sut::does_exist(&service_name, Config::global_config(), MessagingPattern::Event), eq Ok(true));
+        assert_that!(Sut::does_exist(&service_name, &config, MessagingPattern::Event), eq Ok(true));
 
         assert_that!(notifier.notify(), eq Ok(1));
 
@@ -778,7 +802,8 @@ mod service_event {
     #[test]
     fn ports_of_dropped_service_block_new_service_creation<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .event()
@@ -811,7 +836,8 @@ mod service_event {
     fn try_wait_does_not_block<Sut: Service>() {
         let _watch_dog = Watchdog::new();
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -827,7 +853,8 @@ mod service_event {
     fn timed_wait_blocks_for_at_least_timeout<Sut: Service>() {
         let _watch_dog = Watchdog::new();
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -847,7 +874,8 @@ mod service_event {
     ) {
         let _watch_dog = Watchdog::new();
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -928,7 +956,8 @@ mod service_event {
     fn try_wait_all_does_not_block<Sut: Service>() {
         let _watch_dog = Watchdog::new();
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -947,7 +976,8 @@ mod service_event {
     fn timed_wait_all_blocks_for_at_least_timeout<Sut: Service>() {
         let _watch_dog = Watchdog::new();
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1009,7 +1039,8 @@ mod service_event {
     ) {
         let _watch_dog = Watchdog::new();
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)

--- a/iceoryx2/tests/service_publish_subscribe_tests.rs
+++ b/iceoryx2/tests/service_publish_subscribe_tests.rs
@@ -28,6 +28,7 @@ mod service_publish_subscribe {
     use iceoryx2::service::port_factory::publisher::UnableToDeliverStrategy;
     use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
     use iceoryx2::service::{Service, ServiceDetails};
+    use iceoryx2::testing::*;
     use iceoryx2_bb_elementary::alignment::Alignment;
     use iceoryx2_bb_elementary::CallbackProgression;
     use iceoryx2_bb_log::{set_log_level, LogLevel};
@@ -51,7 +52,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_or_create_with_attributes_succeeds_when_service_does_exist<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let attr = AttributeVerifier::new();
         let sut = node
             .service_builder(&service_name)
@@ -70,7 +72,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_or_create_with_attributes_succeeds_when_attribute_is_satisfied<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let attr = AttributeVerifier::new().require("hello", "world");
         let sut = node
             .service_builder(&service_name)
@@ -90,7 +93,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_or_create_with_attributes_failed_when_service_payload_types_differ<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let attr = AttributeVerifier::new();
         let sut = node
             .service_builder(&service_name)
@@ -109,7 +113,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_or_create_with_attributes_failed_when_attribute_isnt_satisfied<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let attr = AttributeVerifier::new().require("hello", "world");
         let sut = node
             .service_builder(&service_name)
@@ -129,7 +134,8 @@ mod service_publish_subscribe {
     #[test]
     fn creating_non_existing_service_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -143,7 +149,8 @@ mod service_publish_subscribe {
     #[test]
     fn creating_same_service_twice_fails<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -164,7 +171,8 @@ mod service_publish_subscribe {
     #[test]
     fn recreate_after_drop_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -183,7 +191,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_does_not_exist<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -195,7 +204,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_succeeds_when_service_does_exist<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -212,7 +222,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_has_wrong_type<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -230,7 +241,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_has_wrong_slice_base_type<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<[u64]>()
@@ -248,7 +260,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_is_slice_based_and_typed_is_requested<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<[u64]>()
@@ -266,7 +279,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_is_type_based_and_slice_is_requested<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -284,7 +298,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_does_not_satisfy_max_nodes_requirement<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -316,7 +331,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_does_not_satisfy_max_publishers_requirement<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -348,7 +364,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_does_not_satisfy_max_subscribers_requirement<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -380,7 +397,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_does_not_satisfy_safe_overflow_requirement<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -404,7 +422,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_does_not_satisfy_history_requirement<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -436,7 +455,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_does_not_satisfy_subscriber_max_borrow_requirement<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -470,7 +490,8 @@ mod service_publish_subscribe {
         Sut: Service,
     >() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -502,7 +523,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_service_does_not_satisfy_alignment_requirement<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -534,7 +556,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_does_not_fail_when_service_owner_is_dropped<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -559,7 +582,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_fails_when_all_previous_owners_have_been_dropped<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -586,7 +610,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_or_create_creates_service_if_it_does_not_exist<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<[u64]>()
@@ -598,7 +623,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_or_create_opens_service_if_it_does_exist<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let _sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -638,7 +664,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_uses_predefined_settings_when_nothing_is_specified<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -678,7 +705,8 @@ mod service_publish_subscribe {
     #[test]
     fn settings_can_be_modified_via_custom_config<Sut: Service>() {
         let service_name = generate_name();
-        let mut custom_config = Config::default();
+        let config = generate_isolated_config();
+        let mut custom_config = config.clone();
         custom_config.defaults.publish_subscribe.max_nodes = 2;
         custom_config.defaults.publish_subscribe.max_publishers = 9;
         custom_config.defaults.publish_subscribe.max_subscribers = 10;
@@ -702,7 +730,7 @@ mod service_publish_subscribe {
             .config(&custom_config)
             .create::<Sut>()
             .unwrap();
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node_1
             .service_builder(&service_name)
@@ -724,6 +752,8 @@ mod service_publish_subscribe {
             .open()
             .unwrap();
 
+        // NOTE: although node_2 did specify a config with default values, since
+        // node_1 was created first, the values of that node have to be preset
         assert_that!(sut2.static_config().max_nodes(), eq 2);
         assert_that!(sut2.static_config().max_publishers(), eq 9);
         assert_that!(sut2.static_config().max_subscribers(), eq 10);
@@ -736,7 +766,8 @@ mod service_publish_subscribe {
     #[test]
     fn number_of_publishers_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX_PUBLISHERS: usize = 8;
 
         let sut = node
@@ -779,7 +810,8 @@ mod service_publish_subscribe {
     fn type_informations_are_correct<Sut: Service>() {
         type Header = iceoryx2::service::header::publish_subscribe::Header;
         type PayloadType = u64;
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let service_name = generate_name();
 
@@ -811,7 +843,8 @@ mod service_publish_subscribe {
         type PayloadType = u64;
 
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -837,7 +870,8 @@ mod service_publish_subscribe {
     #[test]
     fn number_of_subscribers_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX_SUBSCRIBERS: usize = 8;
 
         let sut = node
@@ -881,7 +915,8 @@ mod service_publish_subscribe {
         let service_name = generate_name();
         const MAX_NODES: usize = 8;
 
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -896,7 +931,7 @@ mod service_publish_subscribe {
         services.push(sut.unwrap());
 
         for _ in 1..MAX_NODES {
-            let node = NodeBuilder::new().create::<Sut>().unwrap();
+            let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
             let sut = node
                 .service_builder(&service_name)
                 .publish_subscribe::<u64>()
@@ -907,7 +942,7 @@ mod service_publish_subscribe {
             services.push(sut.unwrap());
         }
 
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -919,7 +954,7 @@ mod service_publish_subscribe {
         nodes.pop();
         services.pop();
 
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -931,7 +966,8 @@ mod service_publish_subscribe {
     #[test]
     fn simple_communication_works_subscriber_created_first<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -968,7 +1004,8 @@ mod service_publish_subscribe {
     #[test]
     fn simple_communication_works_publisher_created_first<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1001,7 +1038,8 @@ mod service_publish_subscribe {
     #[test]
     fn custom_payload_alignment_cannot_be_smaller_than_payload_type_alignment<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1018,7 +1056,8 @@ mod service_publish_subscribe {
         const BUFFER_SIZE: usize = 100;
         const ALIGNMENT: usize = 512;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let service_pub = node
             .service_builder(&service_name)
@@ -1059,7 +1098,8 @@ mod service_publish_subscribe {
     #[test]
     fn publisher_reclaims_all_samples_after_disconnect<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const RECONNECTIONS: usize = 20;
         const MAX_SUBSCRIBERS: usize = 10;
 
@@ -1096,7 +1136,8 @@ mod service_publish_subscribe {
     #[test]
     fn publisher_updates_connections_after_reconnect<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const RECONNECTIONS: usize = 20;
         const MAX_SUBSCRIBERS: usize = 10;
 
@@ -1131,7 +1172,8 @@ mod service_publish_subscribe {
     #[test]
     fn subscriber_updates_connections_after_reconnect<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const RECONNECTIONS: usize = 20;
         const MAX_PUBLISHERS: usize = 10;
 
@@ -1175,7 +1217,8 @@ mod service_publish_subscribe {
         let create_service_barrier = Barrier::new(2);
         let service_name = generate_name();
         let keep_running = AtomicBool::new(true);
-        let node = Mutex::new(NodeBuilder::new().create::<Sut>().unwrap());
+        let config = generate_isolated_config();
+        let node = Mutex::new(NodeBuilder::new().config(&config).create::<Sut>().unwrap());
 
         thread::scope(|s| {
             s.spawn(|| {
@@ -1242,7 +1285,8 @@ mod service_publish_subscribe {
         let service_name = generate_name();
         let keep_running = AtomicBool::new(true);
         let reconnection_cycle = AtomicUsize::new(0);
-        let node = Mutex::new(NodeBuilder::new().create::<Sut>().unwrap());
+        let config = generate_isolated_config();
+        let node = Mutex::new(NodeBuilder::new().config(&config).create::<Sut>().unwrap());
 
         thread::scope(|s| {
             s.spawn(|| {
@@ -1305,7 +1349,8 @@ mod service_publish_subscribe {
         const MAX_SUB: usize = 6;
         const NUMBER_OF_ITERATIONS: u64 = 128;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1350,7 +1395,8 @@ mod service_publish_subscribe {
         const MAX_SUB: usize = 7;
         const NUMBER_OF_ITERATIONS: u64 = 128;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let _sut = node
             .service_builder(&service_name)
@@ -1404,7 +1450,8 @@ mod service_publish_subscribe {
     #[test]
     fn publish_safely_overflows_when_enabled<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const BUFFER_SIZE: usize = 2;
 
         let sut = node
@@ -1435,7 +1482,8 @@ mod service_publish_subscribe {
     #[test]
     fn publish_does_not_overflow_when_deactivated<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const BUFFER_SIZE: usize = 5;
 
         let sut = node
@@ -1470,7 +1518,8 @@ mod service_publish_subscribe {
     #[test]
     fn publish_non_overflow_with_greater_history_than_buffer_fails<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1491,7 +1540,8 @@ mod service_publish_subscribe {
     fn publish_history_is_delivered_on_subscription<Sut: Service>() {
         const BUFFER_SIZE: usize = 2;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1520,7 +1570,8 @@ mod service_publish_subscribe {
     fn publish_history_of_zero_works<Sut: Service>() {
         const BUFFER_SIZE: usize = 2;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1543,7 +1594,8 @@ mod service_publish_subscribe {
     #[test]
     fn publish_send_copy_with_huge_overflow_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const BUFFER_SIZE: usize = 5;
 
         let sut = node
@@ -1583,7 +1635,8 @@ mod service_publish_subscribe {
     ) {
         const ITERATIONS: usize = 16;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1764,7 +1817,8 @@ mod service_publish_subscribe {
     ) {
         const ITERATIONS: usize = 16;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -1887,7 +1941,8 @@ mod service_publish_subscribe {
         const MAX_SUBSCRIBERS: usize = 8;
 
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -1942,7 +1997,8 @@ mod service_publish_subscribe {
     #[test]
     fn set_max_nodes_to_zero_adjusts_it_to_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -1956,7 +2012,8 @@ mod service_publish_subscribe {
     #[test]
     fn set_max_publishers_to_zero_adjusts_it_to_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -1970,7 +2027,8 @@ mod service_publish_subscribe {
     #[test]
     fn set_max_subscribers_to_zero_adjusts_it_to_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -1984,7 +2042,8 @@ mod service_publish_subscribe {
     #[test]
     fn set_subscriber_max_borrowed_samples_to_zero_adjusts_it_to_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -1998,7 +2057,8 @@ mod service_publish_subscribe {
     #[test]
     fn set_buffer_size_to_zero_adjusts_it_to_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -2012,8 +2072,9 @@ mod service_publish_subscribe {
     #[test]
     fn does_exist_works_single<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
-        assert_that!(Sut::does_exist(&service_name, Config::global_config(), MessagingPattern::PublishSubscribe).unwrap(), eq false);
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        assert_that!(Sut::does_exist(&service_name, &config, MessagingPattern::PublishSubscribe).unwrap(), eq false);
 
         let _sut = node
             .service_builder(&service_name)
@@ -2021,25 +2082,26 @@ mod service_publish_subscribe {
             .create()
             .unwrap();
 
-        assert_that!(Sut::does_exist(&service_name, Config::global_config(), MessagingPattern::PublishSubscribe).unwrap(), eq true);
-        assert_that!(Sut::does_exist(&service_name, Config::global_config(), MessagingPattern::PublishSubscribe).unwrap(), eq true);
+        assert_that!(Sut::does_exist(&service_name, &config, MessagingPattern::PublishSubscribe).unwrap(), eq true);
+        assert_that!(Sut::does_exist(&service_name, &config, MessagingPattern::PublishSubscribe).unwrap(), eq true);
 
         drop(_sut);
 
-        assert_that!(Sut::does_exist(&service_name, Config::global_config(), MessagingPattern::PublishSubscribe).unwrap(), eq false);
+        assert_that!(Sut::does_exist(&service_name, &config, MessagingPattern::PublishSubscribe).unwrap(), eq false);
     }
 
     #[test]
     fn does_exist_works_many<Sut: Service>() {
         const NUMBER_OF_SERVICES: usize = 8;
 
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let mut services = vec![];
         let mut service_names = vec![];
 
         for i in 0..NUMBER_OF_SERVICES {
             let service_name = generate_name();
-            assert_that!(Sut::does_exist(&service_name, Config::global_config(), MessagingPattern::PublishSubscribe).unwrap(), eq false);
+            assert_that!(Sut::does_exist(&service_name, &config, MessagingPattern::PublishSubscribe).unwrap(), eq false);
 
             services.push(
                 node.service_builder(&service_name)
@@ -2050,13 +2112,13 @@ mod service_publish_subscribe {
             service_names.push(service_name);
 
             for s in service_names.iter().take(i + 1) {
-                assert_that!(Sut::does_exist(s, Config::global_config(), MessagingPattern::PublishSubscribe).unwrap(), eq true);
+                assert_that!(Sut::does_exist(s, &config, MessagingPattern::PublishSubscribe).unwrap(), eq true);
             }
         }
 
         for i in 0..NUMBER_OF_SERVICES {
             for s in service_names.iter().take(NUMBER_OF_SERVICES - i) {
-                assert_that!(Sut::does_exist(s, Config::global_config(), MessagingPattern::PublishSubscribe).unwrap(), eq true);
+                assert_that!(Sut::does_exist(s, &config, MessagingPattern::PublishSubscribe).unwrap(), eq true);
             }
 
             for s in service_names
@@ -2064,7 +2126,7 @@ mod service_publish_subscribe {
                 .take(NUMBER_OF_SERVICES)
                 .skip(NUMBER_OF_SERVICES - i)
             {
-                assert_that!(Sut::does_exist(s, Config::global_config(), MessagingPattern::PublishSubscribe).unwrap(), eq false);
+                assert_that!(Sut::does_exist(s, &config, MessagingPattern::PublishSubscribe).unwrap(), eq false);
             }
 
             services.pop();
@@ -2075,7 +2137,8 @@ mod service_publish_subscribe {
     fn list_works<Sut: Service>() {
         const NUMBER_OF_SERVICES: usize = 8;
 
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let mut services = vec![];
         let mut service_names = vec![];
 
@@ -2109,7 +2172,7 @@ mod service_publish_subscribe {
             service_names.push(service_name);
 
             let mut service_list = vec![];
-            Sut::list(Config::global_config(), |s| {
+            Sut::list(&config, |s| {
                 service_list.push(s);
                 CallbackProgression::Continue
             })
@@ -2124,7 +2187,7 @@ mod service_publish_subscribe {
             service_names.pop();
 
             let mut service_list = vec![];
-            Sut::list(Config::global_config(), |s| {
+            Sut::list(&config, |s| {
                 service_list.push(s);
                 CallbackProgression::Continue
             })
@@ -2137,7 +2200,8 @@ mod service_publish_subscribe {
     #[test]
     fn dropping_service_keeps_established_communication<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -2157,7 +2221,8 @@ mod service_publish_subscribe {
     #[test]
     fn ports_of_dropped_service_block_new_service_creation<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -2195,7 +2260,8 @@ mod service_publish_subscribe {
     fn subscriber_can_decrease_buffer_size<Sut: Service>() {
         const BUFFER_SIZE: usize = 16;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -2247,7 +2313,8 @@ mod service_publish_subscribe {
     fn subscriber_creation_fails_when_buffer_size_exceeds_service_max<Sut: Service>() {
         const BUFFER_SIZE: usize = 16;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let _sut = node
             .service_builder(&service_name)
@@ -2273,7 +2340,8 @@ mod service_publish_subscribe {
     #[test]
     fn subscriber_buffer_size_is_at_least_one<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -2288,7 +2356,8 @@ mod service_publish_subscribe {
     fn sliced_service_works<Sut: Service>() {
         const MAX_ELEMENTS: usize = 91;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = node
             .service_builder(&service_name)
             .publish_subscribe::<[u64]>()
@@ -2320,7 +2389,8 @@ mod service_publish_subscribe {
         const MAX_ELEMENTS: usize = 91;
         const ALIGNMENT: usize = 64;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let service_pub = node
             .service_builder(&service_name)
@@ -2364,7 +2434,8 @@ mod service_publish_subscribe {
     #[test]
     fn simple_communication_with_user_header_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -2405,7 +2476,8 @@ mod service_publish_subscribe {
     #[test]
     fn same_payload_type_but_different_user_header_does_not_connect<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let _sut = node
             .service_builder(&service_name)
@@ -2426,7 +2498,8 @@ mod service_publish_subscribe {
     #[test]
     fn create_with_custom_payload_type_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let _sut = unsafe {
             node.service_builder(&service_name)
@@ -2457,7 +2530,8 @@ mod service_publish_subscribe {
     #[test]
     fn create_with_custom_user_header_type_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const HEADER_SIZE: usize = 1024;
 
         let sut_pub = unsafe {
@@ -2511,7 +2585,8 @@ mod service_publish_subscribe {
     #[test]
     fn open_with_custom_payload_type_works<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let _sut = node
             .service_builder(&service_name)
@@ -2600,7 +2675,8 @@ mod service_publish_subscribe {
     #[test]
     fn has_samples_tracks_receivable_samples_in_subscriber<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -2624,7 +2700,8 @@ mod service_publish_subscribe {
     fn subscriber_can_still_receive_sample_when_publisher_was_disconnected<Sut: Service>() {
         const NUMBER_OF_SAMPLES: usize = 4;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -2656,7 +2733,8 @@ mod service_publish_subscribe {
         set_log_level(LogLevel::Error);
         const NUMBER_OF_SAMPLES: usize = 4;
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)
@@ -2689,7 +2767,8 @@ mod service_publish_subscribe {
     fn subscriber_acquires_samples_of_disconnected_publisher_first<Sut: Service>() {
         set_log_level(LogLevel::Error);
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = node
             .service_builder(&service_name)

--- a/iceoryx2/tests/service_static_config_tests.rs
+++ b/iceoryx2/tests/service_static_config_tests.rs
@@ -26,10 +26,10 @@ mod service_static_config_message_type_details {
         #[repr(C)]
         struct Tmp;
         let sut = TypeDetail::__internal_new::<Tmp>(TypeVariant::FixedSize);
-        let expected = TypeDetail{
+        let expected = TypeDetail {
             variant: TypeVariant::FixedSize,
-            type_name: "service_static_config_tests::service_static_config_message_type_details::test_internal_new::Tmp".to_string(),
-            size: 0 ,
+            type_name: core::any::type_name::<Tmp>().to_string(),
+            size: 0,
             alignment: 1,
         };
         assert_that!(sut, eq expected);
@@ -37,7 +37,7 @@ mod service_static_config_message_type_details {
         let sut = TypeDetail::__internal_new::<i64>(TypeVariant::FixedSize);
         let expected = TypeDetail {
             variant: TypeVariant::FixedSize,
-            type_name: "i64".to_string(),
+            type_name: core::any::type_name::<i64>().to_string(),
             size: 8,
             alignment: ALIGNMENT,
         };
@@ -47,8 +47,7 @@ mod service_static_config_message_type_details {
         let sut = TypeDetail::__internal_new::<TypeDetail>(TypeVariant::FixedSize);
         let expected = TypeDetail {
             variant: TypeVariant::FixedSize,
-            type_name: "iceoryx2::service::static_config::message_type_details::TypeDetail"
-                .to_string(),
+            type_name: core::any::type_name::<TypeDetail>().to_string(),
             size: size_of::<TypeDetail>(),
             alignment: ALIGNMENT,
         };

--- a/iceoryx2/tests/service_tests.rs
+++ b/iceoryx2/tests/service_tests.rs
@@ -26,6 +26,7 @@ mod service {
     use iceoryx2::service::messaging_pattern::MessagingPattern;
     use iceoryx2::service::port_factory::{event, publish_subscribe};
     use iceoryx2::service::{ServiceDetailsError, ServiceListError};
+    use iceoryx2::testing::*;
     use iceoryx2_bb_log::{set_log_level, LogLevel};
     use iceoryx2_bb_posix::system_configuration::SystemInfo;
     use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
@@ -215,7 +216,8 @@ mod service {
         Factory: SutFactory<Sut>,
     >() {
         let service_name = generate_name();
-        let node_1 = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut_pub_sub = node_1
             .service_builder(&service_name)
             .publish_subscribe::<u64>()
@@ -223,7 +225,7 @@ mod service {
         assert_that!(sut_pub_sub, is_ok);
         let sut_pub_sub = sut_pub_sub.unwrap();
 
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut_event = node_2.service_builder(&service_name).event().create();
         assert_that!(sut_event, is_ok);
         let sut_event = sut_event.unwrap();
@@ -258,11 +260,12 @@ mod service {
         let barrier_enter = Barrier::new(number_of_threads);
         let barrier_exit = Barrier::new(number_of_threads);
 
+        let config = generate_isolated_config();
         std::thread::scope(|s| {
             let mut threads = vec![];
             for _ in 0..number_of_threads {
                 threads.push(s.spawn(|| {
-                    let node = NodeBuilder::new().create::<Sut>().unwrap();
+                    let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
                     for _ in 0..NUMBER_OF_ITERATIONS {
                         let service_name = generate_name();
                         barrier_enter.wait();
@@ -297,11 +300,12 @@ mod service {
         let barrier_exit = Barrier::new(number_of_threads);
         let service_name = generate_name();
 
+        let config = generate_isolated_config();
         std::thread::scope(|s| {
             let mut threads = vec![];
             for _ in 0..number_of_threads {
                 threads.push(s.spawn(|| {
-                    let node = NodeBuilder::new().create::<Sut>().unwrap();
+                    let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
                     for _ in 0..NUMBER_OF_ITERATIONS {
                         barrier_enter.wait();
 
@@ -350,10 +354,11 @@ mod service {
         let service_names: Vec<_> = (0..NUMBER_OF_ITERATIONS).map(|_| generate_name()).collect();
         let service_names = &service_names;
 
+        let config = generate_isolated_config();
         std::thread::scope(|s| {
             let mut threads = vec![];
             threads.push(s.spawn(|| {
-                let node = NodeBuilder::new().create::<Sut>().unwrap();
+                let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
                 for service_name in service_names {
                     let sut = test
                         .create(&node, &service_name, &AttributeSpecifier::new())
@@ -367,7 +372,7 @@ mod service {
 
             for _ in 0..number_of_open_threads {
                 threads.push(s.spawn(|| {
-                    let node = NodeBuilder::new().create::<Sut>().unwrap();
+                    let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
                     for service_name in service_names {
                         barrier_enter.wait();
                         let sut = test.open(&node, &service_name, &AttributeVerifier::new());
@@ -401,8 +406,9 @@ mod service {
             .define("1. Hello", "Hypnotoad")
             .define("2. No more", "Coffee")
             .define("3. Just have a", "lick on the toad");
-        let node_1 = NodeBuilder::new().create::<Sut>().unwrap();
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut_create = test
             .create(&node_1, &service_name, &defined_attributes)
             .unwrap();
@@ -420,8 +426,9 @@ mod service {
     fn opener_succeeds_when_attributes_do_match<Sut: Service, Factory: SutFactory<Sut>>() {
         let test = Factory::new();
         let service_name = generate_name();
-        let node_1 = NodeBuilder::new().create::<Sut>().unwrap();
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let defined_attributes = AttributeSpecifier::new()
             .define("1. Hello", "Hypnotoad")
             .define("1. Hello", "Take a number")
@@ -451,8 +458,9 @@ mod service {
     fn opener_fails_when_attribute_value_does_not_match<Sut: Service, Factory: SutFactory<Sut>>() {
         let test = Factory::new();
         let service_name = generate_name();
-        let node_1 = NodeBuilder::new().create::<Sut>().unwrap();
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let defined_attributes = AttributeSpecifier::new()
             .define("1. Hello", "Hypnotoad")
             .define("2. No more", "Coffee");
@@ -474,8 +482,9 @@ mod service {
     fn opener_fails_when_attribute_key_does_not_exist<Sut: Service, Factory: SutFactory<Sut>>() {
         let test = Factory::new();
         let service_name = generate_name();
-        let node_1 = NodeBuilder::new().create::<Sut>().unwrap();
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let defined_attributes = AttributeSpecifier::new()
             .define("1. Hello", "Hypnotoad")
             .define("2. No more", "Coffee");
@@ -497,8 +506,9 @@ mod service {
     fn opener_fails_when_attribute_value_does_not_exist<Sut: Service, Factory: SutFactory<Sut>>() {
         let test = Factory::new();
         let service_name = generate_name();
-        let node_1 = NodeBuilder::new().create::<Sut>().unwrap();
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let defined_attributes = AttributeSpecifier::new()
             .define("1. Hello", "Hypnotoad")
             .define("1. Hello", "Number Two")
@@ -526,8 +536,9 @@ mod service {
     >() {
         let test = Factory::new();
         let service_name = generate_name();
-        let node_1 = NodeBuilder::new().create::<Sut>().unwrap();
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let defined_attributes = AttributeSpecifier::new()
             .define("1. Hello", "Hypnotoad")
             .define("2. No more", "Coffee");
@@ -552,8 +563,9 @@ mod service {
     >() {
         let test = Factory::new();
         let service_name = generate_name();
-        let node_1 = NodeBuilder::new().create::<Sut>().unwrap();
-        let node_2 = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node_1 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        let node_2 = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let defined_attributes = AttributeSpecifier::new()
             .define("1. Hello", "Hypnotoad")
             .define("2. No more", "Coffee");
@@ -608,12 +620,13 @@ mod service {
         const NUMBER_OF_SERVICES: usize = 16;
         let test = Factory::new();
 
+        let config = generate_isolated_config();
         let mut services = vec![];
         let mut service_ids = vec![];
         let mut nodes = vec![];
         for _ in 0..NUMBER_OF_SERVICES {
             let service_name = generate_name();
-            let node = NodeBuilder::new().create::<Sut>().unwrap();
+            let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
             let sut = test
                 .create(&node, &service_name, &AttributeSpecifier::new())
                 .unwrap();
@@ -624,7 +637,7 @@ mod service {
         }
 
         let mut listed_services = vec![];
-        let result = Sut::list(Config::global_config(), |service| {
+        let result = Sut::list(&config, |service| {
             listed_services.push(service.static_details.service_id().clone());
             CallbackProgression::Continue
         });
@@ -642,7 +655,8 @@ mod service {
     >() {
         const NUMBER_OF_SERVICES: usize = 16;
         let test = Factory::new();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let mut services = vec![];
         for _ in 0..NUMBER_OF_SERVICES {
@@ -655,7 +669,7 @@ mod service {
         }
 
         let mut service_counter = 0;
-        let result = Sut::list(Config::global_config(), |_service| {
+        let result = Sut::list(&config, |_service| {
             service_counter += 1;
             CallbackProgression::Stop
         });
@@ -671,11 +685,12 @@ mod service {
         const NUMBER_OF_ITERATIONS: usize = 40;
         let barrier = Barrier::new(number_of_creators);
 
+        let config = generate_isolated_config();
         std::thread::scope(|s| {
             let mut threads = vec![];
             for _ in 0..number_of_creators {
                 threads.push(s.spawn(|| {
-                    let node = NodeBuilder::new().create::<Sut>().unwrap();
+                    let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
                     barrier.wait();
 
                     for _ in 0..NUMBER_OF_ITERATIONS {
@@ -685,7 +700,7 @@ mod service {
                             .unwrap();
 
                         let mut found_me = false;
-                        let result = Sut::list(Config::global_config(), |s| {
+                        let result = Sut::list(&config, |s| {
                             if sut.service_id() == s.static_details.service_id() {
                                 found_me = true;
                             }
@@ -715,7 +730,8 @@ mod service {
         const NUMBER_OF_ITERATIONS: usize = 30;
         let barrier = Barrier::new(number_of_creators);
 
-        let main_node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let main_node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service_name = generate_name();
         let attributes = AttributeVerifier::new();
         let _service = test.create(&main_node, &service_name, &AttributeSpecifier::new());
@@ -727,7 +743,7 @@ mod service {
                     barrier.wait();
 
                     for _ in 0..NUMBER_OF_ITERATIONS {
-                        let node = NodeBuilder::new().create::<Sut>().unwrap();
+                        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
                         let service = test.open(&node, &service_name, &attributes).unwrap();
 
                         let mut found_me = false;
@@ -778,7 +794,8 @@ mod service {
         const NUMBER_OF_ITERATIONS: usize = 30;
         let barrier = Barrier::new(number_of_creators);
 
-        let main_node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let main_node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service_name = generate_name();
         let attributes = AttributeVerifier::new();
         let _service = test.create(&main_node, &service_name, &AttributeSpecifier::new());
@@ -790,16 +807,13 @@ mod service {
                     barrier.wait();
 
                     for _ in 0..NUMBER_OF_ITERATIONS {
-                        let node = NodeBuilder::new().create::<Sut>().unwrap();
+                        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
                         let _service = test.open(&node, &service_name, &attributes).unwrap();
 
-                        let service_details = Sut::details(
-                            &service_name,
-                            Config::global_config(),
-                            Factory::messaging_pattern(),
-                        )
-                        .unwrap()
-                        .unwrap();
+                        let service_details =
+                            Sut::details(&service_name, &config, Factory::messaging_pattern())
+                                .unwrap()
+                                .unwrap();
 
                         assert_that!(service_details.dynamic_details, is_some);
                         let dynamic_details = service_details.dynamic_details.unwrap();
@@ -843,7 +857,8 @@ mod service {
         let test = Factory::new();
         const NUMBER_OF_NODES: usize = 5;
 
-        let main_node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let main_node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let service_name = generate_name();
         let attributes = AttributeVerifier::new();
         let main_service = test
@@ -873,7 +888,7 @@ mod service {
         };
 
         for _ in 0..NUMBER_OF_NODES {
-            let node = NodeBuilder::new().create::<Sut>().unwrap();
+            let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
             let service = test.open(&node, &service_name, &attributes).unwrap();
 
             let registered_node_ids = get_registered_node_ids(&service);
@@ -907,7 +922,8 @@ mod service {
         let service_name = generate_name();
         const REPETITIONS: usize = 128;
 
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         let sut = test.create(&node, &service_name, &AttributeSpecifier::new());
         assert_that!(sut, is_ok);
 
@@ -925,7 +941,8 @@ mod service {
     fn uuid_is_equal_in_within_all_opened_instances<Sut: Service, Factory: SutFactory<Sut>>() {
         let test = Factory::new();
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
 
         let sut = test
             .create(&node, &service_name, &AttributeSpecifier::new())

--- a/iceoryx2/tests/subscriber_tests.rs
+++ b/iceoryx2/tests/subscriber_tests.rs
@@ -18,6 +18,7 @@ mod subscriber {
         node::NodeBuilder,
         port::subscriber::{SubscriberCreateError, SubscriberReceiveError},
         service::{service_name::ServiceName, Service},
+        testing::*,
     };
     use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_testing::assert_that;
@@ -47,7 +48,8 @@ mod subscriber {
     #[test]
     fn id_is_unique<Sut: Service>() {
         let service_name = generate_name();
-        let node = NodeBuilder::new().create::<Sut>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX_SUBSCRIBERS: usize = 8;
 
         let sut = node

--- a/iceoryx2/tests/waitset_tests.rs
+++ b/iceoryx2/tests/waitset_tests.rs
@@ -18,6 +18,7 @@ mod waitset {
     use iceoryx2::port::notifier::Notifier;
     use iceoryx2::port::waitset::{WaitSetAttachmentError, WaitSetRunError};
     use iceoryx2::prelude::{WaitSetBuilder, *};
+    use iceoryx2::testing::*;
     use iceoryx2_bb_posix::config::test_directory;
     use iceoryx2_bb_posix::directory::Directory;
     use iceoryx2_bb_posix::file::Permission;
@@ -98,7 +99,8 @@ mod waitset {
         const LISTENER_LIMIT: usize = 16;
         const EXTERNAL_LIMIT: usize = 16;
 
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
         let mut listeners = vec![];
         let mut sockets = vec![];
@@ -139,7 +141,8 @@ mod waitset {
     where
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
 
         let (listener, _) = create_event::<S>(&node);
@@ -157,7 +160,8 @@ mod waitset {
     where
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
 
         let (listener, _) = create_event::<S>(&node);
@@ -176,7 +180,8 @@ mod waitset {
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
         set_log_level(LogLevel::Debug);
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
 
         let (listener_1, notifier_1) = create_event::<S>(&node);
@@ -222,7 +227,8 @@ mod waitset {
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
         let _watchdog = Watchdog::new();
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
 
         let (listener, _) = create_event::<S>(&node);
@@ -248,7 +254,8 @@ mod waitset {
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
         let _watchdog = Watchdog::new();
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
 
         let (listener, _) = create_event::<S>(&node);
@@ -268,7 +275,8 @@ mod waitset {
     where
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
 
         let (listener_1, notifier_1) = create_event::<S>(&node);
@@ -361,7 +369,8 @@ mod waitset {
     where
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
 
         let (listener_1, notifier_1) = create_event::<S>(&node);
@@ -430,7 +439,8 @@ mod waitset {
     where
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
-        let node = NodeBuilder::new().create::<S>().unwrap();
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();
 
         let (listener_1, notifier_1) = create_event::<S>(&node);


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The PR makes the remaining tests available to bazel.

Since bazel runs the tests in parallel, some of them needed to be adjusted for isolation.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #349 
