### PR TITLE
[#488] waitset attachment id improvements

### DIFF
--- a/iceoryx2-ffi/cxx/include/iox2/waitset.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/waitset.hpp
@@ -80,6 +80,8 @@ class WaitSetAttachmentId {
     friend auto operator==(const WaitSetAttachmentId<ST>&, const WaitSetAttachmentId<ST>&) -> bool;
     template <ServiceType ST>
     friend auto operator<(const WaitSetAttachmentId<ST>&, const WaitSetAttachmentId<ST>&) -> bool;
+    template <ServiceType ST>
+    friend auto operator<<(std::ostream& stream, const WaitSetAttachmentId<ST>& self) -> std::ostream&;
 
     void drop();
 
@@ -91,6 +93,9 @@ auto operator==(const WaitSetAttachmentId<S>& lhs, const WaitSetAttachmentId<S>&
 
 template <ServiceType S>
 auto operator<(const WaitSetAttachmentId<S>& lhs, const WaitSetAttachmentId<S>& rhs) -> bool;
+
+template <ServiceType S>
+auto operator<<(std::ostream& stream, const WaitSetAttachmentId<S>& self) -> std::ostream&;
 
 /// The [`WaitSet`] implements a reactor pattern and allows to wait on multiple events in one
 /// single call [`WaitSet::try_wait_and_process()`] until it wakes up or to run repeatedly with

--- a/iceoryx2-ffi/cxx/include/iox2/waitset.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/waitset.hpp
@@ -72,6 +72,9 @@ class WaitSetAttachmentId {
     /// Returns true if the deadline for the attachment corresponding to [`WaitSetGuard`] was missed.
     auto has_missed_deadline(const WaitSetGuard<S>& guard) const -> bool;
 
+    /// Returns the a non-secure hash for the [`WaitSetAttachmentId`].
+    auto hash() const -> std::size_t;
+
   private:
     explicit WaitSetAttachmentId(iox2_waitset_attachment_id_h handle);
     template <ServiceType>
@@ -227,5 +230,19 @@ class WaitSetBuilder {
     iox2_waitset_builder_h m_handle;
 };
 } // namespace iox2
+
+template <>
+struct std::hash<iox2::WaitSetAttachmentId<iox2::ServiceType::Ipc>> {
+    auto operator()(const iox2::WaitSetAttachmentId<iox2::ServiceType::Ipc>& self) -> std::size_t {
+        return self.hash();
+    }
+};
+
+template <>
+struct std::hash<iox2::WaitSetAttachmentId<iox2::ServiceType::Local>> {
+    auto operator()(const iox2::WaitSetAttachmentId<iox2::ServiceType::Local>& self) -> std::size_t {
+        return self.hash();
+    }
+};
 
 #endif

--- a/iceoryx2-ffi/cxx/include/iox2/waitset.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/waitset.hpp
@@ -230,19 +230,4 @@ class WaitSetBuilder {
     iox2_waitset_builder_h m_handle;
 };
 } // namespace iox2
-
-template <>
-struct std::hash<iox2::WaitSetAttachmentId<iox2::ServiceType::Ipc>> {
-    auto operator()(const iox2::WaitSetAttachmentId<iox2::ServiceType::Ipc>& self) -> std::size_t {
-        return self.hash();
-    }
-};
-
-template <>
-struct std::hash<iox2::WaitSetAttachmentId<iox2::ServiceType::Local>> {
-    auto operator()(const iox2::WaitSetAttachmentId<iox2::ServiceType::Local>& self) -> std::size_t {
-        return self.hash();
-    }
-};
-
 #endif

--- a/iceoryx2-ffi/cxx/include/iox2/waitset_hash.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/waitset_hash.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef IOX2_WAITSET_HASH_HPP
+#define IOX2_WAITSET_HASH_HPP
+
+#include "iox2/waitset.hpp"
+
+template <>
+struct std::hash<iox2::WaitSetAttachmentId<iox2::ServiceType::Ipc>> {
+    auto operator()(const iox2::WaitSetAttachmentId<iox2::ServiceType::Ipc>& self) -> std::size_t {
+        return self.hash();
+    }
+};
+
+template <>
+struct std::hash<iox2::WaitSetAttachmentId<iox2::ServiceType::Local>> {
+    auto operator()(const iox2::WaitSetAttachmentId<iox2::ServiceType::Local>& self) -> std::size_t {
+        return self.hash();
+    }
+};
+
+#endif

--- a/iceoryx2-ffi/cxx/src/waitset.cpp
+++ b/iceoryx2-ffi/cxx/src/waitset.cpp
@@ -69,6 +69,14 @@ void WaitSetAttachmentId<S>::drop() {
 }
 
 template <ServiceType S>
+auto WaitSetAttachmentId<S>::hash() const -> std::size_t {
+    auto len = iox2_waitset_attachment_id_debug_len(&m_handle);
+    std::string empty(len, '\0');
+    iox2_waitset_attachment_id_debug(&m_handle, empty.data(), len);
+    return std::hash<std::string> {}(empty);
+}
+
+template <ServiceType S>
 auto operator==(const WaitSetAttachmentId<S>& lhs, const WaitSetAttachmentId<S>& rhs) -> bool {
     return iox2_waitset_attachment_id_equal(&lhs.m_handle, &rhs.m_handle);
 }

--- a/iceoryx2-ffi/cxx/src/waitset.cpp
+++ b/iceoryx2-ffi/cxx/src/waitset.cpp
@@ -78,6 +78,14 @@ auto operator<(const WaitSetAttachmentId<S>& lhs, const WaitSetAttachmentId<S>& 
     return iox2_waitset_attachment_id_less(&lhs.m_handle, &rhs.m_handle);
 }
 
+template <ServiceType S>
+auto operator<<(std::ostream& stream, const WaitSetAttachmentId<S>& self) -> std::ostream& {
+    auto len = iox2_waitset_attachment_id_debug_len(&self.m_handle);
+    std::string empty(len, '\0');
+    iox2_waitset_attachment_id_debug(&self.m_handle, empty.data(), len);
+    stream << empty;
+    return stream;
+}
 
 ////////////////////////////
 // END: WaitSetAttachmentId
@@ -328,4 +336,7 @@ template auto operator<(const WaitSetAttachmentId<ServiceType::Ipc>& lhs,
                         const WaitSetAttachmentId<ServiceType::Ipc>& rhs) -> bool;
 template auto operator<(const WaitSetAttachmentId<ServiceType::Local>& lhs,
                         const WaitSetAttachmentId<ServiceType::Local>& rhs) -> bool;
+template auto operator<<(std::ostream& stream, const WaitSetAttachmentId<ServiceType::Ipc>& self) -> std::ostream&;
+template auto operator<<(std::ostream& stream, const WaitSetAttachmentId<ServiceType::Local>& self) -> std::ostream&;
+
 } // namespace iox2

--- a/iceoryx2/src/port/waitset.rs
+++ b/iceoryx2/src/port/waitset.rs
@@ -274,10 +274,21 @@ enum AttachmentIdType {
 }
 
 /// Represents an attachment to the [`WaitSet`]
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct WaitSetAttachmentId<Service: crate::service::Service> {
     attachment_type: AttachmentIdType,
     _data: PhantomData<Service>,
+}
+
+impl<Service: crate::service::Service> Debug for WaitSetAttachmentId<Service> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "WaitSetAttachmentId<{}> {{ attachment_type: {:?} }}",
+            core::any::type_name::<Service>(),
+            self.attachment_type
+        )
+    }
 }
 
 impl<Service: crate::service::Service> WaitSetAttachmentId<Service> {


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

To be able to perform better debugging, the streaming operator for the waitset attachment id was added. Furthermore, `std::hash` was implemented for it to be able to organize it in a hash map.

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #488 
