### PR TITLE
[#490] Enable loan_slice APIs in CXX bindings

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -58,6 +58,9 @@
 -->
 
 * APIs to support slices in the C++ bindings [#490](https://github.com/eclipse-iceoryx/iceoryx2/issues/490)
+* Rename `iox2_publisher_loan` to `iox2_publisher_loan_slice_uninit` [#490](https://github.com/eclipse-iceoryx/iceoryx2/issues/490)
+    1. C always loans slices, for a single element, specify the
+       `number_of_elements` to be 1
 
 ### API Breaking Changes
 

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -15,6 +15,7 @@
 * Add `PeriodicTimer` into POSIX building blocks [#425](https://github.com/eclipse-iceoryx/iceoryx2/issues/425)
 * Developer permissions for resources [#460](https://github.com/eclipse-iceoryx/iceoryx2/issues/460)
 * Add `--send-copy` flag to Benchmark to consider mem operations [#483](https://github.com/eclipse-iceoryx/iceoryx2/issues/483)
+* Support for slices in the C++ bindings [#490](https://github.com/eclipse-iceoryx/iceoryx2/issues/490)
 
 ### Bugfixes
 
@@ -56,7 +57,7 @@
     conflicts when merging.
 -->
 
-* Example text [#1](https://github.com/eclipse-iceoryx/iceoryx2/issues/1)
+* APIs to support slices in the C++ bindings [#490](https://github.com/eclipse-iceoryx/iceoryx2/issues/490)
 
 ### API Breaking Changes
 

--- a/examples/c/domains/src/publisher.c
+++ b/examples/c/domains/src/publisher.c
@@ -99,7 +99,7 @@ int main(int argc, char** argv) {
 
         // loan sample
         iox2_sample_mut_h sample = NULL;
-        if (iox2_publisher_loan(&publisher, NULL, &sample) != IOX2_OK) {
+        if (iox2_publisher_loan_slice_uninit(&publisher, NULL, &sample, 1) != IOX2_OK) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }

--- a/examples/c/publish_subscribe/src/publisher.c
+++ b/examples/c/publish_subscribe/src/publisher.c
@@ -79,7 +79,7 @@ int main(void) {
 
         // loan sample
         iox2_sample_mut_h sample = NULL;
-        if (iox2_publisher_loan(&publisher, NULL, &sample) != IOX2_OK) {
+        if (iox2_publisher_loan_slice_uninit(&publisher, NULL, &sample, 1) != IOX2_OK) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }

--- a/examples/c/publish_subscribe_with_user_header/src/publisher.c
+++ b/examples/c/publish_subscribe_with_user_header/src/publisher.c
@@ -92,7 +92,7 @@ int main(void) {
 
         // loan sample
         iox2_sample_mut_h sample = NULL;
-        if (iox2_publisher_loan(&publisher, NULL, &sample) != IOX2_OK) {
+        if (iox2_publisher_loan_slice_uninit(&publisher, NULL, &sample, 1) != IOX2_OK) {
             printf("Failed to loan sample\n");
             goto drop_publisher;
         }

--- a/examples/cxx/publish_subscribe_dynamic_data/src/publisher.cpp
+++ b/examples/cxx/publish_subscribe_dynamic_data/src/publisher.cpp
@@ -32,25 +32,25 @@ auto main() -> int {
                        .open_or_create()
                        .expect("successful service creation/opening");
 
-    uint64_t worst_case_memory_size = 1024; // NOLINT
+    const uint64_t worst_case_memory_size = 1024; // NOLINT
     auto publisher = service.publisher_builder()
                          .max_slice_len(worst_case_memory_size)
                          .create()
                          .expect("successful publisher creation");
 
-    auto counter = 1;
+    auto counter = 0;
 
     while (node.wait(CYCLE_TIME).has_value()) {
-        counter += 1;
-
-        auto required_memory_size = (8 + counter) % 16; // NOLINT
+        const auto required_memory_size = (counter % 16) + 1; // NOLINT
         auto sample = publisher.loan_slice_uninit(required_memory_size).expect("acquire sample");
         sample.write_from_fn([&](auto byte_idx) { return (byte_idx + counter) % 255; }); // NOLINT
 
         auto initialized_sample = assume_init(std::move(sample));
         send(std::move(initialized_sample)).expect("send successful");
 
-        std::cout << "Send sample " << counter << "..." << std::endl;
+        std::cout << "Send sample " << counter << " with " << required_memory_size << " bytes..." << std::endl;
+
+        counter++;
     }
 
     std::cout << "exit" << std::endl;

--- a/examples/cxx/publish_subscribe_dynamic_data/src/publisher.cpp
+++ b/examples/cxx/publish_subscribe_dynamic_data/src/publisher.cpp
@@ -32,11 +32,11 @@ auto main() -> int {
                        .open_or_create()
                        .expect("successful service creation/opening");
 
-    const uint64_t worst_case_memory_size = 1024; // NOLINT
-    auto publisher = service.publisher_builder()
-                         .max_slice_len(worst_case_memory_size)
-                         .create()
-                         .expect("successful publisher creation");
+    // Since the payload type is uint8_t, this number is the same as the number of bytes in the payload.
+    // For other types, number of bytes used by the payload will be max_slice_len * sizeof(Payload::ValueType)
+    const uint64_t maximum_elements = 1024; // NOLINT
+    auto publisher =
+        service.publisher_builder().max_slice_len(maximum_elements).create().expect("successful publisher creation");
 
     auto counter = 0;
 

--- a/examples/cxx/publish_subscribe_dynamic_data/src/subscriber.cpp
+++ b/examples/cxx/publish_subscribe_dynamic_data/src/subscriber.cpp
@@ -17,6 +17,7 @@
 #include "iox2/service_type.hpp"
 
 #include <cstdint>
+#include <iomanip>
 #include <iostream>
 
 constexpr iox::units::Duration CYCLE_TIME = iox::units::Duration::fromSeconds(1);
@@ -35,9 +36,9 @@ auto main() -> int {
     while (node.wait(CYCLE_TIME).has_value()) {
         auto sample = subscriber.receive().expect("receive succeeds");
         while (sample.has_value()) {
-            std::cout << "received " << sample->payload().size() << " bytes: ";
-            for (auto byte : sample->payload()) {
-                std::cout << std::hex << byte << " ";
+            std::cout << "received " << std::dec << static_cast<int>(sample->payload_slice().size()) << " bytes: ";
+            for (auto byte : sample->payload_slice()) {
+                std::cout << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(byte) << " ";
             }
             std::cout << std::endl;
             sample = subscriber.receive().expect("receive succeeds");

--- a/examples/cxx/publish_subscribe_dynamic_data/src/subscriber.cpp
+++ b/examples/cxx/publish_subscribe_dynamic_data/src/subscriber.cpp
@@ -36,8 +36,9 @@ auto main() -> int {
     while (node.wait(CYCLE_TIME).has_value()) {
         auto sample = subscriber.receive().expect("receive succeeds");
         while (sample.has_value()) {
-            std::cout << "received " << std::dec << static_cast<int>(sample->payload_slice().size()) << " bytes: ";
-            for (auto byte : sample->payload_slice()) {
+            auto payload = sample->payload();
+            std::cout << "received " << std::dec << static_cast<int>(payload.size()) << " bytes: ";
+            for (auto byte : payload) {
                 std::cout << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(byte) << " ";
             }
             std::cout << std::endl;

--- a/examples/cxx/publish_subscribe_dynamic_data/src/subscriber.cpp
+++ b/examples/cxx/publish_subscribe_dynamic_data/src/subscriber.cpp
@@ -37,7 +37,7 @@ auto main() -> int {
         auto sample = subscriber.receive().expect("receive succeeds");
         while (sample.has_value()) {
             auto payload = sample->payload();
-            std::cout << "received " << std::dec << static_cast<int>(payload.size()) << " bytes: ";
+            std::cout << "received " << std::dec << static_cast<int>(payload.number_of_bytes()) << " bytes: ";
             for (auto byte : payload) {
                 std::cout << std::setw(2) << std::setfill('0') << std::hex << static_cast<int>(byte) << " ";
             }

--- a/iceoryx2-ffi/cxx/include/iox/slice.hpp
+++ b/iceoryx2-ffi/cxx/include/iox/slice.hpp
@@ -40,25 +40,35 @@ class Slice {
     /// @param[in] n The index of the element to access.
     /// @return A const reference to the element at the specified index.
     /// @pre The index must be less than the number of elements in the slice.
-    template <typename U = T, typename = std::enable_if_t<std::is_const_v<U>>>
-    auto operator[](uint64_t n) const -> const ValueType&;
+    auto operator[](uint64_t n) const -> std::conditional_t<std::is_const_v<T>, const ValueType&, ValueType&>;
 
     /// @brief Accesses the element at the specified index (non-const version).
     /// @param[in] n The index of the element to access.
     /// @return A reference to the element at the specified index.
     /// @pre The index must be less than the number of elements in the slice.
-    template <typename U = T, typename = std::enable_if_t<!std::is_const_v<U>>>
-    auto operator[](uint64_t n) -> ValueType&;
+    auto operator[](uint64_t n) -> std::conditional_t<std::is_const_v<T>, const ValueType&, ValueType&>;
 
-    /// @brief Returns an iterator to the beginning of the slice.
+    /// @brief Returns an iterator to the beginning of the slice (const version).
+    /// @return An iterator pointing to the first element of the slice.
+    auto begin() const -> Iterator;
+
+    /// @brief Returns an iterator to the beginning of the slice (non-const version).
     /// @return An iterator pointing to the first element of the slice.
     auto begin() -> Iterator;
 
-    /// @brief Returns an iterator to the end of the slice.
+    /// @brief Returns an iterator to the end of the slice (const version).
+    /// @return An iterator pointing one past the last element of the slice.
+    auto end() const -> Iterator;
+
+    /// @brief Returns an iterator to the end of the slice (non-const version).
     /// @return An iterator pointing one past the last element of the slice.
     auto end() -> Iterator;
 
-    /// @brief Returns a pointer to the underlying data of the slice.
+    /// @brief Returns a pointer to the underlying data of the slice (const version).
+    /// @return A pointer to the first element of the slice.
+    auto data() const -> Iterator;
+
+    /// @brief Returns a pointer to the underlying data of the slice (non-const version).
     /// @return A pointer to the first element of the slice.
     auto data() -> Iterator;
 
@@ -90,15 +100,14 @@ auto Slice<T>::number_of_elements() const -> uint64_t {
 }
 
 template <typename T>
-template <typename U, typename>
-auto Slice<T>::operator[](const uint64_t n) const -> const ValueType& {
+auto Slice<T>::operator[](const uint64_t n) const
+    -> std::conditional_t<std::is_const_v<T>, const ValueType&, ValueType&> {
     IOX_ASSERT(n < m_number_of_elements, "Index out of bounds");
     return *(m_data + n);
 }
 
 template <typename T>
-template <typename U, typename>
-auto Slice<T>::operator[](const uint64_t n) -> ValueType& {
+auto Slice<T>::operator[](const uint64_t n) -> std::conditional_t<std::is_const_v<T>, const ValueType&, ValueType&> {
     IOX_ASSERT(n < m_number_of_elements, "Index out of bounds");
     return *(m_data + n);
 }
@@ -109,13 +118,29 @@ auto Slice<T>::begin() -> Iterator {
 }
 
 template <typename T>
+auto Slice<T>::begin() const -> Iterator {
+    return m_data;
+}
+
+template <typename T>
 auto Slice<T>::end() -> Iterator {
     static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
     return m_data + m_number_of_elements;
 }
 
 template <typename T>
+auto Slice<T>::end() const -> Iterator {
+    static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
+    return m_data + m_number_of_elements;
+}
+
+template <typename T>
 auto Slice<T>::data() -> Iterator {
+    return m_data;
+}
+
+template <typename T>
+auto Slice<T>::data() const -> Iterator {
     return m_data;
 }
 

--- a/iceoryx2-ffi/cxx/include/iox/slice.hpp
+++ b/iceoryx2-ffi/cxx/include/iox/slice.hpp
@@ -19,15 +19,14 @@
 #include <type_traits>
 
 namespace iox {
+
 template <typename T>
 class Slice {
   public:
-    using Iterator = T*;
-    using ConstIterator = const T*;
-    using ValueType = T;
+    using Iterator = std::conditional_t<std::is_const_v<T>, const T*, T*>;
+    using ValueType = std::remove_const_t<T>;
 
     Slice(T* data, uint64_t number_of_elements);
-    Slice(const T* data, uint64_t number_of_elements);
 
     /// @brief Returns the size of the slice in bytes.
     /// @return The size of the slice in bytes.
@@ -41,37 +40,27 @@ class Slice {
     /// @param[in] n The index of the element to access.
     /// @return A const reference to the element at the specified index.
     /// @pre The index must be less than the number of elements in the slice.
-    auto operator[](uint64_t n) const -> const T&;
+    template <typename U = T, typename = std::enable_if_t<std::is_const_v<U>>>
+    auto operator[](uint64_t n) const -> const ValueType&;
 
     /// @brief Accesses the element at the specified index (non-const version).
     /// @param[in] n The index of the element to access.
     /// @return A reference to the element at the specified index.
     /// @pre The index must be less than the number of elements in the slice.
-    auto operator[](uint64_t n) -> T&;
+    template <typename U = T, typename = std::enable_if_t<!std::is_const_v<U>>>
+    auto operator[](uint64_t n) -> ValueType&;
 
     /// @brief Returns an iterator to the beginning of the slice.
     /// @return An iterator pointing to the first element of the slice.
     auto begin() -> Iterator;
 
-    /// @brief Returns a const iterator to the beginning of the slice.
-    /// @return A const iterator pointing to the first element of the slice.
-    auto begin() const -> ConstIterator;
-
     /// @brief Returns an iterator to the end of the slice.
     /// @return An iterator pointing one past the last element of the slice.
     auto end() -> Iterator;
 
-    /// @brief Returns a const iterator to the end of the slice.
-    /// @return A const iterator pointing one past the last element of the slice.
-    auto end() const -> ConstIterator;
-
     /// @brief Returns a pointer to the underlying data of the slice.
     /// @return A pointer to the first element of the slice.
-    auto data() -> T*;
-
-    /// @brief Returns a const pointer to the underlying data of the slice.
-    /// @return A const pointer to the first element of the slice.
-    auto data() const -> const T*;
+    auto data() -> Iterator;
 
   private:
     T* m_data;
@@ -79,16 +68,14 @@ class Slice {
 };
 
 template <typename T>
-Slice<T>::Slice(T* data, uint64_t number_of_elements)
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) constness protected by const class specification
-    : m_data { data }
-    , m_number_of_elements { number_of_elements } {
-}
+using MutableSlice = Slice<T>;
 
 template <typename T>
-Slice<T>::Slice(const T* data, uint64_t number_of_elements)
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) constness protected by const class specification
-    : m_data { const_cast<T*>(data) }
+using ImmutableSlice = Slice<const T>;
+
+template <typename T>
+Slice<T>::Slice(T* data, uint64_t number_of_elements)
+    : m_data { data }
     , m_number_of_elements { number_of_elements } {
 }
 
@@ -103,13 +90,15 @@ auto Slice<T>::number_of_elements() const -> uint64_t {
 }
 
 template <typename T>
-auto Slice<T>::operator[](const uint64_t n) const -> const T& {
+template <typename U, typename>
+auto Slice<T>::operator[](const uint64_t n) const -> const ValueType& {
     IOX_ASSERT(n < m_number_of_elements, "Index out of bounds");
     return *(m_data + n);
 }
 
 template <typename T>
-auto Slice<T>::operator[](const uint64_t n) -> T& {
+template <typename U, typename>
+auto Slice<T>::operator[](const uint64_t n) -> ValueType& {
     IOX_ASSERT(n < m_number_of_elements, "Index out of bounds");
     return *(m_data + n);
 }
@@ -120,29 +109,13 @@ auto Slice<T>::begin() -> Iterator {
 }
 
 template <typename T>
-auto Slice<T>::begin() const -> ConstIterator {
-    return m_data;
-}
-
-template <typename T>
 auto Slice<T>::end() -> Iterator {
     static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
     return m_data + m_number_of_elements;
 }
 
 template <typename T>
-auto Slice<T>::end() const -> ConstIterator {
-    static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
-    return m_data + m_number_of_elements;
-}
-
-template <typename T>
-auto Slice<T>::data() -> T* {
-    return m_data;
-}
-
-template <typename T>
-auto Slice<T>::data() const -> const T* {
+auto Slice<T>::data() -> Iterator {
     return m_data;
 }
 

--- a/iceoryx2-ffi/cxx/include/iox/slice.hpp
+++ b/iceoryx2-ffi/cxx/include/iox/slice.hpp
@@ -26,26 +26,64 @@ class Slice {
     using ConstIterator = const T*;
     using ValueType = T;
 
+    Slice(T* data, uint64_t number_of_elements);
     Slice(const T* data, uint64_t number_of_elements);
 
+    /// @brief Returns the size of the slice in bytes.
+    /// @return The size of the slice in bytes.
     auto size() const -> uint64_t;
+
+    /// @brief Returns the number of elements in the slice.
+    /// @return The number of elements in the slice.
     auto number_of_elements() const -> uint64_t;
 
+    /// @brief Accesses the element at the specified index (const version).
+    /// @param[in] n The index of the element to access.
+    /// @return A const reference to the element at the specified index.
+    /// @pre The index must be less than the number of elements in the slice.
     auto operator[](uint64_t n) const -> const T&;
+
+    /// @brief Accesses the element at the specified index (non-const version).
+    /// @param[in] n The index of the element to access.
+    /// @return A reference to the element at the specified index.
+    /// @pre The index must be less than the number of elements in the slice.
     auto operator[](uint64_t n) -> T&;
 
+    /// @brief Returns an iterator to the beginning of the slice.
+    /// @return An iterator pointing to the first element of the slice.
     auto begin() -> Iterator;
+
+    /// @brief Returns a const iterator to the beginning of the slice.
+    /// @return A const iterator pointing to the first element of the slice.
     auto begin() const -> ConstIterator;
+
+    /// @brief Returns an iterator to the end of the slice.
+    /// @return An iterator pointing one past the last element of the slice.
     auto end() -> Iterator;
+
+    /// @brief Returns a const iterator to the end of the slice.
+    /// @return A const iterator pointing one past the last element of the slice.
     auto end() const -> ConstIterator;
 
+    /// @brief Returns a pointer to the underlying data of the slice.
+    /// @return A pointer to the first element of the slice.
     auto data() -> T*;
+
+    /// @brief Returns a const pointer to the underlying data of the slice.
+    /// @return A const pointer to the first element of the slice.
     auto data() const -> const T*;
 
   private:
     T* m_data;
     uint64_t m_number_of_elements;
 };
+
+template <typename T>
+Slice<T>::Slice(T* data, uint64_t number_of_elements)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) constness protected by const class specification
+    : m_data { data }
+    , m_number_of_elements { number_of_elements } {
+}
 
 template <typename T>
 Slice<T>::Slice(const T* data, uint64_t number_of_elements)

--- a/iceoryx2-ffi/cxx/include/iox/slice.hpp
+++ b/iceoryx2-ffi/cxx/include/iox/slice.hpp
@@ -28,7 +28,9 @@ class Slice {
 
     Slice(const T* data, uint64_t number_of_elements);
 
+    auto size() const -> uint64_t;
     auto number_of_elements() const -> uint64_t;
+
     auto operator[](uint64_t n) const -> const T&;
     auto operator[](uint64_t n) -> T&;
 
@@ -50,6 +52,11 @@ Slice<T>::Slice(const T* data, uint64_t number_of_elements)
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) constness protected by const class specification
     : m_data { const_cast<T*>(data) }
     , m_number_of_elements { number_of_elements } {
+}
+
+template <typename T>
+auto Slice<T>::size() const -> uint64_t {
+    return (sizeof(ValueType) * m_number_of_elements + alignof(ValueType) - 1) & ~(alignof(ValueType) - 1);
 }
 
 template <typename T>

--- a/iceoryx2-ffi/cxx/include/iox/slice.hpp
+++ b/iceoryx2-ffi/cxx/include/iox/slice.hpp
@@ -96,6 +96,7 @@ template <typename T>
 Slice<T>::Slice(T* data, uint64_t number_of_elements)
     : m_data { data }
     , m_number_of_elements { number_of_elements } {
+    static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
 }
 
 template <typename T>
@@ -133,13 +134,11 @@ auto Slice<T>::begin() const -> Iterator {
 
 template <typename T>
 auto Slice<T>::end() -> Iterator {
-    static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
     return m_data + m_number_of_elements;
 }
 
 template <typename T>
 auto Slice<T>::end() const -> Iterator {
-    static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
     return m_data + m_number_of_elements;
 }
 

--- a/iceoryx2-ffi/cxx/include/iox/slice.hpp
+++ b/iceoryx2-ffi/cxx/include/iox/slice.hpp
@@ -20,17 +20,26 @@
 
 namespace iox {
 
+/// @brief A class representing a slice of contiguous elements of type T.
+///
+/// A Slice provides a view into a contiguous sequence of elements without owning the memory.
+/// It allows for efficient access and iteration over a portion of a contiguous data structure.
+///
+/// @tparam T The type of elements in the slice. Can be const-qualified for read-only slices.
 template <typename T>
 class Slice {
   public:
     using Iterator = std::conditional_t<std::is_const_v<T>, const T*, T*>;
     using ValueType = std::remove_const_t<T>;
 
+    /// @brief Constructs a Slice object.
+    /// @param[in] data Pointer to the beginning of the data.
+    /// @param[in] number_of_elements The number of elements in the slice.
     Slice(T* data, uint64_t number_of_elements);
 
-    /// @brief Returns the size of the slice in bytes.
-    /// @return The size of the slice in bytes.
-    auto size() const -> uint64_t;
+    /// @brief Returns the total number of bytes occupied by the slice.
+    /// @return The number of bytes occupied by the slice, rounded up to the nearest alignment boundary.
+    auto number_of_bytes() const -> uint64_t;
 
     /// @brief Returns the number of elements in the slice.
     /// @return The number of elements in the slice.
@@ -90,7 +99,7 @@ Slice<T>::Slice(T* data, uint64_t number_of_elements)
 }
 
 template <typename T>
-auto Slice<T>::size() const -> uint64_t {
+auto Slice<T>::number_of_bytes() const -> uint64_t {
     return (sizeof(ValueType) * m_number_of_elements + alignof(ValueType) - 1) & ~(alignof(ValueType) - 1);
 }
 

--- a/iceoryx2-ffi/cxx/include/iox/slice.hpp
+++ b/iceoryx2-ffi/cxx/include/iox/slice.hpp
@@ -16,6 +16,7 @@
 #include "iox/assertions_addendum.hpp"
 
 #include <cstdint>
+#include <type_traits>
 
 namespace iox {
 template <typename T>
@@ -25,28 +26,80 @@ class Slice {
     using ConstIterator = const T*;
     using ValueType = T;
 
-    auto size() const -> uint64_t {
-        IOX_TODO();
-    }
-    auto operator[](const uint64_t n) const -> const T& {
-        IOX_TODO();
-    }
-    auto operator[](const uint64_t n) -> T& {
-        IOX_TODO();
-    }
-    auto begin() -> Iterator {
-        IOX_TODO();
-    }
-    auto begin() const -> ConstIterator {
-        IOX_TODO();
-    }
-    auto end() -> Iterator {
-        IOX_TODO();
-    }
-    auto end() const -> ConstIterator {
-        IOX_TODO();
-    }
+    Slice(const T* data, uint64_t number_of_elements);
+
+    auto number_of_elements() const -> uint64_t;
+    auto operator[](uint64_t n) const -> const T&;
+    auto operator[](uint64_t n) -> T&;
+
+    auto begin() -> Iterator;
+    auto begin() const -> ConstIterator;
+    auto end() -> Iterator;
+    auto end() const -> ConstIterator;
+
+    auto data() -> T*;
+    auto data() const -> const T*;
+
+  private:
+    T* m_data;
+    uint64_t m_number_of_elements;
 };
+
+template <typename T>
+Slice<T>::Slice(const T* data, uint64_t number_of_elements)
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast) constness protected by const class specification
+    : m_data { const_cast<T*>(data) }
+    , m_number_of_elements { number_of_elements } {
+}
+
+template <typename T>
+auto Slice<T>::number_of_elements() const -> uint64_t {
+    return m_number_of_elements;
+}
+
+template <typename T>
+auto Slice<T>::operator[](const uint64_t n) const -> const T& {
+    IOX_ASSERT(n < m_number_of_elements, "Index out of bounds");
+    return *(m_data + n);
+}
+
+template <typename T>
+auto Slice<T>::operator[](const uint64_t n) -> T& {
+    IOX_ASSERT(n < m_number_of_elements, "Index out of bounds");
+    return *(m_data + n);
+}
+
+template <typename T>
+auto Slice<T>::begin() -> Iterator {
+    return m_data;
+}
+
+template <typename T>
+auto Slice<T>::begin() const -> ConstIterator {
+    return m_data;
+}
+
+template <typename T>
+auto Slice<T>::end() -> Iterator {
+    static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
+    return m_data + m_number_of_elements;
+}
+
+template <typename T>
+auto Slice<T>::end() const -> ConstIterator {
+    static_assert(!std::is_same_v<T, void>, "Slice<void> is not allowed");
+    return m_data + m_number_of_elements;
+}
+
+template <typename T>
+auto Slice<T>::data() -> T* {
+    return m_data;
+}
+
+template <typename T>
+auto Slice<T>::data() const -> const T* {
+    return m_data;
+}
 
 template <typename>
 struct IsSlice {

--- a/iceoryx2-ffi/cxx/include/iox/slice.hpp
+++ b/iceoryx2-ffi/cxx/include/iox/slice.hpp
@@ -29,7 +29,8 @@ namespace iox {
 template <typename T>
 class Slice {
   public:
-    using Iterator = std::conditional_t<std::is_const_v<T>, const T*, T*>;
+    using Iterator = T*;
+    using ConstIterator = const T*;
     using ValueType = std::remove_const_t<T>;
 
     /// @brief Constructs a Slice object.
@@ -49,7 +50,7 @@ class Slice {
     /// @param[in] n The index of the element to access.
     /// @return A const reference to the element at the specified index.
     /// @pre The index must be less than the number of elements in the slice.
-    auto operator[](uint64_t n) const -> std::conditional_t<std::is_const_v<T>, const ValueType&, ValueType&>;
+    auto operator[](uint64_t n) const -> const ValueType&;
 
     /// @brief Accesses the element at the specified index (non-const version).
     /// @param[in] n The index of the element to access.
@@ -59,7 +60,7 @@ class Slice {
 
     /// @brief Returns an iterator to the beginning of the slice (const version).
     /// @return An iterator pointing to the first element of the slice.
-    auto begin() const -> Iterator;
+    auto begin() const -> ConstIterator;
 
     /// @brief Returns an iterator to the beginning of the slice (non-const version).
     /// @return An iterator pointing to the first element of the slice.
@@ -67,7 +68,7 @@ class Slice {
 
     /// @brief Returns an iterator to the end of the slice (const version).
     /// @return An iterator pointing one past the last element of the slice.
-    auto end() const -> Iterator;
+    auto end() const -> ConstIterator;
 
     /// @brief Returns an iterator to the end of the slice (non-const version).
     /// @return An iterator pointing one past the last element of the slice.
@@ -75,7 +76,7 @@ class Slice {
 
     /// @brief Returns a pointer to the underlying data of the slice (const version).
     /// @return A pointer to the first element of the slice.
-    auto data() const -> Iterator;
+    auto data() const -> ConstIterator;
 
     /// @brief Returns a pointer to the underlying data of the slice (non-const version).
     /// @return A pointer to the first element of the slice.
@@ -110,8 +111,7 @@ auto Slice<T>::number_of_elements() const -> uint64_t {
 }
 
 template <typename T>
-auto Slice<T>::operator[](const uint64_t n) const
-    -> std::conditional_t<std::is_const_v<T>, const ValueType&, ValueType&> {
+auto Slice<T>::operator[](const uint64_t n) const -> const ValueType& {
     IOX_ASSERT(n < m_number_of_elements, "Index out of bounds");
     return *(m_data + n);
 }
@@ -128,7 +128,7 @@ auto Slice<T>::begin() -> Iterator {
 }
 
 template <typename T>
-auto Slice<T>::begin() const -> Iterator {
+auto Slice<T>::begin() const -> ConstIterator {
     return m_data;
 }
 
@@ -138,7 +138,7 @@ auto Slice<T>::end() -> Iterator {
 }
 
 template <typename T>
-auto Slice<T>::end() const -> Iterator {
+auto Slice<T>::end() const -> ConstIterator {
     return m_data + m_number_of_elements;
 }
 
@@ -148,7 +148,7 @@ auto Slice<T>::data() -> Iterator {
 }
 
 template <typename T>
-auto Slice<T>::data() const -> Iterator {
+auto Slice<T>::data() const -> ConstIterator {
     return m_data;
 }
 

--- a/iceoryx2-ffi/cxx/include/iox2/payload_info.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/payload_info.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef IOX2_PAYLOAD_INFO_HPP
+#define IOX2_PAYLOAD_INFO_HPP
+
+#include "iox/slice.hpp"
+
+namespace iox2 {
+
+template <typename T>
+struct PayloadInfo {
+    using TYPE = T;
+};
+
+template <typename T>
+struct PayloadInfo<iox::Slice<T>> {
+    using TYPE = typename iox::Slice<T>::ValueType;
+};
+
+} // namespace iox2
+#endif

--- a/iceoryx2-ffi/cxx/include/iox2/payload_info.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/payload_info.hpp
@@ -19,12 +19,12 @@ namespace iox2 {
 
 template <typename T>
 struct PayloadInfo {
-    using TYPE = T;
+    using ValueType = T;
 };
 
 template <typename T>
 struct PayloadInfo<iox::Slice<T>> {
-    using TYPE = typename iox::Slice<T>::ValueType;
+    using ValueType = typename iox::Slice<T>::ValueType;
 };
 
 } // namespace iox2

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
@@ -73,18 +73,8 @@ PortFactoryPublisher<S, Payload, UserHeader>::create() && -> iox::expected<Publi
             &m_handle, static_cast<iox2_unable_to_deliver_strategy_e>(iox::into<int>(value)));
     });
     m_max_slice_len
-        .and_then([&](auto value) {
-            // The payload type used by the C API is always a [u8].
-            // Thus need to convert from N to N * sizeof(payload).
-            // TODO: Consider alignment... not aligning each element properly will impact performance
-            iox2_port_factory_publisher_builder_set_max_slice_len(
-                &m_handle, value * sizeof(typename PayloadInfo<Payload>::ValueType));
-        })
-        .or_else([&]() {
-            // Assume only one element if not otherwise specified
-            iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle,
-                                                                  sizeof(typename PayloadInfo<Payload>::ValueType));
-        });
+        .and_then([&](auto value) { iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle, value); })
+        .or_else([&]() { iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle, 1); });
     m_max_loaned_samples.and_then(
         [&](auto value) { iox2_port_factory_publisher_builder_set_max_loaned_samples(&m_handle, value); });
 

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
@@ -77,13 +77,13 @@ PortFactoryPublisher<S, Payload, UserHeader>::create() && -> iox::expected<Publi
             // The payload type used by the C API is always a [u8].
             // Thus need to convert from N to N * sizeof(payload).
             // TODO: Consider alignment... not aligning each element properly will impact performance
-            iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle,
-                                                                  value * sizeof(typename PayloadInfo<Payload>::TYPE));
+            iox2_port_factory_publisher_builder_set_max_slice_len(
+                &m_handle, value * sizeof(typename PayloadInfo<Payload>::ValueType));
         })
         .or_else([&]() {
             // Assume only one element if not otherwise specified
             iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle,
-                                                                  sizeof(typename PayloadInfo<Payload>::TYPE));
+                                                                  sizeof(typename PayloadInfo<Payload>::ValueType));
         });
     m_max_loaned_samples.and_then(
         [&](auto value) { iox2_port_factory_publisher_builder_set_max_loaned_samples(&m_handle, value); });

--- a/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/port_factory_publisher.hpp
@@ -17,6 +17,7 @@
 #include "iox/builder_addendum.hpp"
 #include "iox/expected.hpp"
 #include "iox2/internal/iceoryx2.hpp"
+#include "iox2/payload_info.hpp"
 #include "iox2/publisher.hpp"
 #include "iox2/service_type.hpp"
 #include "iox2/unable_to_deliver_strategy.hpp"
@@ -76,20 +77,13 @@ PortFactoryPublisher<S, Payload, UserHeader>::create() && -> iox::expected<Publi
             // The payload type used by the C API is always a [u8].
             // Thus need to convert from N to N * sizeof(payload).
             // TODO: Consider alignment... not aligning each element properly will impact performance
-            if constexpr (iox::IsSlice<Payload>::VALUE) {
-                iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle,
-                                                                      value * sizeof(typename Payload::ValueType));
-            } else {
-                iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle, value * sizeof(Payload));
-            }
+            iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle,
+                                                                  value * sizeof(typename PayloadInfo<Payload>::TYPE));
         })
         .or_else([&]() {
             // Assume only one element if not otherwise specified
-            if constexpr (iox::IsSlice<Payload>::VALUE) {
-                iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle, sizeof(typename Payload::ValueType));
-            } else {
-                iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle, sizeof(Payload));
-            }
+            iox2_port_factory_publisher_builder_set_max_slice_len(&m_handle,
+                                                                  sizeof(typename PayloadInfo<Payload>::TYPE));
         });
     m_max_loaned_samples.and_then(
         [&](auto value) { iox2_port_factory_publisher_builder_set_max_loaned_samples(&m_handle, value); });

--- a/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
@@ -50,6 +50,7 @@ class Publisher {
     auto unable_to_deliver_strategy() const -> UnableToDeliverStrategy;
 
     /// Returns the maximum number of elements that can be loaned in a slice.
+    template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
     auto max_slice_len() const -> uint64_t;
 
     /// Copies the input `value` into a [`SampleMut`] and delivers it.
@@ -152,16 +153,9 @@ inline auto Publisher<S, Payload, UserHeader>::unable_to_deliver_strategy() cons
 
 
 template <ServiceType S, typename Payload, typename UserHeader>
+template <typename T, typename>
 inline auto Publisher<S, Payload, UserHeader>::max_slice_len() const -> uint64_t {
-    // NOTE: The C API always uses a [u8] payload, therefore the max length returned is the number of bytes.
-    //       Dividing by the size gives the number of slice elements available to the C++ API.
-    //
-    // NOTE: For non-slice types, the number of slice elements is always 1.
-    if constexpr (iox::IsSlice<Payload>::VALUE) {
-        return iox2_publisher_max_slice_len(&m_handle) / sizeof(typename Payload::ValueType);
-    } else {
-        return iox2_publisher_max_slice_len(&m_handle) / sizeof(Payload);
-    }
+    return iox2_publisher_max_slice_len(&m_handle);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/publisher.hpp
@@ -248,7 +248,7 @@ inline auto Publisher<S, Payload, UserHeader>::loan_slice(const uint64_t number_
     }
     auto sample_init = std::move(sample_uninit.value());
 
-    for (auto& item : sample_init.payload_slice_mut()) {
+    for (auto& item : sample_init.payload_mut()) {
         new (&item) ValueType();
     }
 

--- a/iceoryx2-ffi/cxx/include/iox2/sample.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample.hpp
@@ -17,10 +17,12 @@
 #include "iox/slice.hpp"
 #include "iox2/header_publish_subscribe.hpp"
 #include "iox2/internal/iceoryx2.hpp"
+#include "iox2/payload_info.hpp"
 #include "iox2/service_type.hpp"
 #include "iox2/unique_port_id.hpp"
 
 namespace iox2 {
+
 /// It stores the payload and is acquired by the [`Subscriber`] whenever
 /// it receives new data from a [`Publisher`] via
 /// [`Subscriber::receive()`].
@@ -35,6 +37,8 @@ namespace iox2 {
 template <ServiceType, typename Payload, typename UserHeader>
 // NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init,hicpp-member-init) 'm_sample' is not used directly but only via the initialized 'm_handle'; furthermore, it will be initialized on the call site
 class Sample {
+    using ValueType = typename PayloadInfo<Payload>::ValueType;
+
   public:
     Sample(Sample&& rhs) noexcept;
     auto operator=(Sample&& rhs) noexcept -> Sample&;
@@ -55,7 +59,7 @@ class Sample {
 
     /// Returns a slice to navigate the payload of the [`Sample`]
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice() const -> Payload;
+    auto payload_slice() const -> iox::ImmutableSlice<const ValueType>;
 
     /// Returns a reference to the user_header of the [`Sample`]
     template <typename T = UserHeader, typename = std::enable_if_t<!std::is_same_v<void, UserHeader>, T>>
@@ -138,13 +142,13 @@ inline auto Sample<S, Payload, UserHeader>::payload() const -> const Payload& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto Sample<S, Payload, UserHeader>::payload_slice() const -> Payload {
+inline auto Sample<S, Payload, UserHeader>::payload_slice() const -> iox::ImmutableSlice<ValueType> {
     const void* ptr = nullptr;
     size_t number_of_elements = 0;
 
     iox2_sample_payload(&m_handle, &ptr, &number_of_elements);
 
-    return Payload(static_cast<const typename Payload::ValueType*>(ptr), number_of_elements);
+    return iox::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), number_of_elements);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-ffi/cxx/include/iox2/sample.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample.hpp
@@ -59,7 +59,7 @@ class Sample {
 
     /// Returns a slice to navigate the payload of the [`Sample`]
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice() const -> iox::ImmutableSlice<const ValueType>;
+    auto payload_slice() const -> iox::ImmutableSlice<ValueType>;
 
     /// Returns a reference to the user_header of the [`Sample`]
     template <typename T = UserHeader, typename = std::enable_if_t<!std::is_same_v<void, UserHeader>, T>>

--- a/iceoryx2-ffi/cxx/include/iox2/sample.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample.hpp
@@ -59,7 +59,7 @@ class Sample {
 
     /// Returns a slice to navigate the payload of the [`Sample`]
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice() const -> iox::ImmutableSlice<ValueType>;
+    auto payload() const -> iox::ImmutableSlice<ValueType>;
 
     /// Returns a reference to the user_header of the [`Sample`]
     template <typename T = UserHeader, typename = std::enable_if_t<!std::is_same_v<void, UserHeader>, T>>
@@ -142,7 +142,7 @@ inline auto Sample<S, Payload, UserHeader>::payload() const -> const Payload& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto Sample<S, Payload, UserHeader>::payload_slice() const -> iox::ImmutableSlice<ValueType> {
+inline auto Sample<S, Payload, UserHeader>::payload() const -> iox::ImmutableSlice<ValueType> {
     const void* ptr = nullptr;
     size_t number_of_elements = 0;
 

--- a/iceoryx2-ffi/cxx/include/iox2/sample.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample.hpp
@@ -55,7 +55,7 @@ class Sample {
 
     /// Returns a reference to the payload of the [`Sample`]
     template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, void>>
-    auto payload() const -> const Payload&;
+    auto payload() const -> const ValueType&;
 
     /// Returns a slice to navigate the payload of the [`Sample`]
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
@@ -132,12 +132,12 @@ inline auto Sample<S, Payload, UserHeader>::operator->() const -> const Payload*
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto Sample<S, Payload, UserHeader>::payload() const -> const Payload& {
+inline auto Sample<S, Payload, UserHeader>::payload() const -> const ValueType& {
     const void* ptr = nullptr;
 
     iox2_sample_payload(&m_handle, &ptr, nullptr);
 
-    return *static_cast<const Payload*>(ptr);
+    return *static_cast<const ValueType*>(ptr);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
@@ -88,10 +88,10 @@ class SampleMut {
     auto payload_mut() -> Payload&;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice() const -> iox::ImmutableSlice<ValueType>;
+    auto payload() const -> iox::ImmutableSlice<ValueType>;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice_mut() -> iox::MutableSlice<ValueType>;
+    auto payload_mut() -> iox::MutableSlice<ValueType>;
 
   private:
     template <ServiceType, typename, typename>
@@ -219,7 +219,7 @@ inline auto SampleMut<S, Payload, UserHeader>::payload_mut() -> Payload& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMut<S, Payload, UserHeader>::payload_slice() const -> iox::ImmutableSlice<ValueType> {
+inline auto SampleMut<S, Payload, UserHeader>::payload() const -> iox::ImmutableSlice<ValueType> {
     const void* ptr = nullptr;
     size_t number_of_elements = 0;
 
@@ -230,7 +230,7 @@ inline auto SampleMut<S, Payload, UserHeader>::payload_slice() const -> iox::Imm
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMut<S, Payload, UserHeader>::payload_slice_mut() -> iox::MutableSlice<ValueType> {
+inline auto SampleMut<S, Payload, UserHeader>::payload_mut() -> iox::MutableSlice<ValueType> {
     void* ptr = nullptr;
     size_t number_of_elements = 0;
 

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
@@ -91,7 +91,7 @@ class SampleMut {
     auto payload_slice() const -> iox::ImmutableSlice<ValueType>;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice_mut() const -> iox::MutableSlice<ValueType>;
+    auto payload_slice_mut() -> iox::MutableSlice<ValueType>;
 
   private:
     template <ServiceType, typename, typename>
@@ -230,7 +230,7 @@ inline auto SampleMut<S, Payload, UserHeader>::payload_slice() const -> iox::Imm
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMut<S, Payload, UserHeader>::payload_slice_mut() const -> iox::MutableSlice<ValueType> {
+inline auto SampleMut<S, Payload, UserHeader>::payload_slice_mut() -> iox::MutableSlice<ValueType> {
     void* ptr = nullptr;
     size_t number_of_elements = 0;
 

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
@@ -85,7 +85,7 @@ class SampleMut {
     auto payload_mut() -> Payload&;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice() const -> const Payload;
+    auto payload_slice() const -> Payload;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
     auto payload_slice_mut() -> Payload;
@@ -216,13 +216,13 @@ inline auto SampleMut<S, Payload, UserHeader>::payload_mut() -> Payload& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMut<S, Payload, UserHeader>::payload_slice() const -> const Payload {
+inline auto SampleMut<S, Payload, UserHeader>::payload_slice() const -> Payload {
     const void* ptr = nullptr;
     size_t number_of_elements = 0;
 
     iox2_sample_mut_payload(&m_handle, &ptr, &number_of_elements);
 
-    return Payload(static_cast<typename Payload::ValueType*>(const_cast<void*>(ptr)), number_of_elements);
+    return Payload(static_cast<const typename Payload::ValueType*>(ptr), number_of_elements);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
@@ -233,7 +233,7 @@ inline auto SampleMut<S, Payload, UserHeader>::payload_slice_mut() -> Payload {
 
     iox2_sample_mut_payload_mut(&m_handle, &ptr, &number_of_elements);
 
-    return Payload(static_cast<typename Payload::ValueType*>(const_cast<void*>(ptr)), number_of_elements);
+    return Payload(static_cast<typename Payload::ValueType*>(ptr), number_of_elements);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
@@ -15,6 +15,7 @@
 
 #include "iox/assertions.hpp"
 #include "iox/expected.hpp"
+#include "iox/slice.hpp"
 #include "iox2/header_publish_subscribe.hpp"
 #include "iox2/iceoryx2.h"
 #include "iox2/internal/iceoryx2.hpp"

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut.hpp
@@ -81,11 +81,11 @@ class SampleMut {
 
     /// Returns a reference to the const payload of the sample.
     template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, void>>
-    auto payload() const -> const Payload&;
+    auto payload() const -> const ValueType&;
 
     /// Returns a reference to the payload of the sample.
     template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, void>>
-    auto payload_mut() -> Payload&;
+    auto payload_mut() -> ValueType&;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
     auto payload() const -> iox::ImmutableSlice<ValueType>;
@@ -199,22 +199,22 @@ inline auto SampleMut<S, Payload, UserHeader>::user_header_mut() -> T& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMut<S, Payload, UserHeader>::payload() const -> const Payload& {
+inline auto SampleMut<S, Payload, UserHeader>::payload() const -> const ValueType& {
     const void* ptr = nullptr;
 
     iox2_sample_mut_payload(&m_handle, &ptr, nullptr);
 
-    return *static_cast<const Payload*>(ptr);
+    return *static_cast<const ValueType*>(ptr);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMut<S, Payload, UserHeader>::payload_mut() -> Payload& {
+inline auto SampleMut<S, Payload, UserHeader>::payload_mut() -> ValueType& {
     void* ptr = nullptr;
 
     iox2_sample_mut_payload_mut(&m_handle, &ptr, nullptr);
 
-    return *static_cast<Payload*>(ptr);
+    return *static_cast<ValueType*>(ptr);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
@@ -66,10 +66,10 @@ class SampleMutUninit {
     auto payload_mut() -> Payload&;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice() const -> iox::ImmutableSlice<ValueType>;
+    auto payload() const -> iox::ImmutableSlice<ValueType>;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
-    auto payload_slice_mut() -> iox::MutableSlice<ValueType>;
+    auto payload_mut() -> iox::MutableSlice<ValueType>;
 
     /// Writes the payload to the sample
     template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, T>>
@@ -155,14 +155,14 @@ inline auto SampleMutUninit<S, Payload, UserHeader>::payload_mut() -> Payload& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMutUninit<S, Payload, UserHeader>::payload_slice() const -> iox::ImmutableSlice<ValueType> {
-    return m_sample.payload_slice();
+inline auto SampleMutUninit<S, Payload, UserHeader>::payload() const -> iox::ImmutableSlice<ValueType> {
+    return m_sample.payload();
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMutUninit<S, Payload, UserHeader>::payload_slice_mut() -> iox::MutableSlice<ValueType> {
-    return m_sample.payload_slice_mut();
+inline auto SampleMutUninit<S, Payload, UserHeader>::payload_mut() -> iox::MutableSlice<ValueType> {
+    return m_sample.payload_mut();
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
@@ -175,7 +175,7 @@ template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline void SampleMutUninit<S, Payload, UserHeader>::write_from_fn(
     const iox::function<typename T::ValueType(uint64_t)>& initializer) {
-    auto slice = payload_slice_mut();
+    auto slice = payload_mut();
     for (uint64_t i = 0; i < slice.number_of_elements(); ++i) {
         new (&slice[i]) typename T::ValueType(initializer(i));
     }
@@ -184,7 +184,7 @@ inline void SampleMutUninit<S, Payload, UserHeader>::write_from_fn(
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline void SampleMutUninit<S, Payload, UserHeader>::write_from_slice(iox::ImmutableSlice<ValueType>& value) {
-    auto dest = payload_slice_mut();
+    auto dest = payload_mut();
     IOX_ASSERT(dest.size() >= value.size(), "Destination payload size is smaller than source slice size");
     std::memcpy(dest.begin(), value.begin(), value.size());
 }

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
@@ -173,13 +173,18 @@ template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline void SampleMutUninit<S, Payload, UserHeader>::write_from_fn(
     const iox::function<typename T::ValueType(uint64_t)>& initializer) {
-    IOX_TODO();
+    auto slice = payload_slice_mut();
+    for (uint64_t i = 0; i < slice.number_of_elements(); ++i) {
+        new (&slice[i]) typename T::ValueType(initializer(i));
+    }
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline void SampleMutUninit<S, Payload, UserHeader>::write_from_slice(const T& value) {
-    IOX_TODO();
+    auto dest = payload_slice_mut();
+    IOX_ASSERT(dest.size() >= value.size(), "Destination payload size is smaller than source slice size");
+    std::memcpy(dest.begin(), value.begin(), value.size());
 }
 } // namespace iox2
 

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
@@ -59,11 +59,11 @@ class SampleMutUninit {
 
     /// Returns a reference to the const payload of the sample.
     template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, void>>
-    auto payload() const -> const Payload&;
+    auto payload() const -> const ValueType&;
 
     /// Returns a reference to the payload of the sample.
     template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, void>>
-    auto payload_mut() -> Payload&;
+    auto payload_mut() -> ValueType&;
 
     template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
     auto payload() const -> iox::ImmutableSlice<ValueType>;
@@ -143,13 +143,13 @@ inline auto SampleMutUninit<S, Payload, UserHeader>::user_header_mut() -> T& {
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMutUninit<S, Payload, UserHeader>::payload() const -> const Payload& {
+inline auto SampleMutUninit<S, Payload, UserHeader>::payload() const -> const ValueType& {
     return m_sample.payload();
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
-inline auto SampleMutUninit<S, Payload, UserHeader>::payload_mut() -> Payload& {
+inline auto SampleMutUninit<S, Payload, UserHeader>::payload_mut() -> ValueType& {
     return m_sample.payload_mut();
 }
 

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
@@ -56,10 +56,18 @@ class SampleMutUninit {
     auto user_header_mut() -> T&;
 
     /// Returns a reference to the const payload of the sample.
+    template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, void>>
     auto payload() const -> const Payload&;
 
     /// Returns a reference to the payload of the sample.
+    template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, void>>
     auto payload_mut() -> Payload&;
+
+    template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
+    auto payload_slice() const -> Payload;
+
+    template <typename T = Payload, typename = std::enable_if_t<iox::IsSlice<T>::VALUE, void>>
+    auto payload_slice_mut() -> Payload;
 
     /// Writes the payload to the sample
     template <typename T = Payload, typename = std::enable_if_t<!iox::IsSlice<T>::VALUE, T>>
@@ -132,13 +140,27 @@ inline auto SampleMutUninit<S, Payload, UserHeader>::user_header_mut() -> T& {
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
+template <typename T, typename>
 inline auto SampleMutUninit<S, Payload, UserHeader>::payload() const -> const Payload& {
     return m_sample.payload();
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
+template <typename T, typename>
 inline auto SampleMutUninit<S, Payload, UserHeader>::payload_mut() -> Payload& {
     return m_sample.payload_mut();
+}
+
+template <ServiceType S, typename Payload, typename UserHeader>
+template <typename T, typename>
+inline auto SampleMutUninit<S, Payload, UserHeader>::payload_slice() const -> Payload {
+    return m_sample.payload_slice();
+}
+
+template <ServiceType S, typename Payload, typename UserHeader>
+template <typename T, typename>
+inline auto SampleMutUninit<S, Payload, UserHeader>::payload_slice_mut() -> Payload {
+    return m_sample.payload_slice_mut();
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/sample_mut_uninit.hpp
@@ -185,8 +185,9 @@ template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline void SampleMutUninit<S, Payload, UserHeader>::write_from_slice(iox::ImmutableSlice<ValueType>& value) {
     auto dest = payload_mut();
-    IOX_ASSERT(dest.size() >= value.size(), "Destination payload size is smaller than source slice size");
-    std::memcpy(dest.begin(), value.begin(), value.size());
+    IOX_ASSERT(dest.number_of_bytes() >= value.number_of_bytes(),
+               "Destination payload size is smaller than source slice size");
+    std::memcpy(dest.begin(), value.begin(), value.number_of_bytes());
 }
 } // namespace iox2
 

--- a/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -19,6 +19,7 @@
 #include "iox2/attribute_specifier.hpp"
 #include "iox2/attribute_verifier.hpp"
 #include "iox2/internal/iceoryx2.hpp"
+#include "iox2/payload_info.hpp"
 #include "iox2/port_factory_publish_subscribe.hpp"
 #include "iox2/service_builder_publish_subscribe_error.hpp"
 #include "iox2/service_type.hpp"
@@ -26,16 +27,6 @@
 #include <typeinfo>
 
 namespace iox2 {
-
-template <typename T>
-struct PayloadValueType {
-    using TYPE = T;
-};
-
-template <typename T>
-struct PayloadValueType<iox::Slice<T>> {
-    using TYPE = typename iox::Slice<T>::ValueType;
-};
 
 /// Builder to create new [`MessagingPattern::PublishSubscribe`] based [`Service`]s
 template <typename Payload, typename UserHeader, ServiceType S>
@@ -149,7 +140,7 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
         [&](auto value) { iox2_service_builder_pub_sub_set_payload_alignment(&m_handle, value); });
     m_max_nodes.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_nodes(&m_handle, value); });
 
-    using ValueType = typename PayloadValueType<Payload>::TYPE;
+    using ValueType = typename PayloadInfo<Payload>::TYPE;
     auto type_variant = iox::IsSlice<Payload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
 
     // payload type details

--- a/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -140,7 +140,7 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
         [&](auto value) { iox2_service_builder_pub_sub_set_payload_alignment(&m_handle, value); });
     m_max_nodes.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_nodes(&m_handle, value); });
 
-    using ValueType = typename PayloadInfo<Payload>::TYPE;
+    using ValueType = typename PayloadInfo<Payload>::ValueType;
     auto type_variant = iox::IsSlice<Payload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
 
     // payload type details

--- a/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -26,6 +26,17 @@
 #include <typeinfo>
 
 namespace iox2 {
+
+template <typename T>
+struct PayloadValueType {
+    using TYPE = T;
+};
+
+template <typename T>
+struct PayloadValueType<iox::Slice<T>> {
+    using TYPE = typename iox::Slice<T>::ValueType;
+};
+
 /// Builder to create new [`MessagingPattern::PublishSubscribe`] based [`Service`]s
 template <typename Payload, typename UserHeader, ServiceType S>
 class ServiceBuilderPublishSubscribe {
@@ -125,7 +136,6 @@ inline ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::ServiceBuilderPub
 
 template <typename Payload, typename UserHeader, ServiceType S>
 inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_parameters() {
-    m_payload_alignment.and_then([](auto) { IOX_TODO(); });
     m_enable_safe_overflow.and_then(
         [&](auto value) { iox2_service_builder_pub_sub_set_enable_safe_overflow(&m_handle, value); });
     m_subscriber_max_borrowed_samples.and_then(
@@ -135,20 +145,21 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
         [&](auto value) { iox2_service_builder_pub_sub_set_subscriber_max_buffer_size(&m_handle, value); });
     m_max_subscribers.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_subscribers(&m_handle, value); });
     m_max_publishers.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_publishers(&m_handle, value); });
+    m_payload_alignment.and_then(
+        [&](auto value) { iox2_service_builder_pub_sub_set_payload_alignment(&m_handle, value); });
     m_max_nodes.and_then([&](auto value) { iox2_service_builder_pub_sub_set_max_nodes(&m_handle, value); });
 
-    // payload type details
-    const auto* payload_type_name = typeid(Payload).name();
-    const auto payload_type_name_len = strlen(payload_type_name);
-    const auto payload_type_size = sizeof(Payload);
-    const auto payload_type_align = alignof(Payload);
+    using ValueType = typename PayloadValueType<Payload>::TYPE;
+    auto type_variant = iox::IsSlice<Payload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
 
-    const auto payload_result = iox2_service_builder_pub_sub_set_payload_type_details(&m_handle,
-                                                                                      iox2_type_variant_e_FIXED_SIZE,
-                                                                                      payload_type_name,
-                                                                                      payload_type_name_len,
-                                                                                      payload_type_size,
-                                                                                      payload_type_align);
+    // payload type details
+    const auto* payload_type_name = typeid(ValueType).name();
+    const auto payload_type_name_len = strlen(payload_type_name);
+    const auto payload_type_size = sizeof(ValueType);
+    const auto payload_type_align = alignof(ValueType);
+
+    const auto payload_result = iox2_service_builder_pub_sub_set_payload_type_details(
+        &m_handle, type_variant, payload_type_name, payload_type_name_len, payload_type_size, payload_type_align);
 
     if (payload_result != IOX2_OK) {
         IOX_PANIC("This should never happen! Implementation failure while setting the Payload-Type.");
@@ -161,13 +172,12 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
     const auto user_header_type_size = header_layout.size();
     const auto user_header_type_align = header_layout.alignment();
 
-    const auto user_header_result =
-        iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
-                                                                  iox2_type_variant_e_FIXED_SIZE,
-                                                                  user_header_type_name,
-                                                                  user_header_type_name_len,
-                                                                  user_header_type_size,
-                                                                  user_header_type_align);
+    const auto user_header_result = iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
+                                                                                              type_variant,
+                                                                                              user_header_type_name,
+                                                                                              user_header_type_name_len,
+                                                                                              user_header_type_size,
+                                                                                              user_header_type_align);
 
     if (user_header_result != IOX2_OK) {
         IOX_PANIC("This should never happen! Implementation failure while setting the User-Header-Type.");

--- a/iceoryx2-ffi/cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -228,7 +228,7 @@ struct DummyData {
     bool z { DEFAULT_VALUE_Z };
 };
 
-// NOLINTBEGIN(cppcoreguidelines-cognitive-complexity) : Cognitive complexity of 26 (+1) is OK. Test case is complex.
+// NOLINTBEGIN(readability-function-cognitive-complexity) : Cognitive complexity of 26 (+1) is OK. Test case is complex.
 TYPED_TEST(ServicePublishSubscribeTest, slice_copy_send_receive_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
     constexpr auto SLICE_MAX_LENGTH = 10;
@@ -263,7 +263,7 @@ TYPED_TEST(ServicePublishSubscribeTest, slice_copy_send_receive_works) {
     ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(SLICE_MAX_LENGTH));
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
-// NOLINTEND(cppcoreguidelines-cognitive-complexity)
+// NOLINTEND(readability-function-cognitive-complexity)
 
 TYPED_TEST(ServicePublishSubscribeTest, loan_slice_send_receive_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
@@ -301,6 +301,7 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_send_receive_works) {
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
 
+// NOLINTBEGIN(readability-function-cognitive-complexity) : Cognitive complexity of 26 (+1) is OK. Test case is complex.
 TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_send_receive_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
     constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
@@ -342,6 +343,7 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_send_receive_works) {
     ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(SLICE_MAX_LENGTH));
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_with_bytes_send_receive_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
@@ -371,8 +373,7 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_with_bytes_send_receiv
 
     auto recv_sample = std::move(recv_result.value());
     ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(sizeof(DummyData)));
-
-    const auto* recv_data = static_cast<const DummyData*>(static_cast<const void*>(recv_sample.payload().data()));
+    const auto* recv_data = reinterpret_cast<const DummyData*>(recv_sample.payload().data()); // NOLINT
 
     ASSERT_THAT(recv_data->a, Eq(DummyData::DEFAULT_VALUE_A));
     ASSERT_THAT(recv_data->z, Eq(DummyData::DEFAULT_VALUE_Z));
@@ -411,6 +412,7 @@ TYPED_TEST(ServicePublishSubscribeTest, write_from_fn_send_receive_works) {
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
 
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 TYPED_TEST(ServicePublishSubscribeTest, write_from_slice_send_receive_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
     constexpr auto SLICE_MAX_LENGTH = 10;
@@ -447,6 +449,7 @@ TYPED_TEST(ServicePublishSubscribeTest, write_from_slice_send_receive_works) {
     ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(SLICE_MAX_LENGTH));
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 TYPED_TEST(ServicePublishSubscribeTest, update_connections_delivers_history) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;

--- a/iceoryx2-ffi/cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -254,13 +254,13 @@ TYPED_TEST(ServicePublishSubscribeTest, slice_copy_send_receive_works) {
     auto recv_sample = std::move(recv_result.value());
 
     auto iterations = 0;
-    for (const auto& item : recv_sample.payload_slice()) {
+    for (const auto& item : recv_sample.payload()) {
         ASSERT_THAT(item.a, Eq(DummyData::DEFAULT_VALUE_A));
         ASSERT_THAT(item.z, Eq(DummyData::DEFAULT_VALUE_Z));
         ++iterations;
     }
 
-    ASSERT_THAT(recv_sample.payload_slice().number_of_elements(), Eq(SLICE_MAX_LENGTH));
+    ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(SLICE_MAX_LENGTH));
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
 // NOLINTEND(cppcoreguidelines-cognitive-complexity)
@@ -291,13 +291,13 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_send_receive_works) {
     auto recv_sample = std::move(recv_result.value());
 
     auto iterations = 0;
-    for (const auto& item : recv_sample.payload_slice()) {
+    for (const auto& item : recv_sample.payload()) {
         ASSERT_THAT(item.a, Eq(DummyData::DEFAULT_VALUE_A));
         ASSERT_THAT(item.z, Eq(DummyData::DEFAULT_VALUE_Z));
         ++iterations;
     }
 
-    ASSERT_THAT(recv_sample.payload_slice().number_of_elements(), Eq(SLICE_MAX_LENGTH));
+    ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(SLICE_MAX_LENGTH));
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
 
@@ -321,7 +321,7 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_send_receive_works) {
     auto send_sample = sut_publisher.loan_slice_uninit(SLICE_MAX_LENGTH).expect("");
 
     auto iterations = 0;
-    for (auto& item : send_sample.payload_slice_mut()) {
+    for (auto& item : send_sample.payload_mut()) {
         new (&item) DummyData { DummyData::DEFAULT_VALUE_A + iterations, iterations % 2 == 0 };
         ++iterations;
     }
@@ -333,13 +333,13 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_send_receive_works) {
     auto recv_sample = std::move(recv_result.value());
 
     iterations = 0;
-    for (const auto& item : recv_sample.payload_slice()) {
+    for (const auto& item : recv_sample.payload()) {
         ASSERT_THAT(item.a, Eq(DummyData::DEFAULT_VALUE_A + iterations));
         ASSERT_THAT(item.z, Eq(iterations % 2 == 0));
         ++iterations;
     }
 
-    ASSERT_THAT(recv_sample.payload_slice().number_of_elements(), Eq(SLICE_MAX_LENGTH));
+    ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(SLICE_MAX_LENGTH));
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
 
@@ -362,7 +362,7 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_with_bytes_send_receiv
 
     auto send_sample = sut_publisher.loan_slice_uninit(sizeof(DummyData)).expect("");
 
-    new (send_sample.payload_slice_mut().data()) DummyData {};
+    new (send_sample.payload_mut().data()) DummyData {};
 
     send(assume_init(std::move(send_sample))).expect("");
 
@@ -370,9 +370,9 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_with_bytes_send_receiv
     ASSERT_TRUE(recv_result.has_value());
 
     auto recv_sample = std::move(recv_result.value());
-    ASSERT_THAT(recv_sample.payload_slice().number_of_elements(), Eq(sizeof(DummyData)));
+    ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(sizeof(DummyData)));
 
-    const auto* recv_data = static_cast<const DummyData*>(static_cast<const void*>(recv_sample.payload_slice().data()));
+    const auto* recv_data = static_cast<const DummyData*>(static_cast<const void*>(recv_sample.payload().data()));
 
     ASSERT_THAT(recv_data->a, Eq(DummyData::DEFAULT_VALUE_A));
     ASSERT_THAT(recv_data->z, Eq(DummyData::DEFAULT_VALUE_Z));
@@ -401,13 +401,13 @@ TYPED_TEST(ServicePublishSubscribeTest, write_from_fn_send_receive_works) {
     auto recv_sample = std::move(recv_result.value());
 
     auto iterations = 0;
-    for (const auto& item : recv_sample.payload_slice()) {
+    for (const auto& item : recv_sample.payload()) {
         ASSERT_THAT(item.a, Eq(DummyData::DEFAULT_VALUE_A + iterations));
         ASSERT_THAT(item.z, Eq(iterations % 2 == 0));
         ++iterations;
     }
 
-    ASSERT_THAT(recv_sample.payload_slice().number_of_elements(), Eq(SLICE_MAX_LENGTH));
+    ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(SLICE_MAX_LENGTH));
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
 
@@ -438,13 +438,13 @@ TYPED_TEST(ServicePublishSubscribeTest, write_from_slice_send_receive_works) {
     auto recv_sample = std::move(recv_result.value());
 
     auto iterations = 0;
-    for (const auto& item : recv_sample.payload_slice()) {
+    for (const auto& item : recv_sample.payload()) {
         ASSERT_THAT(item.a, Eq(DummyData::DEFAULT_VALUE_A));
         ASSERT_THAT(item.z, Eq(DummyData::DEFAULT_VALUE_Z));
         ++iterations;
     }
 
-    ASSERT_THAT(recv_sample.payload_slice().number_of_elements(), Eq(SLICE_MAX_LENGTH));
+    ASSERT_THAT(recv_sample.payload().number_of_elements(), Eq(SLICE_MAX_LENGTH));
     ASSERT_THAT(iterations, Eq(SLICE_MAX_LENGTH));
 }
 

--- a/iceoryx2-ffi/cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -246,7 +246,7 @@ TYPED_TEST(ServicePublishSubscribeTest, slice_copy_send_receive_works) {
     for (auto& item : elements) {
         new (&item) DummyData {};
     }
-    auto payload = iox::Slice(elements.begin(), SLICE_MAX_LENGTH);
+    auto payload = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
     sut_publisher.send_slice_copy(payload).expect("");
 
     auto recv_result = sut_subscriber.receive().expect("");
@@ -321,7 +321,7 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_send_receive_works) {
     auto send_sample = sut_publisher.loan_slice_uninit(SLICE_MAX_LENGTH).expect("");
 
     auto iterations = 0;
-    for (auto& item : send_sample.payload_slice()) {
+    for (auto& item : send_sample.payload_slice_mut()) {
         new (&item) DummyData { DummyData::DEFAULT_VALUE_A + iterations, iterations % 2 == 0 };
         ++iterations;
     }
@@ -362,7 +362,7 @@ TYPED_TEST(ServicePublishSubscribeTest, loan_slice_uninit_with_bytes_send_receiv
 
     auto send_sample = sut_publisher.loan_slice_uninit(sizeof(DummyData)).expect("");
 
-    new (send_sample.payload_slice().data()) DummyData {};
+    new (send_sample.payload_slice_mut().data()) DummyData {};
 
     send(assume_init(std::move(send_sample))).expect("");
 
@@ -428,7 +428,7 @@ TYPED_TEST(ServicePublishSubscribeTest, write_from_slice_send_receive_works) {
     for (auto& item : elements) {
         new (&item) DummyData {};
     }
-    auto payload = iox::Slice(elements.begin(), SLICE_MAX_LENGTH);
+    auto payload = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
     auto send_sample = sut_publisher.loan_slice_uninit(SLICE_MAX_LENGTH).expect("");
     send_sample.write_from_slice(payload);
     send(assume_init(std::move(send_sample))).expect("");

--- a/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include "iox/slice.hpp"
+#include "test.hpp"
+
+namespace {
+
+struct DummyData {
+    static constexpr uint64_t DEFAULT_VALUE_A = 42;
+    static constexpr bool DEFAULT_VALUE_Z { false };
+    uint64_t a { DEFAULT_VALUE_A };
+    bool z { DEFAULT_VALUE_Z };
+};
+
+TEST(SliceTest, const_correctness_is_maintained) {
+    constexpr uint64_t SLICE_MAX_LENGTH = 10;
+
+    auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
+
+    auto slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(slice.begin())>>::value);
+    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(slice.end())>>::value);
+    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(slice.data())>>::value);
+    ASSERT_FALSE(std::is_const<std::remove_reference_t<decltype(slice[0])>>::value);
+
+    auto const_slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(const_slice.begin())>>::value);
+    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(const_slice.end())>>::value);
+    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(const_slice.data())>>::value);
+    ASSERT_TRUE(std::is_const<std::remove_reference_t<decltype(const_slice[0])>>::value);
+}
+
+} // namespace

--- a/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
@@ -28,16 +28,16 @@ TEST(SliceTest, const_correctness_is_maintained) {
     auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
 
     auto mutable_slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
-    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(mutable_slice.begin())>>::value);
-    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(mutable_slice.end())>>::value);
-    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(mutable_slice.data())>>::value);
-    ASSERT_FALSE(std::is_const<std::remove_reference_t<decltype(mutable_slice[0])>>::value);
+    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(mutable_slice.begin())>>);
+    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(mutable_slice.end())>>);
+    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(mutable_slice.data())>>);
+    ASSERT_FALSE(std::is_const_v<std::remove_reference_t<decltype(mutable_slice[0])>>);
 
     auto immutable_slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
-    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(immutable_slice.begin())>>::value);
-    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(immutable_slice.end())>>::value);
-    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(immutable_slice.data())>>::value);
-    ASSERT_TRUE(std::is_const<std::remove_reference_t<decltype(immutable_slice[0])>>::value);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.begin())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.end())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.data())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_reference_t<decltype(immutable_slice[0])>>);
 }
 
 } // namespace

--- a/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
@@ -27,17 +27,17 @@ TEST(SliceTest, const_correctness_is_maintained) {
 
     auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
 
-    auto slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
-    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(slice.begin())>>::value);
-    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(slice.end())>>::value);
-    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(slice.data())>>::value);
-    ASSERT_FALSE(std::is_const<std::remove_reference_t<decltype(slice[0])>>::value);
+    auto mutable_slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(mutable_slice.begin())>>::value);
+    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(mutable_slice.end())>>::value);
+    ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(mutable_slice.data())>>::value);
+    ASSERT_FALSE(std::is_const<std::remove_reference_t<decltype(mutable_slice[0])>>::value);
 
-    auto const_slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
-    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(const_slice.begin())>>::value);
-    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(const_slice.end())>>::value);
-    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(const_slice.data())>>::value);
-    ASSERT_TRUE(std::is_const<std::remove_reference_t<decltype(const_slice[0])>>::value);
+    auto immutable_slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(immutable_slice.begin())>>::value);
+    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(immutable_slice.end())>>::value);
+    ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(immutable_slice.data())>>::value);
+    ASSERT_TRUE(std::is_const<std::remove_reference_t<decltype(immutable_slice[0])>>::value);
 }
 
 } // namespace

--- a/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
@@ -13,6 +13,8 @@
 #include "iox/slice.hpp"
 #include "test.hpp"
 
+#include <array>
+
 namespace {
 
 struct DummyData {
@@ -27,25 +29,25 @@ TEST(SliceTest, const_correctness_is_maintained) {
 
     auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
 
-    auto mutable_slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    auto mutable_slice = iox::MutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(mutable_slice.begin())>>);
     ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(mutable_slice.end())>>);
     ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(mutable_slice.data())>>);
     ASSERT_FALSE(std::is_const_v<std::remove_reference_t<decltype(mutable_slice[0])>>);
 
-    const auto const_mutable_slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    const auto const_mutable_slice = iox::MutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.begin())>>);
     ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.end())>>);
     ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.data())>>);
     ASSERT_FALSE(std::is_const_v<std::remove_reference_t<decltype(const_mutable_slice[0])>>);
 
-    auto immutable_slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    auto immutable_slice = iox::ImmutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.begin())>>);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.end())>>);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.data())>>);
     ASSERT_TRUE(std::is_const_v<std::remove_reference_t<decltype(immutable_slice[0])>>);
 
-    const auto const_immutable_slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    const auto const_immutable_slice = iox::ImmutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_immutable_slice.begin())>>);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_immutable_slice.end())>>);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_immutable_slice.data())>>);
@@ -57,7 +59,7 @@ TEST(SliceTest, can_iterate_mutable_slice) {
 
     auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
 
-    auto mutable_slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    auto mutable_slice = iox::MutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     auto iterations = 0;
     for (auto element : mutable_slice) {
         ASSERT_THAT(element.a, Eq(DummyData::DEFAULT_VALUE_A));
@@ -72,7 +74,7 @@ TEST(SliceTest, can_iterate_const_mutable_slice) {
 
     auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
 
-    const auto slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    const auto slice = iox::MutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     auto iterations = 0;
     for (auto element : slice) {
         ASSERT_THAT(element.a, Eq(DummyData::DEFAULT_VALUE_A));
@@ -87,7 +89,7 @@ TEST(SliceTest, can_iterate_immutable_slice) {
 
     auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
 
-    auto slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    auto slice = iox::ImmutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     auto iterations = 0;
     for (auto element : slice) {
         ASSERT_THAT(element.a, Eq(DummyData::DEFAULT_VALUE_A));
@@ -102,7 +104,7 @@ TEST(SliceTest, can_iterate_const_immutable_slice) {
 
     auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
 
-    const auto slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    const auto slice = iox::ImmutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     auto iterations = 0;
     for (auto element : slice) {
         ASSERT_THAT(element.a, Eq(DummyData::DEFAULT_VALUE_A));

--- a/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
@@ -33,11 +33,83 @@ TEST(SliceTest, const_correctness_is_maintained) {
     ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(mutable_slice.data())>>);
     ASSERT_FALSE(std::is_const_v<std::remove_reference_t<decltype(mutable_slice[0])>>);
 
+    const auto const_mutable_slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.begin())>>);
+    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.end())>>);
+    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.data())>>);
+    ASSERT_FALSE(std::is_const_v<std::remove_reference_t<decltype(const_mutable_slice[0])>>);
+
     auto immutable_slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.begin())>>);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.end())>>);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.data())>>);
     ASSERT_TRUE(std::is_const_v<std::remove_reference_t<decltype(immutable_slice[0])>>);
+
+    const auto const_immutable_slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_immutable_slice.begin())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_immutable_slice.end())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_immutable_slice.data())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_reference_t<decltype(const_immutable_slice[0])>>);
+}
+
+TEST(SliceTest, can_iterate_mutable_slice) {
+    constexpr uint64_t SLICE_MAX_LENGTH = 10;
+
+    auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
+
+    auto mutable_slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    auto iterations = 0;
+    for (auto element : mutable_slice) {
+        ASSERT_THAT(element.a, Eq(DummyData::DEFAULT_VALUE_A));
+        ASSERT_THAT(element.z, Eq(DummyData::DEFAULT_VALUE_Z));
+        iterations++;
+    }
+    ASSERT_EQ(iterations, SLICE_MAX_LENGTH);
+}
+
+TEST(SliceTest, can_iterate_const_mutable_slice) {
+    constexpr uint64_t SLICE_MAX_LENGTH = 10;
+
+    auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
+
+    const auto slice = iox::MutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    auto iterations = 0;
+    for (auto element : slice) {
+        ASSERT_THAT(element.a, Eq(DummyData::DEFAULT_VALUE_A));
+        ASSERT_THAT(element.z, Eq(DummyData::DEFAULT_VALUE_Z));
+        iterations++;
+    }
+    ASSERT_EQ(iterations, SLICE_MAX_LENGTH);
+}
+
+TEST(SliceTest, can_iterate_immutable_slice) {
+    constexpr uint64_t SLICE_MAX_LENGTH = 10;
+
+    auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
+
+    auto slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    auto iterations = 0;
+    for (auto element : slice) {
+        ASSERT_THAT(element.a, Eq(DummyData::DEFAULT_VALUE_A));
+        ASSERT_THAT(element.z, Eq(DummyData::DEFAULT_VALUE_Z));
+        iterations++;
+    }
+    ASSERT_EQ(iterations, SLICE_MAX_LENGTH);
+}
+
+TEST(SliceTest, can_iterate_const_immutable_slice) {
+    constexpr uint64_t SLICE_MAX_LENGTH = 10;
+
+    auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
+
+    const auto slice = iox::ImmutableSlice<DummyData>(elements.begin(), SLICE_MAX_LENGTH);
+    auto iterations = 0;
+    for (auto element : slice) {
+        ASSERT_THAT(element.a, Eq(DummyData::DEFAULT_VALUE_A));
+        ASSERT_THAT(element.z, Eq(DummyData::DEFAULT_VALUE_Z));
+        iterations++;
+    }
+    ASSERT_EQ(iterations, SLICE_MAX_LENGTH);
 }
 
 } // namespace

--- a/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/slice_tests.cpp
@@ -35,11 +35,12 @@ TEST(SliceTest, const_correctness_is_maintained) {
     ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(mutable_slice.data())>>);
     ASSERT_FALSE(std::is_const_v<std::remove_reference_t<decltype(mutable_slice[0])>>);
 
+    // const instances of MutableSlice are also not mutable
     const auto const_mutable_slice = iox::MutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
-    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.begin())>>);
-    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.end())>>);
-    ASSERT_FALSE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.data())>>);
-    ASSERT_FALSE(std::is_const_v<std::remove_reference_t<decltype(const_mutable_slice[0])>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.begin())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.end())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(const_mutable_slice.data())>>);
+    ASSERT_TRUE(std::is_const_v<std::remove_reference_t<decltype(const_mutable_slice[0])>>);
 
     auto immutable_slice = iox::ImmutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     ASSERT_TRUE(std::is_const_v<std::remove_pointer_t<decltype(immutable_slice.begin())>>);

--- a/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
@@ -173,6 +173,32 @@ impl HandleToType for iox2_port_factory_publisher_builder_h_ref {
 
 // BEGIN C API
 
+#[no_mangle]
+pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_max_slice_len(
+    port_factory_handle: iox2_port_factory_publisher_builder_h_ref,
+    value: c_size_t,
+) {
+    port_factory_handle.assert_non_null();
+
+    let port_factory_struct = unsafe { &mut *port_factory_handle.as_type() };
+    match port_factory_struct.service_type {
+        iox2_service_type_e::IPC => {
+            let port_factory = ManuallyDrop::take(&mut port_factory_struct.value.as_mut().ipc);
+
+            port_factory_struct.set(PortFactoryPublisherBuilderUnion::new_ipc(
+                port_factory.max_slice_len(value),
+            ));
+        }
+        iox2_service_type_e::LOCAL => {
+            let port_factory = ManuallyDrop::take(&mut port_factory_struct.value.as_mut().local);
+
+            port_factory_struct.set(PortFactoryPublisherBuilderUnion::new_local(
+                port_factory.max_slice_len(value),
+            ));
+        }
+    }
+}
+
 /// Sets the max loaned samples for the publisher
 ///
 /// # Arguments

--- a/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_publisher_builder.rs
@@ -173,6 +173,17 @@ impl HandleToType for iox2_port_factory_publisher_builder_h_ref {
 
 // BEGIN C API
 
+/// Sets the max slice length for the publisher
+///
+/// # Arguments
+///
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_h_ref`]
+///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder).
+/// * `value` - The value to set max slice length to
+///
+/// # Safety
+///
+/// * `port_factory_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_max_slice_len(
     port_factory_handle: iox2_port_factory_publisher_builder_h_ref,

--- a/iceoryx2-ffi/ffi/src/api/publisher.rs
+++ b/iceoryx2-ffi/ffi/src/api/publisher.rs
@@ -249,6 +249,18 @@ pub unsafe extern "C" fn iox2_publisher_unable_to_deliver_strategy(
     }
 }
 
+/// Returns the maximum `[u8]` length that can be loaned in one sample, i.e. the max number of
+/// elements in the `[u8]` payload type used by the C binding.
+///
+/// # Arguments
+///
+/// * `publisher_handle` obtained by [`iox2_port_factory_publisher_builder_create`](crate::iox2_port_factory_publisher_builder_create)
+///
+/// Returns the maximum number of elements as a [`c_int`].
+///
+/// # Safety
+///
+/// * `publisher_handle` is valid and non-null
 #[no_mangle]
 pub unsafe extern "C" fn iox2_publisher_max_slice_len(
     publisher_handle: iox2_publisher_h_ref,

--- a/iceoryx2-ffi/ffi/src/api/publisher.rs
+++ b/iceoryx2-ffi/ffi/src/api/publisher.rs
@@ -182,7 +182,7 @@ impl HandleToType for iox2_publisher_h_ref {
 unsafe fn send_copy<S: Service>(
     publisher: &Publisher<S, PayloadFfi, UserHeaderFfi>,
     data_ptr: *const c_void,
-    data_len: usize,
+    size_of_element: usize,
     number_of_recipients: *mut usize,
 ) -> c_int {
     // loan_slice_uninit(1) <= 1 is correct here since it defines the number of
@@ -193,6 +193,37 @@ unsafe fn send_copy<S: Service>(
         Err(e) => return e.into_c_int(),
     };
 
+    if sample.payload().len() < size_of_element {
+        return iox2_publisher_send_error_e::LOAN_ERROR_EXCEEDS_MAX_LOAN_SIZE as c_int;
+    }
+
+    let sample_ptr = sample.payload_mut().as_mut_ptr();
+    core::ptr::copy_nonoverlapping(data_ptr, sample_ptr.cast(), size_of_element);
+    match sample.assume_init().send() {
+        Ok(v) => {
+            if !number_of_recipients.is_null() {
+                *number_of_recipients = v;
+            }
+        }
+        Err(e) => return e.into_c_int(),
+    }
+
+    IOX2_OK
+}
+
+unsafe fn send_slice_copy<S: Service>(
+    publisher: &Publisher<S, PayloadFfi, UserHeaderFfi>,
+    data_ptr: *const c_void,
+    size_of_element: usize,
+    number_of_elements: usize,
+    number_of_recipients: *mut usize,
+) -> c_int {
+    let mut sample = match publisher.loan_custom_payload(number_of_elements) {
+        Ok(sample) => sample,
+        Err(e) => return e.into_c_int(),
+    };
+
+    let data_len = size_of_element * number_of_elements;
     if sample.payload().len() < data_len {
         return iox2_publisher_send_error_e::LOAN_ERROR_EXCEEDS_MAX_LOAN_SIZE as c_int;
     }
@@ -314,6 +345,59 @@ pub unsafe extern "C" fn iox2_publisher_id(
 
     (*storage_ptr).init(id, deleter);
     *id_handle_ptr = (*storage_ptr).as_handle();
+}
+
+/// Sends a copy of the provided slice data via the publisher.
+///
+/// # Arguments
+///
+/// * `publisher_handle` - Handle to the publisher obtained from `iox2_port_factory_publisher_builder_create`
+/// * `data_ptr` - Pointer to the start of the slice data to be sent
+/// * `size_of_element` - Size of each element in the slice in bytes
+/// * `number_of_elements` - Number of elements in the slice
+/// * `number_of_recipients` - Optional pointer to store the number of subscribers that received the data
+///
+/// # Returns
+///
+/// Returns `IOX2_OK` on success, otherwise an error code from `iox2_publisher_send_error_e`
+///
+/// # Safety
+///
+/// * `publisher_handle` must be valid and non-null
+/// * `data_ptr` must be a valid pointer to the start of the slice data
+/// * `size_of_element` must be the correct size of each element in bytes
+/// * `number_of_elements` must accurately represent the number of elements in the slice
+/// * `number_of_recipients` can be null, otherwise it must be a valid pointer to a `usize`
+#[no_mangle]
+pub unsafe extern "C" fn iox2_publisher_send_slice_copy(
+    publisher_handle: iox2_publisher_h_ref,
+    data_ptr: *const c_void,
+    size_of_element: usize,
+    number_of_elements: usize,
+    number_of_recipients: *mut usize,
+) -> c_int {
+    publisher_handle.assert_non_null();
+    debug_assert!(!data_ptr.is_null());
+    debug_assert!(size_of_element != 0);
+
+    let publisher = &mut *publisher_handle.as_type();
+
+    match publisher.service_type {
+        iox2_service_type_e::IPC => send_slice_copy(
+            &publisher.value.as_mut().ipc,
+            data_ptr,
+            size_of_element,
+            number_of_elements,
+            number_of_recipients,
+        ),
+        iox2_service_type_e::LOCAL => send_slice_copy(
+            &publisher.value.as_mut().local,
+            data_ptr,
+            size_of_element,
+            number_of_elements,
+            number_of_recipients,
+        ),
+    }
 }
 
 /// Sends a copy of the provided data via the publisher. The data must be copyable via `memcpy`.

--- a/iceoryx2-ffi/ffi/src/api/sample_mut.rs
+++ b/iceoryx2-ffi/ffi/src/api/sample_mut.rs
@@ -157,7 +157,7 @@ pub unsafe extern "C" fn iox2_sample_mut_move(
 ///
 /// # Safety
 ///
-/// * `handle` obtained by [`iox2_publisher_loan()`](crate::iox2_publisher_loan())
+/// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
 /// * `header_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_user_header(
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn iox2_sample_mut_user_header(
 ///
 /// # Safety
 ///
-/// * `handle` obtained by [`iox2_publisher_loan()`](crate::iox2_publisher_loan())
+/// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
 /// * `header_struct_ptr` - Must be either a NULL pointer or a pointer to a valid
 ///     [`iox2_publish_subscribe_header_t`]. If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `header_handle_ptr` valid pointer to a [`iox2_publish_subscribe_header_h`].
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn iox2_sample_mut_header(
 ///
 /// # Safety
 ///
-/// * `handle` obtained by [`iox2_publisher_loan()`](crate::iox2_publisher_loan())
+/// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
 /// * `header_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_user_header_mut(
@@ -242,28 +242,32 @@ pub unsafe extern "C" fn iox2_sample_mut_user_header_mut(
 ///
 /// # Safety
 ///
-/// * `handle` obtained by [`iox2_publisher_loan()`](crate::iox2_publisher_loan())
+/// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
 /// * `payload_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
 /// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_payload_mut(
     handle: iox2_sample_mut_h_ref,
     payload_ptr: *mut *mut c_void,
-    payload_len: *mut c_size_t,
+    number_of_elements: *mut c_size_t,
 ) {
     handle.assert_non_null();
     debug_assert!(!payload_ptr.is_null());
 
     let sample = &mut *handle.as_type();
+    let payload = sample.value.as_mut().ipc.payload_mut();
 
-    let payload = match sample.service_type {
-        iox2_service_type_e::IPC => sample.value.as_mut().ipc.payload_mut(),
-        iox2_service_type_e::LOCAL => sample.value.as_mut().local.payload_mut(),
+    match sample.service_type {
+        iox2_service_type_e::IPC => {
+            *payload_ptr = payload.as_mut_ptr().cast();
+        }
+        iox2_service_type_e::LOCAL => {
+            *payload_ptr = payload.as_mut_ptr().cast();
+        }
     };
 
-    *payload_ptr = payload.as_mut_ptr().cast();
-    if !payload_len.is_null() {
-        *payload_len = payload.len();
+    if !number_of_elements.is_null() {
+        *number_of_elements = sample.value.as_mut().local.header().number_of_elements() as c_size_t;
     }
 }
 
@@ -271,28 +275,32 @@ pub unsafe extern "C" fn iox2_sample_mut_payload_mut(
 ///
 /// # Safety
 ///
-/// * `handle` obtained by [`iox2_publisher_loan()`](crate::iox2_publisher_loan())
+/// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
 /// * `payload_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
 /// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_sample_mut_payload(
     handle: iox2_sample_mut_h_ref,
     payload_ptr: *mut *const c_void,
-    payload_len: *mut c_size_t,
+    number_of_elements: *mut c_size_t,
 ) {
     handle.assert_non_null();
     debug_assert!(!payload_ptr.is_null());
 
     let sample = &mut *handle.as_type();
+    let payload = sample.value.as_mut().ipc.payload_mut();
 
-    let payload = match sample.service_type {
-        iox2_service_type_e::IPC => sample.value.as_mut().ipc.payload(),
-        iox2_service_type_e::LOCAL => sample.value.as_mut().local.payload(),
+    match sample.service_type {
+        iox2_service_type_e::IPC => {
+            *payload_ptr = payload.as_mut_ptr().cast();
+        }
+        iox2_service_type_e::LOCAL => {
+            *payload_ptr = payload.as_mut_ptr().cast();
+        }
     };
 
-    *payload_ptr = payload.as_ptr().cast();
-    if !payload_len.is_null() {
-        *payload_len = payload.len();
+    if !number_of_elements.is_null() {
+        *number_of_elements = sample.value.as_mut().local.header().number_of_elements() as c_size_t;
     }
 }
 
@@ -300,7 +308,7 @@ pub unsafe extern "C" fn iox2_sample_mut_payload(
 ///
 /// # Safety
 ///
-/// * `handle` obtained by [`iox2_publisher_loan()`](crate::iox2_publisher_loan())
+/// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
 /// * `number_of_recipients`, can be null or must point to a valid [`c_size_t`] to store the number
 ///                 of subscribers that received the sample
 #[no_mangle]

--- a/iceoryx2-ffi/ffi/src/api/service_builder_pub_sub.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder_pub_sub.rs
@@ -480,6 +480,17 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_subscribers(
     }
 }
 
+/// Sets the payload alignment for the builder
+///
+/// # Arguments
+///
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_pub_sub_h_ref`]
+///   obtained by [`iox2_service_builder_pub_sub`](crate::iox2_service_builder_pub_sub).
+/// * `value` - The value to set the payload alignment to
+///
+/// # Safety
+///
+/// * `service_builder_handle` must be valid handles
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_payload_alignment(
     service_builder_handle: iox2_service_builder_pub_sub_h_ref,

--- a/iceoryx2-ffi/ffi/src/api/service_builder_pub_sub.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder_pub_sub.rs
@@ -480,6 +480,41 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_max_subscribers(
     }
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn iox2_service_builder_pub_sub_set_payload_alignment(
+    service_builder_handle: iox2_service_builder_pub_sub_h_ref,
+    value: c_size_t,
+) {
+    service_builder_handle.assert_non_null();
+
+    let service_builder_struct = unsafe { &mut *service_builder_handle.as_type() };
+
+    match service_builder_struct.service_type {
+        iox2_service_type_e::IPC => {
+            let service_builder =
+                ManuallyDrop::take(&mut service_builder_struct.value.as_mut().ipc);
+
+            let service_builder = ManuallyDrop::into_inner(service_builder.pub_sub);
+            service_builder_struct.set(ServiceBuilderUnion::new_ipc_pub_sub(
+                service_builder.payload_alignment(
+                    Alignment::new(value).unwrap_or(Alignment::new_unchecked(8)),
+                ),
+            ));
+        }
+        iox2_service_type_e::LOCAL => {
+            let service_builder =
+                ManuallyDrop::take(&mut service_builder_struct.value.as_mut().local);
+
+            let service_builder = ManuallyDrop::into_inner(service_builder.pub_sub);
+            service_builder_struct.set(ServiceBuilderUnion::new_local_pub_sub(
+                service_builder.payload_alignment(
+                    Alignment::new(value).unwrap_or(Alignment::new_unchecked(8)),
+                ),
+            ));
+        }
+    }
+}
+
 /// Sets the history size
 ///
 /// # Arguments

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -704,6 +704,11 @@ impl<Service: service::Service, Payload: Debug + ?Sized, UserHeader: Debug>
         self.data_segment.config.unable_to_deliver_strategy
     }
 
+    /// Returns the maximum slice length configured for this [`Publisher`].
+    pub fn max_slice_len(&self) -> usize {
+        self.data_segment.config.max_slice_len
+    }
+
     fn allocate(&self, layout: Layout) -> Result<ShmPointer, PublisherLoanError> {
         let msg = "Unable to allocate Sample with";
 


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

1. Implement `iox::Slice`
2. Implement `loan_slice` APIs in C++ binding
3. Expose properties `payload_alignment` and `max_slice_len` in C++ binding

## Pre-Review Checklist for the PR Author

1. [x] Add sensible notes for the reviewer
1. [x] PR title is short, expressive and meaningful
1. [x] Relevant issues are linked in the [References](#references) section
1. [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
1. [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Tests follow the [best practice for testing][testing]
1. [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
1. [x] Assign PR to reviewer
1. [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Unit tests have been written for new behavior
- [x] Public API is documented
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #490
