### PR TITLE
[#559] Reuse existing cargo build for C and C++ bindings

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -223,7 +223,7 @@ jobs:
                 -DBUILD_TESTING=ON \
                 -DCMAKE_C_FLAGS="-m32" \
                 -DCMAKE_CXX_FLAGS="-m32" \
-                -DRUST_BUILD_ARTIFACT_PATH="${{ github.workspace }}/target/${{ matrix.mode.name }}" \
+                -DRUST_BUILD_ARTIFACT_PATH="${{ github.workspace }}/target/i686-unknown-linux-gnu/${{ matrix.mode.name }}" \
                 ${{ matrix.mode.cmake-build-type }}
           cmake --build target/ffi/build
           cmake --install target/ffi/build

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -172,7 +172,7 @@ jobs:
       matrix:
         os: [ubuntu-latest] # [windows-latest, ubuntu-latest, macos-latest]
         toolchain: [stable] # [stable, 1.75.0, beta, nightly]
-        mode: 
+        mode:
           - name: "release"
             arg: "--release"
             cmake-build-type: "-DCMAKE_BUILD_TYPE=Release"
@@ -221,9 +221,9 @@ jobs:
                 -DBUILD_CXX_BINDING=OFF \
                 -DBUILD_EXAMPLES=ON \
                 -DBUILD_TESTING=ON \
-                -DRUST_TARGET_TRIPLET="i686-unknown-linux-gnu" \
                 -DCMAKE_C_FLAGS="-m32" \
                 -DCMAKE_CXX_FLAGS="-m32" \
+                -DRUST_BUILD_ARTIFACT_PATH="${{ github.workspace }}/target/${{ matrix.mode.name }}" \
                 ${{ matrix.mode.cmake-build-type }}
           cmake --build target/ffi/build
           cmake --install target/ffi/build
@@ -332,8 +332,9 @@ jobs:
           cargo rustc -q -- --print=native-static-libs
 
       - name: Build language bindings
+        # NOTE: the cmake command is in a single line since Windows complains about breaking up lines with '\'
         run: |
-          cmake -S . -B target/ffi/build -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ${{ matrix.mode.cmake-build-type }} ${{ matrix.mode.cmake-cxx-flags }} ${{ matrix.cmake-build-system-generator }} -DCMAKE_INSTALL_PREFIX=target/ffi/install -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/iceoryx/install"
+          cmake -S . -B target/ffi/build -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON ${{ matrix.mode.cmake-build-type }} ${{ matrix.mode.cmake-cxx-flags }} ${{ matrix.cmake-build-system-generator }} -DCMAKE_INSTALL_PREFIX=target/ffi/install -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/iceoryx/install" -DRUST_BUILD_ARTIFACT_PATH="${{ github.workspace }}/target/${{ matrix.mode.name }}"
           cmake --build target/ffi/build ${{ matrix.mode.cmake-build-config }}
           cmake --install target/ffi/build ${{ matrix.mode.cmake-build-config }}
 
@@ -351,11 +352,13 @@ jobs:
         run: rm -rf target/ffi/build
 
       - name: Build C language binding examples in out-of-tree configuration
+        # NOTE: the cmake command is in a single line since Windows complains about breaking up lines with '\'
         run: |
           cmake -S examples/c -B target/ffi/out-of-tree-c ${{ matrix.mode.cmake-build-type }} ${{ matrix.mode.cmake-cxx-flags }} ${{ matrix.cmake-build-system-generator }} -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ffi/install"
           cmake --build target/ffi/out-of-tree-c ${{ matrix.mode.cmake-build-config }}
 
       - name: Build C++ language binding examples in out-of-tree configuration
+        # NOTE: the cmake command is in a single line since Windows complains about breaking up lines with '\'
         run: |
           cmake -S examples/cxx -B target/ffi/out-of-tree-cxx ${{ matrix.mode.cmake-build-type }} ${{ matrix.mode.cmake-cxx-flags }} ${{ matrix.cmake-build-system-generator }} -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ffi/install;${{ github.workspace }}/target/iceoryx/install"
           cmake --build target/ffi/out-of-tree-cxx ${{ matrix.mode.cmake-build-config }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,12 +76,18 @@ add_option(
 )
 
 add_param(
-    NAME RUST_TARGET_TRIPLET
-    DESCRIPTION "The target triplet for cross compilation, e.g. 'aarch64-unknown-linux-gnu'"
+    NAME RUST_BUILD_ARTIFACT_PATH
+    DESCRIPTION "The path to the folder with the Rust build artifacts, e.g. '/full/path/to/iceoryx2/target/release'"
     DEFAULT_VALUE ""
 )
 
-message(STATUS "iceoryx2 Rust feature flags:")
+add_param(
+    NAME RUST_TARGET_TRIPLET
+    DESCRIPTION "The target triplet for cross compilation when 'RUST_BUILD_ARTIFACT_PATH' is not set, e.g. 'aarch64-unknown-linux-gnu'"
+    DEFAULT_VALUE ""
+)
+
+message(STATUS "iceoryx2 Rust feature flags (only used when 'RUST_BUILD_ARTIFACT_PATH' is not set):")
 
 add_rust_feature(
     NAME IOX2_FEATURE_DEV_PERMISSIONS

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -25,6 +25,7 @@
 * Add benchmark for iceoryx2 queues [#535](https://github.com/eclipse-iceoryx/iceoryx2/issues/535)
 * Add auto event mission for create, drop and dead notifiers [#550](https://github.com/eclipse-iceoryx/iceoryx2/issues/550)
 * Introduce health monitoring example [#555](https://github.com/eclipse-iceoryx/iceoryx2/issues/555)
+* Reuse existing cargo build with C and C++ bindings [#559](https://github.com/eclipse-iceoryx/iceoryx2/issues/559)
 
 ### Bugfixes
 

--- a/iceoryx2-ffi/c/CMakeLists.txt
+++ b/iceoryx2-ffi/c/CMakeLists.txt
@@ -19,24 +19,40 @@ set(PREFIX iceoryx2/v${CMAKE_PROJECT_VERSION})
 ########## Rust target ##########
 #
 
-set(RUST_BUILD_TYPE "release")
-set(RUST_BUILD_TYPE_FLAG "--${RUST_BUILD_TYPE}")
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(RUST_BUILD_TYPE "debug")
-    set(RUST_BUILD_TYPE_FLAG "")
+set(USE_CARGO FALSE)
+if("${RUST_BUILD_ARTIFACT_PATH}" STREQUAL "")
+    set(USE_CARGO TRUE)
 endif()
 
-if("${RUST_TARGET_TRIPLET}" STREQUAL "")
-    set(RUST_TARGET_DIR ${CMAKE_BINARY_DIR}/rust/native)
-    set(RUST_TARGET_DIR_FULL ${CMAKE_BINARY_DIR}/rust/native/${RUST_BUILD_TYPE})
-    set(RUST_TARGET_TRIPLET_FLAG "")
-else()
-    set(RUST_TARGET_DIR ${CMAKE_BINARY_DIR}/rust)
-    set(RUST_TARGET_DIR_FULL ${CMAKE_BINARY_DIR}/rust/${RUST_TARGET_TRIPLET}/${RUST_BUILD_TYPE})
-    set(RUST_TARGET_TRIPLET_FLAG "--target=${RUST_TARGET_TRIPLET}")
+if(${USE_CARGO})
+    message(WARNING "\
+#############################################################
+Using cargo to build the Rust part of iceoryx2.
+This is fine for development but for production, it is
+recommended to use an existing installation with
+'-DRUST_BUILD_ARTIFACT_PATH=/full/path/to/iceoryx2/target/release'!
+#############################################################
+")
+
+    set(RUST_BUILD_TYPE "release")
+    set(RUST_BUILD_TYPE_FLAG "--${RUST_BUILD_TYPE}")
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(RUST_BUILD_TYPE "debug")
+        set(RUST_BUILD_TYPE_FLAG "")
+    endif()
+
+    if("${RUST_TARGET_TRIPLET}" STREQUAL "")
+        set(RUST_TARGET_DIR ${CMAKE_BINARY_DIR}/rust/native)
+        set(RUST_BUILD_ARTIFACT_PATH ${CMAKE_BINARY_DIR}/rust/native/${RUST_BUILD_TYPE})
+        set(RUST_TARGET_TRIPLET_FLAG "")
+    else()
+        set(RUST_TARGET_DIR ${CMAKE_BINARY_DIR}/rust)
+        set(RUST_BUILD_ARTIFACT_PATH ${CMAKE_BINARY_DIR}/rust/${RUST_TARGET_TRIPLET}/${RUST_BUILD_TYPE})
+        set(RUST_TARGET_TRIPLET_FLAG "--target=${RUST_TARGET_TRIPLET}")
+    endif()
 endif()
 
-set(ICEORYX2_C_INCLUDE_DIR ${RUST_TARGET_DIR_FULL}/iceoryx2-ffi-cbindgen/include)
+set(ICEORYX2_C_INCLUDE_DIR ${RUST_BUILD_ARTIFACT_PATH}/iceoryx2-ffi-cbindgen/include)
 
 set(ICEORYX2_C_LIB iceoryx2_ffi)
 set(ICEORYX2_C_STATIC_LIB_LINK_NAME lib${ICEORYX2_C_LIB}.a)
@@ -53,14 +69,14 @@ elseif(APPLE)
     set(ICEORYX2_C_SHARED_LIB_LINK_NAME lib${ICEORYX2_C_LIB}.dylib)
 endif()
 
-set(ICEORYX2_C_STATIC_LIB_LINK_FILE ${RUST_TARGET_DIR_FULL}/${ICEORYX2_C_STATIC_LIB_LINK_NAME})
-set(ICEORYX2_C_SHARED_LIB_LINK_FILE ${RUST_TARGET_DIR_FULL}/${ICEORYX2_C_SHARED_LIB_LINK_NAME})
+set(ICEORYX2_C_STATIC_LIB_LINK_FILE ${RUST_BUILD_ARTIFACT_PATH}/${ICEORYX2_C_STATIC_LIB_LINK_NAME})
+set(ICEORYX2_C_SHARED_LIB_LINK_FILE ${RUST_BUILD_ARTIFACT_PATH}/${ICEORYX2_C_SHARED_LIB_LINK_NAME})
 set(ICEORYX2_C_SHARED_LIB_DLL_FILE) # intentionally empty; only used on Windows
 
 list(APPEND ICEORYX2_C_LIB_ARTIFACTS ${ICEORYX2_C_STATIC_LIB_LINK_FILE})
 list(APPEND ICEORYX2_C_LIB_ARTIFACTS ${ICEORYX2_C_SHARED_LIB_LINK_FILE})
 if(WIN32)
-    set(ICEORYX2_C_SHARED_LIB_DLL_FILE ${RUST_TARGET_DIR_FULL}/${ICEORYX2_C_LIB}.dll)
+    set(ICEORYX2_C_SHARED_LIB_DLL_FILE ${RUST_BUILD_ARTIFACT_PATH}/${ICEORYX2_C_LIB}.dll)
     list(APPEND ICEORYX2_C_LIB_ARTIFACTS ${ICEORYX2_C_SHARED_LIB_DLL_FILE})
 endif()
 
@@ -71,19 +87,23 @@ if(IOX2_RUST_FEATURES_COUNT GREATER 0)
     set(RUST_FEATURE_FLAGS "--features=${RUST_FEATURE_FLAGS_STRING}")
 endif()
 
-# run cargo
-add_custom_target(
-    iceoryx2-build-step ALL
-    COMMAND cargo build ${RUST_BUILD_TYPE_FLAG} ${RUST_FEATURE_FLAGS} --package iceoryx2-ffi --target-dir=${RUST_TARGET_DIR} ${RUST_TARGET_TRIPLET_FLAG}
-    BYPRODUCTS
-        ${ICEORYX2_C_INCLUDE_DIR}/iox2/iceoryx2.h
-        ${ICEORYX2_C_STATIC_LIB_LINK_FILE}
-        ${ICEORYX2_C_SHARED_LIB_LINK_FILE}
-        ${ICEORYX2_C_SHARED_LIB_DLL_FILE}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../..
-    VERBATIM
-    USES_TERMINAL
-)
+if(${USE_CARGO})
+    # run cargo
+    add_custom_target(
+        iceoryx2-build-step ALL
+        COMMAND cargo build ${RUST_BUILD_TYPE_FLAG} ${RUST_FEATURE_FLAGS} --package iceoryx2-ffi --target-dir=${RUST_TARGET_DIR} ${RUST_TARGET_TRIPLET_FLAG}
+        BYPRODUCTS
+            ${ICEORYX2_C_INCLUDE_DIR}/iox2/iceoryx2.h
+            ${ICEORYX2_C_STATIC_LIB_LINK_FILE}
+            ${ICEORYX2_C_SHARED_LIB_LINK_FILE}
+            ${ICEORYX2_C_SHARED_LIB_DLL_FILE}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/../..
+        VERBATIM
+        USES_TERMINAL
+    )
+else()
+    add_custom_target(iceoryx2-build-step)
+endif()
 
 #
 ########## C target ##########

--- a/iceoryx2-ffi/c/README.md
+++ b/iceoryx2-ffi/c/README.md
@@ -1,10 +1,37 @@
 # iceoryx2-ffi-C
 
-## Build instructions
+## Build instructions - simple developer setup
 
 In the repository root folder, execute this steps.
 
 ```bash
 cmake -S . -B target/ffi/build
 cmake --build target/ffi/build
+```
+
+This is the most simple way to build the C bindings for `iceoryx2`, which
+utilizes cargo to build the Rust part of iceoryx2.
+
+If only the C bindings should be build, without the C++ bindings, the
+`-DBUILD_CXX_BINDING=OFF` cmake parameter can be used.
+
+## Build instructions for integrator
+
+For production, it is recommended to separately build `iceoryx2-ffi`.
+
+In the repository root folder, execute this steps:
+
+```bash
+cargo build --release --package iceoryx2-ffi
+cmake -S . -B target/ffi/build -DCMAKE_INSTALL_PREFIX=target/ffi/install -DBUILD_CXX_BINDING=OFF -DRUST_BUILD_ARTIFACT_PATH="$( pwd )/target/release"
+cmake --build target/ffi/build
+cmake --install target/ffi/build
+```
+
+The installed libraries can the be used for out-of-tree builds of the example or
+custom C projects. This are the required steps:
+
+```bash
+cmake -S examples/c -B target/out-of-tree/examples/c -DCMAKE_PREFIX_PATH="$( pwd )/target/ffi/install"
+cmake --build target/out-of-tree/examples/c
 ```

--- a/iceoryx2-ffi/cxx/README.md
+++ b/iceoryx2-ffi/cxx/README.md
@@ -1,8 +1,8 @@
 # iceoryx2-ffi-cxx
 
-## Build instructions
+## Build instructions - simple developer setup
 
-In the repository root folder, execute this steps.
+In the repository root folder, execute this steps:
 
 ```bash
 cmake -S . -B target/ffi/build
@@ -10,7 +10,23 @@ cmake --build target/ffi/build
 ```
 
 This is the most simple way to build the C++ bindings for `iceoryx2`, which rely
-on the `iceorx_hoofs` C++ base library.
+on the `iceorx_hoofs` C++ base library and utilizes cargo to build the Rust part
+of iceoryx2.
+
+## Build instructions for integrator
+
+For production, it is recommended to separately build `iceoryx2-ffi` and
+`iceoryx_hoofs`.
+
+### Use cargo to build `iceoryx-ffi`
+
+In the repository root folder, execute this steps:
+
+```bash
+cargo build --release --package iceoryx2-ffi
+```
+
+### Build and install `iceoryx_hoofs`
 
 For production it is recommended though to separately build `iceoryx_hoofs` and
 specify the path to the install directory with `-DCMAKE_PREFIX_PATH`.
@@ -20,7 +36,7 @@ specify the path to the install directory with `-DCMAKE_PREFIX_PATH`.
 ```bash
 git clone https://github.com/eclipse-iceoryx/iceoryx.git target/iceoryx/src
 
-cmake -S target/iceoryx/src/iceoryx_platform -B -DCMAKE_BUILD_TYPE=Release target/iceoryx/build/platform -DCMAKE_INSTALL_PREFIX=target/iceoryx/install
+cmake -S target/iceoryx/src/iceoryx_platform -B target/iceoryx/build/platform -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=target/iceoryx/install
 cmake --build target/iceoryx/build/platform
 cmake --install target/iceoryx/build/platform
 
@@ -29,11 +45,15 @@ cmake --build target/iceoryx/build/hoofs
 cmake --install target/iceoryx/build/hoofs
 ```
 
-The C++ bindings can use the installed `iceoryx_hoofs` and be installed to be
-used by custom projects. This are the steps:
+### Putting it together
+
+The C++ bindings can use the existing Rust artifacts via
+`-DRUST_BUILD_ARTIFACT_PATH` and the installed `iceoryx_hoofs` via
+`-DCMAKE_PREFIX_PATH`. The C++ bindings can be installed to be used by custom
+projects. This are the steps:
 
 ```bash
-cmake -S . -B target/ffi/build -DCMAKE_INSTALL_PREFIX=target/ffi/install -DCMAKE_PREFIX_PATH="$( pwd )/target/iceoryx/install"
+cmake -S . -B target/ffi/build -DCMAKE_INSTALL_PREFIX=target/ffi/install -DCMAKE_PREFIX_PATH="$( pwd )/target/iceoryx/install" -DRUST_BUILD_ARTIFACT_PATH="$( pwd )/target/release"
 cmake --build target/ffi/build
 cmake --install target/ffi/build
 ```

--- a/iceoryx2-ffi/cxx/cmake/fetch-iceoryx-hoofs.cmake
+++ b/iceoryx2-ffi/cxx/cmake/fetch-iceoryx-hoofs.cmake
@@ -62,7 +62,7 @@ message(WARNING "\
 The project was build by obtaining iceoryx with FetchContent.
 This is fine for development but for production, it is
 recommended to use an existing installation with
-'-DCMAKE_PREFIX_PATH=/path/to/installed/iceoryx'!
+'-DCMAKE_PREFIX_PATH=/full/path/to/installed/iceoryx'!
 #############################################################
 ")
 endif()


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR adds a cmake option to use existing artifacts of the iceoryx2 cargo build.

The documentation is also updated and the CI uses this new mechanism to speed up the builds.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #599

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
