### PR TITLE
[#566] Fix event based comm cxx example

### DIFF
--- a/examples/cxx/event_based_communication/src/custom_subscriber.hpp
+++ b/examples/cxx/event_based_communication/src/custom_subscriber.hpp
@@ -23,6 +23,8 @@
 #include "pubsub_event.hpp"
 #include "transmission_data.hpp"
 
+constexpr uint64_t HISTORY_SIZE = 20;
+
 // High-level subscriber class that contains besides a subscriber also a notifier
 // and a listener. The notifier is used to send events like
 // `PubSubEvent::ReceivedSample` or to notify the publisher that a new subscriber
@@ -45,8 +47,12 @@ class CustomSubscriber : public iox2::FileDescriptorBased {
 
     static auto create(iox2::Node<iox2::ServiceType::Ipc>& node, const iox2::ServiceName& service_name)
         -> CustomSubscriber {
-        auto pubsub_service =
-            node.service_builder(service_name).publish_subscribe<TransmissionData>().open_or_create().expect("");
+        auto pubsub_service = node.service_builder(service_name)
+                                  .publish_subscribe<TransmissionData>()
+                                  .history_size(HISTORY_SIZE)
+                                  .subscriber_max_buffer_size(HISTORY_SIZE)
+                                  .open_or_create()
+                                  .expect("");
         auto event_service = node.service_builder(service_name).event().open_or_create().expect("");
 
         auto listener = event_service.listener_builder().create().expect("");


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

Inconsistent history requirements lead to a connection failure when the subscriber was created first.

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #566 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
