### PR TITLE
[#458] corrupted services cleanup

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -21,6 +21,8 @@
     conflicts when merging.
 -->
 
+* Corrupted services are removed when they are part of a dead node
+    [#458](https://github.com/eclipse-iceoryx/iceoryx2/issues/458)
 * Completion queue capacity exceeded when history > buffer
     [#571](https://github.com/eclipse-iceoryx/iceoryx2/issues/571)
 * Increase max supported shared memory size in Windows that restricts

--- a/iceoryx2-ffi/cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/enum_translation.hpp
@@ -1519,6 +1519,8 @@ constexpr auto from<int, iox2::NodeCleanupFailure>(const int value) noexcept -> 
         return iox2::NodeCleanupFailure::InternalError;
     case iox2_node_cleanup_failure_e_INSUFFICIENT_PERMISSIONS:
         return iox2::NodeCleanupFailure::InsufficientPermissions;
+    case iox2_node_cleanup_failure_e_VERSION_MISMATCH:
+        return iox2::NodeCleanupFailure::VersionMismatch;
     }
 
     IOX_UNREACHABLE();

--- a/iceoryx2-ffi/cxx/include/iox2/node_failure_enums.hpp
+++ b/iceoryx2-ffi/cxx/include/iox2/node_failure_enums.hpp
@@ -46,6 +46,8 @@ enum class NodeCleanupFailure : uint8_t {
     /// The stale resources of a dead [`Node`] could not be removed since the process does not have sufficient
     /// permissions.
     InsufficientPermissions,
+    /// Trying to cleanup resources from a [`Node`] node which was using a different iceoryx2 version.
+    VersionMismatch,
 };
 
 } // namespace iox2

--- a/iceoryx2-ffi/ffi/src/api/node.rs
+++ b/iceoryx2-ffi/ffi/src/api/node.rs
@@ -88,6 +88,8 @@ pub enum iox2_node_cleanup_failure_e {
     INTERNAL_ERROR,
     /// The stale resources of a dead node could not be removed since the process does not have sufficient permissions.
     INSUFFICIENT_PERMISSIONS,
+    /// Trying to cleanup resources from a dead node which was using a different iceoryx2 version.
+    VERSION_MISMATCH,
 }
 
 impl IntoCInt for NodeCleanupFailure {
@@ -98,6 +100,7 @@ impl IntoCInt for NodeCleanupFailure {
             NodeCleanupFailure::InsufficientPermissions => {
                 iox2_node_cleanup_failure_e::INSUFFICIENT_PERMISSIONS
             }
+            NodeCleanupFailure::VersionMismatch => iox2_node_cleanup_failure_e::VERSION_MISMATCH,
         }) as c_int
     }
 }

--- a/iceoryx2/src/node/mod.rs
+++ b/iceoryx2/src/node/mod.rs
@@ -269,7 +269,7 @@ pub enum NodeCleanupFailure {
     InternalError,
     /// The stale resources of a dead [`Node`] could not be removed since the process does not have sufficient permissions.
     InsufficientPermissions,
-    /// Trying to cleanup resources from a dead node which was using a different iceoryx2 version.
+    /// Trying to cleanup resources from a dead [`Node`] which was using a different iceoryx2 version.
     VersionMismatch,
 }
 

--- a/iceoryx2/src/node/mod.rs
+++ b/iceoryx2/src/node/mod.rs
@@ -523,7 +523,7 @@ impl<Service: service::Service> DeadNodeView<Service> {
         }
         let cleaner = cleaner.unwrap();
 
-        let mut cleanup_failure = Ok(false);
+        let mut cleanup_failure = Ok(());
         let remove_node_from_service = |service_id: &ServiceId| {
             match Service::__internal_remove_node_from_service(self.id(), service_id, config) {
                 Ok(()) => {

--- a/iceoryx2/src/service/builder/event.rs
+++ b/iceoryx2/src/service/builder/event.rs
@@ -394,6 +394,12 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
                             fail!(from self, with EventOpenError::ExceedsMaxNumberOfNodes,
                                 "{} since it would exceed the maximum number of supported nodes.", msg);
                         }
+                        Err(OpenDynamicStorageFailure::DynamicStorageOpenError(
+                            DynamicStorageOpenError::DoesNotExist,
+                        )) => {
+                            fail!(from self, with EventOpenError::ServiceInCorruptedState,
+                                "{} since the dynamic segment of the service is missing.", msg);
+                        }
                         Err(e) => {
                             if self.base.is_service_available(msg)?.is_none() {
                                 fail!(from self, with EventOpenError::DoesNotExist,

--- a/iceoryx2/src/service/builder/publish_subscribe.rs
+++ b/iceoryx2/src/service/builder/publish_subscribe.rs
@@ -638,6 +638,12 @@ impl<Payload: Debug + ?Sized, UserHeader: Debug, ServiceType: service::Service>
                             fail!(from self, with PublishSubscribeOpenError::ExceedsMaxNumberOfNodes,
                                 "{} since it would exceed the maximum number of supported nodes.", msg);
                         }
+                        Err(OpenDynamicStorageFailure::DynamicStorageOpenError(
+                            DynamicStorageOpenError::DoesNotExist,
+                        )) => {
+                            fail!(from self, with PublishSubscribeOpenError::ServiceInCorruptedState,
+                                "{} since the dynamic segment of the service is missing.", msg);
+                        }
                         Err(e) => {
                             if self.is_service_available(msg)?.is_none() {
                                 fail!(from self, with PublishSubscribeOpenError::DoesNotExist,

--- a/iceoryx2/src/service/naming_scheme.rs
+++ b/iceoryx2/src/service/naming_scheme.rs
@@ -18,10 +18,9 @@ use iceoryx2_bb_system_types::file_name::FileName;
 pub(crate) fn event_concept_name(listener_id: &UniqueListenerId) -> FileName {
     let msg = "The system does not support the required file name length for the listeners event concept name.";
     let origin = "event_concept_name()";
-    let mut file = fatal_panic!(from origin, when FileName::new(listener_id.0.pid().to_string().as_bytes()), "{}", msg);
-    fatal_panic!(from origin, when file.push(b'_'), "{}", msg);
-    fatal_panic!(from origin, when file.push_bytes(listener_id.0.value().to_string().as_bytes()), "{}", msg);
-    file
+    fatal_panic!(from origin,
+                 when FileName::new(listener_id.0.value().to_string().as_bytes()),
+                 "{}", msg)
 }
 
 pub(crate) fn connection_name(
@@ -55,8 +54,7 @@ pub(crate) fn data_segment_name(publisher_id: &UniquePublisherId) -> FileName {
     let msg = "The system does not support the required file name length for the publishers data segment.";
     let origin = "data_segment_name()";
 
-    let mut file = fatal_panic!(from origin, when FileName::new(publisher_id.0.pid().to_string().as_bytes()), "{}", msg);
-    fatal_panic!(from origin, when file.push(b'_'), "{}", msg);
-    fatal_panic!(from origin, when file.push_bytes(publisher_id.0.value().to_string().as_bytes()), "{}", msg);
-    file
+    fatal_panic!(from origin,
+                 when FileName::new(publisher_id.0.value().to_string().as_bytes()),
+                 "{}", msg)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Shared Memory is not persistent in Windows. Whenever the last process that holds a shared memory handle terminates or crashes Windows removes the memory-mapped file from the file system. When a new process starts, it detects that there seems to exist the service but the dynamic segment of the service is missing - since the last process holding it crashed. So, it is correctly identified as corrupted, and the cleanup aborts here.

The solution is, when the node cleans up all stale resources and identifies a service as corrupted it deletes the static service config so that the service is removed completely.

In Windows we have to also handle the shm state file - which stores the shared memory size. So whenever a new shared memory is created and the state file already exists but the corresponding shared memory does not. The state file is removed and recreated again.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #458

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
