### PR TITLE
[#605] remove sigpoll

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -44,6 +44,9 @@
 * Undefined behavior due to ZeroCopyConnection removal when stale resources
     are cleaned up
     [#596](https://github.com/eclipse-iceoryx/iceoryx2/issues/596)
+* Remove `SIGPOLL` that lead to compile issues on older glibc versions.
+    Fixe issue where fatal signals are generated with non-fatal values.
+    [#605](https://github.com/eclipse-iceoryx/iceoryx2/issues/605)
 
 ### Refactoring
 

--- a/iceoryx2-bb/posix/src/signal.rs
+++ b/iceoryx2-bb/posix/src/signal.rs
@@ -193,7 +193,6 @@ define_signals! {
     BackgroundProcessReadAttempt = posix::SIGTTIN,
     BackgroundProcessWriteAttempt = posix::SIGTTOU,
     UserDefined1 = posix::SIGUSR1,
-    PollableEvent = posix::SIGPOLL,
     ProfilingTimerExpired = posix::SIGPROF,
     UrgentDataAvailableAtSocket = posix::SIGURG,
     VirtualTimerExpired = posix::SIGVTALRM

--- a/iceoryx2-bb/posix/src/signal.rs
+++ b/iceoryx2-bb/posix/src/signal.rs
@@ -102,7 +102,7 @@ macro_rules! define_signals {
         #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, Sequence)]
         #[repr(i32)]
         pub enum FatalFetchableSignal {
-          $($fatal_entry = $fatal_nn::$value),*,
+          $($fatal_entry = $fatal_nn::$fatal_value),*,
         }
 
         enum_gen! {

--- a/iceoryx2-pal/posix/src/freebsd/constants.rs
+++ b/iceoryx2-pal/posix/src/freebsd/constants.rs
@@ -53,7 +53,6 @@ pub const PTHREAD_BARRIER_SERIAL_THREAD: int = crate::internal::PTHREAD_BARRIER_
 pub const PTHREAD_EXPLICIT_SCHED: int = crate::internal::PTHREAD_EXPLICIT_SCHED as _;
 pub const PTHREAD_INHERIT_SCHED: int = crate::internal::PTHREAD_INHERIT_SCHED as _;
 
-pub const SIGPOLL: int = crate::internal::SIGIO as _;
 pub const MAX_SIGNAL_VALUE: usize = 34;
 
 pub const SO_PASSCRED: int = crate::internal::LOCAL_PEERCRED as _;

--- a/iceoryx2-pal/posix/src/linux/constants.rs
+++ b/iceoryx2-pal/posix/src/linux/constants.rs
@@ -53,7 +53,6 @@ pub const PTHREAD_BARRIER_SERIAL_THREAD: int = crate::internal::PTHREAD_BARRIER_
 pub const PTHREAD_EXPLICIT_SCHED: int = crate::internal::PTHREAD_EXPLICIT_SCHED as _;
 pub const PTHREAD_INHERIT_SCHED: int = crate::internal::PTHREAD_INHERIT_SCHED as _;
 
-pub const SIGPOLL: int = crate::internal::SIGPOLL as _;
 pub const MAX_SIGNAL_VALUE: usize = 32;
 
 pub const SO_PASSCRED: int = crate::internal::SO_PASSCRED as _;

--- a/iceoryx2-pal/posix/src/macos/constants.rs
+++ b/iceoryx2-pal/posix/src/macos/constants.rs
@@ -55,7 +55,6 @@ pub const PTHREAD_BARRIER_SERIAL_THREAD: int = int::MAX;
 pub const PTHREAD_EXPLICIT_SCHED: int = crate::internal::PTHREAD_EXPLICIT_SCHED as _;
 pub const PTHREAD_INHERIT_SCHED: int = crate::internal::PTHREAD_INHERIT_SCHED as _;
 
-pub const SIGPOLL: int = crate::internal::SIGIO as _;
 pub const MAX_SIGNAL_VALUE: usize = 34;
 
 pub const SO_PASSCRED: int = crate::internal::LOCAL_PEERCRED as _;

--- a/iceoryx2-pal/posix/src/windows/constants.rs
+++ b/iceoryx2-pal/posix/src/windows/constants.rs
@@ -127,7 +127,6 @@ pub const SIGVTALRM: int = 24;
 pub const SIGXCPU: int = 25;
 pub const SIGXFSZ: int = 26;
 pub const SIG_ERR: sighandler_t = sighandler_t::MAX;
-pub const SIGPOLL: int = 27;
 pub const SIG_DFL: int = 0;
 pub const SIG_IGN: int = 1;
 pub const SA_RESTART: int = 1;


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #605 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
