### PR TITLE
[#608] fix log level

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -47,6 +47,8 @@
 * Remove `SIGPOLL` that lead to compile issues on older glibc versions.
     Fixe issue where fatal signals are generated with non-fatal values.
     [#605](https://github.com/eclipse-iceoryx/iceoryx2/issues/605)
+* LogLevel is considered for custom loggers.
+    [#608](https://github.com/eclipse-iceoryx/iceoryx2/issues/608)
 
 ### Refactoring
 

--- a/iceoryx2-bb/log/src/lib.rs
+++ b/iceoryx2-bb/log/src/lib.rs
@@ -233,5 +233,7 @@ pub fn get_logger() -> &'static dyn Log {
 
 #[doc(hidden)]
 pub fn __internal_print_log_msg(log_level: LogLevel, origin: Arguments, args: Arguments) {
-    get_logger().log(log_level, origin, args)
+    if get_log_level() <= log_level as u8 {
+        get_logger().log(log_level, origin, args)
+    }
 }

--- a/iceoryx2-bb/log/src/logger/console.rs
+++ b/iceoryx2-bb/log/src/logger/console.rs
@@ -19,7 +19,7 @@ use std::io::IsTerminal;
 
 use termsize::Size;
 
-use crate::{get_log_level, LogLevel};
+use crate::LogLevel;
 
 pub enum ConsoleLogOrder {
     Time,
@@ -181,10 +181,6 @@ impl crate::Log for Logger {
         formatted_message: core::fmt::Arguments,
     ) {
         let counter = self.counter.fetch_add(1, Ordering::Relaxed);
-
-        if get_log_level() > log_level as u8 {
-            return;
-        }
 
         let origin_str = origin.to_string();
         let msg_str = formatted_message.to_string();

--- a/iceoryx2-ffi/cxx/tests/src/log_tests.cpp
+++ b/iceoryx2-ffi/cxx/tests/src/log_tests.cpp
@@ -65,6 +65,7 @@ class TestLogger : public Log {
 };
 
 TEST(Log, custom_logger_works) {
+    set_log_level(LogLevel::Trace);
     ASSERT_TRUE(set_logger(TestLogger::get_instance()));
 
     log(LogLevel::Trace, "hello", "world");


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Fix the issue where the logger forwarded log messages to the custom logger that should have been filtered away by the log level.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #608 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
