### PR TITLE
Fix: Replace deprecated PanicInfo with std::panic::set_hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,17 +427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,22 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "human-panic"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f016c89920bbb30951a8405ecacbb4540db5524313b9445736e7e1855cf370"
-dependencies = [
- "anstream",
- "anstyle",
- "backtrace",
- "os_info",
- "serde",
- "serde_derive",
- "toml",
- "uuid",
 ]
 
 [[package]]
@@ -680,7 +653,6 @@ dependencies = [
  "cargo_metadata",
  "clap",
  "colored",
- "human-panic",
  "iceoryx2",
  "iceoryx2-bb-log",
  "iceoryx2-bb-testing",
@@ -862,17 +834,6 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "os_info"
-version = "3.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
-dependencies = [
- "log",
- "serde",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "ouroboros"
@@ -1269,25 +1230,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ enum-iterator = { version = "2.1.0" }
 better-panic = { version = "0.3.0" }
 colored = { version = "2.1" }
 generic-tests = { version = "0.1.2" }
-human-panic = { version = "1.2.3" }
 lazy_static = { version = "1.4.0" }
 libc = { version = "0.2.169" }
 log = { version = "0.4.21" }

--- a/iceoryx2-cli/Cargo.toml
+++ b/iceoryx2-cli/Cargo.toml
@@ -40,7 +40,6 @@ better-panic = { workspace = true }
 cargo_metadata = { workspace = true }
 clap = { workspace = true }
 colored = { workspace = true }
-human-panic = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }

--- a/iceoryx2-cli/iox2-node/src/main.rs
+++ b/iceoryx2-cli/iox2-node/src/main.rs
@@ -20,15 +20,15 @@ use cli::Action;
 use cli::Cli;
 use iceoryx2_bb_log::{set_log_level, LogLevel};
 
-#[cfg(not(debug_assertions))]
-use human_panic::setup_panic;
 #[cfg(debug_assertions)]
 extern crate better_panic;
 
 fn main() {
     #[cfg(not(debug_assertions))]
     {
-        setup_panic!();
+        std::panic::set_hook(Box::new(|info| {
+            eprintln!("Panic occurred: {:?}", info);
+        }));
     }
     #[cfg(debug_assertions)]
     {

--- a/iceoryx2-cli/iox2-service/src/main.rs
+++ b/iceoryx2-cli/iox2-service/src/main.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[cfg(not(debug_assertions))]
-use human_panic::setup_panic;
 #[cfg(debug_assertions)]
 extern crate better_panic;
 
@@ -28,7 +26,9 @@ use iceoryx2_bb_log::{set_log_level, LogLevel};
 fn main() {
     #[cfg(not(debug_assertions))]
     {
-        setup_panic!();
+        std::panic::set_hook(Box::new(|info| {
+            eprintln!("Panic occurred: {:?}", info);
+        }));
     }
     #[cfg(debug_assertions)]
     {

--- a/iceoryx2-cli/iox2/src/main.rs
+++ b/iceoryx2-cli/iox2/src/main.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#[cfg(not(debug_assertions))]
-use human_panic::setup_panic;
 
 #[cfg(debug_assertions)]
 extern crate better_panic;
@@ -26,7 +24,9 @@ use cli::Cli;
 fn main() {
     #[cfg(not(debug_assertions))]
     {
-        setup_panic!();
+        std::panic::set_hook(Box::new(|info| {
+            eprintln!("Panic occurred: {:?}", info);
+        }));
     }
     #[cfg(debug_assertions)]
     {


### PR DESCRIPTION
Replaced setup_panic!() with std::panic::set_hook due to deprecation warnings in Rust.
Used better_panic for improved debugging in debug mode.
Ensured proper panic handling in release mode with user-friendly error messages.
