### PR TITLE
[#3] Fix CI for new rust 1.85

### DIFF
--- a/iceoryx2-bb/lock-free/src/mpmc/unique_index_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/unique_index_set.rs
@@ -259,7 +259,7 @@ impl HeadDetails {
 
     fn value(&self) -> u64 {
         (((self.head & 0x00ffffff) as u64) << 40)
-            | (self.aba as u64) << 24
+            | ((self.aba as u64) << 24)
             | ((self.borrowed_indices & 0x00ffffff) as u64)
     }
 }

--- a/iceoryx2-cal/src/shm_allocator/pointer_offset.rs
+++ b/iceoryx2-cal/src/shm_allocator/pointer_offset.rs
@@ -54,7 +54,7 @@ impl PointerOffset {
 
     /// Creates a new [`PointerOffset`] from an offset and a [`SegmentId`]
     pub const fn from_offset_and_segment_id(offset: usize, segment_id: SegmentId) -> PointerOffset {
-        Self((offset as u64) << (SegmentIdUnderlyingType::BITS) | segment_id.value() as u64)
+        Self(((offset as u64) << (SegmentIdUnderlyingType::BITS)) | segment_id.value() as u64)
     }
 
     /// Creates a new [`PointerOffset`] from a provided raw value.

--- a/iceoryx2-pal/posix/src/macos/inet.rs
+++ b/iceoryx2-pal/posix/src/macos/inet.rs
@@ -14,7 +14,10 @@
 #![allow(clippy::missing_safety_doc)]
 
 unsafe fn swap_endianess_32(v: u32) -> u32 {
-    (v & 0xff000000) >> 24 | (v & 0x00ff0000) >> 8 | (v & 0x0000ff00) << 8 | (v & 0x000000ff) << 24
+    ((v & 0xff000000) >> 24)
+        | ((v & 0x00ff0000) >> 8)
+        | ((v & 0x0000ff00) << 8)
+        | ((v & 0x000000ff) << 24)
 }
 
 unsafe fn swap_endianess_16(v: u16) -> u16 {

--- a/iceoryx2-pal/posix/src/windows/socket.rs
+++ b/iceoryx2-pal/posix/src/windows/socket.rs
@@ -226,7 +226,7 @@ pub unsafe fn getsockopt(
 unsafe fn create_uds_address(port: u16) -> sockaddr_in {
     let mut udp_address = sockaddr_in::new();
     udp_address.sin_family = AF_INET as _;
-    let localhost: u32 = 127 << 24 | 1;
+    let localhost: u32 = (127 << 24) | 1;
     udp_address.set_s_addr(htonl(localhost));
     udp_address.sin_port = htons(port);
     udp_address


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #3 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
