### PR TITLE
[#637] Remove line-length correction from markdown linting script

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -73,7 +73,7 @@ jobs:
           node-version: '20'
 
       - name: Install linters
-        run: npm install -g markdownlint-cli prettier
+        run: npm install -g markdownlint-cli
 
       - name: Check linting
         env:
@@ -81,7 +81,7 @@ jobs:
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
           GITHUB_BEFORE: ${{ github.event.before }}
           GITHUB_AFTER: ${{ github.event.after }}
-        run: ./internal/scripts/check_markdown_linting.sh
+        run: ./internal/scripts/ci_check_markdown_linting.sh
 
   static-code-analysis-rust:
     needs: preflight-check

--- a/internal/scripts/ci_check_markdown_linting.sh
+++ b/internal/scripts/ci_check_markdown_linting.sh
@@ -75,12 +75,6 @@ if ! command -v markdownlint &> /dev/null; then
     exit 1
 fi
 
-if ! command -v prettier &> /dev/null; then
-    echo "Error: prettier is not installed. Please install it using npm:"
-    echo "npm install -g prettier"
-    exit 1
-fi
-
 # Check for markdownlint config existence
 if [ ! -f "$MARKDOWNLINT_CONFIG" ]; then
     echo "Error: .markdownlint.yaml file not found at $MARKDOWNLINT_CONFIG"
@@ -120,9 +114,6 @@ print_file_list "$MODE" "$md_files"
 
 # Execute
 if [ "$MODE" = "fix" ]; then
-    echo "\nRunning Prettier to format line length..."
-    echo "$md_files" | xargs prettier --write --embedded-language-formatting off --parser markdown --prose-wrap always --print-width 80
-    
     echo "\nRunning markdownlint to fix other issues..."
     echo "$md_files" | xargs markdownlint -c "$MARKDOWNLINT_CONFIG" --fix
     


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Removes automatic line correction from markdown linting script because it was occasionally breaking markdown formatting.

Also renamed the script to match the convention of other CI scripts: `check_markdown_linting.sh` -> `ci_check_markdown_linting.sh`

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [ ] Assign PR to reviewer
* [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #637  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
