### PR TITLE
[#682] Fix miri borrow checker for MetaVec

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -69,6 +69,8 @@
     [#677](https://github.com/eclipse-iceoryx/iceoryx2/issues/677)
 * Fix `wait_and_process_once_with_timeout` deadlock
     [#695](https://github.com/eclipse-iceoryx/iceoryx2/issues/695)
+* Fix Miri issues with MetaVec due to temporary borrow
+    [#682](https://github.com/eclipse-iceoryx/iceoryx2/issues/682)
 
 ### Refactoring
 

--- a/iceoryx2-bb/container/src/vec.rs
+++ b/iceoryx2-bb/container/src/vec.rs
@@ -183,19 +183,14 @@ pub mod details {
 
         fn deref(&self) -> &Self::Target {
             self.verify_init("deref()");
-            unsafe { core::slice::from_raw_parts((*self.data_ptr.as_ptr()).as_ptr(), self.len) }
+            unsafe { self.as_slice_impl() }
         }
     }
 
     impl<T, Ptr: GenericPointer> DerefMut for MetaVec<T, Ptr> {
         fn deref_mut(&mut self) -> &mut Self::Target {
             self.verify_init("deref_mut()");
-            unsafe {
-                core::slice::from_raw_parts_mut(
-                    (*self.data_ptr.as_mut_ptr()).as_mut_ptr(),
-                    self.len,
-                )
-            }
+            unsafe { self.as_mut_slice_impl() }
         }
     }
 


### PR DESCRIPTION
Changed to use internal slice impl that does
.cast() on ptr instead creating temporary reference that is then cases into ptr again. This causes miri to go crazy and think borrow stack is broken.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #682

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
