### PR TITLE
[#689] Fix typos in doc

### DIFF
--- a/iceoryx2-ffi/ffi/src/api/active_request.rs
+++ b/iceoryx2-ffi/ffi/src/api/active_request.rs
@@ -95,9 +95,9 @@ impl iox2_active_request_t {
 }
 
 pub struct iox2_active_request_h_t;
-/// The owning handle for `iox2_active_request_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_active_request_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_active_request_h = *mut iox2_active_request_h_t;
-/// The non-owning handle for `iox2_active_request_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_active_request_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_active_request_h_ref = *const iox2_active_request_h;
 
 impl AssertNonNullHandle for iox2_active_request_h {
@@ -144,7 +144,7 @@ impl HandleToType for iox2_active_request_h_ref {
 ///
 /// # Safety
 ///
-/// * `handle` must be valid a handle
+/// * `handle` must be a valid handle
 #[no_mangle]
 pub unsafe extern "C" fn iox2_active_request_is_connected(
     handle: iox2_active_request_h_ref,
@@ -197,7 +197,7 @@ pub unsafe extern "C" fn iox2_active_request_header(
     *header_handle_ptr = (*storage_ptr).as_handle();
 }
 
-/// Acquires the requests user header.
+/// Acquires the request user header.
 ///
 /// # Safety
 ///
@@ -221,14 +221,14 @@ pub unsafe extern "C" fn iox2_active_request_user_header(
     *header_ptr = (header as *const UserHeaderFfi).cast();
 }
 
-/// Acquires the requests payload.
+/// Acquires the request payload.
 ///
 /// # Safety
 ///
 /// * `handle` - Must be a valid [`iox2_active_request_h_ref`]
-///   obtained by [`iox2_request_mut_send`](crate::iox2_request_mut_send).
+///   obtained by [`iox2_server_receive`](crate::iox2_server_receive).
 /// * `payload_ptr` a valid, non-null pointer pointing to a `*const c_void` pointer.
-/// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
+/// * `number_of_elements` (optional) either a null pointer or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_active_request_payload(
     handle: iox2_active_request_h_ref,
@@ -277,11 +277,11 @@ pub unsafe extern "C" fn iox2_active_request_payload(
 ///
 /// # Arguments
 ///
-/// * `handle` - Must be a valid [`iox2_active_request_h_ref`]
-///   obtained by [`iox2_request_mut_send`](crate::iox2_request_mut_send).
+/// * `active_request_handle` - Must be a valid [`iox2_active_request_h_ref`]
+///   obtained by [`iox2_server_receive`](crate::iox2_server_receive).
 /// * `response_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_response_mut_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
-/// * `response_handle_ptr` - An uninitialized or dangling [`iox2_response_mut_h`] handle which will be initialized by this function call if a sample is obtained, otherwise it will be set to NULL.
+/// * `response_handle_ptr` - An uninitialized or dangling [`iox2_response_mut_h`] handle which will be initialized by this function call if a response is obtained, otherwise it will be set to NULL.
 /// * `number_of_elements` - The number of elements to loan from the server's payload segment
 ///
 /// Return [`IOX2_OK`] on success, otherwise [`iox2_loan_error_e`](crate::iox2_loan_error_e).
@@ -385,8 +385,8 @@ unsafe fn send_copy<S: Service>(
 ///
 /// # Arguments
 ///
-/// * `handle` - Must be a valid [`iox2_active_request_h_ref`]
-///   obtained by [`iox2_request_mut_send`](crate::iox2_request_mut_send).
+/// * `active_request_handle` - Must be a valid [`iox2_active_request_h_ref`]
+///   obtained by [`iox2_server_receive`](crate::iox2_server_receive).
 /// * `data_ptr` pointer to the payload that shall be transmitted
 /// * `size_of_element` the size of the payload in bytes
 /// * `number_of_elements` the number of elements stored in data_ptr

--- a/iceoryx2-ffi/ffi/src/api/client.rs
+++ b/iceoryx2-ffi/ffi/src/api/client.rs
@@ -92,9 +92,9 @@ impl iox2_client_t {
 }
 
 pub struct iox2_client_h_t;
-/// The owning handle for `iox2_client_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_client_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_client_h = *mut iox2_client_h_t;
-/// The non-owning handle for `iox2_client_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_client_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_client_h_ref = *const iox2_client_h;
 
 impl AssertNonNullHandle for iox2_client_h {
@@ -233,10 +233,10 @@ pub unsafe extern "C" fn iox2_client_id(
 ///
 /// # Arguments
 ///
-/// * `handle` obtained by [`iox2_port_factory_client_builder_create`](crate::iox2_port_factory_client_builder_create)
+/// * `client_handle` obtained by [`iox2_port_factory_client_builder_create`](crate::iox2_port_factory_client_builder_create)
 /// * `request_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_request_mut_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
-/// * `request_handle_ptr` - An uninitialized or dangling [`iox2_request_mut_h`] handle which will be initialized by this function call if a sample is obtained, otherwise it will be set to NULL.
+/// * `request_handle_ptr` - An uninitialized or dangling [`iox2_request_mut_h`] handle which will be initialized by this function call if a request is obtained, otherwise it will be set to NULL.
 /// * `number_of_elements` - The number of elements to loan from the clients's payload segment
 ///
 /// Return [`IOX2_OK`] on success, otherwise [`iox2_loan_error_e`](crate::iox2_loan_error_e).
@@ -341,10 +341,10 @@ unsafe fn send_copy<S: Service>(
 ///
 /// # Arguments
 ///
-/// * `handle` obtained by [`iox2_port_factory_client_builder_create`](crate::iox2_port_factory_client_builder_create)
+/// * `client_handle` obtained by [`iox2_port_factory_client_builder_create`](crate::iox2_port_factory_client_builder_create)
 /// * `pending_response_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_pending_response_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
-/// * `pending_response_handle_ptr` - An uninitialized or dangling [`iox2_pending_response_h`] handle which will be initialized by this function call if a sample is obtained, otherwise it will be set to NULL.
+/// * `pending_response_handle_ptr` - An uninitialized or dangling [`iox2_pending_response_h`] handle which will be initialized by this function call.
 /// * `data_ptr` pointer to the payload that shall be transmitted
 /// * `size_of_element` the size of the payload in bytes
 /// * `number_of_elements` the number of elements in the payload

--- a/iceoryx2-ffi/ffi/src/api/config.rs
+++ b/iceoryx2-ffi/ffi/src/api/config.rs
@@ -1745,7 +1745,7 @@ pub unsafe extern "C" fn iox2_config_defaults_request_response_enable_safe_overf
         .enable_safe_overflow_for_requests
 }
 
-/// Enables/disables safe overflow
+/// Enables/disables safe overflow for requests
 ///
 /// # Safety
 ///
@@ -1790,7 +1790,7 @@ pub unsafe extern "C" fn iox2_config_defaults_request_response_enable_safe_overf
         .enable_safe_overflow_for_responses
 }
 
-/// Enables/disables safe overflow
+/// Enables/disables safe overflow for responses
 ///
 /// # Safety
 ///
@@ -1812,7 +1812,7 @@ pub unsafe extern "C" fn iox2_config_defaults_request_response_set_enable_safe_o
         .enable_safe_overflow_for_responses = value;
 }
 
-/// Returns how many active requests a [`iox2_client_h`](crate::api::iox2_client_h) send out in
+/// Returns how many active requests a [`iox2_client_h`](crate::api::iox2_client_h) can send out in
 /// parallel and expect responses from.
 ///
 /// # Safety

--- a/iceoryx2-ffi/ffi/src/api/pending_response.rs
+++ b/iceoryx2-ffi/ffi/src/api/pending_response.rs
@@ -97,9 +97,9 @@ impl iox2_pending_response_t {
 }
 
 pub struct iox2_pending_response_h_t;
-/// The owning handle for `iox2_pending_response_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_pending_response_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_pending_response_h = *mut iox2_pending_response_h_t;
-/// The non-owning handle for `iox2_pending_response_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_pending_response_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_pending_response_h_ref = *const iox2_pending_response_h;
 
 impl AssertNonNullHandle for iox2_pending_response_h {
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn iox2_pending_response_user_header(
 /// * `handle` - Must be a valid [`iox2_pending_response_h_ref`]
 ///   obtained by [`iox2_request_mut_send`](crate::iox2_request_mut_send).
 /// * `payload_ptr` a valid, non-null pointer pointing to a `*const c_void` pointer.
-/// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
+/// * `number_of_elements` (optional) either a null pointer or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_pending_response_payload(
     handle: iox2_pending_response_h_ref,
@@ -339,7 +339,7 @@ pub unsafe extern "C" fn iox2_pending_response_payload(
     }
 }
 
-/// Takes a response ouf of the buffer.
+/// Takes a response out of the buffer.
 ///
 /// # Arguments
 ///
@@ -350,7 +350,7 @@ pub unsafe extern "C" fn iox2_pending_response_payload(
 /// * `response_handle_ptr` - An uninitialized or dangling [`iox2_response_h`] handle which will be initialized by this function call if a sample is obtained, otherwise it will be set to NULL.
 ///
 /// Returns IOX2_OK on success, an [`iox2_receive_error_e`](crate::iox2_receive_error_e) otherwise.
-/// Attention, an empty subscriber queue is not an error and even with IOX2_OK it is possible to get a NULL in `response_handle_ptr`.
+/// Attention, an empty response buffer is not an error and even with IOX2_OK it is possible to get a NULL in `response_handle_ptr`.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/ffi/src/api/port_factory_client_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_client_builder.rs
@@ -131,9 +131,9 @@ impl iox2_port_factory_client_builder_t {
 }
 
 pub struct iox2_port_factory_client_builder_h_t;
-/// The owning handle for `iox2_port_factory_client_builder_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_port_factory_client_builder_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_port_factory_client_builder_h = *mut iox2_port_factory_client_builder_h_t;
-/// The non-owning handle for `iox2_port_factory_client_builder_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_port_factory_client_builder_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_port_factory_client_builder_h_ref = *const iox2_port_factory_client_builder_h;
 
 impl AssertNonNullHandle for iox2_port_factory_client_builder_h {
@@ -197,11 +197,11 @@ pub unsafe extern "C" fn iox2_client_create_error_string(
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_client_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_client_builder`](crate::iox2_port_factory_request_response_client_builder).
-/// * `value` - The value to set max slice length to
+/// * `value` - The value to set the allocation strategy to
 ///
 /// # Safety
 ///
-/// * `port_factory_handle` must be valid handles
+/// * `port_factory_handle` must be a valid handle
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_client_builder_set_allocation_strategy(
     port_factory_handle: iox2_port_factory_client_builder_h_ref,
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn iox2_port_factory_client_builder_set_initial_max_slice_
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_client_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_client_builder`](crate::iox2_port_factory_request_response_client_builder).
-/// * `value` - The value to set max slice length to
+/// * `value` - The value to set the unable to deliver strategy to
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/ffi/src/api/port_factory_request_response.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_request_response.rs
@@ -101,9 +101,9 @@ impl iox2_port_factory_request_response_t {
 }
 
 pub struct iox2_port_factory_request_response_h_t;
-/// The owning handle for `iox2_port_factory_request_response_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_port_factory_request_response_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_port_factory_request_response_h = *mut iox2_port_factory_request_response_h_t;
-/// The non-owning handle for `iox2_port_factory_request_response_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_port_factory_request_response_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_port_factory_request_response_h_ref = *const iox2_port_factory_request_response_h;
 
 impl AssertNonNullHandle for iox2_port_factory_request_response_h {
@@ -153,7 +153,7 @@ impl HandleToType for iox2_port_factory_request_response_h_ref {
 ///
 /// # Safety
 ///
-/// * The `port_factory_handle` is still valid after the return of this function and can be use in another function call.
+/// * The `port_factory_handle` is still valid after the return of this function and can be used in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_request_response_server_builder(
     port_factory_handle: iox2_port_factory_request_response_h_ref,
@@ -193,7 +193,7 @@ pub unsafe extern "C" fn iox2_port_factory_request_response_server_builder(
     (*builder_struct_ptr).as_handle()
 }
 
-/// Instantiates a [`iox2_port_factory_server_builder_h`] to build a client.
+/// Instantiates a [`iox2_port_factory_client_builder_h`] to build a client.
 ///
 /// # Arguments
 ///
@@ -206,7 +206,7 @@ pub unsafe extern "C" fn iox2_port_factory_request_response_server_builder(
 ///
 /// # Safety
 ///
-/// * The `port_factory_handle` is still valid after the return of this function and can be use in another function call.
+/// * The `port_factory_handle` is still valid after the return of this function and can be used in another function call.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_request_response_client_builder(
     port_factory_handle: iox2_port_factory_request_response_h_ref,
@@ -246,11 +246,11 @@ pub unsafe extern "C" fn iox2_port_factory_request_response_client_builder(
     (*builder_struct_ptr).as_handle()
 }
 
-/// Returnes the services attributes.
+/// Returns the services attributes.
 ///
 /// # Safety
 ///
-/// * The `port_factory_handle` is invalid after the return of this function and leads to undefined behavior if used in another function call!
+/// * The `port_factory_handle` is still valid after the return of this function and can be used in another function call.
 /// * The `port_factory_handle` must live longer than the returned `iox2_attribute_set_h_ref`.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_port_factory_request_response_attributes(
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn iox2_port_factory_request_response_attributes(
 ///
 /// # Safety
 ///
-/// * The `_handle` must be valid and obtained by [`iox2_service_builder_request_response_open`](crate::iox2_service_builder_request_response_open) or
+/// * The `port_factory_handle` must be valid and obtained by [`iox2_service_builder_request_response_open`](crate::iox2_service_builder_request_response_open) or
 ///   [`iox2_service_builder_request_response_open_or_create`](crate::iox2_service_builder_request_response_open_or_create)!
 /// * The `static_config` must be a valid pointer and non-null.
 #[no_mangle]

--- a/iceoryx2-ffi/ffi/src/api/port_factory_server_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/port_factory_server_builder.rs
@@ -132,9 +132,9 @@ impl iox2_port_factory_server_builder_t {
 }
 
 pub struct iox2_port_factory_server_builder_h_t;
-/// The owning handle for `iox2_port_factory_server_builder_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_port_factory_server_builder_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_port_factory_server_builder_h = *mut iox2_port_factory_server_builder_h_t;
-/// The non-owning handle for `iox2_port_factory_publisher_builder_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_port_factory_server_builder_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_port_factory_server_builder_h_ref = *const iox2_port_factory_server_builder_h;
 
 impl AssertNonNullHandle for iox2_port_factory_server_builder_h {
@@ -199,7 +199,7 @@ pub unsafe extern "C" fn iox2_server_create_error_string(
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_server_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_server_builder`](crate::iox2_port_factory_request_response_server_builder).
-/// * `value` - The value to set max slice length to
+/// * `value` - The value to set the allocation strategy to
 ///
 /// # Safety
 ///
@@ -273,7 +273,7 @@ pub unsafe extern "C" fn iox2_port_factory_server_builder_set_initial_max_slice_
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_server_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_server_builder`](crate::iox2_port_factory_request_response_server_builder).
-/// * `value` - The value to set max slice length to
+/// * `value` - The value to set max loaned responses to
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/ffi/src/api/request_header.rs
+++ b/iceoryx2-ffi/ffi/src/api/request_header.rs
@@ -44,9 +44,9 @@ impl iox2_request_header_t {
 }
 
 pub struct iox2_request_header_h_t;
-/// The owning handle for [`iox2_request_header_t`]. Passing the handle to an function transfers the ownership.
+/// The owning handle for [`iox2_request_header_t`]. Passing the handle to a function transfers the ownership.
 pub type iox2_request_header_h = *mut iox2_request_header_h_t;
-/// The non-owning handle for [`iox2_request_header_t`]. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for [`iox2_request_header_t`]. Passing the handle to a function does not transfer the ownership.
 pub type iox2_request_header_h_ref = *const iox2_request_header_h;
 
 // NOTE check the README.md for using opaque types with renaming
@@ -106,11 +106,11 @@ pub unsafe extern "C" fn iox2_request_header_drop(handle: iox2_request_header_h)
     (header.deleter)(header);
 }
 
-/// Returns the unique client id of the source of the sample.
+/// Returns the unique client id of the source of the request.
 ///
 /// # Arguments
 ///
-/// * `handle` is valid, non-null and is initialized
+/// * `header_handle` is valid, non-null and is initialized
 /// * `id_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_unique_client_id_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `id_handle_ptr` valid pointer to a [`iox2_unique_client_id_h`].
@@ -155,7 +155,7 @@ pub unsafe extern "C" fn iox2_request_header_client_id(
 ///
 /// # Arguments
 ///
-/// * `handle` is valid, non-null and initialized
+/// * `header_handle` is valid, non-null and initialized
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/ffi/src/api/request_mut.rs
+++ b/iceoryx2-ffi/ffi/src/api/request_mut.rs
@@ -151,9 +151,9 @@ impl iox2_request_mut_t {
 }
 
 pub struct iox2_request_mut_h_t;
-/// The owning handle for `iox2_request_mut_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_request_mut_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_request_mut_h = *mut iox2_request_mut_h_t;
-/// The non-owning handle for `iox2_request_mut_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_request_mut_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_request_mut_h_ref = *const iox2_request_mut_h;
 
 impl AssertNonNullHandle for iox2_request_mut_h {
@@ -337,7 +337,7 @@ pub unsafe extern "C" fn iox2_request_mut_user_header_mut(
 ///
 /// * `handle` obtained by [`iox2_client_loan_slice_uninit()`](crate::iox2_client_loan_slice_uninit())
 /// * `payload_ptr` a valid, non-null pointer pointing to a `*mut c_void` pointer.
-/// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
+/// * `number_of_elements` (optional) either a null pointer or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_request_mut_payload_mut(
     handle: iox2_request_mut_h_ref,
@@ -365,13 +365,13 @@ pub unsafe extern "C" fn iox2_request_mut_payload_mut(
     }
 }
 
-/// Acquires the samples payload.
+/// Acquires the request payload.
 ///
 /// # Safety
 ///
 /// * `handle` obtained by [`iox2_client_loan_slice_uninit()`](crate::iox2_client_loan_slice_uninit())
 /// * `payload_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
-/// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
+/// * `number_of_elements` (optional) either a null pointer or a valid pointer pointing to a [`c_size_t`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_request_mut_payload(
     handle: iox2_request_mut_h_ref,
@@ -399,7 +399,7 @@ pub unsafe extern "C" fn iox2_request_mut_payload(
     }
 }
 
-/// Takes the ownership of the sample and sends it
+/// Takes the ownership of the request and sends it
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/ffi/src/api/response.rs
+++ b/iceoryx2-ffi/ffi/src/api/response.rs
@@ -71,9 +71,9 @@ impl iox2_response_t {
 }
 
 pub struct iox2_response_h_t;
-/// The owning handle for `iox2_sample_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_response_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_response_h = *mut iox2_response_h_t;
-/// The non-owning handle for `iox2_response_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_response_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_response_h_ref = *const iox2_response_h;
 
 impl AssertNonNullHandle for iox2_response_h {

--- a/iceoryx2-ffi/ffi/src/api/response_header.rs
+++ b/iceoryx2-ffi/ffi/src/api/response_header.rs
@@ -22,7 +22,7 @@ use crate::{
 
 // BEGIN types definition
 
-/// Sample header used by `MessagingPattern::ResponseResponse`
+/// Response header used by `MessagingPattern::RequestResponse`
 #[repr(C)]
 #[repr(align(8))] // core::mem::align_of::<Option<ResponseHeader>>()
 pub struct iox2_response_header_storage_t {
@@ -48,9 +48,9 @@ impl iox2_response_header_t {
 }
 
 pub struct iox2_response_header_h_t;
-/// The owning handle for [`iox2_response_header_t`]. Passing the handle to an function transfers the ownership.
+/// The owning handle for [`iox2_response_header_t`]. Passing the handle to a function transfers the ownership.
 pub type iox2_response_header_h = *mut iox2_response_header_h_t;
-/// The non-owning handle for [`iox2_response_header_t`]. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for [`iox2_response_header_t`]. Passing the handle to a function does not transfer the ownership.
 pub type iox2_response_header_h_ref = *const iox2_response_header_h;
 
 // NOTE check the README.md for using opaque types with renaming
@@ -110,11 +110,11 @@ pub unsafe extern "C" fn iox2_response_header_drop(handle: iox2_response_header_
     (header.deleter)(header);
 }
 
-/// Returns the unique server id of the source of the sample.
+/// Returns the unique server id of the source of the response.
 ///
 /// # Arguments
 ///
-/// * `handle` is valid, non-null and was initialized with
+/// * `header_handle` is valid, non-null and was initialized with
 ///   [`iox2_response_header()`](crate::iox2_response_header)
 /// * `id_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_unique_server_id_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
@@ -160,7 +160,7 @@ pub unsafe extern "C" fn iox2_response_header_server_id(
 ///
 /// # Arguments
 ///
-/// * `handle` is valid, non-null and was initialized with
+/// * `header_handle` is valid, non-null and was initialized with
 ///   [`iox2_response_header()`](crate::iox2_response_header)
 ///
 /// # Safety

--- a/iceoryx2-ffi/ffi/src/api/response_mut.rs
+++ b/iceoryx2-ffi/ffi/src/api/response_mut.rs
@@ -76,9 +76,9 @@ impl iox2_response_mut_t {
 }
 
 pub struct iox2_response_mut_h_t;
-/// The owning handle for `iox2_response_mut_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_response_mut_t`. Passing the handle to a function transfer the ownership.
 pub type iox2_response_mut_h = *mut iox2_response_mut_h_t;
-/// The non-owning handle for `iox2_response_mut_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_response_mut_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_response_mut_h_ref = *const iox2_response_mut_h;
 
 impl AssertNonNullHandle for iox2_response_mut_h {
@@ -311,7 +311,7 @@ pub unsafe extern "C" fn iox2_response_mut_payload_mut(
 ///
 /// # Safety
 ///
-/// * `handle` obtained by
+/// * `response_handle` obtained by
 ///   [`iox2_active_request_loan_slice_uninit()`](crate::iox2_active_request_loan_slice_uninit())
 #[no_mangle]
 pub unsafe extern "C" fn iox2_response_mut_send(response_handle: iox2_response_mut_h) -> c_int {
@@ -349,7 +349,7 @@ pub unsafe extern "C" fn iox2_response_mut_send(response_handle: iox2_response_m
 ///
 /// # Safety
 ///
-/// * `handle` obtained by
+/// * `response_handle` obtained by
 ///   [`iox2_active_request_loan_slice_uninit()`](crate::iox2_active_request_loan_slice_uninit())
 #[no_mangle]
 pub unsafe extern "C" fn iox2_response_mut_drop(response_handle: iox2_response_mut_h) {

--- a/iceoryx2-ffi/ffi/src/api/server.rs
+++ b/iceoryx2-ffi/ffi/src/api/server.rs
@@ -78,9 +78,9 @@ impl iox2_server_t {
 }
 
 pub struct iox2_server_h_t;
-/// The owning handle for `iox2_server_t`. Passing the handle to an function transfers the ownership.
+/// The owning handle for `iox2_server_t`. Passing the handle to a function transfers the ownership.
 pub type iox2_server_h = *mut iox2_server_h_t;
-/// The non-owning handle for `iox2_publisher_t`. Passing the handle to an function does not transfers the ownership.
+/// The non-owning handle for `iox2_server_t`. Passing the handle to a function does not transfer the ownership.
 pub type iox2_server_h_ref = *const iox2_server_h;
 
 impl AssertNonNullHandle for iox2_server_h {
@@ -129,8 +129,8 @@ impl HandleToType for iox2_server_h_ref {
 ///
 /// # Safety
 ///
-/// * `subscriber_handle` is valid, non-null and was obtained via [`iox2_port_factory_server_builder_create`](crate::iox2_port_factory_server_builder_create)
-/// * `id` is valid and non-null
+/// * `handle` is valid, non-null and was obtained via [`iox2_port_factory_server_builder_create`](crate::iox2_port_factory_server_builder_create)
+/// * `id_handle_ptr` is valid and non-null
 #[no_mangle]
 pub unsafe extern "C" fn iox2_server_id(
     handle: iox2_server_h_ref,
@@ -209,7 +209,7 @@ pub unsafe extern "C" fn iox2_server_has_requests(
 /// # Safety
 ///
 /// * `handle` - Must be a valid [`iox2_server_h_ref`]
-///   obtained by [`iox2_port_factory_subscriber_builder_create`](crate::iox2_port_factory_subscriber_builder_create).
+///   obtained by [`iox2_port_factory_server_builder_create`](crate::iox2_port_factory_server_builder_create).
 #[no_mangle]
 pub unsafe extern "C" fn iox2_server_initial_max_slice_len(handle: iox2_server_h_ref) -> c_size_t {
     handle.assert_non_null();
@@ -231,15 +231,15 @@ pub unsafe extern "C" fn iox2_server_initial_max_slice_len(handle: iox2_server_h
 /// * `active_request_struct_ptr` - Must be either a NULL pointer or a pointer to a valid [`iox2_active_request_t`].
 ///   If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `active_request_handle_ptr` - An uninitialized or dangling [`iox2_active_request_h`] handle
-///   which will be initialized by this function call if a sample is obtained, otherwise it will be
+///   which will be initialized by this function call if a request is obtained, otherwise it will be
 ///   set to NULL.
 ///
 /// Returns IOX2_OK on success, an [`iox2_receive_error_e`](crate::iox2_receive_error_e) otherwise.
-/// Attention, an empty server queue is not an error and even with IOX2_OK it is possible to get a NULL in `sample_handle_ptr`.
+/// Attention, an empty server queue is not an error and even with IOX2_OK it is possible to get a NULL in `active_request_handle_ptr`.
 ///
 /// # Safety
 ///
-/// * The `server_handle` is still valid after the return of this function and can be use in another function call.
+/// * The `server_handle` is still valid after the return of this function and can be used in another function call.
 /// * The `active_request_handle_ptr` is pointing to a valid [`iox2_active_request_h`].
 #[no_mangle]
 pub unsafe extern "C" fn iox2_server_receive(
@@ -309,7 +309,7 @@ pub unsafe extern "C" fn iox2_server_receive(
 ///
 /// # Safety
 ///
-/// * The `server_handle` is invalid after the return of this function and leads to undefined behavior if used in another function call!
+/// * The `handle` is invalid after the return of this function and leads to undefined behavior if used in another function call!
 /// * The corresponding [`iox2_server_t`] can be re-used with a call to
 ///   [`iox2_port_factory_subscriber_builder_create`](crate::iox2_port_factory_subscriber_builder_create)!
 #[no_mangle]

--- a/iceoryx2-ffi/ffi/src/api/service_builder.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder.rs
@@ -406,7 +406,7 @@ pub unsafe extern "C" fn iox2_service_builder_pub_sub(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_request_response_h`] obtained by [`iox2_node_service_builder`](crate::iox2_node_service_builder)
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_h`] obtained by [`iox2_node_service_builder`](crate::iox2_node_service_builder)
 ///
 /// Returns a [`iox2_service_builder_request_response_h`] for the request-response service builder
 ///

--- a/iceoryx2-ffi/ffi/src/api/service_builder_request_response.rs
+++ b/iceoryx2-ffi/ffi/src/api/service_builder_request_response.rs
@@ -231,7 +231,7 @@ pub(crate) unsafe fn create_type_details(
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_request_response_h_ref`]
 ///   obtained by [`iox2_service_builder_request_response`](crate::iox2_service_builder_request_response).
 /// * `type_variant` - The [`iox2_type_variant_e`] for the payload
-/// * `type_name_str` - Must string for the type name.
+/// * `type_name_str` - string for the type name.
 /// * `type_name_len` - The length of the type name string, not including a null
 /// * `size` - The size of the payload
 /// * `alignment` - The alignment of the payload
@@ -292,7 +292,7 @@ pub unsafe extern "C" fn iox2_service_builder_request_response_set_request_heade
 /// * `service_builder_handle` - Must be a valid [`iox2_service_builder_request_response_h_ref`]
 ///   obtained by [`iox2_service_builder_request_response`](crate::iox2_service_builder_request_response).
 /// * `type_variant` - The [`iox2_type_variant_e`] for the payload
-/// * `type_name_str` - Must string for the type name.
+/// * `type_name_str` - string for the type name.
 /// * `type_name_len` - The length of the type name string, not including a null
 /// * `size` - The size of the payload
 /// * `alignment` - The alignment of the payload
@@ -508,7 +508,7 @@ pub unsafe extern "C" fn iox2_service_builder_request_response_enable_fire_and_f
     }
 }
 
-/// Enables/disables save overflow for requests
+/// Enables/disables safe overflow for requests
 ///
 /// # Safety
 ///
@@ -546,7 +546,7 @@ pub unsafe extern "C" fn iox2_service_builder_request_response_enable_safe_overf
     }
 }
 
-/// Enables/disables save overflow for responses
+/// Enables/disables safe overflow for responses
 ///
 /// # Safety
 ///
@@ -976,6 +976,7 @@ pub unsafe extern "C" fn iox2_service_builder_request_response_open_or_create(
 ///   obtained by [`iox2_service_builder_request_response`](crate::iox2_service_builder_request_response)
 /// * `port_factory_struct_ptr` - Must be either a NULL pointer or a pointer to a valid
 ///   [`iox2_port_factory_request_response_t`]. If it is a NULL pointer, the storage will be allocated on the heap.
+/// * `attribute_verifier_handle` - An initialized valid handle to an [`iox2_attribute_verifier_h_ref`].
 /// * `port_factory_handle_ptr` - An uninitialized or dangling [`iox2_port_factory_request_response_h`] handle which will be initialized by this function call.
 ///
 /// Returns IOX2_OK on success, an [`iox2_request_response_open_or_create_error_e`] otherwise.
@@ -1046,6 +1047,7 @@ pub unsafe extern "C" fn iox2_service_builder_request_response_open(
 ///   obtained by [`iox2_service_builder_request_response`](crate::iox2_service_builder_request_response)
 /// * `port_factory_struct_ptr` - Must be either a NULL pointer or a pointer to a valid
 ///   [`iox2_port_factory_request_response_t`]. If it is a NULL pointer, the storage will be allocated on the heap.
+/// * `attribute_verifier_handle` - An initialized valid handle to an [`iox2_attribute_verifier_h_ref`].
 /// * `port_factory_handle_ptr` - An uninitialized or dangling [`iox2_port_factory_request_response_h`] handle which will be initialized by this function call.
 ///
 /// Returns IOX2_OK on success, an [`iox2_request_response_open_or_create_error_e`] otherwise. Note, only the errors annotated with `O_` are relevant.
@@ -1116,6 +1118,7 @@ pub unsafe extern "C" fn iox2_service_builder_request_response_create(
 ///   obtained by [`iox2_service_builder_request_response`](crate::iox2_service_builder_request_response)
 /// * `port_factory_struct_ptr` - Must be either a NULL pointer or a pointer to a valid
 ///   [`iox2_port_factory_request_response_t`]. If it is a NULL pointer, the storage will be allocated on the heap.
+/// * `attribute_specifier_handle` - An initialized valid handle to an [`iox2_attribute_specifier_h_ref`].
 /// * `port_factory_handle_ptr` - An uninitialized or dangling [`iox2_port_factory_request_response_h`] handle which will be initialized by this function call.
 ///
 /// Returns IOX2_OK on success, an [`iox2_request_response_open_or_create_error_e`] otherwise. Note, only the errors annotated with `C_` are relevant.
@@ -1125,7 +1128,7 @@ pub unsafe extern "C" fn iox2_service_builder_request_response_create(
 /// * The `service_builder_handle` is invalid after the return of this function and leads to undefined behavior if used in another function call!
 /// * The corresponding [`iox2_service_builder_t`](crate::iox2_service_builder_t) can be re-used with
 ///   a call to [`iox2_node_service_builder`](crate::iox2_node_service_builder)!
-/// * The `attribute_verifier_handle` must be valid.
+/// * The `attribute_specifier_handle` must be valid.
 #[no_mangle]
 pub unsafe extern "C" fn iox2_service_builder_request_response_create_with_attributes(
     service_builder_handle: iox2_service_builder_request_response_h,


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #689 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
