### PR TITLE
[#739] Fix flaky windows test

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -84,6 +84,8 @@
     [#682](https://github.com/eclipse-iceoryx/iceoryx2/issues/682)
 * Do not set default log level for cargo
     [#711](https://github.com/eclipse-iceoryx/iceoryx2/issues/711)
+* Fix flaky windows test
+    [#739](https://github.com/eclipse-iceoryx/iceoryx2/issues/739)
 
 ### Refactoring
 

--- a/iceoryx2/tests/service_tests.rs
+++ b/iceoryx2/tests/service_tests.rs
@@ -263,7 +263,8 @@ mod service {
                 any_of([
                     RequestResponseCreateError::AlreadyExists,
                     RequestResponseCreateError::IsBeingCreatedByAnotherInstance,
-                    RequestResponseCreateError::HangsInCreation
+                    RequestResponseCreateError::HangsInCreation,
+                    RequestResponseCreateError::ServiceInCorruptedState
                 ])
             );
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #739 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
