### PR TITLE
[#794] filter out self delivery

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -13,7 +13,7 @@
 
 * All port factories implement `Send`
   [#768](https://github.com/eclipse-iceoryx/iceoryx2/issues/768)
-* `iox2 service listen` and `iox2_service notify`
+* `iox2 service listen` and `iox2 service notify`
   [#790](https://github.com/eclipse-iceoryx/iceoryx2/issues/790)
 
 ### Bugfixes
@@ -64,7 +64,8 @@
     conflicts when merging.
 -->
 
-* Example text [#1](https://github.com/eclipse-iceoryx/iceoryx2/issues/1)
+* Add API to prevent self notification `Notifier::__internal_notify()`
+  [#794](https://github.com/eclipse-iceoryx/iceoryx2/issues/794)
 
 ### API Breaking Changes
 

--- a/iceoryx2/src/port/notifier.rs
+++ b/iceoryx2/src/port/notifier.rs
@@ -391,6 +391,15 @@ impl<Service: service::Service> Notifier<Service> {
         self.__internal_notify(value, false)
     }
 
+    /// Notifies all [`crate::port::listener::Listener`] connected to the service with a custom
+    /// [`EventId`].
+    /// On success the number of
+    /// [`crate::port::listener::Listener`]s that were notified otherwise it returns
+    /// [`NotifierNotifyError`].
+    ///
+    /// When `skip_self_deliver` is set to true the [`Notifier`] will only notify
+    /// [`crate::port::listener::Listener`]s that were NOT created by the same node (have the same
+    /// [`crate::node::NodeId`])
     #[doc(hidden)]
     pub fn __internal_notify(
         &self,

--- a/iceoryx2/src/port/notifier.rs
+++ b/iceoryx2/src/port/notifier.rs
@@ -420,7 +420,7 @@ impl<Service: service::Service> Notifier<Service> {
 
         for i in 0..self.listener_connections.len() {
             if let Some(ref connection) = self.listener_connections.get(i) {
-                if !skip_self_deliver || (skip_self_deliver && connection.node_id != self.node_id) {
+                if !(skip_self_deliver && connection.node_id == self.node_id) {
                     match connection.notifier.notify(value) {
                         Err(iceoryx2_cal::event::NotifierNotifyError::Disconnected) => {
                             self.listener_connections.remove(i);


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #794 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
