### PR TITLE
[#822] Introduce newtypes for 'uid' and 'gid'

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -62,6 +62,8 @@
 * Add `recommended::Ipc` and `recommended::Local` to iceoryx2 concepts for
   to provide link the best implementation for the specific platform
   [#806](https://github.com/eclipse-iceoryx/iceoryx2/issues/806)
+* Introduce newtypes for 'uid' and 'gid'
+  [#822](https://github.com/eclipse-iceoryx/iceoryx2/issues/822)
 
 ### Workflow
 

--- a/iceoryx2-bb/posix/src/file_descriptor.rs
+++ b/iceoryx2-bb/posix/src/file_descriptor.rs
@@ -71,9 +71,11 @@ use core::fmt::Debug;
 
 use crate::config::EINTR_REPETITIONS;
 use crate::file::*;
+use crate::group::Gid;
 use crate::metadata::Metadata;
 use crate::ownership::*;
 use crate::permission::{Permission, PermissionExt};
+use crate::user::Uid;
 use iceoryx2_bb_log::{error, fail, fatal_panic};
 use iceoryx2_pal_posix::posix::errno::Errno;
 use iceoryx2_pal_posix::*;
@@ -252,8 +254,8 @@ pub trait FileDescriptorManagement: FileDescriptorBased + Debug + Sized {
         let attr =
             fail!(from self, when File::acquire_attributes(self), "Unable to read file owner.");
         Ok(OwnershipBuilder::new()
-            .uid(attr.st_uid)
-            .gid(attr.st_gid)
+            .uid(Uid::new_from_native(attr.st_uid))
+            .gid(Gid::new_from_native(attr.st_gid))
             .create())
     }
 

--- a/iceoryx2-bb/posix/src/metadata.rs
+++ b/iceoryx2-bb/posix/src/metadata.rs
@@ -17,7 +17,9 @@
 
 use crate::clock::{ClockType, Time, TimeBuilder};
 use crate::file_type::FileType;
+use crate::group::Gid;
 use crate::permission::{Permission, PermissionExt};
+use crate::user::Uid;
 use iceoryx2_pal_posix::*;
 
 /// Contains all informations like type, credentials, size, access times about every
@@ -27,8 +29,8 @@ use iceoryx2_pal_posix::*;
 #[derive(Debug)]
 pub struct Metadata {
     file_type: FileType,
-    uid: u32,
-    gid: u32,
+    uid: Uid,
+    gid: Gid,
     size: u64,
     block_size: u64,
     permission: Permission,
@@ -75,12 +77,12 @@ impl Metadata {
     }
 
     /// returns the user id (uid) of the files owner
-    pub fn uid(&self) -> u32 {
+    pub fn uid(&self) -> Uid {
         self.uid
     }
 
     /// returns the group id (gid) of the files owner
-    pub fn gid(&self) -> u32 {
+    pub fn gid(&self) -> Gid {
         self.gid
     }
 
@@ -103,8 +105,8 @@ impl Metadata {
                 .create(),
             permission: attr.st_mode.as_permission(),
             file_type: FileType::from_mode_t(attr.st_mode),
-            uid: attr.st_uid,
-            gid: attr.st_gid,
+            uid: Uid::new_from_native(attr.st_uid),
+            gid: Gid::new_from_native(attr.st_gid),
         }
     }
 }

--- a/iceoryx2-bb/posix/src/ownership.rs
+++ b/iceoryx2-bb/posix/src/ownership.rs
@@ -27,48 +27,56 @@
 //! println!("The uid/gid of root/root is: {}/{}", ownership.uid(), ownership.gid());
 //! ```
 
+use crate::group::Gid;
+use crate::user::Uid;
+
 /// Defines the owner in a unix environment consisting of user and group.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Ownership {
-    uid: u32,
-    gid: u32,
+    uid: Uid,
+    gid: Gid,
 }
 
 /// The builder to the [`Ownership`] struct.
 /// One can use [`crate::user::User`] and [`crate::group::Group`] to acquire the ids quickly from
 /// the names.
-pub struct OwnershipBuilder {
-    ownership: Ownership,
-}
+pub struct OwnershipBuilder {}
 
 impl Default for OwnershipBuilder {
     fn default() -> Self {
-        OwnershipBuilder {
-            ownership: Ownership {
-                uid: u32::MAX,
-                gid: u32::MAX,
-            },
+        Self::new()
+    }
+}
+
+pub struct OwnershipBuilderWithUid {
+    uid: Uid,
+}
+
+pub struct OwnershipBuilderWithUidAndGid {
+    ownership: Ownership,
+}
+
+impl OwnershipBuilder {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Sets the user id
+    pub fn uid(self, uid: Uid) -> OwnershipBuilderWithUid {
+        OwnershipBuilderWithUid { uid }
+    }
+}
+
+impl OwnershipBuilderWithUid {
+    /// Sets the group id
+    pub fn gid(self, gid: Gid) -> OwnershipBuilderWithUidAndGid {
+        OwnershipBuilderWithUidAndGid {
+            ownership: Ownership { uid: self.uid, gid },
         }
     }
 }
 
-impl OwnershipBuilder {
-    pub fn new() -> OwnershipBuilder {
-        Self::default()
-    }
-
-    /// Sets the user id
-    pub fn uid(mut self, uid: u32) -> Self {
-        self.ownership.uid = uid;
-        self
-    }
-
-    /// Sets the group id
-    pub fn gid(mut self, gid: u32) -> Self {
-        self.ownership.gid = gid;
-        self
-    }
-
+impl OwnershipBuilderWithUidAndGid {
     pub fn create(self) -> Ownership {
         self.ownership
     }
@@ -76,12 +84,12 @@ impl OwnershipBuilder {
 
 impl Ownership {
     /// returns the user id
-    pub fn uid(&self) -> u32 {
+    pub fn uid(&self) -> Uid {
         self.uid
     }
 
     /// returns the group id
-    pub fn gid(&self) -> u32 {
+    pub fn gid(&self) -> Gid {
         self.gid
     }
 }

--- a/iceoryx2-bb/posix/tests/group_tests.rs
+++ b/iceoryx2-bb/posix/tests/group_tests.rs
@@ -31,10 +31,10 @@ fn group_works() {
         unreachable!("Neither group 'root' not group 'wheel' is found!")
     };
 
-    let group_from_gid = Group::from_gid(0).unwrap();
+    let group_from_gid = Group::from_gid(Gid::new_from_native(0)).unwrap();
 
     assert_that!(group_from_name.gid(), eq group_from_gid.gid());
-    assert_that!(group_from_name.gid(), eq 0);
+    assert_that!(group_from_name.gid().value(), eq 0);
 
     let group_details = group_from_name.details().unwrap();
     let group_from_gid_details = group_from_gid.details().unwrap();
@@ -58,8 +58,8 @@ fn group_as_works() {
         .as_group()
         .unwrap();
 
-    assert_that!(root_2.gid(), eq 0);
-    assert_that!(root_3.gid(), eq 0);
+    assert_that!(root_2.gid().value(), eq 0);
+    assert_that!(root_3.gid().value(), eq 0);
 
     assert_that!(root_1.details().unwrap().members().len(), ge 0);
 }

--- a/iceoryx2-bb/posix/tests/ownership_tests.rs
+++ b/iceoryx2-bb/posix/tests/ownership_tests.rs
@@ -20,16 +20,6 @@ use iceoryx2_bb_testing::test_requires;
 use iceoryx2_pal_posix::posix::POSIX_SUPPORT_USERS_AND_GROUPS;
 
 #[test]
-fn ownership_builder_defaults_are_correct() {
-    test_requires!(POSIX_SUPPORT_USERS_AND_GROUPS);
-
-    let ownership = OwnershipBuilder::new().create();
-
-    assert_that!(ownership.uid(), eq u32::MAX);
-    assert_that!(ownership.gid(), eq u32::MAX);
-}
-
-#[test]
 fn ownership_builder_works() {
     test_requires!(POSIX_SUPPORT_USERS_AND_GROUPS);
 
@@ -49,6 +39,6 @@ fn ownership_builder_works() {
         .gid(group.gid())
         .create();
 
-    assert_that!(ownership.uid(), eq 0);
-    assert_that!(ownership.gid(), eq 0);
+    assert_that!(ownership.uid().value(), eq 0);
+    assert_that!(ownership.gid().value(), eq 0);
 }

--- a/iceoryx2-bb/posix/tests/socket_ancillary_tests.rs
+++ b/iceoryx2-bb/posix/tests/socket_ancillary_tests.rs
@@ -15,9 +15,11 @@ use iceoryx2_bb_elementary::unique_id::*;
 use iceoryx2_bb_posix::config;
 use iceoryx2_bb_posix::file::*;
 use iceoryx2_bb_posix::file_descriptor::*;
+use iceoryx2_bb_posix::group::Gid;
 use iceoryx2_bb_posix::process::ProcessId;
 use iceoryx2_bb_posix::socket_ancillary::*;
 use iceoryx2_bb_posix::testing::create_test_directory;
+use iceoryx2_bb_posix::user::Uid;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
 use iceoryx2_bb_testing::assert_that;
@@ -77,16 +79,16 @@ fn socket_ancillary_credentials_work() {
 
     let mut credentials = SocketCred::new();
     credentials.set_pid(ProcessId::new(123));
-    credentials.set_uid(456);
-    credentials.set_gid(789);
+    credentials.set_uid(Uid::new_from_native(456));
+    credentials.set_gid(Gid::new_from_native(789));
     sut.set_creds(&credentials);
     assert_that!(sut.get_creds(), eq Some(credentials));
     assert_that!(sut.is_full(), eq false);
     assert_that!(sut, is_not_empty);
 
     credentials.set_pid(ProcessId::new(999));
-    credentials.set_uid(888);
-    credentials.set_gid(777);
+    credentials.set_uid(Uid::new_from_native(888));
+    credentials.set_gid(Gid::new_from_native(777));
     sut.set_creds(&credentials);
     assert_that!(sut.get_creds(), eq Some(credentials));
     assert_that!(sut.is_full(), eq false);

--- a/iceoryx2-bb/posix/tests/users_tests.rs
+++ b/iceoryx2-bb/posix/tests/users_tests.rs
@@ -21,16 +21,16 @@ fn user_works() {
     test_requires!(POSIX_SUPPORT_USERS_AND_GROUPS);
 
     let root = User::from_name(&UserName::new(b"root").unwrap()).unwrap();
-    let root_from_uid = User::from_uid(0).unwrap();
+    let root_from_uid = User::from_uid(Uid::new_from_native(0)).unwrap();
 
     assert_that!(root.uid(), eq root_from_uid.uid());
-    assert_that!(root.uid(), eq 0);
+    assert_that!(root.uid().value(), eq 0);
 
     let root_details = root.details().unwrap();
     let root_from_uid_details = root_from_uid.details().unwrap();
 
     assert_that!(root_details.gid(), eq root_from_uid_details.gid());
-    assert_that!(root_details.gid(), eq 0);
+    assert_that!(root_details.gid().value(), eq 0);
 
     assert_that!(root_details.name(), eq root_from_uid_details.name());
     assert_that!(root_details.name().as_bytes(), eq b"root");


### PR DESCRIPTION
## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

On some platforms the `uid_t` and `gid_t` differ from `u32`. Using a simple `into()` and `try_into()` will lead to clippy warnings.

This PR introduces newtypes for `uid` and `gid`

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #822

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
