### PR TITLE
Fix build and linker error on linux with gcc 8 and 9

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -141,12 +141,12 @@ bazel_skylib_workspace()
 
 
 # Load iceoryx rules
-ICEORYX_VERSION = "2.95.5"
+ICEORYX_VERSION = "2.95.6"
 
 maybe(
     name = "iceoryx",
     repo_rule = http_archive,
-    sha256 = "b68d0603ca39a852db5d12d8e83b0c7b560acdbe8d4cbcdfca1a07ada433bdd5",
+    sha256 = "745927c5e5e034cd840c1a18dff217818c042507b814d7bf001bcc61bcf5281b",
     strip_prefix = "iceoryx-{}".format(ICEORYX_VERSION),
     url = "https://github.com/eclipse-iceoryx/iceoryx/archive/v{}.tar.gz".format(ICEORYX_VERSION),
 )

--- a/doc/bazel/README.md
+++ b/doc/bazel/README.md
@@ -22,7 +22,7 @@ http_archive(
 
 
 # Load iceoryx rules
-ICEORYX_VERSION = "2.95.5"
+ICEORYX_VERSION = "2.95.6"
 
 maybe(
     name = "iceoryx",

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -63,6 +63,8 @@
     [#875](https://github.com/eclipse-iceoryx/iceoryx2/issues/875)
 * Make `update_connections` public for all ports
     [#923](https://github.com/eclipse-iceoryx/iceoryx2/issues/923)
+* Fix linker error on linux
+    [#855](https://github.com/eclipse-iceoryx/iceoryx2/issues/855)
 
 ### Refactoring
 

--- a/iceoryx2-ffi/c/CMakeLists.txt
+++ b/iceoryx2-ffi/c/CMakeLists.txt
@@ -147,6 +147,7 @@ target_link_libraries(static-lib INTERFACE
     $<$<AND:$<PLATFORM_ID:Windows>,$<OR:$<C_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:MSVC>>>:bcrypt synchronization>
     $<$<PLATFORM_ID:Darwin>:stdc++>
     $<$<PLATFORM_ID:FreeBSD>:rt util>
+    $<$<PLATFORM_ID:Linux>:dl rt>
 )
 target_link_libraries(shared-lib INTERFACE
     iceoryx2-c::includes-only

--- a/iceoryx2-ffi/cxx/CMakeLists.txt
+++ b/iceoryx2-ffi/cxx/CMakeLists.txt
@@ -12,7 +12,7 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-set(ICEORYX_HOOFS_VERSION 2.95.5)
+set(ICEORYX_HOOFS_VERSION 2.95.6)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/fetch-iceoryx-hoofs.cmake)
 
 project(iceoryx2-cxx VERSION ${IOX2_VERSION_STRING} LANGUAGES CXX)

--- a/iceoryx2-ffi/cxx/README.md
+++ b/iceoryx2-ffi/cxx/README.md
@@ -38,7 +38,7 @@ specify the path to the install directory with `-DCMAKE_PREFIX_PATH`.
 `iceoryx_hoofs` can be build with this steps:
 
 ```bash
-git clone --depth 1 --branch v2.95.5 https://github.com/eclipse-iceoryx/iceoryx.git target/iceoryx/src
+git clone --depth 1 --branch v2.95.6 https://github.com/eclipse-iceoryx/iceoryx.git target/iceoryx/src
 
 cmake -S target/iceoryx/src/iceoryx_platform -B target/iceoryx/build/platform -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=target/iceoryx/install
 cmake --build target/iceoryx/build/platform

--- a/internal/scripts/ci_build_and_install_iceoryx_hoofs.ps1
+++ b/internal/scripts/ci_build_and_install_iceoryx_hoofs.ps1
@@ -21,7 +21,7 @@ $ErrorActionPreference = "Stop"
 
 $NUM_JOBS = (Get-WmiObject Win32_processor).NumberOfLogicalProcessors
 
-git clone --depth 1 --branch v2.95.5 https://github.com/eclipse-iceoryx/iceoryx.git target/iceoryx/src
+git clone --depth 1 --branch v2.95.6 https://github.com/eclipse-iceoryx/iceoryx.git target/iceoryx/src
 
 switch ($mode) {
     "release" {

--- a/internal/scripts/ci_build_and_install_iceoryx_hoofs.sh
+++ b/internal/scripts/ci_build_and_install_iceoryx_hoofs.sh
@@ -26,7 +26,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     NUM_JOBS=$(sysctl -n hw.ncpu)
 fi
 
-git clone --depth 1 --branch v2.95.5 https://github.com/eclipse-iceoryx/iceoryx.git target/iceoryx/src
+git clone --depth 1 --branch v2.95.6 https://github.com/eclipse-iceoryx/iceoryx.git target/iceoryx/src
 
 cmake -S target/iceoryx/src/iceoryx_platform -B target/iceoryx/build/platform -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=target/iceoryx/install
 cmake --build target/iceoryx/build/platform -j$NUM_JOBS

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,7 @@
     <url type="bugtracker">https://github.com/eclipse-iceoryx/iceoryx2/issues</url>
     <url type="repository">https://github.com/eclipse-iceoryx/iceoryx2</url>
     <buildtool_depend>cmake</buildtool_depend>
-    <depend version_gte="2.95.5">iceoryx_hoofs</depend>
+    <depend version_gte="2.95.6">iceoryx_hoofs</depend>
     <export>
         <build_type>cmake</build_type>
     </export>


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This only adds `dl` and `rt` explicitly to target_link_libraries to resolve linking errors in linux with older toolchains.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

Closes #855 
<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->


<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
