### PR TITLE
Fix miri for base_string as_bytes API

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -55,6 +55,8 @@
     [#799](https://github.com/eclipse-iceoryx/iceoryx2/issues/799)
 * CMake no longer installs unusable binaries when FetchContent is used
     [#814](https://github.com/eclipse-iceoryx/iceoryx2/issues/814)
+* Miri complains about byte_string as_bytes* operations
+    [#875](https://github.com/eclipse-iceoryx/iceoryx2/issues/875)
 
 ### Refactoring
 

--- a/iceoryx2-bb/container/src/byte_string.rs
+++ b/iceoryx2-bb/container/src/byte_string.rs
@@ -399,22 +399,22 @@ impl<const CAPACITY: usize> FixedSizeByteString<CAPACITY> {
 
     /// Returns a slice to the underlying bytes
     pub const fn as_bytes(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.data[0].as_ptr(), self.len) }
+        unsafe { core::slice::from_raw_parts(self.data.as_ptr() as *const u8, self.len) }
     }
 
     /// Returns a null-terminated slice to the underlying bytes
     pub const fn as_bytes_with_nul(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.data[0].as_ptr(), self.len + 1) }
+        unsafe { core::slice::from_raw_parts(self.data.as_ptr() as *const u8, self.len + 1) }
     }
 
     /// Returns a zero terminated slice of the underlying bytes
     pub const fn as_c_str(&self) -> *const core::ffi::c_char {
-        self.data[0].as_ptr() as *const core::ffi::c_char
+        self.data.as_ptr() as *const core::ffi::c_char
     }
 
     /// Returns a mutable slice to the underlying bytes
     pub fn as_mut_bytes(&mut self) -> &mut [u8] {
-        unsafe { core::slice::from_raw_parts_mut(self.data[0].as_mut_ptr(), self.len) }
+        unsafe { core::slice::from_raw_parts_mut(self.data.as_mut_ptr() as *mut u8, self.len) }
     }
 
     /// Returns the content as a string slice if the bytes are valid UTF-8


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #875 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
