### PR TITLE
[#883] Redirect all log output to stderr

### DIFF
--- a/iceoryx2-bb/log/src/logger/console.rs
+++ b/iceoryx2-bb/log/src/logger/console.rs
@@ -105,10 +105,10 @@ impl Logger {
 
     fn print(separator: &str, color: &str, output: &str) {
         if std::io::stderr().is_terminal() {
-            std::print!("{color}");
+            std::eprint!("{color}");
         }
 
-        std::print!("{separator}{output}");
+        std::eprint!("{separator}{output}");
 
         if std::io::stderr().is_terminal() {
             std::eprintln!("\x1b[0m");
@@ -122,7 +122,7 @@ impl Logger {
     }
 
     fn print_origin(log_level: crate::LogLevel, origin: &str) {
-        print!("{} ", Logger::log_level_string(log_level));
+        eprint!("{} ", Logger::log_level_string(log_level));
         Self::print("", Logger::origin_color(log_level), origin);
     }
 }
@@ -147,7 +147,7 @@ impl crate::Log for Logger {
 
                 match origin_str.is_empty() {
                     false => {
-                        std::print!(
+                        std::eprint!(
                             "{}{}.{:0>9} ",
                             Logger::counter_color(log_level),
                             time.as_secs(),
@@ -166,10 +166,10 @@ impl crate::Log for Logger {
             }
             ConsoleLogOrder::Counter => match origin.to_string().is_empty() {
                 false => {
-                    std::print!("{}{} ", Logger::counter_color(log_level), counter);
+                    std::eprint!("{}{} ", Logger::counter_color(log_level), counter);
                     Self::print_origin(log_level, &origin_str);
                 }
-                true => std::print!(
+                true => std::eprint!(
                     "{}{:9} {} ",
                     Logger::counter_color(log_level),
                     counter,


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

With #885 not every part of the log message was redirected to stderr but some were still printed to stdout. This PR redirects all parts of the log message to stderr.

No entry in the changelog since this feature was not yet released.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #883 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
