### PR TITLE
[#908] Remove Drop restriction from ZeroCopySend

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -115,6 +115,8 @@
   [#794](https://github.com/eclipse-iceoryx/iceoryx2/issues/794)
 * Enable the usage of semaphore based events in C/C++
   [#795](https://github.com/eclipse-iceoryx/iceoryx2/issues/795)
+* Remove `impl Drop` restriction from `ZeroCopySend` trait
+  [#908](https://github.com/eclipse-iceoryx/iceoryx2/issues/908)
 
 ### Config Breaking Changes
 

--- a/iceoryx2-bb/elementary-traits/src/zero_copy_send.rs
+++ b/iceoryx2-bb/elementary-traits/src/zero_copy_send.rs
@@ -30,10 +30,9 @@ use iceoryx2_pal_concurrency_sync::iox_atomic::*;
 ///       * a list must be implemented using indices to structure itself
 ///  * the types must have a uniform memory representation, meaning they are annotated with
 ///    `#[repr(C)]`.
-///  * the types and their members do not implement `Drop` explicitly.
 ///
 pub unsafe trait ZeroCopySend {
-    /// The unique identifier of the type. It shall be used to identify a specific type accross
+    /// The unique identifier of the type. It shall be used to identify a specific type across
     /// processes and languages.
     ///
     /// # Safety


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer

Removed restriction on `impl Drop` from `ZeroCopySend` trait.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #908 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
