### PR TITLE
[#936] CMake build for cxx container library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,17 @@ if(WARNING_AS_ERROR)
     endif()
 endif()
 
+if(BUILD_TESTING)
+    enable_testing()
+endif()
+
 if(SANITIZERS)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fsanitize=undefined")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=undefined")
 endif()
+
+# C++ containers
+add_subdirectory(iceoryx2-bb/cxx)
 
 # C binding
 add_subdirectory(iceoryx2-ffi/c)

--- a/iceoryx2-bb/cxx/CMakeLists.txt
+++ b/iceoryx2-bb/cxx/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+cmake_minimum_required(VERSION 3.22)
+
+project(iceoryx2-bb VERSION ${IOX2_VERSION_STRING} LANGUAGES CXX)
+
+set(PREFIX iceoryx2/v${CMAKE_PROJECT_VERSION})
+
+# include only lib -> includes are installed only once despite being used in static lib as well as shared lib
+
+add_library(iceoryx2-bb-containers INTERFACE)
+add_library(iceoryx2-cxx::iceoryx2-bb-containers ALIAS iceoryx2-bb-containers)
+
+target_include_directories(iceoryx2-bb-containers
+    INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PREFIX}>
+)
+
+target_compile_features(iceoryx2-bb-containers INTERFACE cxx_std_14)
+
+# include install setup
+# @todo
+
+# add tests
+
+if(${BUILD_TESTING})
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/iceoryx2-bb/cxx/tests/CMakeLists.txt
+++ b/iceoryx2-bb/cxx/tests/CMakeLists.txt
@@ -12,21 +12,23 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-project(iceoryx2-cxx-tests VERSION ${IOX2_VERSION_STRING} LANGUAGES CXX)
+project(iceoryx2-bb-cxx-tests VERSION ${IOX2_VERSION_STRING} LANGUAGES CXX)
 
 include(cmake/googletest.cmake)
 
 find_package(iceoryx2-cxx REQUIRED)
 
-file(GLOB TEST_FILES src/*.cpp)
+add_executable(iceoryx2-bb-containers-tests ${TEST_FILES})
+target_sources(iceoryx2-bb-containers-tests
+    PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/main.cpp
+)
 
-add_executable(${PROJECT_NAME} ${TEST_FILES})
+target_link_libraries(iceoryx2-bb-containers-tests iceoryx2-cxx::iceoryx2-bb-containers GTest::gtest GTest::gmock)
+target_compile_options(iceoryx2-bb-containers-tests PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
+target_compile_features(iceoryx2-bb-containers-tests PRIVATE cxx_std_14)
 
-target_link_libraries(${PROJECT_NAME} iceoryx2-cxx::static-lib-cxx GTest::gtest GTest::gmock)
-target_compile_options(${PROJECT_NAME} PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/bigobj>)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-
-set_target_properties(${PROJECT_NAME} PROPERTIES
+set_target_properties(iceoryx2-bb-containers-tests PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests"
     RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/tests"
     RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/tests"
@@ -34,4 +36,4 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/tests"
 )
 
-add_test(NAME "iceoryx2 C++ FFI Tests" COMMAND ${PROJECT_NAME})
+add_test(NAME "iceoryx2 C++ BB Container Tests" COMMAND iceoryx2-bb-containers-tests)

--- a/iceoryx2-bb/cxx/tests/cmake/googletest.cmake
+++ b/iceoryx2-bb/cxx/tests/cmake/googletest.cmake
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+include(FetchContent)
+
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.14.0
+    EXCLUDE_FROM_ALL
+)
+
+FetchContent_GetProperties(googletest)
+if(NOT googletest_POPULATED)
+    message(STATUS "googletest not found! Using FetchContent!")
+endif()
+FetchContent_MakeAvailable(googletest)

--- a/iceoryx2-bb/cxx/tests/src/main.cpp
+++ b/iceoryx2-bb/cxx/tests/src/main.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#include <gtest/gtest.h>
+
+auto main(int argc, char* argv[]) -> int {
+    ::testing::InitGoogleTest(&argc, argv);
+
+    return RUN_ALL_TESTS();
+}

--- a/iceoryx2-ffi/cxx/CMakeLists.txt
+++ b/iceoryx2-ffi/cxx/CMakeLists.txt
@@ -100,10 +100,9 @@ target_link_libraries(iceoryx2-cxx-object-lib
 add_library(static-lib-cxx STATIC $<TARGET_OBJECTS:iceoryx2-cxx-object-lib>)
 add_library(iceoryx2-cxx::static-lib-cxx ALIAS static-lib-cxx)
 
+target_compile_features(static-lib-cxx PUBLIC cxx_std_17)
 set_target_properties(static-lib-cxx
     PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
     OUTPUT_NAME "iceoryx2_cxx"
 )
@@ -120,10 +119,9 @@ target_link_libraries(static-lib-cxx
 add_library(shared-lib-cxx SHARED $<TARGET_OBJECTS:iceoryx2-cxx-object-lib>)
 add_library(iceoryx2-cxx::shared-lib-cxx ALIAS shared-lib-cxx)
 
+target_compile_features(shared-lib-cxx PUBLIC cxx_std_17)
 set_target_properties(shared-lib-cxx
     PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
     POSITION_INDEPENDENT_CODE ON
     OUTPUT_NAME "iceoryx2_cxx"
 )
@@ -141,6 +139,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/install.cmake)
 
 # add tests
 
-if(${BUILD_TESTING})
+if(BUILD_TESTING)
+    enable_testing()
     add_subdirectory(tests)
 endif()


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
This sets up the CMake build infrastructure for the C++ container library. Other build systems are still missing at the moment.

I also added CTest support for the ffi unit tests with this, as that only required a couple of lines of code, and I changed the method for setting the C++ standard version to use the more robust `target_compile_features`. There is further potential for cleaning up these scripts if we decide to bump the minimum required version in the future:

- 3.23 introduces file sets for `target_sources`
- 3.24 introduces the `COMPILE_WARNING_AS_ERROR` target property

There is some duplication necessary, most visible in the duplicated `googletest.cmake` file. This is due to the fact that iceoryx currently maintains ffi and its tests as a self-contained CMake projects. According to @elfenpiff this is intentional and should be supported going forward. As a consequence, supporting scripts like `googletest.cmake` have either be duplicated or placed outside the source tree of the project. Both of these are not ideal, but given the alternatives I find the former to be far more preferable, so I went with this approach here. Any input on the issue is highly appreciated.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [ ] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [ ] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [ ] Commits messages are according to this [guideline][commit-guidelines]
    * [ ] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [ ] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [ ] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [ ] Assign PR to reviewer
* [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [ ] Commits are properly organized and messages are according to the guideline
* [ ] Unit tests have been written for new behavior
* [ ] Public API is documented
* [ ] PR title describes the changes

## Post-review Checklist for the PR Author

* [ ] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #936 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
