### PR TITLE
[#4] Update faq

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -149,6 +149,33 @@ has something to read. If you do not handle all notifications, for example, with
 `Listener::try_wait_one()`, the WaitSet will wake up immediately again,
 potentially causing an infinite loop and resulting in 100% CPU usage.
 
+## `SIGBUS` Error
+
+This error is usually caused by insufficient memory. When iceoryx2 allocates
+shared memory, the operating system can overcommit by allocating more memory
+than is physically available. As soon as the process actually accesses this
+overcommitted memory, a `SIGBUS` signal is raised. This can occur with both
+fixed-size and dynamic messages such as slices.
+
+When using dynamic messages, the error may appear later, once your data size
+grows and iceoryx2 needs to reallocate memory. For this reason, you should
+avoid relying on dynamic memory in critical systems.
+
+### Check
+
+You can check how much memory iceoryx2 is currently using by inspecting the
+shared memory objects in /dev/shm:
+
+```sh
+du -sh /dev/shm
+```
+
+### Docker
+
+By default, a Docker container has a shared memory size of 64 MB. This can be
+exceeded quickly, since iceoryx2 always pre-allocates memory for the worst-case
+scenario.
+
 ## Does iceoryx2 Offer an Async API?
 
 No, but it is

--- a/FAQ.md
+++ b/FAQ.md
@@ -176,6 +176,9 @@ By default, a Docker container has a shared memory size of 64 MB. This can be
 exceeded quickly, since iceoryx2 always pre-allocates memory for the worst-case
 scenario.
 
+The shared memory size can be adjusted with the `--shm-size=` parameter, see:
+[https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)
+
 ## Does iceoryx2 Offer an Async API?
 
 No, but it is


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #4 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
