### PR TITLE
[#1099] Add string memory layout component test

### DIFF
--- a/iceoryx2-bb/container/src/string/static_string.rs
+++ b/iceoryx2-bb/container/src/string/static_string.rs
@@ -364,3 +364,39 @@ impl<const CAPACITY: usize> String for StaticString<CAPACITY> {
         self.len as usize
     }
 }
+
+#[allow(missing_docs)]
+pub struct StringMemoryLayoutMetrics {
+    pub string_size: usize,
+    pub string_alignment: usize,
+    pub size_data: usize,
+    pub offset_data: usize,
+    pub size_len: usize,
+    pub offset_len: usize,
+    pub len_is_unsigned: bool,
+}
+
+trait _StringMemoryLayoutFieldLenInspection {
+    fn is_unsigned(&self) -> bool;
+}
+
+impl _StringMemoryLayoutFieldLenInspection for u64 {
+    fn is_unsigned(&self) -> bool {
+        true
+    }
+}
+
+impl StringMemoryLayoutMetrics {
+    #[allow(missing_docs)]
+    pub fn from_string<const CAPACITY: usize>(v: &StaticString<CAPACITY>) -> Self {
+        StringMemoryLayoutMetrics {
+            string_size: core::mem::size_of_val(v),
+            string_alignment: core::mem::align_of_val(v),
+            size_data: core::mem::size_of_val(&v.data) + core::mem::size_of_val(&v.terminator),
+            offset_data: core::mem::offset_of!(StaticString<CAPACITY>, data),
+            size_len: core::mem::size_of_val(&v.len),
+            offset_len: core::mem::offset_of!(StaticString<CAPACITY>, len),
+            len_is_unsigned: v.len.is_unsigned(),
+        }
+    }
+}

--- a/iceoryx2-bb/cxx/include/iox2/container/static_string.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/container/static_string.hpp
@@ -450,6 +450,30 @@ class StaticString {
         return !(lhs == rhs);
     }
 
+    /// Obtains metrics about the internal memory layout of the vector.
+    /// This function is intended for internal use only.
+    constexpr auto static_memory_layout_metrics() noexcept {
+        struct StringMemoryLayoutMetrics {
+            size_t string_alignment;
+            size_t string_size;
+            size_t sizeof_data;
+            size_t offset_data;
+            size_t sizeof_size;
+            size_t offset_size;
+            bool size_is_unsigned;
+        } ret;
+        using Self = std::remove_reference_t<decltype(*this)>;
+        ret.string_size = sizeof(Self);
+        ret.string_alignment = alignof(Self);
+        ret.sizeof_data = sizeof(m_string);
+        ret.offset_data = offsetof(Self, m_string);
+        ret.sizeof_size = sizeof(m_size);
+        ret.offset_size = offsetof(Self, m_size);
+        // NOLINTNEXTLINE(modernize-type-traits), _v requires C++17
+        ret.size_is_unsigned = std::is_unsigned<decltype(m_size)>::value;
+        return ret;
+    }
+
   private:
     auto is_valid_next(char character) const noexcept -> bool {
         constexpr char const CODE_UNIT_UPPER_BOUND = 127;


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
The missing string layout component test from #1113.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1099

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
