### PR TITLE
iox-1163: Fix QNX8 builds

### DIFF
--- a/iceoryx2-pal/posix/src/qnx/types.rs
+++ b/iceoryx2-pal/posix/src/qnx/types.rs
@@ -66,9 +66,6 @@ impl MemZeroedStruct for sigset_t {}
 pub type pthread_barrier_t = crate::internal::pthread_barrier_t;
 impl MemZeroedStruct for pthread_barrier_t {}
 
-pub type sync_t = crate::internal::sync_t;
-impl MemZeroedStruct for sync_t {}
-
 pub type sync_attr_t = crate::internal::_sync_attr;
 impl MemZeroedStruct for sync_attr_t {}
 
@@ -91,11 +88,16 @@ pub type pthread_rwlockattr_t = sync_attr_t;
 pub type pthread_rwlock_t = crate::internal::pthread_rwlock_t;
 impl MemZeroedStruct for pthread_rwlock_t {}
 
-pub type pthread_mutex_t = sync_t;
+pub type pthread_mutex_t = crate::internal::pthread_mutex_t;
+impl MemZeroedStruct for pthread_mutex_t {}
 
 pub type pthread_mutexattr_t = sync_attr_t;
 
-pub type sem_t = sync_t;
+pub type sem_t = crate::internal::sem_t;
+
+// For qnx710 this is implemented by pthread_mutex_t as both are alias to same type.
+#[cfg(target_env = "nto80")]
+impl MemZeroedStruct for sem_t {}
 
 pub type flock = crate::internal::flock;
 impl MemZeroedStruct for flock {}


### PR DESCRIPTION
The posix pal for QNX now uses internal
type sync_t from bindgen. In QNX8 the type aliasing is different. Start using public alias for posix types from bindgen

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Every source code file has a copyright header with `SPDX-License-Identifier: Apache-2.0 OR MIT`
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * [x] Commit author matches [Eclipse Contributor Agreement][eca](and ECA is signed)
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## Checklist for the PR Reviewer

* [x] Commits are properly organized and messages are according to the guideline
* [x] Unit tests have been written for new behavior
* [x] Public API is documented
* [x] PR title describes the changes

## Post-review Checklist for the PR Author

* [x] All open points are addressed and tracked via issues

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1163 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
