### PR TITLE
[#154] Use null logger if none of other defaults are set

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -138,6 +138,34 @@ CMake package.
 
 ### API Breaking Changes
 
+1. **Rust:** Split logger frontend and backend, requiring the crate
+   `iceoryx2_loggers` to be linked to all binaries so that the logger
+   backend can be used by the frontend.
+
+   ```rust
+   // old
+   use iceoryx2_bb_log::*;
+
+   set_log_level(LogLevel::Info);
+   info!("some log message")
+
+   // new
+   extern crate iceoryx2_loggers;
+
+   use iceoryx2_log::*;
+
+   set_log_level(LogLevel::Info);
+   info!("some log message")
+   ```
+
+   Binary crates must also include `iceoryx2_loggers` as a dependency and the
+   default logger must be specified via feature flag (maximum one). If no
+   feature flag is enabled, the logs are discarded.
+
+    ```toml
+    iceoryx2-loggers = { version = "0.7.0", features = ["logger_console"] }
+    ```
+
 1. **Rust:** Replaced the `FixedSizeVec` with the `StaticVec`
 
    ```rust
@@ -234,7 +262,7 @@ CMake package.
 1. Removed the `cdr` serializer from `iceoryx2-cal`, it is recommended to
    switch to the `postcard` serializer in its place
 
-7. Merged `iox2/semantic_string.hpp` with imported `iox2/bb/semantic_string.hpp`
+1. Merged `iox2/semantic_string.hpp` with imported `iox2/bb/semantic_string.hpp`
    from `iceoryx_hoofs`
 
    With this merge, the `SemanticStringError` moved from the `iox2` namespace
@@ -251,7 +279,7 @@ CMake package.
    // ...
    auto foo() -> expected<void, iox2::bb::SemanticStringError>
 
-8. **Rust:** The blackboard's `EntryValueUninit::write()` has been extended so
+1. **Rust:** The blackboard's `EntryValueUninit::write()` has been extended so
    that it also updates the entry and was renamed to `update_with_copy()`;
    `EntryValue` was removed.
 
@@ -264,7 +292,8 @@ CMake package.
    let entry_handle_mut = entry_value_uninit.update_with_copy(123);
    ```
 
-8. Replace `iox::optional` from `iceoryx_hoofs` with `iox2::container::Optional`
+1. **C++:** Replace `iox::optional` from `iceoryx_hoofs` with
+   `iox2::container::Optional`
 
   The new `Optional` in iceoryx2 has a reduced API compared to the one from
   `iceroyx_hoofs`. The functional interface, which deviated from the STL was

--- a/iceoryx2-log/loggers/src/lib.rs
+++ b/iceoryx2-log/loggers/src/lib.rs
@@ -126,7 +126,13 @@ pub extern "Rust" fn __internal_default_logger() -> &'static dyn Log {
     }
 }
 
-#[cfg(not(any(feature = "logger_console", feature = "logger_buffer")))]
+#[cfg(not(any(
+    feature = "logger_console",
+    feature = "logger_buffer",
+    feature = "logger_file",
+    feature = "logger_log",
+    feature = "logger_tracing"
+)))]
 #[no_mangle]
 pub extern "Rust" fn __internal_default_logger() -> &'static dyn Log {
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Fixes an oversight in: https://github.com/eclipse-iceoryx/iceoryx2/pull/1224

The null logger is now used if **none** of the other defaults are set.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] ~~Tests follow the [best practice for testing][testing]~~
* [ ] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~
* [x] Assign PR to reviewer
* [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #154  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
