### PR TITLE
[#301] Fix bazel cc_library rule not having cpp files to compile

### DIFF
--- a/iceoryx2-bb/cxx/BUILD.bazel
+++ b/iceoryx2-bb/cxx/BUILD.bazel
@@ -48,14 +48,16 @@ cc_library(
     srcs = glob(
         [
             "src/**",
-        ]),
+        ],
+        allow_empty = True,
+    ),
     hdrs = glob(["include/**"]),
     strip_include_prefix = "include",
     deps = select({
-        "//:cfg_use_std_expected": [ ":iceoryx2-bb-cxx-variation-std-expected" ],
-        "//conditions:default": [ ":iceoryx2-bb-cxx-variation-iox2-expected" ],
+        "//:cfg_use_std_expected": [":iceoryx2-bb-cxx-variation-std-expected"],
+        "//conditions:default": [":iceoryx2-bb-cxx-variation-iox2-expected"],
     }) + select({
-        "//:cfg_use_std_optional": [ ":iceoryx2-bb-cxx-variation-std-optional" ],
-        "//conditions:default": [ ":iceoryx2-bb-cxx-variation-iox2-optional" ],
+        "//:cfg_use_std_optional": [":iceoryx2-bb-cxx-variation-std-optional"],
+        "//conditions:default": [":iceoryx2-bb-cxx-variation-iox2-optional"],
     }),
 )


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Cherry-picked from #1264 

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to PR #1264 
Relates to Issue #301 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
