### PR TITLE
[#1007] Replace array::from_fn where possible

### DIFF
--- a/iceoryx2-bb/container/src/queue.rs
+++ b/iceoryx2-bb/container/src/queue.rs
@@ -77,7 +77,7 @@
 //!     pub fn new() -> Self {
 //!         let mut new_self = Self {
 //!             queue: unsafe { RelocatableQueue::new_uninit(QUEUE_CAPACITY) },
-//!             queue_memory: core::array::from_fn(|_| MaybeUninit::uninit()),
+//!             queue_memory: [const { MaybeUninit::uninit() }; QUEUE_CAPACITY] ,
 //!         };
 //!
 //!         let allocator = BumpAllocator::new(new_self.queue_memory.as_mut_ptr().cast());

--- a/iceoryx2-bb/container/src/string/relocatable_string.rs
+++ b/iceoryx2-bb/container/src/string/relocatable_string.rs
@@ -35,7 +35,7 @@
 //!     pub fn new() -> Self {
 //!         let mut new_self = Self {
 //!             my_str: unsafe { RelocatableString::new_uninit(STRING_CAPACITY) },
-//!             str_memory: core::array::from_fn(|_| MaybeUninit::uninit()),
+//!             str_memory: [const { MaybeUninit::uninit() }; STRING_CAPACITY + 1] ,
 //!         };
 //!
 //!         let allocator = BumpAllocator::new(new_self.str_memory.as_mut_ptr().cast());

--- a/iceoryx2-bb/container/src/vector/relocatable_vec.rs
+++ b/iceoryx2-bb/container/src/vector/relocatable_vec.rs
@@ -33,7 +33,7 @@
 //!     pub fn new() -> Self {
 //!         let mut new_self = Self {
 //!             vec: unsafe { RelocatableVec::new_uninit(VEC_CAPACITY) },
-//!             vec_memory: core::array::from_fn(|_| MaybeUninit::uninit()),
+//!             vec_memory: [const { MaybeUninit::uninit() }; VEC_CAPACITY] ,
 //!         };
 //!
 //!         let allocator = BumpAllocator::new(new_self.vec_memory.as_mut_ptr().cast());

--- a/iceoryx2-bb/lock-free/src/mpmc/bit_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/bit_set.rs
@@ -310,7 +310,7 @@ impl<const CAPACITY: usize> Default for FixedSizeBitSet<CAPACITY> {
     fn default() -> Self {
         let mut new_self = Self {
             bitset: unsafe { RelocatableBitSet::new_uninit(CAPACITY) },
-            data: core::array::from_fn(|_| details::BitsetElement::new(0)),
+            data: [const { details::BitsetElement::new(0) }; CAPACITY],
         };
 
         let allocator = BumpAllocator::new(new_self.data.as_mut_ptr().cast());

--- a/iceoryx2-bb/lock-free/src/mpmc/container.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/container.rs
@@ -462,8 +462,8 @@ impl<T: Copy + Debug, const CAPACITY: usize> Default for FixedSizeContainer<T, C
             container: unsafe { Container::new_uninit(CAPACITY) },
             next_free_index: core::array::from_fn(|i| UnsafeCell::new(i as u32 + 1)),
             next_free_index_plus_one: UnsafeCell::new(CAPACITY as u32 + 1),
-            active_index: core::array::from_fn(|_| AtomicU64::new(0)),
-            data: core::array::from_fn(|_| UnsafeCell::new(MaybeUninit::uninit())),
+            active_index: [const { AtomicU64::new(0) }; CAPACITY],
+            data: [const { UnsafeCell::new(MaybeUninit::uninit()) }; CAPACITY],
         };
 
         let allocator = BumpAllocator::new(new_self.next_free_index.as_mut_ptr().cast());

--- a/iceoryx2-bb/lock-free/src/spsc/index_queue.rs
+++ b/iceoryx2-bb/lock-free/src/spsc/index_queue.rs
@@ -400,7 +400,7 @@ impl<const CAPACITY: usize> FixedSizeIndexQueue<CAPACITY> {
     pub fn new() -> Self {
         let mut new_self = Self {
             state: unsafe { RelocatableIndexQueue::new_uninit(CAPACITY) },
-            data: core::array::from_fn(|_| UnsafeCell::new(0)),
+            data: [const { UnsafeCell::new(0) }; CAPACITY],
         };
 
         let allocator = BumpAllocator::new(new_self.data.as_mut_ptr().cast());

--- a/iceoryx2-bb/lock-free/src/spsc/queue.rs
+++ b/iceoryx2-bb/lock-free/src/spsc/queue.rs
@@ -102,7 +102,7 @@ impl<T: Copy, const CAPACITY: usize> Queue<T, CAPACITY> {
     /// Creates a new empty queue
     pub fn new() -> Self {
         Self {
-            data: core::array::from_fn(|_| UnsafeCell::new(MaybeUninit::uninit())),
+            data: [const { UnsafeCell::new(MaybeUninit::uninit()) }; CAPACITY],
             write_position: AtomicU64::new(0),
             read_position: AtomicU64::new(0),
             has_producer: AtomicBool::new(true),

--- a/iceoryx2-bb/lock-free/src/spsc/safely_overflowing_index_queue.rs
+++ b/iceoryx2-bb/lock-free/src/spsc/safely_overflowing_index_queue.rs
@@ -447,7 +447,7 @@ impl<const CAPACITY: usize> FixedSizeSafelyOverflowingIndexQueue<CAPACITY> {
     pub fn new() -> Self {
         let mut new_self = Self {
             state: unsafe { RelocatableSafelyOverflowingIndexQueue::new_uninit(CAPACITY) },
-            data: core::array::from_fn(|_| UnsafeCell::new(0)),
+            data: [const { UnsafeCell::new(0) }; CAPACITY],
             data_plus_one: UnsafeCell::new(0),
         };
 

--- a/iceoryx2-bb/posix/src/signal.rs
+++ b/iceoryx2-bb/posix/src/signal.rs
@@ -543,7 +543,7 @@ impl SignalHandler {
 
     fn new() -> Self {
         let mut sighandle = SignalHandler {
-            registered_signals: core::array::from_fn(|_| None),
+            registered_signals: [const { None }; posix::MAX_SIGNAL_VALUE],
             do_repeat_eintr_call: false,
         };
 

--- a/iceoryx2-cal/src/zero_copy_connection/used_chunk_list.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/used_chunk_list.rs
@@ -166,7 +166,7 @@ impl<const CAPACITY: usize> Default for FixedSizeUsedChunkList<CAPACITY> {
     fn default() -> Self {
         let mut new_self = Self {
             list: unsafe { RelocatableUsedChunkList::new_uninit(CAPACITY) },
-            data: core::array::from_fn(|_| AtomicBool::new(false)),
+            data: [const { AtomicBool::new(false) }; CAPACITY],
         };
 
         let allocator = BumpAllocator::new(new_self.data.as_mut_ptr().cast());


### PR DESCRIPTION
For array initialization with constant values we don't need to use array::from_fn, instead we can pass the value directly.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] ~Tests follow the [best practice for testing][testing]~
* [x] ~Changelog updated [in the unreleased section][changelog] including API breaking changes~
* [x] Assign PR to reviewer
* [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1007  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
