### PR TITLE
Change `$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}` to `${CMAKE_INSTALL_FULL_LIBDIR}`

### DIFF
--- a/iceoryx2-c/CMakeLists.txt
+++ b/iceoryx2-c/CMakeLists.txt
@@ -62,7 +62,7 @@ include(GNUInstallDirs)
 target_link_libraries(static-lib INTERFACE
     iceoryx2-c::includes-only
     $<BUILD_INTERFACE:${ICEORYX2_C_STATIC_LIB_LINK_FILE}>
-    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/${ICEORYX2_C_STATIC_LIB_LINK_NAME}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_LIBDIR}/${ICEORYX2_C_STATIC_LIB_LINK_NAME}>
     $<$<NOT:$<PLATFORM_ID:Windows,QNX,Android>>:m pthread>
     $<$<PLATFORM_ID:Windows>:userenv ntdll psapi ws2_32 wsock32>
     $<$<AND:$<PLATFORM_ID:Windows>,$<OR:$<C_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:MSVC>>>:bcrypt synchronization>
@@ -74,7 +74,7 @@ target_link_libraries(static-lib INTERFACE
 target_link_libraries(shared-lib INTERFACE
     iceoryx2-c::includes-only
     $<BUILD_INTERFACE:${ICEORYX2_C_SHARED_LIB_LINK_FILE}>
-    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/${ICEORYX2_C_SHARED_LIB_LINK_NAME}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_LIBDIR}/${ICEORYX2_C_SHARED_LIB_LINK_NAME}>
 )
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/install.cmake)


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

According to [CMake snips here](https://github.com/jtojnar/cmake-snips/#concatenating-paths-when-building-pkg-config-files), `CMAKE_INSTALL_LIBDIR` could be an absolute path and concatenate it may cause problems.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [ ] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [ ] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [ ] Assign PR to reviewer
* [] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
