### PR TITLE
[#996] Use `NonNull<u8>` in `elementary/BumpAllocator`

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -48,6 +48,10 @@
     NOTE: Add new entries sorted by issue number to minimize the possibility of
     conflicts when merging.
 -->
+
+* Use 'NonNull' in 'elementary/BumpAllocator'
+  [#996](https://github.com/eclipse-iceoryx/iceoryx2/issues/996)
+
 * Remove support for Bazel Workspaces
   [#1263](https://github.com/eclipse-iceoryx/iceoryx2/issues/1263)
 * Adjust test names to naming convention
@@ -107,4 +111,21 @@
 
    set_log_level(LogLevel::Info);
    info!("some log message")
+   ```
+
+1. Creating a BumpAllocator expects a `NonNull<u8>` instead of a mutable raw pointer.
+
+   ```rust
+   // old
+    let mut memory = [0u8; 8192];
+    let allocator = BumpAllocator::new(memory.as_mut_ptr());
+
+   // new
+   let mut memory = [0u8; 8192];
+   let allocator = BumpAllocator::new(
+       core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast()).expect(
+           "Precondition failed: Memory pointer is null"),
+            core::mem::size_of_val(&memory)
+   )
+   .unwrap();
    ```

--- a/iceoryx2-bb/concurrency/src/cell.rs
+++ b/iceoryx2-bb/concurrency/src/cell.rs
@@ -66,6 +66,10 @@ impl<T> RefCell<T> {
     pub fn borrow_mut(&self) -> RefMut<'_, T> {
         self.0.borrow_mut()
     }
+
+    pub fn replace(&self, t: T) -> T {
+        self.0.replace(t)
+    }
 }
 
 impl<T: Default> PlacementDefault for RefCell<T> {

--- a/iceoryx2-bb/container/src/string/relocatable_string.rs
+++ b/iceoryx2-bb/container/src/string/relocatable_string.rs
@@ -38,7 +38,12 @@
 //!             str_memory: [const { MaybeUninit::uninit() }; STRING_CAPACITY + 1] ,
 //!         };
 //!
-//!         let allocator = BumpAllocator::new(new_self.str_memory.as_mut_ptr().cast());
+//!         let allocator = BumpAllocator::new(
+//!         core::ptr::NonNull::<u8>::new(new_self.str_memory.as_mut_ptr().cast())
+//!         .expect("Precondition failed: Pointer to memory is null"),
+//!         core::mem::size_of_val(&new_self.str_memory)
+//!         );
+//!
 //!         unsafe {
 //!             new_self.my_str.init(&allocator).expect("Enough memory provided.")
 //!         };
@@ -60,7 +65,11 @@
 //! const MEM_SIZE: usize = RelocatableString::const_memory_size(STRING_CAPACITY);
 //! let mut memory = [0u8; MEM_SIZE];
 //!
-//! let bump_allocator = BumpAllocator::new(memory.as_mut_ptr());
+//! let bump_allocator = BumpAllocator::new(
+//!     core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast())
+//!     .expect("Precondition failed: Pointer to memory is null"),
+//!     core::mem::size_of_val(&memory)
+//!     );
 //!
 //! let mut my_str = unsafe { RelocatableString::new_uninit(STRING_CAPACITY) };
 //! unsafe { my_str.init(&bump_allocator).expect("string init failed") };

--- a/iceoryx2-bb/container/src/vector/relocatable_vec.rs
+++ b/iceoryx2-bb/container/src/vector/relocatable_vec.rs
@@ -36,7 +36,11 @@
 //!             vec_memory: [const { MaybeUninit::uninit() }; VEC_CAPACITY] ,
 //!         };
 //!
-//!         let allocator = BumpAllocator::new(new_self.vec_memory.as_mut_ptr().cast());
+//!         let allocator = BumpAllocator::new(
+//!         core::ptr::NonNull::<u8>::new(new_self.vec_memory.as_mut_ptr().cast())
+//!         .expect("Precondition failed: Pointer to memory is null"),
+//!         core::mem::size_of_val(&new_self.vec_memory)
+//!         );
 //!         unsafe {
 //!             new_self.vec.init(&allocator).expect("Enough memory provided.")
 //!         };
@@ -57,7 +61,11 @@
 //! const MEM_SIZE: usize = RelocatableVec::<u128>::const_memory_size(VEC_CAPACITY);
 //! let mut memory = [0u8; MEM_SIZE];
 //!
-//! let bump_allocator = BumpAllocator::new(memory.as_mut_ptr());
+//! let bump_allocator = BumpAllocator::new(
+//!     core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast())
+//!     .expect("Precondition failed: Pointer to memory is null"),
+//!     core::mem::size_of_val(&memory)
+//! );
 //!
 //! let mut vec = unsafe { RelocatableVec::<u128>::new_uninit(VEC_CAPACITY) };
 //! unsafe { vec.init(&bump_allocator).expect("vec init failed") };

--- a/iceoryx2-bb/container/tests/flatmap_tests.rs
+++ b/iceoryx2-bb/container/tests/flatmap_tests.rs
@@ -216,7 +216,11 @@ mod flat_map {
     fn double_init_call_causes_panic() {
         const MEM_SIZE: usize = RelocatableFlatMap::<u8, u8>::const_memory_size(CAPACITY);
         let mut memory = [0u8; MEM_SIZE];
-        let bump_allocator = BumpAllocator::new(memory.as_mut_ptr());
+        let bump_allocator = BumpAllocator::new(
+            core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast())
+                .expect("Precondition failed: Pointer to memory is null"),
+            core::mem::size_of_val(&memory),
+        );
 
         let mut sut = unsafe { RelocatableFlatMap::<u8, u8>::new_uninit(CAPACITY) };
         unsafe { sut.init(&bump_allocator).expect("sut init failed") };

--- a/iceoryx2-bb/container/tests/polymorphic_string_tests.rs
+++ b/iceoryx2-bb/container/tests/polymorphic_string_tests.rs
@@ -39,7 +39,9 @@ impl Test {
         unsafe {
             if (*self.allocator.get()).is_none() {
                 *self.allocator.get() = Some(Box::new(BumpAllocator::new(
-                    (*self.raw_memory.get()).as_mut_ptr(),
+                    core::ptr::NonNull::<u8>::new((*self.raw_memory.get()).as_mut_ptr().cast())
+                        .expect("Precondition failed: Pointer to memory is null"),
+                    core::mem::size_of_val((*self.raw_memory.get()).as_ref()),
                 )))
             }
         };

--- a/iceoryx2-bb/container/tests/polymorphic_vec_tests.rs
+++ b/iceoryx2-bb/container/tests/polymorphic_vec_tests.rs
@@ -39,7 +39,9 @@ impl Test {
         unsafe {
             if (*self.allocator.get()).is_none() {
                 *self.allocator.get() = Some(Box::new(BumpAllocator::new(
-                    (*self.raw_memory.get()).as_mut_ptr(),
+                    core::ptr::NonNull::<u8>::new((*self.raw_memory.get()).as_mut_ptr().cast())
+                        .expect("Precondition failed: Pointer to memory is null"),
+                    core::mem::size_of_val((*self.raw_memory.get()).as_ref()),
                 )))
             }
         };

--- a/iceoryx2-bb/container/tests/queue_tests.rs
+++ b/iceoryx2-bb/container/tests/queue_tests.rs
@@ -24,7 +24,11 @@ mod queue {
     #[test]
     fn relocatable_push_pop_works_with_uninitialized_memory() {
         let mut memory = [0u8; 1024];
-        let allocator = BumpAllocator::new(memory.as_mut_ptr());
+        let allocator = BumpAllocator::new(
+            core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast())
+                .expect("Precondition failed: Pointer to memory is null"),
+            core::mem::size_of_val(&memory),
+        );
 
         let mut sut = unsafe { RelocatableQueue::<usize>::new_uninit(SUT_CAPACITY) };
         unsafe { assert_that!(sut.init(&allocator), is_ok) };
@@ -53,7 +57,11 @@ mod queue {
     #[test]
     fn relocatable_clear_empties_queue() {
         let mut memory = [0u8; 1024];
-        let allocator = BumpAllocator::new(memory.as_mut_ptr());
+        let allocator = BumpAllocator::new(
+            core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast())
+                .expect("Precondition failed: Pointer to memory is null"),
+            core::mem::size_of_val(&memory),
+        );
 
         let mut sut = unsafe { RelocatableQueue::<usize>::new_uninit(SUT_CAPACITY) };
         unsafe { assert_that!(sut.init(&allocator), is_ok) };
@@ -332,7 +340,11 @@ mod queue {
     fn double_init_call_causes_panic() {
         const MEM_SIZE: usize = RelocatableQueue::<usize>::const_memory_size(SUT_CAPACITY);
         let mut memory = [0u8; MEM_SIZE];
-        let bump_allocator = BumpAllocator::new(memory.as_mut_ptr());
+        let bump_allocator = BumpAllocator::new(
+            core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast())
+                .expect("Precondition failed: Pointer to memory is null"),
+            core::mem::size_of_val(&memory),
+        );
 
         let mut sut = unsafe { RelocatableQueue::<usize>::new_uninit(SUT_CAPACITY) };
         unsafe { sut.init(&bump_allocator).expect("sut init failed") };

--- a/iceoryx2-bb/container/tests/relocatable_vec_tests.rs
+++ b/iceoryx2-bb/container/tests/relocatable_vec_tests.rs
@@ -22,7 +22,11 @@ fn double_init_call_causes_panic() {
     const CAPACITY: usize = 12;
     const MEM_SIZE: usize = RelocatableVec::<u128>::const_memory_size(CAPACITY);
     let mut memory = [0u8; MEM_SIZE];
-    let bump_allocator = BumpAllocator::new(memory.as_mut_ptr());
+    let bump_allocator = BumpAllocator::new(
+        core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast())
+            .expect("Precondition failed: Pointer to data in memory is null"),
+        core::mem::size_of_val(&memory),
+    );
     let mut sut = unsafe { RelocatableVec::<u128>::new_uninit(CAPACITY) };
     unsafe { sut.init(&bump_allocator).expect("sut init failed") };
 
@@ -44,8 +48,16 @@ fn two_vectors_with_same_content_are_equal() {
     const MEM_SIZE: usize = RelocatableVec::<usize>::const_memory_size(SUT_CAPACITY);
     let mut memory_1 = [0u8; MEM_SIZE];
     let mut memory_2 = [0u8; MEM_SIZE];
-    let bump_allocator_1 = BumpAllocator::new(memory_1.as_mut_ptr());
-    let bump_allocator_2 = BumpAllocator::new(memory_2.as_mut_ptr());
+    let bump_allocator_1 = BumpAllocator::new(
+        core::ptr::NonNull::<u8>::new(memory_1.as_mut_ptr().cast())
+            .expect("Precondition failed: Pointer to data in memory is null"),
+        core::mem::size_of_val(&memory_1),
+    );
+    let bump_allocator_2 = BumpAllocator::new(
+        core::ptr::NonNull::<u8>::new(memory_2.as_mut_ptr().cast())
+            .expect("Precondition failed: Pointer to data in memory is null"),
+        core::mem::size_of_val(&memory_2),
+    );
     let mut sut_1 = unsafe { RelocatableVec::<usize>::new_uninit(SUT_CAPACITY) };
     unsafe { sut_1.init(&bump_allocator_1).unwrap() };
     let mut sut_2 = unsafe { RelocatableVec::<usize>::new_uninit(SUT_CAPACITY) };
@@ -65,8 +77,16 @@ fn two_vectors_with_different_content_are_not_equal() {
     const MEM_SIZE: usize = RelocatableVec::<usize>::const_memory_size(SUT_CAPACITY);
     let mut memory_1 = [0u8; MEM_SIZE];
     let mut memory_2 = [0u8; MEM_SIZE];
-    let bump_allocator_1 = BumpAllocator::new(memory_1.as_mut_ptr());
-    let bump_allocator_2 = BumpAllocator::new(memory_2.as_mut_ptr());
+    let bump_allocator_1 = BumpAllocator::new(
+        core::ptr::NonNull::<u8>::new(memory_1.as_mut_ptr().cast())
+            .expect("Precondition failed: Pointer to data in memory is null"),
+        core::mem::size_of_val(&memory_1),
+    );
+    let bump_allocator_2 = BumpAllocator::new(
+        core::ptr::NonNull::<u8>::new(memory_2.as_mut_ptr().cast())
+            .expect("Precondition failed: Pointer to data in memory is null"),
+        core::mem::size_of_val(&memory_2),
+    );
     let mut sut_1 = unsafe { RelocatableVec::<usize>::new_uninit(SUT_CAPACITY) };
     unsafe { sut_1.init(&bump_allocator_1).unwrap() };
     let mut sut_2 = unsafe { RelocatableVec::<usize>::new_uninit(SUT_CAPACITY) };
@@ -88,8 +108,16 @@ fn two_vectors_with_different_len_are_not_equal() {
     const MEM_SIZE: usize = RelocatableVec::<usize>::const_memory_size(SUT_CAPACITY);
     let mut memory_1 = [0u8; MEM_SIZE];
     let mut memory_2 = [0u8; MEM_SIZE];
-    let bump_allocator_1 = BumpAllocator::new(memory_1.as_mut_ptr());
-    let bump_allocator_2 = BumpAllocator::new(memory_2.as_mut_ptr());
+    let bump_allocator_1 = BumpAllocator::new(
+        core::ptr::NonNull::<u8>::new(memory_1.as_mut_ptr().cast())
+            .expect("Precondition failed: Pointer to data in memory is null"),
+        core::mem::size_of_val(&memory_1),
+    );
+    let bump_allocator_2 = BumpAllocator::new(
+        core::ptr::NonNull::<u8>::new(memory_2.as_mut_ptr().cast())
+            .expect("Precondition failed: Pointer to data in memory is null"),
+        core::mem::size_of_val(&memory_2),
+    );
     let mut sut_1 = unsafe { RelocatableVec::<usize>::new_uninit(SUT_CAPACITY) };
     unsafe { sut_1.init(&bump_allocator_1).unwrap() };
     let mut sut_2 = unsafe { RelocatableVec::<usize>::new_uninit(SUT_CAPACITY) };

--- a/iceoryx2-bb/container/tests/slotmap_tests.rs
+++ b/iceoryx2-bb/container/tests/slotmap_tests.rs
@@ -243,7 +243,11 @@ mod slot_map {
     fn double_init_call_causes_panic() {
         const MEM_SIZE: usize = RelocatableSlotMap::<usize>::const_memory_size(SUT_CAPACITY);
         let mut memory = [0u8; MEM_SIZE];
-        let bump_allocator = BumpAllocator::new(memory.as_mut_ptr());
+        let bump_allocator = BumpAllocator::new(
+            core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast())
+                .expect("Precondition failed: Pointer to memory is null"),
+            core::mem::size_of_val(&memory),
+        );
 
         let mut sut = unsafe { RelocatableSlotMap::<usize>::new_uninit(SUT_CAPACITY) };
         unsafe { sut.init(&bump_allocator).expect("sut init failed") };

--- a/iceoryx2-bb/container/tests/string_tests.rs
+++ b/iceoryx2-bb/container/tests/string_tests.rs
@@ -59,7 +59,9 @@ mod string {
             unsafe {
                 if (*self.allocator.get()).is_none() {
                     *self.allocator.get() = Some(Box::new(BumpAllocator::new(
-                        (*self.raw_memory.get()).as_mut_ptr(),
+                        core::ptr::NonNull::<u8>::new((*self.raw_memory.get()).as_mut_ptr().cast())
+                            .expect("Precondition failed: Pointer to data in FixedSizeIndexQueue is null"),
+                        core::mem::size_of_val((*self.raw_memory.get()).as_ref()),
                     )))
                 }
             };
@@ -98,7 +100,9 @@ mod string {
             unsafe {
                 if (*self.allocator.get()).is_none() {
                     *self.allocator.get() = Some(Box::new(BumpAllocator::new(
-                        (*self.raw_memory.get()).as_mut_ptr(),
+                        core::ptr::NonNull::<u8>::new((*self.raw_memory.get()).as_mut_ptr().cast())
+                            .expect("Precondition failed: Pointer to data in FixedSizeIndexQueue is null"),
+                        core::mem::size_of_val((*self.raw_memory.get()).as_ref()),
                     )))
                 }
             };

--- a/iceoryx2-bb/elementary/src/bump_allocator.rs
+++ b/iceoryx2-bb/elementary/src/bump_allocator.rs
@@ -10,23 +10,26 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use core::ptr::NonNull;
+use iceoryx2_bb_concurrency::cell::RefCell;
+
 use crate::math::align;
-use iceoryx2_bb_concurrency::atomic::AtomicUsize;
-use iceoryx2_bb_concurrency::atomic::Ordering;
 use iceoryx2_bb_elementary_traits::allocator::{AllocationError, BaseAllocator};
 
 /// A minimalistic [`BumpAllocator`].
 pub struct BumpAllocator {
-    start: *mut u8,
-    pos: AtomicUsize,
+    start: NonNull<u8>,
+    addr_next_free_memory: RefCell<u64>,
+    start_size: usize,
 }
 
 impl BumpAllocator {
     /// Creates a new [`BumpAllocator`] that manages the memory starting at `start`.
-    pub fn new(start: *mut u8) -> Self {
+    pub fn new(start: NonNull<u8>, size: usize) -> Self {
         Self {
             start,
-            pos: AtomicUsize::new(start as usize),
+            addr_next_free_memory: RefCell::<u64>::new(start.as_ptr().cast::<u64>() as u64),
+            start_size: size,
         }
     }
 }
@@ -36,13 +39,26 @@ impl BaseAllocator for BumpAllocator {
         &self,
         layout: core::alloc::Layout,
     ) -> Result<core::ptr::NonNull<[u8]>, AllocationError> {
-        let mem = align(self.pos.load(Ordering::Relaxed), layout.align());
-        self.pos.store(mem + layout.size(), Ordering::Relaxed);
+        let mem = align(
+            *self.addr_next_free_memory.borrow() as usize,
+            layout.align(),
+        ) as u64;
+        let allocated_memory_size =
+            *self.addr_next_free_memory.borrow() as usize - self.start.as_ptr() as usize;
+
+        if allocated_memory_size + layout.size() > self.start_size {
+            return Err(AllocationError::SizeTooLarge);
+        }
+
+        self.addr_next_free_memory
+            .replace(mem + layout.size() as u64);
 
         unsafe {
             Ok(core::ptr::NonNull::new_unchecked(
                 core::ptr::slice_from_raw_parts_mut(
-                    self.start.add(mem - self.start as usize),
+                    self.start
+                        .add(mem as usize - self.start.as_ptr() as usize)
+                        .as_ptr(),
                     layout.size(),
                 ),
             ))
@@ -50,6 +66,7 @@ impl BaseAllocator for BumpAllocator {
     }
 
     unsafe fn deallocate(&self, _ptr: core::ptr::NonNull<u8>, _layout: core::alloc::Layout) {
-        self.pos.store(self.start as usize, Ordering::Relaxed);
+        self.addr_next_free_memory
+            .replace(self.start.as_ptr() as u64);
     }
 }

--- a/iceoryx2-bb/elementary/tests/bump_allocator_tests.rs
+++ b/iceoryx2-bb/elementary/tests/bump_allocator_tests.rs
@@ -15,45 +15,59 @@ use core::{alloc::Layout, ptr::NonNull};
 use iceoryx2_bb_elementary::{bump_allocator::*, math::align};
 use iceoryx2_bb_elementary_traits::allocator::BaseAllocator;
 use iceoryx2_bb_testing::assert_that;
+use std::ptr;
 
 #[test]
 fn start_position_is_correctly_used() {
     let mut memory = [0u8; 8192];
-    let start_position: *mut u8 = memory.as_mut_ptr();
+    let start_position: Option<core::ptr::NonNull<u8>> =
+        core::ptr::NonNull::<u8>::new(memory.as_mut_ptr());
     const MEM_SIZE: usize = 91;
     const MEM_ALIGN: usize = 1;
-    let sut = BumpAllocator::new(start_position);
+    let sut = BumpAllocator::new(start_position.unwrap(), core::mem::size_of_val(&memory));
 
     let memory = sut
         .allocate(Layout::from_size_align(MEM_SIZE, MEM_ALIGN).unwrap())
         .unwrap();
 
-    assert_that!(unsafe { memory.as_ref() }.as_ptr() as usize, eq start_position as usize);
+    assert_that!(unsafe { memory.as_ref() }.as_ptr() as usize, eq start_position.unwrap().as_ptr() as usize);
     assert_that!(unsafe { memory.as_ref() }.len(), eq MEM_SIZE);
 }
 
 #[test]
+#[should_panic]
+fn start_position_is_null() {
+    let null_ptr: *const u8 = ptr::null();
+    let start_position: core::ptr::NonNull<u8> =
+        core::ptr::NonNull::<u8>::new(null_ptr.cast_mut()).unwrap();
+
+    let _sut = BumpAllocator::new(start_position, 0);
+}
+
+#[test]
 fn allocated_memory_is_correctly_aligned() {
-    let mut memory = [0u8; 8192];
-    let start_position: *mut u8 = unsafe { memory.as_mut_ptr().add(1) };
+    let memory = [0u8; 8192];
+    let start_position: core::ptr::NonNull<u8> =
+        unsafe { core::ptr::NonNull::<u8>::new(memory.as_ptr().cast_mut().add(1)).unwrap() };
     const MEM_SIZE: usize = 128;
     const MEM_ALIGN: usize = 64;
-    let sut = BumpAllocator::new(start_position);
+    let sut = BumpAllocator::new(start_position, core::mem::size_of_val(&memory));
 
     let memory = sut
         .allocate(Layout::from_size_align(MEM_SIZE, MEM_ALIGN).unwrap())
         .unwrap();
 
-    assert_that!(unsafe { memory.as_ref() }.as_ptr() as usize, eq align(start_position as usize, MEM_ALIGN));
+    assert_that!(unsafe { memory.as_ref() }.as_ptr() as usize, eq align(start_position.as_ptr() as usize, MEM_ALIGN));
     assert_that!(unsafe { memory.as_ref() }.len(), eq MEM_SIZE);
 }
 
 #[test]
 fn allocating_many_aligned_chunks_work() {
-    let mut memory = [0u8; 8192];
-    let start_position: *mut u8 = unsafe { memory.as_mut_ptr().add(1) };
+    let memory = [0u8; 8192];
+    let start_position: core::ptr::NonNull<u8> =
+        unsafe { core::ptr::NonNull::<u8>::new(memory.as_ptr().cast_mut().add(1)).unwrap() };
     const ITERATIONS: u32 = 5;
-    let sut = BumpAllocator::new(start_position);
+    let sut = BumpAllocator::new(start_position, core::mem::size_of_val(&memory));
 
     let mut last_size = 0;
     let mut last_position = 0;
@@ -76,11 +90,12 @@ fn allocating_many_aligned_chunks_work() {
 
 #[test]
 fn deallocating_releases_everything() {
-    let mut memory = [0u8; 8192];
-    let start_position: *mut u8 = unsafe { memory.as_mut_ptr().add(3) };
+    let memory = [0u8; 8192];
+    let start_position: core::ptr::NonNull<u8> =
+        unsafe { core::ptr::NonNull::<u8>::new(memory.as_ptr().cast_mut().add(3)).unwrap() };
     const MEM_SIZE: usize = 128;
     const MEM_ALIGN: usize = 1;
-    let sut = BumpAllocator::new(start_position);
+    let sut = BumpAllocator::new(start_position, core::mem::size_of_val(&memory));
 
     let layout = Layout::from_size_align(MEM_SIZE, MEM_ALIGN).unwrap();
     let mut memory = sut.allocate(layout).unwrap();
@@ -96,6 +111,6 @@ fn deallocating_releases_everything() {
         .allocate(Layout::from_size_align(MEM_SIZE, MEM_ALIGN).unwrap())
         .unwrap();
 
-    assert_that!(unsafe { memory.as_ref() }.as_ptr() as usize, eq start_position as usize);
+    assert_that!(unsafe { memory.as_ref() }.as_ptr() as usize, eq start_position.as_ptr() as usize);
     assert_that!(unsafe { memory.as_ref() }.len(), eq MEM_SIZE);
 }

--- a/iceoryx2-bb/lock-free/src/mpmc/bit_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/bit_set.rs
@@ -313,7 +313,12 @@ impl<const CAPACITY: usize> Default for FixedSizeBitSet<CAPACITY> {
             data: [const { details::BitsetElement::new(0) }; CAPACITY],
         };
 
-        let allocator = BumpAllocator::new(new_self.data.as_mut_ptr().cast());
+        // SAFETY: Creating a pointer to an existing member is always not null
+        let data_ptr =
+            unsafe { core::ptr::NonNull::<u8>::new_unchecked(new_self.data.as_mut_ptr().cast()) };
+
+        let allocator =
+            BumpAllocator::new(data_ptr, core::mem::size_of_val(new_self.data.as_ref()));
         unsafe {
             new_self
                 .bitset

--- a/iceoryx2-bb/lock-free/src/spsc/index_queue.rs
+++ b/iceoryx2-bb/lock-free/src/spsc/index_queue.rs
@@ -403,7 +403,12 @@ impl<const CAPACITY: usize> FixedSizeIndexQueue<CAPACITY> {
             data: [const { UnsafeCell::new(0) }; CAPACITY],
         };
 
-        let allocator = BumpAllocator::new(new_self.data.as_mut_ptr().cast());
+        // SAFETY: Creating a pointer to an existing member is always not null
+        let data_ptr =
+            unsafe { core::ptr::NonNull::<u8>::new_unchecked(new_self.data.as_mut_ptr().cast()) };
+
+        let allocator =
+            BumpAllocator::new(data_ptr, core::mem::size_of_val(new_self.data.as_ref()));
         unsafe {
             new_self
                 .state

--- a/iceoryx2-bb/lock-free/src/spsc/safely_overflowing_index_queue.rs
+++ b/iceoryx2-bb/lock-free/src/spsc/safely_overflowing_index_queue.rs
@@ -451,7 +451,14 @@ impl<const CAPACITY: usize> FixedSizeSafelyOverflowingIndexQueue<CAPACITY> {
             data_plus_one: UnsafeCell::new(0),
         };
 
-        let allocator = BumpAllocator::new(new_self.data.as_mut_ptr().cast());
+        // SAFETY: Creating a pointer to an existing member is always not null
+        let data_ptr =
+            unsafe { core::ptr::NonNull::<u8>::new_unchecked(new_self.data.as_mut_ptr().cast()) };
+
+        let allocator = BumpAllocator::new(
+            data_ptr,
+            size_of::<Self>() - core::mem::offset_of!(Self, data),
+        );
         unsafe {
             new_self
                 .state

--- a/iceoryx2-bb/lock-free/tests/mpmc_container_tests.rs
+++ b/iceoryx2-bb/lock-free/tests/mpmc_container_tests.rs
@@ -132,7 +132,10 @@ mod mpmc_container {
         // TestType is the largest test type so it is safe to acquire this memory for every test
         // case - hack required since `T` cannot be used in const operations
         let mut memory = [0u8; Container::<crate::TestType>::const_memory_size(129_usize)];
-        let allocator = BumpAllocator::new(memory.as_mut_ptr());
+        let allocator = BumpAllocator::new(
+            core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast()).unwrap(),
+            core::mem::size_of_val(&memory),
+        );
         let mut sut = unsafe { Container::<T>::new_uninit(CAPACITY) };
         unsafe { assert_that!(sut.init(&allocator), is_ok) };
 

--- a/iceoryx2-bb/lock-free/tests/mpmc_unique_index_set_tests.rs
+++ b/iceoryx2-bb/lock-free/tests/mpmc_unique_index_set_tests.rs
@@ -138,7 +138,10 @@ fn mpmc_unique_index_set_borrowed_indices_works() {
 #[test]
 fn mpmc_unique_index_set_acquire_and_release_works_with_uninitialized_memory() {
     let mut memory = [0u8; UniqueIndexSet::const_memory_size(128)];
-    let allocator = BumpAllocator::new(memory.as_mut_ptr());
+    let allocator = BumpAllocator::new(
+        core::ptr::NonNull::<u8>::new(memory.as_mut_ptr().cast()).unwrap(),
+        core::mem::size_of_val(&memory),
+    );
     let mut sut = unsafe { UniqueIndexSet::new_uninit(CAPACITY) };
     unsafe { assert_that!(sut.init(&allocator), is_ok) };
 

--- a/iceoryx2-bb/memory/src/pool_allocator.rs
+++ b/iceoryx2-bb/memory/src/pool_allocator.rs
@@ -344,7 +344,15 @@ impl<const MAX_NUMBER_OF_BUCKETS: usize> FixedSizePoolAllocator<MAX_NUMBER_OF_BU
             next_free_index_plus_one: UnsafeCell::new(MAX_NUMBER_OF_BUCKETS as u32 + 1),
         };
 
-        let allocator = BumpAllocator::new(new_self.next_free_index.as_mut_ptr().cast());
+        // SAFETY: Creating a pointer to an existing member is always not null
+        let data_ptr = unsafe {
+            core::ptr::NonNull::<u8>::new_unchecked(new_self.next_free_index.as_mut_ptr().cast())
+        };
+
+        let allocator = BumpAllocator::new(
+            data_ptr,
+            core::mem::size_of_val(new_self.next_free_index.as_ref()),
+        );
         unsafe {
             new_self
                 .state

--- a/iceoryx2-cal/src/zero_copy_connection/used_chunk_list.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/used_chunk_list.rs
@@ -169,7 +169,12 @@ impl<const CAPACITY: usize> Default for FixedSizeUsedChunkList<CAPACITY> {
             data: [const { AtomicBool::new(false) }; CAPACITY],
         };
 
-        let allocator = BumpAllocator::new(new_self.data.as_mut_ptr().cast());
+        // SAFETY: Creating a pointer to an existing member is always not null
+        let data_ptr =
+            unsafe { core::ptr::NonNull::<u8>::new_unchecked(new_self.data.as_mut_ptr().cast()) };
+
+        let allocator =
+            BumpAllocator::new(data_ptr, core::mem::size_of_val(new_self.data.as_ref()));
         unsafe {
             new_self
                 .list


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

- Use `NonNull<u8>` for start adress in 'BumpAllocator'
- Expect `NonNull<u8>` for start argument in `new()` and return an `Option<BumpAllocator>`

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #996  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
