### PR TITLE
[#4] Add Eclipse IP due diligence document

### DIFF
--- a/doc/eclipse-ip-due-diligence.md
+++ b/doc/eclipse-ip-due-diligence.md
@@ -1,0 +1,90 @@
+# Eclipse IP Due Diligence
+
+As part of the
+[Eclipse Due Diligence process](https://www.eclipse.org/projects/handbook/#ip)
+, we have to scan our third party content for licenses which are approved by
+the Eclipse Foundation. The
+[dash-license](https://github.com/eclipse-dash/dash-licenses) tool can be used
+for this task.
+
+## Scanning Rust Dependencies
+
+For our Rust code, this can be done with the following command:
+
+```sh
+cargo tree -e normal --prefix none --no-dedupe \
+      | sort -u \
+      | grep -v '^[[:space:]]*$' \
+      | grep -v iceoryx2 \
+      | grep -v benchmark \
+      | grep -v component-tests \
+      | grep -v examples \
+      | grep -v zenoh \
+      | sed -E 's|([^ ]+) v([^ ]+).*|crate/cratesio/-/\1/\2|' \
+      | java -jar /path/to/org.eclipse.dash.licenses-x.y.z.jar -
+```
+
+If the following output is printed, no further steps are required.
+
+```console
+[main] INFO Vetted license information was found for all content. No further investigation is required.
+```
+
+In case the tool finds dependencies which are not yet part of the Eclipse license
+database, the output looks like this.
+
+```console
+[main] INFO Querying Eclipse Foundation for license data for 337 items.
+[main] INFO Found 153 items.
+[main] INFO Querying ClearlyDefined for license data for 184 items.
+[main] INFO Found 184 items.
+[main] INFO License information could not be automatically verified for the following content:
+[main] INFO
+[main] INFO crate/cratesio/-/foo/0.8.15
+[main] INFO
+[main] INFO This content is either not correctly mapped by the system, or requires review.
+```
+
+In this case, the dependency must be reported to the IP team. For more details,
+take a look at [Reporting New Dependencies](#reporting-new-dependencies).
+
+## Reporting New Dependencies
+
+In case the license check could not find the information for a third party
+component, an issue must be created at
+<https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab>. This can be done
+automatically with the `dash` license tool. For details, please have a look at
+<https://github.com/eclipse-dash/dash-licenses?tab=readme-ov-file#automatic-ip-team-review-requests>
+
+For Rust dependencies, this is the command to execute:
+
+```sh
+cargo tree -e normal --prefix none --no-dedupe \
+      | sort -u \
+      | grep -v '^[[:space:]]*$' \
+      | grep -v iceoryx2 \
+      | grep -v benchmark \
+      | grep -v component-tests \
+      | grep -v examples \
+      | grep -v zenoh \
+      | sed -E 's|([^ ]+) v([^ ]+).*|crate/cratesio/-/\1/\2|' \
+      | java -jar /path/to/org.eclipse.dash.licenses-x.y.z.jar -review -project technology.iceoryx -token [TOKEN] -
+```
+
+## Listing Dependencies
+
+In order to document the dependencies, e.g. in NOTICE.md, the `dash` tool can
+also be used to list all dependencies.
+
+```sh
+cargo tree -e normal --prefix none --no-dedupe \
+      | sort -u \
+      | grep -v '^[[:space:]]*$' \
+      | grep -v iceoryx2 \
+      | grep -v benchmark \
+      | grep -v component-tests \
+      | grep -v examples \
+      | grep -v zenoh \
+      | sed -E 's|([^ ]+) v([^ ]+).*|crate/cratesio/-/\1/\2|' \
+      | java -jar /path/to/org.eclipse.dash.licenses-x.y.z.jar -summary summary-rust.txt -
+```


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR adds some documentation for the Eclipse IP due diligence process.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #4

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
