### PR TITLE
Correct documentation typo

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -162,7 +162,7 @@ payload data segment
   [`true`|`false`]: Defines if the request buffer of the service safely
   overflows.
 * `defaults.request-response.enable-safe-overflow-for-responses` -
-  [`true`|`false`]: Defines if the request buffer of the service safely
+  [`true`|`false`]: Defines if the response buffer of the service safely
   overflows.
 * `defaults.request-response.max-active-requests-per-client` - [int]:
   The maximum of active requests a server can hold per client

--- a/iceoryx2-cli/iox2-config/src/command/explain.rs
+++ b/iceoryx2-cli/iox2-config/src/command/explain.rs
@@ -328,7 +328,7 @@ pub(crate) fn describe_schema(config: &Config) -> Vec<Section> {
                     key: "defaults.request-response.enable-safe-overflow-for-responses",
                     value_type: "`true`|`false`",
                     default_value: config.defaults.request_response.enable_safe_overflow_for_responses.to_string(),
-                    description: "Defines if the request buffer of the service safely overflows.",
+                    description: "Defines if the response buffer of the service safely overflows.",
                 },
                 Field {
                     key: "defaults.request-response.max-active-requests-per-client",


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [~] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #4

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->