### PR TITLE
[#1345] Ignore warnings from bindgen generated files with bazel

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -63,6 +63,8 @@
   [#1327](https://github.com/eclipse-iceoryx/iceoryx2/issues/1327)
 * `CleanupState` implements `ZeroCopySend`
   [#1331](https://github.com/eclipse-iceoryx/iceoryx2/issues/1331)
+* Ignore warnings from bindgen generated files with bazel build
+  [#1345](https://github.com/eclipse-iceoryx/iceoryx2/issues/1345)
 
 ### Workflow
 

--- a/iceoryx2-pal/os-api/BUILD.bazel
+++ b/iceoryx2-pal/os-api/BUILD.bazel
@@ -35,6 +35,9 @@ rust_bindgen_library(
     cc_lib = ":iceoryx2-pal-os-api-c-lib",
     bindgen_flags = [
         "--use-core",
+        # ignore warnings in the bindgen generated code
+        "--raw-line=#![allow(warnings)]",
+        "--raw-line=#![allow(clippy::all)]",
     ],
 )
 

--- a/iceoryx2-pal/posix/BUILD.bazel
+++ b/iceoryx2-pal/posix/BUILD.bazel
@@ -39,7 +39,10 @@ rust_bindgen_library(
     cc_lib = ":iceoryx2-pal-posix-c-lib",
     bindgen_flags = [
         "--use-core",
-        "--blocklist-type", "max_align_t"
+        "--blocklist-type", "max_align_t",
+        # ignore warnings in the bindgen generated code
+        "--raw-line=#![allow(warnings)]",
+        "--raw-line=#![allow(clippy::all)]",
     ],
 )
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [~] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1345

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
