### PR TITLE
examples/python: add minimal event-based communication example and e2e test

### DIFF
--- a/examples/python/event_based_communication/README.md
+++ b/examples/python/event_based_communication/README.md
@@ -1,0 +1,44 @@
+# Minimal Event-Driven Communication
+
+This is a minimal Python version of the Rust/C++ `event_based_communication`
+example.
+
+It combines:
+
+- `publish_subscribe` for data transport (`TransmissionData`)
+- `event` for signaling
+- `waitset` for event-driven processing
+
+The publisher sends one sample every second and emits event id `4`
+(`SentSample`). The subscriber listens for that event, drains all available
+samples, and emits event id `5` (`ReceivedSample`) as an acknowledgement.
+
+## How to Build
+
+Before running examples, set up the Python environment and build bindings:
+
+```sh
+poetry --project iceoryx2-ffi/python install
+poetry --project iceoryx2-ffi/python build-into-venv
+```
+
+## How to Run
+
+Terminal 1:
+
+```sh
+poetry --project iceoryx2-ffi/python run python examples/python/event_based_communication/subscriber.py
+```
+
+Terminal 2:
+
+```sh
+poetry --project iceoryx2-ffi/python run python examples/python/event_based_communication/publisher.py
+```
+
+Optional: override the service name for isolated runs:
+
+```sh
+IOX2_SERVICE_NAME="My/Funk/ServiceName-Test" python examples/python/event_based_communication/subscriber.py
+IOX2_SERVICE_NAME="My/Funk/ServiceName-Test" python examples/python/event_based_communication/publisher.py
+```

--- a/examples/python/event_based_communication/publisher.py
+++ b/examples/python/event_based_communication/publisher.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+"""Minimal event-driven publisher example."""
+
+import os
+
+import iceoryx2 as iox2
+from transmission_data import TransmissionData
+
+SERVICE_NAME = os.environ.get("IOX2_SERVICE_NAME", "My/Funk/ServiceName")
+CYCLE_TIME = iox2.Duration.from_secs(1)
+
+# Keep the same IDs as the Rust/C++ event-based communication example.
+EVENT_SENT_SAMPLE = iox2.EventId.new(4)
+EVENT_RECEIVED_SAMPLE = iox2.EventId.new(5)
+
+iox2.set_log_level_from_env_or(iox2.LogLevel.Info)
+node = iox2.NodeBuilder.new().create(iox2.ServiceType.Ipc)
+
+pubsub = (
+    node.service_builder(iox2.ServiceName.new(SERVICE_NAME))
+    .publish_subscribe(TransmissionData)
+    .open_or_create()
+)
+publisher = pubsub.publisher_builder().create()
+
+event = node.service_builder(iox2.ServiceName.new(SERVICE_NAME)).event().open_or_create()
+notifier = event.notifier_builder().create()
+listener = event.listener_builder().create()
+
+waitset = iox2.WaitSetBuilder.new().create(iox2.ServiceType.Ipc)
+interval_guard = waitset.attach_interval(CYCLE_TIME)
+listener_guard = waitset.attach_notification(listener)
+
+counter = 0
+print("Minimal event-driven publisher running...")
+
+try:
+    while True:
+        (notifications, result) = waitset.wait_and_process()
+        if result in (
+            iox2.WaitSetRunResult.TerminationRequest,
+            iox2.WaitSetRunResult.Interrupt,
+        ):
+            break
+
+        for attachment in notifications:
+            if attachment.has_event_from(interval_guard):
+                counter += 1
+                sample = publisher.loan_uninit()
+                sample = sample.write_payload(
+                    TransmissionData(
+                        x=counter,
+                        y=counter * 3,
+                        funky=counter * 812.12,
+                    )
+                )
+                sample.send()
+                notifier.notify_with_custom_event_id(EVENT_SENT_SAMPLE)
+                print("send:", counter)
+            elif attachment.has_event_from(listener_guard):
+                for event_id in listener.try_wait_all():
+                    if event_id == EVENT_RECEIVED_SAMPLE:
+                        print("subscriber consumed sample")
+except iox2.WaitSetRunError:
+    print("waitset error")
+
+print("exit")

--- a/examples/python/event_based_communication/subscriber.py
+++ b/examples/python/event_based_communication/subscriber.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+"""Minimal event-driven subscriber example."""
+
+import os
+
+import iceoryx2 as iox2
+from transmission_data import TransmissionData
+
+SERVICE_NAME = os.environ.get("IOX2_SERVICE_NAME", "My/Funk/ServiceName")
+DEADLINE = iox2.Duration.from_secs(2)
+
+# Keep the same IDs as the Rust/C++ event-based communication example.
+EVENT_SENT_SAMPLE = iox2.EventId.new(4)
+EVENT_RECEIVED_SAMPLE = iox2.EventId.new(5)
+
+iox2.set_log_level_from_env_or(iox2.LogLevel.Info)
+node = iox2.NodeBuilder.new().create(iox2.ServiceType.Ipc)
+
+pubsub = (
+    node.service_builder(iox2.ServiceName.new(SERVICE_NAME))
+    .publish_subscribe(TransmissionData)
+    .open_or_create()
+)
+subscriber = pubsub.subscriber_builder().create()
+
+event = node.service_builder(iox2.ServiceName.new(SERVICE_NAME)).event().open_or_create()
+listener = event.listener_builder().create()
+notifier = event.notifier_builder().create()
+
+waitset = iox2.WaitSetBuilder.new().create(iox2.ServiceType.Ipc)
+listener_guard = waitset.attach_deadline(listener, DEADLINE)
+
+print("Minimal event-driven subscriber waiting for events...")
+
+try:
+    while True:
+        (notifications, result) = waitset.wait_and_process()
+        if result in (
+            iox2.WaitSetRunResult.TerminationRequest,
+            iox2.WaitSetRunResult.Interrupt,
+        ):
+            break
+
+        for attachment in notifications:
+            if attachment.has_event_from(listener_guard):
+                for event_id in listener.try_wait_all():
+                    if event_id == EVENT_SENT_SAMPLE:
+                        while True:
+                            sample = subscriber.receive()
+                            if sample is None:
+                                break
+
+                            print("received:", sample.payload().contents)
+                            notifier.notify_with_custom_event_id(EVENT_RECEIVED_SAMPLE)
+            elif attachment.has_missed_deadline(listener_guard):
+                print(
+                    "Contract violation! "
+                    f"The subscriber did not receive a message for {DEADLINE}."
+                )
+except iox2.WaitSetRunError:
+    print("waitset error")
+
+print("exit")

--- a/examples/python/event_based_communication/test_e2e_event_based_communication.exp
+++ b/examples/python/event_based_communication/test_e2e_event_based_communication.exp
@@ -1,0 +1,38 @@
+#!/usr/bin/expect
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#### Common Setup
+
+set REPO_ROOT [exec git rev-parse --show-toplevel]
+cd ${REPO_ROOT}
+
+source ${REPO_ROOT}/internal/end-to-end-testing/common.exp
+
+#### Test Setup
+
+set timeout 15
+set SERVICE_NAME "My/Funk/ServiceName-e2e-[pid]"
+
+spawn env IOX2_SERVICE_NAME=${SERVICE_NAME} python examples/python/event_based_communication/subscriber.py
+set id_subscriber $spawn_id
+
+spawn env IOX2_SERVICE_NAME=${SERVICE_NAME} python examples/python/event_based_communication/publisher.py
+set id_publisher $spawn_id
+
+#### Test Assertion
+
+expect_output_from $id_publisher "send: 1"
+expect_output_from $id_publisher "subscriber consumed sample"
+expect_output_from $id_subscriber "received: TransmissionData { x: 1, y: 3, funky: 812.12 }*"
+
+show_test_passed

--- a/examples/python/event_based_communication/transmission_data.py
+++ b/examples/python/event_based_communication/transmission_data.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+"""Event-based communication payload type."""
+
+import ctypes
+
+
+class TransmissionData(ctypes.Structure):
+    """The strongly typed payload type."""
+
+    _fields_ = [
+        ("x", ctypes.c_int32),
+        ("y", ctypes.c_int32),
+        ("funky", ctypes.c_double),
+    ]
+
+    def __str__(self) -> str:
+        """Returns human-readable string of the contents."""
+        return f"TransmissionData {{ x: {self.x}, y: {self.y}, funky: {self.funky} }}"
+
+    @staticmethod
+    def type_name() -> str:
+        """Returns the system-wide unique type name required for communication."""
+        return "TransmissionData"


### PR DESCRIPTION
## Summary
- add a minimal Python `event_based_communication` example using `pubsub + event + waitset`
- include publisher/subscriber scripts and shared `TransmissionData` payload type
- add `test_e2e_event_based_communication.exp` for end-to-end verification
- allow overriding service name via `IOX2_SERVICE_NAME` for isolated runs

## Validation
- run the new e2e expect test:
  - `expect examples/python/event_based_communication/test_e2e_event_based_communication.exp`
  - observed `Test passed!`