### PR TITLE
[#1374] Remove libc_platform feature flag from nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,32 +53,15 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain: [stable, 1.83.0]
         profile: ["release", "debug"]
-        # NOTE: using 'iceoryx2/libc_platform' to trigger the feature propagation check
-        # by explicitly setting the flag only in the iceoryx2 crate
-        cargo-features-flag: ["", "--features iceoryx2/libc_platform"]
-        include:
-          - cargo-features-flag: "--features libc_platform"
-            profile: release
-            os: ubuntu-latest
-            toolchain: stable
         exclude:
           - os: ubuntu-latest # already tested in Pull-Requests and main branch
             toolchain: stable
             profile: "release"
-          - cargo-features-flag: "--features iceoryx2/libc_platform"
-            toolchain: 1.83.0
-          - os: macos-latest
-            cargo-features-flag: "--features iceoryx2/libc_platform"
-            toolchain: stable
-          - os: windows-latest
-            cargo-features-flag: "--features iceoryx2/libc_platform"
-            toolchain: stable
     uses: ./.github/workflows/reuse_x86_64_stable.yml
     with:
       os: ${{ matrix.os }}
       toolchain: ${{ matrix.toolchain }}
       profile: ${{ matrix.profile }}
-      cargo-features-flag: ${{ matrix.cargo-features-flag }}
 
   unstable-nightly:
     needs: [static-code-analysis-rust-nightly, cargo-nextest-nightly]


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Fix for nightly CI

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [x] Assign PR to reviewer
* [x] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1374 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
