### PR TITLE
Add C++ binding for Config::setup_global_config_from_file

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -59,6 +59,8 @@
   [#1365](https://github.com/eclipse-iceoryx/iceoryx2/issues/1370)
 * Add `update_connection` to Python bindings
   [#1380](https://github.com/eclipse-iceoryx/iceoryx2/issues/1380)
+* Add `Config::setup_global_config_from_file` to C++ bindings
+  [#1395](https://github.com/eclipse-iceoryx/iceoryx2/issues/1395)
 
 ### Refactoring
 

--- a/iceoryx2-cxx/include/iox2/config.hpp
+++ b/iceoryx2-cxx/include/iox2/config.hpp
@@ -441,6 +441,11 @@ class Config {
     /// [`ConfigCreationError`] describing the failure.
     static auto from_file(const iox2::bb::FilePath& file) -> iox2::bb::Expected<Config, ConfigCreationError>;
 
+    /// Sets the global configuration from a file. On success it returns the global config as [`ConfigView`]
+    /// object otherwise a [`ConfigCreationError`] describing the failure.
+    static auto setup_global_config_from_file(const iox2::bb::FilePath& file)
+        -> iox2::bb::Expected<ConfigView, ConfigCreationError>;
+
     /// Returns the [`config::Global`] part of the config
     auto global() -> config::Global;
     /// Returns the [`config::Defaults`] part of the config

--- a/iceoryx2-cxx/src/config.cpp
+++ b/iceoryx2-cxx/src/config.cpp
@@ -91,6 +91,17 @@ auto Config::from_file(const iox2::bb::FilePath& file) -> iox2::bb::Expected<Con
     return iox2::bb::err(iox2::bb::into<ConfigCreationError>(result));
 }
 
+auto Config::setup_global_config_from_file(const iox2::bb::FilePath& file)
+    -> iox2::bb::Expected<ConfigView, ConfigCreationError> {
+    iox2_config_ptr handle = nullptr;
+    auto result = iox2_config_setup_global_config_from_file(&handle, file.as_string().unchecked_access().c_str());
+    if (result == IOX2_OK) {
+        return ConfigView { handle };
+    }
+
+    return iox2::bb::err(iox2::bb::into<ConfigCreationError>(result));
+}
+
 auto Config::global() -> config::Global {
     return config::Global(&this->m_handle);
 }

--- a/iceoryx2-ffi/c/src/api/config.rs
+++ b/iceoryx2-ffi/c/src/api/config.rs
@@ -269,6 +269,38 @@ pub unsafe extern "C" fn iox2_config_from_file(
     IOX2_OK
 }
 
+/// Creates an iceoryx2 config, populated values from the provided file and sets it as global default.
+///
+/// # Safety
+///
+/// * `handle_ptr` - An uninitialized or dangling [`iox2_config_ptr`] handle which will be initialized
+///   by this function call.
+/// * `config_file` - Must be a valid file path to an existing config file.
+#[no_mangle]
+pub unsafe extern "C" fn iox2_config_setup_global_config_from_file(
+    handle_ptr: *mut iox2_config_ptr,
+    config_file: *const c_char,
+) -> c_int {
+    debug_assert!(!handle_ptr.is_null());
+    debug_assert!(!config_file.is_null());
+
+    let file = match FilePath::from_c_str(config_file) {
+        Ok(file) => file,
+        Err(_) => return iox2_config_creation_error_e::INVALID_FILE_PATH as c_int,
+    };
+
+    let config = match Config::setup_global_config_from_file(&file) {
+        Ok(config) => config,
+        Err(e) => {
+            return e.into_c_int();
+        }
+    };
+
+    *handle_ptr = config;
+
+    IOX2_OK
+}
+
 /// Clones a config from the provided [`iox2_config_ptr`].
 ///
 /// # Safety


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
I am not very experienced in Rust and cbindgen, however, this code was tested in a larger project and seems to work fine.
It adds C++ bindings for `Config::setup_global_config_from_file` so it is usable like in Python and Rust.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [ ] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [ ] Assign PR to reviewer
* [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1395 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
