### PR TITLE
[#1425] Add missing getters for PublishSubscribe Publisher

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -33,7 +33,9 @@
   [#1376](https://github.com/eclipse-iceoryx/iceoryx2/issues/1376)
 * Add `iox2 service hz` command with rolling-rate statistics and timeout support
   [#1383](https://github.com/eclipse-iceoryx/iceoryx2/issues/1383)
-
+* Add missing Publisher getters
+  [#1425](https://github.com/eclipse-iceoryx/iceoryx2/issues/1425)
+  
 ### Bugfixes
 
 <!--

--- a/iceoryx2-cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-cxx/include/iox2/enum_translation.hpp
@@ -1917,6 +1917,35 @@ constexpr auto from<iox2::UnableToDeliverStrategy, int>(const iox2::UnableToDeli
 }
 
 template <>
+constexpr auto from<int, iox2::AllocationStrategy>(const int value) noexcept -> iox2::AllocationStrategy {
+    const auto variant = static_cast<iox2_allocation_strategy_e>(value);
+    switch (variant) {
+    case iox2_allocation_strategy_e_STATIC:
+        return iox2::AllocationStrategy::Static;
+    case iox2_allocation_strategy_e_BEST_FIT:
+        return iox2::AllocationStrategy::BestFit;
+    case iox2_allocation_strategy_e_POWER_OF_TWO:
+        return iox2::AllocationStrategy::PowerOfTwo;
+    }
+
+    IOX2_UNREACHABLE();
+}
+
+template <>
+constexpr auto from<iox2::AllocationStrategy, int>(const iox2::AllocationStrategy value) noexcept -> int {
+    switch (value) {
+    case iox2::AllocationStrategy::Static:
+        return iox2_allocation_strategy_e_STATIC;
+    case iox2::AllocationStrategy::BestFit:
+        return iox2_allocation_strategy_e_BEST_FIT;
+    case iox2::AllocationStrategy::PowerOfTwo:
+        return iox2_allocation_strategy_e_POWER_OF_TWO;
+    }
+
+    IOX2_UNREACHABLE();
+}
+
+template <>
 constexpr auto from<int, iox2::ConnectionFailure>(const int value) noexcept -> iox2::ConnectionFailure {
     const auto variant = static_cast<iox2_connection_failure_e>(value);
     switch (variant) {

--- a/iceoryx2-cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-cxx/include/iox2/publisher.hpp
@@ -53,6 +53,14 @@ class Publisher {
     template <typename T = Payload, typename = std::enable_if_t<bb::IsSlice<T>::VALUE, void>>
     auto initial_max_slice_len() const -> uint64_t;
 
+    /// Returns the maximum number of [`SampleMut`] that can be loaned in parallel.
+    auto max_loaned_samples() const -> uint64_t;
+
+    /// Returns the [`AllocationStrategy`] that is used when the provided [`Publisher`] loans a slice bigger than the
+    /// initial maximum slice length.
+    template <typename T = Payload, typename = std::enable_if_t<bb::IsSlice<T>::VALUE, void>>
+    auto allocation_strategy() const -> AllocationStrategy;
+
     /// Copies the input `value` into a [`SampleMut`] and delivers it.
     /// On success it returns the number of [`Subscriber`]s that received
     /// the data, otherwise a [`SendError`] describing the failure.
@@ -156,6 +164,18 @@ template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto Publisher<S, Payload, UserHeader>::initial_max_slice_len() const -> uint64_t {
     return iox2_publisher_initial_max_slice_len(&m_handle);
+}
+
+template <ServiceType S, typename Payload, typename UserHeader>
+inline auto Publisher<S, Payload, UserHeader>::max_loaned_samples() const -> uint64_t{
+    return iox2_publisher_max_loaned_samples(&m_handle);
+}
+
+template <ServiceType S, typename Payload, typename UserHeader>
+template <typename T, typename>
+inline auto Publisher<S, Payload, UserHeader>::allocation_strategy() const -> AllocationStrategy {
+    return iox2::bb::into<AllocationStrategy>(
+        static_cast<int>(iox2_publisher_allocation_strategy(&m_handle)));
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
@@ -55,6 +55,21 @@ impl From<iox2_allocation_strategy_e> for AllocationStrategy {
     }
 }
 
+impl From<AllocationStrategy> for iox2_allocation_strategy_e {
+    fn from(value: AllocationStrategy) -> Self {
+        match value {
+            AllocationStrategy::Static => iox2_allocation_strategy_e::STATIC,
+            AllocationStrategy::BestFit => iox2_allocation_strategy_e::BEST_FIT,
+            AllocationStrategy::PowerOfTwo => iox2_allocation_strategy_e::POWER_OF_TWO,
+        }
+    }
+}
+
+impl IntoCInt for AllocationStrategy {
+    fn into_c_int(self) -> c_int {
+        Into::<iox2_allocation_strategy_e>::into(self) as c_int
+    }
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub enum iox2_unable_to_deliver_strategy_e {

--- a/iceoryx2-ffi/c/src/api/publisher.rs
+++ b/iceoryx2-ffi/c/src/api/publisher.rs
@@ -13,7 +13,7 @@
 #![allow(non_camel_case_types)]
 
 use crate::api::{
-    iox2_service_type_e, iox2_unable_to_deliver_strategy_e, iox2_unique_publisher_id_h,
+    iox2_service_type_e, iox2_unable_to_deliver_strategy_e, iox2_allocation_strategy_e, iox2_unique_publisher_id_h,
     iox2_unique_publisher_id_t, AssertNonNullHandle, HandleToType, PayloadFfi,
     SampleMutUninitUnion, UserHeaderFfi, IOX2_OK,
 };
@@ -319,6 +319,44 @@ pub unsafe extern "C" fn iox2_publisher_unable_to_deliver_strategy(
     }
 }
 
+
+/// Returns the strategy the publisher follows when the slice length requested exceeds the current slice buffer
+///
+/// # Arguments
+///
+/// * `handle` obtained by [`iox2_port_factory_publisher_builder_create`](crate::iox2_port_factory_publisher_builder_create)
+///
+/// Returns [`iox2_allocation_strategy_e`].
+///
+/// # Safety
+///
+/// * `publisher_handle` is valid and non-null
+
+#[no_mangle]
+pub unsafe extern "C" fn iox2_publisher_allocation_strategy(
+    publisher_handle: iox2_publisher_h_ref,
+) -> iox2_allocation_strategy_e {
+    publisher_handle.assert_non_null();
+
+    let publisher = &mut *publisher_handle.as_type();
+
+    match publisher.service_type {
+        iox2_service_type_e::IPC => publisher
+            .value
+            .as_mut()
+            .ipc
+            .allocation_strategy()
+            .into(),
+        iox2_service_type_e::LOCAL => publisher
+            .value
+            .as_mut()
+            .local
+            .allocation_strategy()
+            .into(),
+    }
+}
+
+
 /// Returns the maximum `[u8]` length that can be loaned in one sample, i.e. the max number of
 /// elements in the `[u8]` payload type used by the C binding.
 ///
@@ -345,6 +383,28 @@ pub unsafe extern "C" fn iox2_publisher_initial_max_slice_len(
         iox2_service_type_e::LOCAL => {
             publisher.value.as_mut().local.initial_max_slice_len() as c_size_t
         }
+    }
+}
+
+/// Returns the maximum number of samples that can be loaned at the same time by the publisher.
+///
+/// # Arguments
+/// * `publisher_handle` obtained by [`iox2_port_factory_publisher_builder_create`](crate::iox2_port_factory_publisher_builder_create)
+/// Returns the maximum number of loaned samples as a [`c_size_t`].
+///
+/// # Safety
+///
+/// * `publisher_handle` is valid and non-null
+#[no_mangle]
+pub unsafe extern "C" fn iox2_publisher_max_loaned_samples(
+    publisher_handle: iox2_publisher_h_ref,
+) -> c_size_t {
+    publisher_handle.assert_non_null();
+
+    let publisher = &mut *publisher_handle.as_type();
+    match publisher.service_type {
+        iox2_service_type_e::IPC => {publisher.value.as_mut().ipc.max_loaned_samples() as c_size_t},
+        iox2_service_type_e::LOCAL => {publisher.value.as_mut().local.max_loaned_samples() as c_size_t},
     }
 }
 

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -525,6 +525,22 @@ impl<
             .sender
             .unable_to_deliver_strategy
     }
+
+    /// Returns the strategy the [`Publisher`] follows when a [`SampleMut`] cannot be allocated.
+    pub fn allocation_strategy(&self) -> AllocationStrategy {
+        self.publisher_shared_state
+            .lock()
+            .config
+            .allocation_strategy
+    }
+
+    /// Returns the maximum number of [`SampleMut`]s that can be loaned in parallel.
+    pub fn max_loaned_samples(&self) -> usize {
+        self.publisher_shared_state
+            .lock()
+            .sender.sender_max_borrowed_samples
+    }
+
 }
 
 ////////////////////////


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
Adds `allocation_strategy()` and `max_loaned_samples()` getters to `Publisher`  of `PublishSubscribe` services.
The code re-uses the same logic as other existing getters.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [ ] Assign PR to reviewer
* [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1245

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
