### PR TITLE
[#1425] Add missing getters for PublishSubscribe Publisher

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -16,6 +16,7 @@
 * [#820](https://github.com/eclipse-iceoryx/iceoryx2/issues/820) Allow restricting the gateway to a configurable allowlist of services
 * [#925](https://github.com/eclipse-iceoryx/iceoryx2/issues/925) Adjust event API and guarantee that events can be always delivered.
 * [#1185](https://github.com/eclipse-iceoryx/iceoryx2/issues/1185) Make history configurable per subscriber
+* [#1425](https://github.com/eclipse-iceoryx/iceoryx2/issues/1425) Add missing Publisher getters
 * [#1584](https://github.com/eclipse-iceoryx/iceoryx2/issues/1584) Introduce `Node::force_remove_service` to remove corrupted services manually.
 * [#1544](https://github.com/eclipse-iceoryx/iceoryx2/issues/1544) Announce service removal over the gateway to remote hosts
 * [#1616](https://github.com/eclipse-iceoryx/iceoryx2/issues/1616) Add reactive execution mode to gateway

--- a/iceoryx2-cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-cxx/include/iox2/enum_translation.hpp
@@ -2436,6 +2436,35 @@ constexpr auto from<iox2::BackpressureStrategy, int>(const iox2::BackpressureStr
 }
 
 template <>
+constexpr auto from<int, iox2::AllocationStrategy>(const int value) noexcept -> iox2::AllocationStrategy {
+    const auto variant = static_cast<iox2_allocation_strategy_e>(value);
+    switch (variant) {
+    case iox2_allocation_strategy_e_STATIC:
+        return iox2::AllocationStrategy::Static;
+    case iox2_allocation_strategy_e_BEST_FIT:
+        return iox2::AllocationStrategy::BestFit;
+    case iox2_allocation_strategy_e_POWER_OF_TWO:
+        return iox2::AllocationStrategy::PowerOfTwo;
+    }
+
+    IOX2_UNREACHABLE();
+}
+
+template <>
+constexpr auto from<iox2::AllocationStrategy, int>(const iox2::AllocationStrategy value) noexcept -> int {
+    switch (value) {
+    case iox2::AllocationStrategy::Static:
+        return iox2_allocation_strategy_e_STATIC;
+    case iox2::AllocationStrategy::BestFit:
+        return iox2_allocation_strategy_e_BEST_FIT;
+    case iox2::AllocationStrategy::PowerOfTwo:
+        return iox2_allocation_strategy_e_POWER_OF_TWO;
+    }
+
+    IOX2_UNREACHABLE();
+}
+
+template <>
 constexpr auto from<int, iox2::ConnectionFailure>(const int value) noexcept -> iox2::ConnectionFailure {
     const auto variant = static_cast<iox2_connection_failure_e>(value);
     switch (variant) {

--- a/iceoryx2-cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-cxx/include/iox2/publisher.hpp
@@ -62,6 +62,14 @@ class Publisher {
     template <typename T = Payload, typename = std::enable_if_t<bb::IsSlice<T>::VALUE, void>>
     auto initial_max_slice_len() const -> uint64_t;
 
+    /// Returns the maximum number of [`SampleMut`] that can be loaned in parallel.
+    auto max_loaned_samples() const -> uint64_t;
+
+    /// Returns the [`AllocationStrategy`] that is used when the provided [`Publisher`] loans a slice bigger than the
+    /// initial maximum slice length.
+    template <typename T = Payload, typename = std::enable_if_t<bb::IsSlice<T>::VALUE, void>>
+    auto allocation_strategy() const -> AllocationStrategy;
+
     /// Copies the input `value` into a [`SampleMut`] and delivers it.
     /// On success it returns the number of [`Subscriber`]s that received
     /// the data, otherwise a [`SendError`] describing the failure.
@@ -175,6 +183,17 @@ template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto Publisher<S, Payload, UserHeader>::initial_max_slice_len() const -> uint64_t {
     return iox2_publisher_initial_max_slice_len(&m_handle);
+}
+
+template <ServiceType S, typename Payload, typename UserHeader>
+inline auto Publisher<S, Payload, UserHeader>::max_loaned_samples() const -> uint64_t {
+    return iox2_publisher_max_loaned_samples(&m_handle);
+}
+
+template <ServiceType S, typename Payload, typename UserHeader>
+template <typename T, typename>
+inline auto Publisher<S, Payload, UserHeader>::allocation_strategy() const -> AllocationStrategy {
+    return iox2::bb::into<AllocationStrategy>(static_cast<int>(iox2_publisher_allocation_strategy(&m_handle)));
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -1880,4 +1880,45 @@ TYPED_TEST(ServicePublishSubscribeTest, port_names_can_be_set) {
     ASSERT_THAT(subscriber.name().to_string(), subscriber_name.to_string());
 }
 
+TYPED_TEST(ServicePublishSubscribeTest, publisher_applies_max_loaned_samples) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+
+    const auto service_name = iox2::testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name).template publish_subscribe<uint64_t>().create().value();
+
+    auto publisher_1 = service.publisher_builder().max_loaned_samples(1).create().value();
+    ASSERT_THAT(publisher_1.max_loaned_samples(), Eq(1));
+
+    auto publisher_100 = service.publisher_builder().max_loaned_samples(100).create().value();
+    ASSERT_THAT(publisher_100.max_loaned_samples(), Eq(100));
+}
+
+TYPED_TEST(ServicePublishSubscribeTest, publisher_applies_allocation_strategy) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    using ValueType = uint8_t;
+
+    const auto service_name = iox2::testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service =
+        node.service_builder(service_name).template publish_subscribe<bb::Slice<ValueType>>().create().value();
+
+    auto publisher_default = service.publisher_builder().create().value();
+    ASSERT_THAT(publisher_default.allocation_strategy(), Eq(AllocationStrategy::Static));
+
+    auto publisher_best_fit =
+        service.publisher_builder().allocation_strategy(AllocationStrategy::BestFit).create().value();
+    ASSERT_THAT(publisher_best_fit.allocation_strategy(), Eq(AllocationStrategy::BestFit));
+
+    auto publisher_power_of_two =
+        service.publisher_builder().allocation_strategy(AllocationStrategy::PowerOfTwo).create().value();
+    ASSERT_THAT(publisher_power_of_two.allocation_strategy(), Eq(AllocationStrategy::PowerOfTwo));
+
+    auto publisher_static =
+        service.publisher_builder().allocation_strategy(AllocationStrategy::Static).create().value();
+    ASSERT_THAT(publisher_static.allocation_strategy(), Eq(AllocationStrategy::Static));
+}
+
 } // namespace

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -1882,17 +1882,19 @@ TYPED_TEST(ServicePublishSubscribeTest, port_names_can_be_set) {
 
 TYPED_TEST(ServicePublishSubscribeTest, publisher_applies_max_loaned_samples) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint8_t MAX_LOANEN_SAMPLE_SMALL = 1;
+    constexpr uint8_t MAX_LOANEN_SAMPLE_LARGE = 100;
 
     const auto service_name = iox2::testing::generate_service_name();
 
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
     auto service = node.service_builder(service_name).template publish_subscribe<uint64_t>().create().value();
 
-    auto publisher_1 = service.publisher_builder().max_loaned_samples(1).create().value();
-    ASSERT_THAT(publisher_1.max_loaned_samples(), Eq(1));
+    auto publisher_1 = service.publisher_builder().max_loaned_samples(MAX_LOANEN_SAMPLE_SMALL).create().value();
+    ASSERT_THAT(publisher_1.max_loaned_samples(), Eq(MAX_LOANEN_SAMPLE_SMALL));
 
-    auto publisher_100 = service.publisher_builder().max_loaned_samples(100).create().value();
-    ASSERT_THAT(publisher_100.max_loaned_samples(), Eq(100));
+    auto publisher_100 = service.publisher_builder().max_loaned_samples(MAX_LOANEN_SAMPLE_LARGE).create().value();
+    ASSERT_THAT(publisher_100.max_loaned_samples(), Eq(MAX_LOANEN_SAMPLE_LARGE));
 }
 
 TYPED_TEST(ServicePublishSubscribeTest, publisher_applies_allocation_strategy) {

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -1899,13 +1899,17 @@ TYPED_TEST(ServicePublishSubscribeTest, publisher_applies_max_loaned_samples) {
 
 TYPED_TEST(ServicePublishSubscribeTest, publisher_applies_allocation_strategy) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint8_t MAX_PUBLISHERS = 4;
     using ValueType = uint8_t;
 
     const auto service_name = iox2::testing::generate_service_name();
 
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
-    auto service =
-        node.service_builder(service_name).template publish_subscribe<bb::Slice<ValueType>>().create().value();
+    auto service = node.service_builder(service_name)
+                       .template publish_subscribe<bb::Slice<ValueType>>()
+                       .max_publishers(MAX_PUBLISHERS)
+                       .create()
+                       .value();
 
     auto publisher_default = service.publisher_builder().create().value();
     ASSERT_THAT(publisher_default.allocation_strategy(), Eq(AllocationStrategy::Static));

--- a/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
@@ -57,6 +57,21 @@ impl From<iox2_allocation_strategy_e> for AllocationStrategy {
     }
 }
 
+impl From<AllocationStrategy> for iox2_allocation_strategy_e {
+    fn from(value: AllocationStrategy) -> Self {
+        match value {
+            AllocationStrategy::Static => iox2_allocation_strategy_e::STATIC,
+            AllocationStrategy::BestFit => iox2_allocation_strategy_e::BEST_FIT,
+            AllocationStrategy::PowerOfTwo => iox2_allocation_strategy_e::POWER_OF_TWO,
+        }
+    }
+}
+
+impl IntoCInt for AllocationStrategy {
+    fn into_c_int(self) -> c_int {
+        Into::<iox2_allocation_strategy_e>::into(self) as c_int
+    }
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub enum iox2_backpressure_strategy_e {

--- a/iceoryx2-ffi/c/src/api/publisher.rs
+++ b/iceoryx2-ffi/c/src/api/publisher.rs
@@ -14,8 +14,8 @@
 
 use crate::api::{
     AssertNonNullHandle, HandleToType, IOX2_OK, PayloadFfi, SampleMutUninitUnion, UserHeaderFfi,
-    iox2_backpressure_strategy_e, iox2_port_name_ptr, iox2_service_type_e,
-    iox2_unique_publisher_id_h, iox2_unique_publisher_id_t,
+    iox2_allocation_strategy_e, iox2_backpressure_strategy_e, iox2_port_name_ptr,
+    iox2_service_type_e, iox2_unique_publisher_id_h, iox2_unique_publisher_id_t,
 };
 
 use iceoryx2::port::LoanError;
@@ -320,6 +320,35 @@ pub unsafe extern "C" fn iox2_publisher_backpressure_strategy(
     }
 }
 
+/// Returns the strategy the publisher follows when the slice length requested exceeds the current slice buffer
+///
+/// # Arguments
+///
+/// * `handle` obtained by [`iox2_port_factory_publisher_builder_create`](crate::iox2_port_factory_publisher_builder_create)
+///
+/// Returns [`iox2_allocation_strategy_e`].
+///
+/// # Safety
+///
+/// * `publisher_handle` is valid and non-null
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_publisher_allocation_strategy(
+    publisher_handle: iox2_publisher_h_ref,
+) -> iox2_allocation_strategy_e {
+    publisher_handle.assert_non_null();
+
+    unsafe {
+        let publisher = &mut *publisher_handle.as_type();
+
+        match publisher.service_type {
+            iox2_service_type_e::IPC => publisher.value.as_mut().ipc.allocation_strategy().into(),
+            iox2_service_type_e::LOCAL => {
+                publisher.value.as_mut().local.allocation_strategy().into()
+            }
+        }
+    }
+}
+
 /// Returns the maximum `[u8]` length that can be loaned in one sample, i.e. the max number of
 /// elements in the `[u8]` payload type used by the C binding.
 ///
@@ -345,6 +374,35 @@ pub unsafe extern "C" fn iox2_publisher_initial_max_slice_len(
             }
             iox2_service_type_e::LOCAL => {
                 publisher.value.as_mut().local.initial_max_slice_len() as c_size_t
+            }
+        }
+    }
+}
+
+/// Returns the maximum number of samples that can be loaned at the same time by the publisher.
+///
+/// # Arguments
+/// * `publisher_handle` obtained by [`iox2_port_factory_publisher_builder_create`](crate::iox2_port_factory_publisher_builder_create)
+///
+/// Returns the maximum number of loaned samples as a [`c_size_t`].
+///
+/// # Safety
+///
+/// * `publisher_handle` is valid and non-null
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_publisher_max_loaned_samples(
+    publisher_handle: iox2_publisher_h_ref,
+) -> c_size_t {
+    publisher_handle.assert_non_null();
+
+    unsafe {
+        let publisher = &mut *publisher_handle.as_type();
+        match publisher.service_type {
+            iox2_service_type_e::IPC => {
+                publisher.value.as_mut().ipc.max_loaned_samples() as c_size_t
+            }
+            iox2_service_type_e::LOCAL => {
+                publisher.value.as_mut().local.max_loaned_samples() as c_size_t
             }
         }
     }

--- a/iceoryx2/conformance-tests/src/publisher.rs
+++ b/iceoryx2/conformance-tests/src/publisher.rs
@@ -884,4 +884,75 @@ pub mod publisher {
 
         Ok(())
     }
+
+    #[conformance_test]
+    pub fn allocation_strategy_is_set_correctly<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let node = test.create_node();
+
+        // the allocation_strategy setter is only available for slices
+        let service_slice = node
+            .service_builder(&generate_service_name())
+            .publish_subscribe::<[u64]>()
+            .max_publishers(5)
+            .create()?;
+
+        let publisher_default = service_slice.publisher_builder().create()?;
+        assert_that!(publisher_default.allocation_strategy(), eq AllocationStrategy::Static);
+
+        let publisher_best_fit = service_slice
+            .publisher_builder()
+            .allocation_strategy(AllocationStrategy::BestFit)
+            .create()?;
+        assert_that!(publisher_best_fit.allocation_strategy(), eq AllocationStrategy::BestFit);
+
+        let publisher_power_of_two = service_slice
+            .publisher_builder()
+            .allocation_strategy(AllocationStrategy::PowerOfTwo)
+            .create()?;
+        assert_that!(publisher_power_of_two.allocation_strategy(), eq AllocationStrategy::PowerOfTwo);
+
+        let publisher_static = service_slice
+            .publisher_builder()
+            .allocation_strategy(AllocationStrategy::Static)
+            .create()?;
+        assert_that!(publisher_static.allocation_strategy(), eq AllocationStrategy::Static);
+
+        let service_typed = node
+            .service_builder(&generate_service_name())
+            .publish_subscribe::<u64>()
+            .create()?;
+        let publisher_typed = service_typed.publisher_builder().create()?;
+        assert_that!(publisher_typed.allocation_strategy(), eq AllocationStrategy::Static);
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn max_loaned_samples_is_set_correctly<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .publish_subscribe::<u64>()
+            .max_publishers(3)
+            .create()?;
+
+        let publisher_1 = service.publisher_builder().max_loaned_samples(1).create()?;
+        assert_that!(publisher_1.max_loaned_samples(), eq 1);
+
+        let publisher_5 = service.publisher_builder().max_loaned_samples(5).create()?;
+        assert_that!(publisher_5.max_loaned_samples(), eq 5);
+
+        let publisher_100 = service
+            .publisher_builder()
+            .max_loaned_samples(100)
+            .create()?;
+        assert_that!(publisher_100.max_loaned_samples(), eq 100);
+
+        Ok(())
+    }
 }

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -663,6 +663,22 @@ impl<
 
         Ok(chunk)
     }
+
+    /// Returns the strategy the [`Publisher`] follows when a [`SampleMut`] cannot be allocated.
+    pub fn allocation_strategy(&self) -> AllocationStrategy {
+        self.publisher_shared_state
+            .lock()
+            .config
+            .allocation_strategy
+    }
+
+    /// Returns the maximum number of [`SampleMut`]s that can be loaned in parallel.
+    pub fn max_loaned_samples(&self) -> usize {
+        self.publisher_shared_state
+            .lock()
+            .sender
+            .sender_max_borrowed_chunks
+    }
 }
 
 ////////////////////////


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
Adds `allocation_strategy()` and `max_loaned_samples()` getters to Publisher of PublishSubscribe services.
The code re-uses the same logic as other existing getters.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes
* [ ] Assign PR to reviewer
* [ ] All checks have passed (except `task-list-completed`)

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1425

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
