### PR TITLE
[#1455] Fix 'timer_create' on FreeBSD

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -71,6 +71,8 @@
   [#1444](https://github.com/eclipse-iceoryx/iceoryx2/issues/1444)
 * Fix libc dependency version
   [#1447](https://github.com/eclipse-iceoryx/iceoryx2/issues/1447)
+* Fix FreeBSD build
+  [#1455](https://github.com/eclipse-iceoryx/iceoryx2/issues/1455)
 
 ### Refactoring
 

--- a/iceoryx2-pal/posix/src/freebsd/timer.rs
+++ b/iceoryx2-pal/posix/src/freebsd/timer.rs
@@ -20,7 +20,7 @@ pub unsafe fn timer_create(
     sevp: *mut sigevent,
     timer_id: *mut timer_t,
 ) -> int {
-    crate::internal::timer_create(clock_id, &mut os_specific_buffer, timer_id)
+    crate::internal::timer_create(clock_id, sevp, timer_id)
 }
 
 pub unsafe fn timer_delete(timer_id: timer_t) -> int {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Fix copy&paste error introduced with `timer_create`.

The branch was manually triggered on the nightly CI -> https://github.com/eclipse-iceoryx/iceoryx2/actions/runs/23267655399

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1455 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
