### PR TITLE
[#1463] Fix cleanup of resizable data segments

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -76,6 +76,8 @@
   [#1447](https://github.com/eclipse-iceoryx/iceoryx2/issues/1447)
 * Fix FreeBSD build
   [#1455](https://github.com/eclipse-iceoryx/iceoryx2/issues/1455)
+* Fix cleanup of resizable data segments
+  [#1463](https://github.com/eclipse-iceoryx/iceoryx2/issues/1463)
 
 ### Refactoring
 

--- a/iceoryx2-cal/src/resizable_shared_memory/dynamic.rs
+++ b/iceoryx2-cal/src/resizable_shared_memory/dynamic.rs
@@ -536,7 +536,7 @@ where
 
             // check nymber of digits
             for byte in raw_segment_id.as_bytes() {
-                if byte.is_ascii_digit() {
+                if !byte.is_ascii_digit() {
                     return None;
                 }
             }

--- a/iceoryx2/src/service/stale_resource_cleanup.rs
+++ b/iceoryx2/src/service/stale_resource_cleanup.rs
@@ -22,7 +22,7 @@ use iceoryx2_log::fail;
 
 use crate::config;
 use crate::service;
-use crate::service::config_scheme::data_segment_config;
+use crate::service::config_scheme::{data_segment_config, resizable_data_segment_config};
 use crate::service::naming_scheme::data_segment_name;
 
 use super::config_scheme::connection_config;
@@ -51,6 +51,12 @@ pub(crate) unsafe fn remove_data_segment_of_port<Service: service::Service>(
             &data_segment_name(port_id),
             &data_segment_config::<Service>(config),
         ), "Unable to remove the ports ({port_id}) data segment."
+    );
+
+    fail!(from origin, when <Service::ResizableSharedMemory as NamedConceptMgmt>::remove_cfg(
+            &data_segment_name(port_id),
+            &resizable_data_segment_config::<Service>(config),
+        ), "Unable to remove the ports ({port_id}) resizable data segment."
     );
 
     Ok(())


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The resizable data segments were omitted from the dead node cleanup. This PR adds to code to also take care of these resources.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1463

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
