### PR TITLE
[#1300] use posix constructs instead of native std in iceoryx2 cal conformance tests

### DIFF
--- a/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
@@ -20,14 +20,13 @@ use iceoryx2_bb_conformance_test_macros::conformance_test_module;
 use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_elementary_traits::allocator::*;
 use iceoryx2_bb_posix::barrier::{BarrierBuilder, BarrierHandle};
-use iceoryx2_bb_posix::clock::Time;
+use iceoryx2_bb_posix::clock::{nanosleep, Time};
 use iceoryx2_bb_posix::ipc_capable::Handle;
 use iceoryx2_bb_posix::thread::thread_scope;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_testing::lifetime_tracker::LifetimeTracker;
 use iceoryx2_bb_testing::watchdog::Watchdog;
 use iceoryx2_bb_testing::{assert_that, test_requires};
-use iceoryx2_bb_testing_macros::requires_std;
 use iceoryx2_cal::dynamic_storage::*;
 use iceoryx2_cal::named_concept::*;
 use iceoryx2_cal::testing::*;
@@ -427,7 +426,6 @@ pub mod dynamic_storage_trait {
     }
 
     #[ignore] // TODO: iox2-671 enable this test when the concurrency issue is fixed.
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn initialization_blocks_other_openers<
         Sut: DynamicStorage<TestData>,
@@ -443,16 +441,15 @@ pub mod dynamic_storage_trait {
         let barrier_2 = barrier_1.clone();
 
         thread_scope(|s| {
-            let tstorage_name = storage_name;
             let config_1 = config.clone();
             s.thread_builder().spawn(move || {
                 barrier_1.wait();
-                let _sut = Sut::Builder::new(&tstorage_name)
+                let _sut = Sut::Builder::new(&storage_name)
                     .config(&config_1)
                     .supplementary_size(0)
                     .has_ownership(false)
                     .initializer(|value, _| {
-                        std::thread::sleep(TIMEOUT);
+                        nanosleep(TIMEOUT).unwrap();
                         value.value.store(789, Ordering::Relaxed);
                         true
                     })
@@ -460,12 +457,11 @@ pub mod dynamic_storage_trait {
                     .unwrap();
             })?;
 
-            let tstorage_name = storage_name;
             let config_2 = config.clone();
             s.thread_builder().spawn(move || {
                 barrier_2.wait();
                 loop {
-                let sut2 = Sut::Builder::new(&tstorage_name).config(&config_2).open();
+                let sut2 = Sut::Builder::new(&storage_name).config(&config_2).open();
                 if let Ok(res) = sut2 {
                     assert_that!(res.get().value.load(Ordering::Relaxed), eq 789);
                     break;
@@ -484,7 +480,6 @@ pub mod dynamic_storage_trait {
         }
     }
 
-    #[requires_std("threading", "time")]
     #[conformance_test]
     pub fn initialization_timeout_blocks_for_at_least_timeout<
         Sut: DynamicStorage<TestData>,
@@ -508,7 +503,7 @@ pub mod dynamic_storage_trait {
                     .supplementary_size(0)
                     .initializer(|_, _| {
                         barrier_1.wait();
-                        std::thread::sleep(TIMEOUT * 2);
+                        nanosleep(TIMEOUT * 2).unwrap();
                         true
                     })
                     .create(TestData::new(123))

--- a/iceoryx2-cal/conformance-tests/src/event_signal_mechanism_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/event_signal_mechanism_trait.rs
@@ -26,7 +26,6 @@ pub mod event_signal_mechanism_trait {
         clock::Time,
     };
     use iceoryx2_bb_testing::{assert_that, watchdog::Watchdog};
-    use iceoryx2_bb_testing_macros::requires_std;
     use iceoryx2_cal::event::signal_mechanism::SignalMechanism;
 
     const TIMEOUT: Duration = Duration::from_millis(25);
@@ -49,7 +48,6 @@ pub mod event_signal_mechanism_trait {
         }
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn try_wait_does_not_block_works<Sut: SignalMechanism>() {
         let mut sut = Sut::new();
@@ -63,7 +61,6 @@ pub mod event_signal_mechanism_trait {
         }
     }
 
-    #[requires_std("threading")]
     pub fn wait_blocks<Sut: SignalMechanism, F: FnOnce(&Sut) -> bool + Send>(wait_call: F) {
         let _watchdog = Watchdog::new();
         let mut sut = Sut::new();
@@ -94,13 +91,11 @@ pub mod event_signal_mechanism_trait {
         }
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn timed_wait_blocks<Sut: SignalMechanism>() {
         wait_blocks(|sut: &Sut| unsafe { sut.timed_wait(Duration::from_secs(999)).unwrap() });
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn blocking_wait_blocks<Sut: SignalMechanism>() {
         wait_blocks(|sut: &Sut| unsafe {

--- a/iceoryx2-cal/conformance-tests/src/event_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/event_trait.rs
@@ -31,7 +31,6 @@ pub mod event_trait {
     use iceoryx2_bb_system_types::file_name::FileName;
     use iceoryx2_bb_testing::watchdog::Watchdog;
     use iceoryx2_bb_testing::{assert_that, test_requires};
-    use iceoryx2_bb_testing_macros::requires_std;
     use iceoryx2_cal::event::{TriggerId, *};
     use iceoryx2_cal::named_concept::*;
     use iceoryx2_cal::testing::*;
@@ -98,7 +97,6 @@ pub mod event_trait {
         assert_that!(sut.err().unwrap(), eq NotifierCreateError::DoesNotExist);
     }
 
-    #[requires_std("time")]
     #[conformance_test]
     pub fn notify_with_same_id_does_not_lead_to_non_blocking_timed_wait<Sut: Event>() {
         let _watchdog = Watchdog::new();
@@ -313,7 +311,6 @@ pub mod event_trait {
         assert_that!(result, is_none);
     }
 
-    #[requires_std("time")]
     #[conformance_test]
     pub fn timed_wait_does_block_for_at_least_timeout<Sut: Event>() {
         let name = generate_name();
@@ -334,7 +331,6 @@ pub mod event_trait {
         assert_that!(start.elapsed().unwrap(), time_at_least TIMEOUT);
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn blocking_wait_blocks_until_notification_arrives<Sut: Event>() {
         let _watchdog = Watchdog::new();
@@ -380,7 +376,6 @@ pub mod event_trait {
 
     /// windows sporadically instantly wakes up in a timed receive operation
     #[cfg(not(target_os = "windows"))]
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn timed_wait_blocks_until_notification_arrives<Sut: Event>() {
         let _watchdog = Watchdog::new();
@@ -661,11 +656,8 @@ pub mod event_trait {
         assert_that!(callback_called, eq false);
     }
 
-    #[requires_std("time")]
     #[conformance_test]
     pub fn timed_wait_all_does_block_for_at_least_timeout<Sut: Event>() {
-        use std::time::Instant;
-
         let _watchdog = Watchdog::new();
         let name = generate_name();
         let config = generate_isolated_config::<Sut>();
@@ -684,7 +676,6 @@ pub mod event_trait {
         assert_that!(now.elapsed().unwrap(), time_at_least TIMEOUT);
     }
 
-    #[requires_std("threading")]
     fn wait_all_wakes_up_on_notify<
         Sut: Event,
         F: FnMut(&mut Vec<TriggerId>, &Sut::Listener) + Send,
@@ -734,7 +725,6 @@ pub mod event_trait {
         assert_that!(counter.load(Ordering::Relaxed), eq 1);
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn timed_wait_all_wakes_up_on_notify<Sut: Event>() {
         wait_all_wakes_up_on_notify::<Sut, _>(|v, sut: &Sut::Listener| {
@@ -742,7 +732,6 @@ pub mod event_trait {
         });
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn blocking_wait_all_wakes_up_on_notify<Sut: Event>() {
         wait_all_wakes_up_on_notify::<Sut, _>(|v, sut: &Sut::Listener| {
@@ -750,7 +739,6 @@ pub mod event_trait {
         });
     }
 
-    #[requires_std("for whatever reason, 'sem_bitset_posix_shared_memory' makes 'notify' panic with 'SIGPIPE' for no_std")]
     #[conformance_test]
     pub fn out_of_scope_listener_shall_not_corrupt_notifier<Sut: Event>() {
         let name = generate_name();

--- a/iceoryx2-cal/conformance-tests/src/reactor_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/reactor_trait.rs
@@ -30,7 +30,6 @@ pub mod reactor_trait {
     use iceoryx2_bb_posix::mutex::MutexHandle;
     use iceoryx2_bb_posix::thread::thread_scope;
     use iceoryx2_bb_testing::assert_that;
-    use iceoryx2_bb_testing_macros::requires_std;
     use iceoryx2_cal::event::unix_datagram_socket::*;
     use iceoryx2_cal::event::{Listener, ListenerBuilder, Notifier, NotifierBuilder};
     use iceoryx2_cal::reactor::{Reactor, *};
@@ -351,7 +350,6 @@ pub mod reactor_trait {
         }
     }
 
-    #[requires_std("time")]
     #[conformance_test]
     pub fn timed_wait_blocks_for_at_least_timeout<Sut: Reactor>() {
         const TIMEOUT: Duration = Duration::from_millis(50);
@@ -499,7 +497,6 @@ pub mod reactor_trait {
         assert_that!(triggered_fds, len 0);
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn timed_wait_blocks_until_triggered<Sut: Reactor>() {
         const TIMEOUT: Duration = Duration::from_millis(50);
@@ -556,7 +553,6 @@ pub mod reactor_trait {
         assert_that!(counter_old.load(Ordering::Relaxed), eq 0);
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn blocking_wait_blocks_until_triggered<Sut: Reactor>() {
         const TIMEOUT: Duration = Duration::from_millis(50);

--- a/iceoryx2-cal/conformance-tests/src/shm_allocator_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/shm_allocator_trait.rs
@@ -23,7 +23,6 @@ pub mod shm_allocator_trait {
     use iceoryx2_bb_posix::ipc_capable::Handle;
     use iceoryx2_bb_posix::mutex::{Mutex, MutexBuilder, MutexHandle};
     use iceoryx2_bb_testing::assert_that;
-    use iceoryx2_bb_testing_macros::requires_std;
     use iceoryx2_cal::shm_allocator::{ShmAllocator, *};
 
     const MEMORY_SIZE: usize = 4096;
@@ -174,7 +173,6 @@ pub mod shm_allocator_trait {
         );
     }
 
-    #[requires_std("mutex")]
     #[conformance_test]
     pub fn allocator_id_is_unique<Sut: ShmAllocator>() {
         static MTX_HANDLE: LazyLock<MutexHandle<BTreeSet<u8>>> = LazyLock::new(MutexHandle::new);

--- a/iceoryx2-cal/conformance-tests/src/static_storage_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/static_storage_trait.rs
@@ -23,13 +23,13 @@ pub mod static_storage_trait {
     use iceoryx2_bb_conformance_test_macros::conformance_test;
     use iceoryx2_bb_container::semantic_string::*;
     use iceoryx2_bb_posix::barrier::{BarrierBuilder, BarrierHandle};
+    use iceoryx2_bb_posix::clock::Time;
     use iceoryx2_bb_posix::ipc_capable::Handle;
     use iceoryx2_bb_posix::thread::thread_scope;
     use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
     use iceoryx2_bb_system_types::file_name::FileName;
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_bb_testing::watchdog::Watchdog;
-    use iceoryx2_bb_testing_macros::requires_std;
     use iceoryx2_cal::named_concept::*;
     use iceoryx2_cal::static_storage::StaticStorageCreateError;
     use iceoryx2_cal::static_storage::*;
@@ -273,7 +273,6 @@ pub mod static_storage_trait {
         assert_that!(<Sut as NamedConceptMgmt>::list().unwrap(), len 0);
     }
 
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn concurrent_create_same_locked_storage_multiple_times_fails_for_all_but_one<
         Sut: StaticStorage,
@@ -407,7 +406,6 @@ pub mod static_storage_trait {
         assert_that!(read_content, eq content);
     }
 
-    #[requires_std("time")]
     #[conformance_test]
     pub fn open_locked_with_timeout_works<Sut: StaticStorage>() {
         const TIMEOUT: Duration = Duration::from_millis(100);
@@ -415,7 +413,7 @@ pub mod static_storage_trait {
 
         let _storage_guard = Sut::Builder::new(&storage_name).create_locked();
 
-        let start = std::time::SystemTime::now();
+        let start = Time::now().unwrap();
         let storage_reader = Sut::Builder::new(&storage_name).open(TIMEOUT);
 
         assert_that!(storage_reader, is_err);

--- a/iceoryx2-cal/conformance-tests/src/zero_copy_connection_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/zero_copy_connection_trait.rs
@@ -23,7 +23,7 @@ pub mod zero_copy_connection_trait {
     use iceoryx2_bb_conformance_test_macros::conformance_test;
     use iceoryx2_bb_container::semantic_string::*;
     use iceoryx2_bb_posix::barrier::*;
-    use iceoryx2_bb_posix::clock::Time;
+    use iceoryx2_bb_posix::clock::{nanosleep, Time};
     use iceoryx2_bb_posix::ipc_capable::Handle;
     use iceoryx2_bb_posix::mutex::{MutexBuilder, MutexHandle};
     use iceoryx2_bb_posix::thread::thread_scope;
@@ -784,7 +784,6 @@ pub mod zero_copy_connection_trait {
         }
     }
 
-    #[requires_std("threading", "time")]
     #[conformance_test]
     pub fn blocking_send_blocks<Sut: ZeroCopyConnection>() {
         const TIMEOUT: Duration = Duration::from_millis(25);
@@ -826,9 +825,9 @@ pub mod zero_copy_connection_trait {
                 };
 
                 barrier.wait();
-                std::thread::sleep(TIMEOUT);
+                nanosleep(TIMEOUT).unwrap();
                 let sample_1 = receive_sample();
-                std::thread::sleep(TIMEOUT);
+                nanosleep(TIMEOUT).unwrap();
                 let sample_2 = receive_sample();
 
                 assert_that!(sample_1.offset(), eq sample_offset_1);
@@ -1811,7 +1810,6 @@ pub mod zero_copy_connection_trait {
     }
 
     #[ignore] // TODO: iox2-671 enable this test when the concurrency issue is fixed.
-    #[requires_std("threading")]
     #[conformance_test]
     pub fn concurrent_creation_and_destruction_works<Sut: ZeroCopyConnection>() {
         const ITERATIONS: usize = 1000;


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #1300

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
