### PR TITLE
[#1477] Fix 'SIGPIPE' triggered by 'socketpair'

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -78,6 +78,8 @@
   [#1455](https://github.com/eclipse-iceoryx/iceoryx2/issues/1455)
 * Fix cleanup of resizable data segments
   [#1463](https://github.com/eclipse-iceoryx/iceoryx2/issues/1463)
+* Fix `SIGPIPE` in `local::Service` events triggered by the `socketpair`
+  [#1477](https://github.com/eclipse-iceoryx/iceoryx2/issues/1463)
 
 ### Refactoring
 

--- a/iceoryx2-bb/posix/src/socket_pair.rs
+++ b/iceoryx2-bb/posix/src/socket_pair.rs
@@ -361,7 +361,7 @@ impl StreamingSocket {
                 self.file_descriptor.native_handle(),
                 buf.as_ptr().cast(),
                 buf.len(),
-                0,
+                posix::MSG_NOSIGNAL,
             )
         };
 

--- a/iceoryx2-pal/posix/src/android/constants.rs
+++ b/iceoryx2-pal/posix/src/android/constants.rs
@@ -186,6 +186,7 @@ pub const SOCK_DGRAM: int = libc::SOCK_DGRAM as _;
 pub const IPPROTO_UDP: int = libc::IPPROTO_UDP as _;
 pub const SOCK_NONBLOCK: int = O_NONBLOCK;
 pub const MSG_PEEK: int = libc::MSG_PEEK as _;
+pub const MSG_NOSIGNAL: int = libc::MSG_NOSIGNAL as _;
 pub const SCM_MAX_FD: u32 = 253;
 pub const SCM_RIGHTS: int = libc::SCM_RIGHTS as _;
 pub const SOL_SOCKET: int = libc::SOL_SOCKET as _;

--- a/iceoryx2-pal/posix/src/freebsd/constants.rs
+++ b/iceoryx2-pal/posix/src/freebsd/constants.rs
@@ -188,6 +188,7 @@ pub const SOCK_DGRAM: int = crate::internal::SOCK_DGRAM as _;
 pub const IPPROTO_UDP: int = crate::internal::IPPROTO_UDP as _;
 pub const SOCK_NONBLOCK: int = O_NONBLOCK;
 pub const MSG_PEEK: int = crate::internal::MSG_PEEK as _;
+pub const MSG_NOSIGNAL: int = crate::internal::MSG_NOSIGNAL as _;
 pub const SCM_MAX_FD: u32 = 253;
 pub const SCM_RIGHTS: int = crate::internal::SCM_RIGHTS as _;
 pub const SOL_SOCKET: int = crate::internal::SOL_SOCKET as _;

--- a/iceoryx2-pal/posix/src/linux/constants.rs
+++ b/iceoryx2-pal/posix/src/linux/constants.rs
@@ -187,6 +187,7 @@ pub const SOCK_DGRAM: int = libc::SOCK_DGRAM as _;
 pub const IPPROTO_UDP: int = libc::IPPROTO_UDP as _;
 pub const SOCK_NONBLOCK: int = O_NONBLOCK;
 pub const MSG_PEEK: int = libc::MSG_PEEK as _;
+pub const MSG_NOSIGNAL: int = libc::MSG_NOSIGNAL as _;
 pub const SCM_MAX_FD: u32 = 253;
 pub const SCM_RIGHTS: int = libc::SCM_RIGHTS as _;
 pub const SOL_SOCKET: int = libc::SOL_SOCKET as _;

--- a/iceoryx2-pal/posix/src/macos/constants.rs
+++ b/iceoryx2-pal/posix/src/macos/constants.rs
@@ -190,6 +190,7 @@ pub const SOCK_DGRAM: int = crate::internal::SOCK_DGRAM as _;
 pub const IPPROTO_UDP: int = crate::internal::IPPROTO_UDP as _;
 pub const SOCK_NONBLOCK: int = O_NONBLOCK;
 pub const MSG_PEEK: int = crate::internal::MSG_PEEK as _;
+pub const MSG_NOSIGNAL: int = crate::internal::MSG_NOSIGNAL as _;
 pub const SCM_MAX_FD: u32 = 253;
 pub const SCM_RIGHTS: int = crate::internal::SCM_RIGHTS as _;
 pub const SOL_SOCKET: int = crate::internal::SOL_SOCKET as _;

--- a/iceoryx2-pal/posix/src/qnx/constants.rs
+++ b/iceoryx2-pal/posix/src/qnx/constants.rs
@@ -192,6 +192,7 @@ pub const SOCK_DGRAM: int = crate::internal::SOCK_DGRAM as _;
 pub const IPPROTO_UDP: int = crate::internal::IPPROTO_UDP as _;
 pub const SOCK_NONBLOCK: int = O_NONBLOCK;
 pub const MSG_PEEK: int = crate::internal::MSG_PEEK as _;
+pub const MSG_NOSIGNAL: int = crate::internal::MSG_NOSIGNAL as _;
 pub const SCM_MAX_FD: u32 = 253;
 pub const SCM_RIGHTS: int = crate::internal::SCM_RIGHTS as _;
 pub const SOL_SOCKET: int = crate::internal::SOL_SOCKET as _;

--- a/iceoryx2-pal/posix/src/stub/constants.rs
+++ b/iceoryx2-pal/posix/src/stub/constants.rs
@@ -161,6 +161,7 @@ pub const SOCK_DGRAM: int = 2;
 pub const SOCK_NONBLOCK: int = O_NONBLOCK;
 pub const IPPROTO_UDP: int = 17;
 pub const MSG_PEEK: int = 2;
+pub const MSG_NOSIGNAL: int = 0x4000;
 pub const SCM_MAX_FD: u32 = 253;
 pub const SCM_RIGHTS: int = 128;
 pub const SCM_CREDENTIALS: int = 0x02;

--- a/iceoryx2-pal/posix/src/windows/constants.rs
+++ b/iceoryx2-pal/posix/src/windows/constants.rs
@@ -155,6 +155,7 @@ pub const SOCK_DGRAM: int = windows_sys::Win32::Networking::WinSock::SOCK_DGRAM 
 pub const SOCK_NONBLOCK: int = O_NONBLOCK;
 pub const IPPROTO_UDP: int = windows_sys::Win32::Networking::WinSock::IPPROTO_UDP as _;
 pub const MSG_PEEK: int = windows_sys::Win32::Networking::WinSock::MSG_PEEK as _;
+pub const MSG_NOSIGNAL: int = 0; // this flag is not necessary on Windows since 'send' works as if it is already set
 pub const SCM_MAX_FD: u32 = 253;
 pub const SCM_RIGHTS: int = 128;
 pub const SCM_CREDENTIALS: int = 0x02;


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

While porting the conformance test to no_std, the event tests terminated the tests. As it turned out, it was due to a SIGPIPE signal in the stress test where listener were constantly created and destroyed.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1477

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
