### PR TITLE
[#3] Fix flaky end-to-end test

### DIFF
--- a/iceoryx2-cli/iox2-node/end-to-end-tests/test_e2e_iox2_node_details.exp
+++ b/iceoryx2-cli/iox2-node/end-to-end-tests/test_e2e_iox2_node_details.exp
@@ -27,6 +27,10 @@ set timeout 10
 # Spawn a process that creates a node
 spawn cargo run --example publish_subscribe_subscriber
 set id_subscriber $spawn_id
+# Wait for the subscriber to fully start up and clean the dead nodes,
+# else there is a race with "iox2-node -- list", which might find a dead node
+# and use that ID for the detailed lookup
+expect_output_from $id_subscriber {Subscriber ready to receive data!}
 
 # List nodes to get the node id
 set list_output [exec cargo run --bin iox2-node -- list 2>@1]
@@ -43,10 +47,10 @@ set id_iox2_node $spawn_id
 
 #### Test Assertion
 
-expect_output_from $id_iox2_node "state"
+expect_output_from $id_iox2_node {"state": Alive}
 expect_output_from $id_iox2_node "id"
 expect_output_from $id_iox2_node "pid"
-expect_output_from $id_iox2_node "executable"
+expect_output_from $id_iox2_node {"executable": "publish_subscribe_subscriber"}
 expect_output_from $id_iox2_node "name"
 expect_output_from $id_iox2_node "config"
 

--- a/iceoryx2-cli/iox2-node/src/command/details.rs
+++ b/iceoryx2-cli/iox2-node/src/command/details.rs
@@ -34,6 +34,7 @@ pub(crate) fn details(
                 }
                 Err(e) => {
                     error = Some(e);
+                    return CallbackProgression::Stop;
                 }
             }
         }
@@ -41,5 +42,8 @@ pub(crate) fn details(
     })
     .context("failed to retrieve nodes")?;
 
+    if let Some(err) = error {
+        return Err(err);
+    }
     Ok(())
 }

--- a/iceoryx2-cli/iox2-service/end-to-end-tests/test_e2e_iox2_service_notify.exp
+++ b/iceoryx2-cli/iox2-service/end-to-end-tests/test_e2e_iox2_service_notify.exp
@@ -26,6 +26,8 @@ set timeout 10
 
 spawn cargo run --example event_listener
 set id_listener $spawn_id
+# Wait for the Listener to be ready before sending the event
+expect_output_from $id_listener "Listener ready to receive events!"
 
 spawn cargo run --bin iox2-service -- notify MyEventName
 set id_iox2_service_notify $spawn_id


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The PR fixes the flakiness of two end-to-end test. The issue where
* test_e2e_iox2_node_details.exp: the dead node cleanup of previously run nodes was not yet finished when the node ID of the running node was obtained, resulting in getting a node ID of a dead node -> wait for the node to finish cleanup before running `iox2 node list`
* test_e2e_iox2_service_notify.exp: the event was sent before the listener was waiting -> wait for the listener to be ready before sending the event

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #3

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
