### PR TITLE
[#4] Update custom platform config doc

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -230,15 +230,11 @@ pub mod settings {
     pub const SHARED_MEMORY_DIRECTORY: &[u8] = b"/dev/my_shm/";
     pub const PATH_SEPARATOR: u8 = b'/';
     pub const ROOT: &[u8] = b"/";
+    pub const REQUIRED_SOCKET_DIRECTORY: Option<&[u8]> = None;
     pub const ICEORYX2_ROOT_PATH: &[u8] = b"/my_tmp/";
     pub const FILENAME_LENGTH: usize = 255;
-    // it is actually 4096 but to be more compatible with windows and also safe some stack the number
-    // is reduced to 255
     pub const PATH_LENGTH: usize = 255;
-    #[cfg(not(target_os = "macos"))]
     pub const AT_LEAST_TIMING_VARIANCE: f32 = 0.25;
-    #[cfg(target_os = "macos")]
-    pub const AT_LEAST_TIMING_VARIANCE: f32 = 1.0;
 }
 ```
 
@@ -265,6 +261,11 @@ The build steps are as follows:
    ```console
    warning: iceoryx2-pal-configuration@x.y.z: Building with custom configuration: /my/funky/platform/platform_configuration.rs
    ```
+
+> [!NOTE]
+> If there is an existing build with the default configuration, the `target`
+> folder needs to be deleted after the env variable is set, else the custom
+> config is not picked up.
 
 ## Custom Platform Abstraction Layer
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

There is a new entry in the platform settings, so the docs need an update. I also removed the `maos` platform switch, since it is not important and rather confusing than helpful.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #4

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
