### PR TITLE
[#1491] Update `inventory` crate and remove `disallowed_types` suppression from tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ colored = { version = "2.1" }
 generic-tests = { version = "0.1.2" }
 human-panic = { version = "=2.0.2" }
 libc = { version = "0.2.183", default-features = false, features = ['extra_traits'] }
-inventory = { version = "0.3", default-features = false }
+inventory = { version = "0.3.24", default-features = false }
 libtest-mimic = { version = "0.8" }
 log = { version = "0.4.21" }
 loom = { version = "0.7.2" }

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -122,6 +122,8 @@
   [#1359](https://github.com/eclipse-iceoryx/iceoryx2/issues/1359)
 * Use `libc` constants in linux platform instead of hardcoded values
   [#1388](https://github.com/eclipse-iceoryx/iceoryx2/issues/1388)
+* Update `inventory` crate and remove `disallowed_types` suppression from tests
+  [#1492](https://github.com/eclipse-iceoryx/iceoryx2/issues/1492)
 * Rename `ServiceId` into `ServiceHash`
   [#1508](https://github.com/eclipse-iceoryx/iceoryx2/issues/1508)
 

--- a/iceoryx2-bb/concurrency/tests-common/src/atomic_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/atomic_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing_macros::tests;
 
 #[tests(u64, u128, i64, i128)]

--- a/iceoryx2-bb/concurrency/tests-common/src/lazy_lock_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/lazy_lock_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use alloc::string::String;

--- a/iceoryx2-bb/concurrency/tests-common/src/lib.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/iceoryx2-bb/concurrency/tests-common/src/once_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/once_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_concurrency::atomic::{AtomicU32, Ordering};
 
 use iceoryx2_bb_concurrency::once::Once;

--- a/iceoryx2-bb/concurrency/tests-common/src/spin_lock_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/spin_lock_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec::Vec;
 
 use iceoryx2_bb_concurrency::spin_lock::SpinLock;

--- a/iceoryx2-bb/concurrency/tests-common/src/strategy_barrier_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/strategy_barrier_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_concurrency::atomic::{AtomicI32, Ordering};
 use iceoryx2_bb_concurrency::internal::strategy::barrier::*;
 use iceoryx2_bb_posix::thread::thread_scope;

--- a/iceoryx2-bb/concurrency/tests-common/src/strategy_condition_variable_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/strategy_condition_variable_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_concurrency::atomic::{AtomicBool, AtomicU32, Ordering};

--- a/iceoryx2-bb/concurrency/tests-common/src/strategy_mutex_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/strategy_mutex_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_concurrency::atomic::{AtomicU32, Ordering};

--- a/iceoryx2-bb/concurrency/tests-common/src/strategy_rwlock_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/strategy_rwlock_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_concurrency::atomic::AtomicU32;

--- a/iceoryx2-bb/concurrency/tests-common/src/strategy_semaphore_tests.rs
+++ b/iceoryx2-bb/concurrency/tests-common/src/strategy_semaphore_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_concurrency::atomic::{AtomicU32, Ordering};

--- a/iceoryx2-bb/container/tests-common/src/flatmap_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/flatmap_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec;
 
 use iceoryx2_bb_container::flatmap::*;

--- a/iceoryx2-bb/container/tests-common/src/lib.rs
+++ b/iceoryx2-bb/container/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/iceoryx2-bb/container/tests-common/src/polymorphic_string_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/polymorphic_string_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::boxed::Box;
 
 use iceoryx2_bb_concurrency::cell::UnsafeCell;

--- a/iceoryx2-bb/container/tests-common/src/polymorphic_vec_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/polymorphic_vec_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::boxed::Box;
 
 use iceoryx2_bb_concurrency::cell::UnsafeCell;

--- a/iceoryx2-bb/container/tests-common/src/queue_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/queue_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::queue::*;
 use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
 use iceoryx2_bb_elementary_traits::placement_default::PlacementDefault;

--- a/iceoryx2-bb/container/tests-common/src/relocatable_option_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/relocatable_option_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::mem::MaybeUninit;
 
 use alloc::vec;

--- a/iceoryx2-bb/container/tests-common/src/relocatable_vec_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/relocatable_vec_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::vector::relocatable_vec::*;
 use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/container/tests-common/src/slotmap_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/slotmap_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec;
 
 use iceoryx2_bb_container::slotmap::*;

--- a/iceoryx2-bb/container/tests-common/src/static_string_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/static_string_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::str::FromStr;
 
 use iceoryx2_bb_container::string::*;

--- a/iceoryx2-bb/container/tests-common/src/static_vec_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/static_vec_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::mem::MaybeUninit;
 use iceoryx2_bb_container::vector::{static_vec::*, VectorModificationError};
 use iceoryx2_bb_elementary_traits::placement_default::PlacementDefault;

--- a/iceoryx2-bb/container/tests-common/src/string_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/string_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing_macros::tests;
 
 #[tests(

--- a/iceoryx2-bb/container/tests-common/src/string_utils_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/string_utils_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::format;
 
 use iceoryx2_bb_container::string::*;

--- a/iceoryx2-bb/container/tests-common/src/vector_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/vector_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing_macros::tests;
 
 #[tests(PolymorphicVecFactory, RelocatableVecFactory, StaticVecFactory)]

--- a/iceoryx2-bb/derive-macros/tests-common/src/lib.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![no_std]
 
 extern crate iceoryx2_bb_loggers;

--- a/iceoryx2-bb/derive-macros/tests-common/src/placement_default_tests.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/placement_default_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_derive_macros::PlacementDefault;
 use iceoryx2_bb_elementary_traits::placement_default::PlacementDefault;
 use iceoryx2_bb_testing::{assert_that, memory::RawMemory};

--- a/iceoryx2-bb/derive-macros/tests-common/src/zero_copy_send_tests.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/zero_copy_send_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_derive_macros::ZeroCopySend;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/elementary/tests-common/src/alignment_tests.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/alignment_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_elementary::alignment::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/elementary/tests-common/src/bump_allocator_tests.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/bump_allocator_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::{alloc::Layout, ptr::NonNull};
 
 use iceoryx2_bb_elementary::{bump_allocator::*, math::align};

--- a/iceoryx2-bb/elementary/tests-common/src/cyclic_tagger_tests.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/cyclic_tagger_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_elementary::cyclic_tagger::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/elementary/tests-common/src/lib.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![no_std]
 
 extern crate iceoryx2_bb_loggers;

--- a/iceoryx2-bb/elementary/tests-common/src/math_tests.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/math_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_elementary::math::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/elementary/tests-common/src/package_version_tests.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/package_version_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_elementary::package_version::PackageVersion;
 use iceoryx2_bb_testing::{assert_that, test_requires};
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/elementary/tests-common/src/relocatable_ptr_tests.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/relocatable_ptr_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_elementary::relocatable_ptr::RelocatablePointer;
 use iceoryx2_bb_elementary_traits::pointer_trait::PointerTrait;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/elementary/tests-common/src/scope_guard_tests.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/scope_guard_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_concurrency::atomic::{AtomicU64, Ordering};
 
 use iceoryx2_bb_elementary::scope_guard::*;

--- a/iceoryx2-bb/elementary/tests-common/src/unique_id_tests.rs
+++ b/iceoryx2-bb/elementary/tests-common/src/unique_id_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_elementary::unique_id::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/lock-free/tests-common/src/bitset_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/bitset_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_concurrency::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/iceoryx2-bb/lock-free/tests-common/src/lib.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_container_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_container_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing_macros::tests;
 
 #[tests(usize, TestType)]
@@ -21,8 +19,8 @@ pub mod generic {
     use alloc::vec;
     use alloc::vec::Vec;
     use core::fmt::Debug;
-    use core::sync::atomic::{AtomicU32, Ordering};
 
+    use iceoryx2_bb_concurrency::atomic::{AtomicU32, Ordering};
     use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
     use iceoryx2_bb_elementary::CallbackProgression;
     use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_unique_index_set_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_unique_index_set_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec;
 use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
 use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;

--- a/iceoryx2-bb/lock-free/tests-common/src/spmc_unrestricted_atomic_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/spmc_unrestricted_atomic_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 #[cfg(not(feature = "std"))]
 use iceoryx2_bb_concurrency::spin_lock::SpinLock as Mutex;
 #[cfg(feature = "std")]
@@ -19,8 +17,8 @@ use std::sync::Mutex;
 
 use alloc::alloc::{alloc, dealloc, Layout};
 use core::ptr::addr_of;
-use core::sync::atomic::{AtomicBool, Ordering};
 
+use iceoryx2_bb_concurrency::atomic::{AtomicBool, Ordering};
 use iceoryx2_bb_elementary::math::align;
 use iceoryx2_bb_lock_free::spmc::unrestricted_atomic::*;
 use iceoryx2_bb_posix::barrier::{BarrierBuilder, BarrierHandle, Handle};

--- a/iceoryx2-bb/lock-free/tests-common/src/spsc_index_queue_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/spsc_index_queue_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_lock_free::spsc::index_queue::*;
 use iceoryx2_bb_posix::barrier::{BarrierBuilder, BarrierHandle, Handle};
 use iceoryx2_bb_posix::thread::thread_scope;

--- a/iceoryx2-bb/lock-free/tests-common/src/spsc_queue_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/spsc_queue_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_lock_free::spsc::queue::*;
 use iceoryx2_bb_posix::thread::thread_scope;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/lock-free/tests-common/src/spsc_safely_overflowing_index_queue_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/spsc_safely_overflowing_index_queue_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec;
 use alloc::vec::Vec;
 use iceoryx2_bb_posix::mutex::{MutexBuilder, MutexHandle};

--- a/iceoryx2-bb/memory/tests-common/src/bump_allocator_tests.rs
+++ b/iceoryx2-bb/memory/tests-common/src/bump_allocator_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_elementary_traits::allocator::*;
 use iceoryx2_bb_memory::bump_allocator::*;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/memory/tests-common/src/heap_allocator_tests.rs
+++ b/iceoryx2-bb/memory/tests-common/src/heap_allocator_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::{alloc::Layout, ptr::NonNull};
 
 use iceoryx2_bb_memory::heap_allocator::*;

--- a/iceoryx2-bb/memory/tests-common/src/lib.rs
+++ b/iceoryx2-bb/memory/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/iceoryx2-bb/memory/tests-common/src/one_chunk_allocator_tests.rs
+++ b/iceoryx2-bb/memory/tests-common/src/one_chunk_allocator_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_elementary::math::*;
 use iceoryx2_bb_elementary_traits::allocator::*;
 use iceoryx2_bb_memory::one_chunk_allocator::*;

--- a/iceoryx2-bb/memory/tests-common/src/pool_allocator_tests.rs
+++ b/iceoryx2-bb/memory/tests-common/src/pool_allocator_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/iceoryx2-bb/posix/tests-common/src/access_mode_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/access_mode_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::format;
 
 use iceoryx2_bb_posix::access_mode::*;

--- a/iceoryx2-bb/posix/tests-common/src/adaptive_wait_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/adaptive_wait_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_posix::adaptive_wait::*;

--- a/iceoryx2-bb/posix/tests-common/src/barrier_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/barrier_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_concurrency::atomic::{AtomicU64, Ordering};
 use iceoryx2_bb_posix::barrier::*;
 use iceoryx2_bb_posix::thread::thread_scope;

--- a/iceoryx2-bb/posix/tests-common/src/clock_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/clock_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 use iceoryx2_bb_posix::clock::*;
 use iceoryx2_bb_posix::system_configuration::Feature;

--- a/iceoryx2-bb/posix/tests-common/src/creation_mode_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/creation_mode_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::format;
 
 use iceoryx2_bb_posix::creation_mode::*;

--- a/iceoryx2-bb/posix/tests-common/src/deadline_queue_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/deadline_queue_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec;
 use core::time::Duration;
 

--- a/iceoryx2-bb/posix/tests-common/src/directory_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/directory_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec;

--- a/iceoryx2-bb/posix/tests-common/src/file_descriptor_set_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/file_descriptor_set_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use alloc::format;

--- a/iceoryx2-bb/posix/tests-common/src/file_descriptor_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/file_descriptor_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing_macros::tests;
 
 #[tests(File, SharedMemory)]

--- a/iceoryx2-bb/posix/tests-common/src/file_lock_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/file_lock_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::string::ToString;
 use alloc::vec;
 

--- a/iceoryx2-bb/posix/tests-common/src/file_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/file_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::string::String;
 use alloc::string::ToString;
 

--- a/iceoryx2-bb/posix/tests-common/src/file_type_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/file_type_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_posix::file_type::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/posix/tests-common/src/group_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/group_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::string::ToString;
 
 use iceoryx2_bb_container::semantic_string::*;

--- a/iceoryx2-bb/posix/tests-common/src/ipc_capable_trait_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/ipc_capable_trait_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing_macros::tests;
 
 #[tests(BarrierTest, UnnamedSemaphoreTest, MutexTest, ReadWriteMutexTest)]

--- a/iceoryx2-bb/posix/tests-common/src/lib.rs
+++ b/iceoryx2-bb/posix/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/iceoryx2-bb/posix/tests-common/src/memory_lock_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/memory_lock_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_posix::memory_lock::*;
 use iceoryx2_bb_testing::{assert_that, test_requires};
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/posix/tests-common/src/memory_mapping_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/memory_mapping_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_posix::testing::generate_file_path;
 use iceoryx2_bb_posix::{
     file::{CreationMode, FileBuilder},

--- a/iceoryx2-bb/posix/tests-common/src/memory_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/memory_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_posix::memory::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/posix/tests-common/src/metadata_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/metadata_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::semantic_string::SemanticString;
 use iceoryx2_bb_posix::config::*;
 use iceoryx2_bb_posix::creation_mode::*;

--- a/iceoryx2-bb/posix/tests-common/src/mutex_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/mutex_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_posix::barrier::*;

--- a/iceoryx2-bb/posix/tests-common/src/ownership_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/ownership_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_posix::group::*;
 use iceoryx2_bb_posix::ownership::*;

--- a/iceoryx2-bb/posix/tests-common/src/permission_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/permission_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_posix::permission::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/posix/tests-common/src/process_state_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/process_state_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::string::ToString;
 
 use iceoryx2_bb_container::semantic_string::SemanticString;

--- a/iceoryx2-bb/posix/tests-common/src/process_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/process_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_posix::process::*;
 use iceoryx2_bb_testing::{assert_that, test_requires};
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/posix/tests-common/src/read_write_mutex_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/read_write_mutex_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 use iceoryx2_bb_concurrency::atomic::{AtomicUsize, Ordering};
 use iceoryx2_bb_posix::barrier::*;

--- a/iceoryx2-bb/posix/tests-common/src/scheduler_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/scheduler_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_posix::config::DEFAULT_SCHEDULER;
 use iceoryx2_bb_posix::scheduler::*;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/posix/tests-common/src/semaphore_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/semaphore_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 use iceoryx2_bb_concurrency::atomic::{AtomicUsize, Ordering};
 use iceoryx2_bb_posix::barrier::*;

--- a/iceoryx2-bb/posix/tests-common/src/shared_memory_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/shared_memory_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec;
 
 use iceoryx2_bb_posix::shared_memory::*;

--- a/iceoryx2-bb/posix/tests-common/src/signal_set_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/signal_set_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec::Vec;
 
 use iceoryx2_bb_posix::{

--- a/iceoryx2-bb/posix/tests-common/src/signal_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/signal_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 use iceoryx2_bb_concurrency::atomic::AtomicUsize;
 use iceoryx2_bb_concurrency::spin_lock::{SpinLock, SpinLockGuard};

--- a/iceoryx2-bb/posix/tests-common/src/socket_ancillary_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/socket_ancillary_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::string::ToString;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/iceoryx2-bb/posix/tests-common/src/socket_pair_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/socket_pair_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::vec;
 use alloc::vec::Vec;
 use core::time::Duration;

--- a/iceoryx2-bb/posix/tests-common/src/thread_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/thread_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_concurrency::atomic::{AtomicU64, Ordering};

--- a/iceoryx2-bb/posix/tests-common/src/udp_socket_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/udp_socket_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_concurrency::atomic::{AtomicU64, Ordering};
 use iceoryx2_bb_posix::barrier::*;
 use iceoryx2_bb_posix::clock::{nanosleep, Time};

--- a/iceoryx2-bb/posix/tests-common/src/unique_system_id_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/unique_system_id_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::collections::BTreeSet;
 use alloc::vec::Vec;
 use core::time::Duration;

--- a/iceoryx2-bb/posix/tests-common/src/unix_datagram_socket_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/unix_datagram_socket_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec;

--- a/iceoryx2-bb/posix/tests-common/src/users_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/users_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use alloc::string::ToString;
 
 use iceoryx2_bb_container::semantic_string::*;

--- a/iceoryx2-bb/system-types/tests-common/src/base64url_tests.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/base64url_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_system_types::base64url::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/system-types/tests-common/src/file_name_tests.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/file_name_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_system_types::file_name::*;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/system-types/tests-common/src/file_path_tests.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/file_path_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::*;

--- a/iceoryx2-bb/system-types/tests-common/src/group_name_tests.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/group_name_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_system_types::group_name::*;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/system-types/tests-common/src/ipv4_address_tests.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/ipv4_address_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_system_types::ipv4_address::{
     Ipv4Address, Ipv4AddressParseError, BROADCAST, LOCALHOST, UNSPECIFIED,
 };

--- a/iceoryx2-bb/system-types/tests-common/src/lib.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![no_std]
 
 extern crate iceoryx2_bb_loggers;

--- a/iceoryx2-bb/system-types/tests-common/src/path_tests.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/path_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_system_types::path::*;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/system-types/tests-common/src/port_tests.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/port_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_system_types::port::*;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_bb_testing_macros::test;

--- a/iceoryx2-bb/system-types/tests-common/src/user_name_tests.rs
+++ b/iceoryx2-bb/system-types/tests-common/src/user_name_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_container::semantic_string::*;
 use iceoryx2_bb_system_types::user_name::*;
 use iceoryx2_bb_testing::assert_that;

--- a/iceoryx2-bb/threadsafe/tests-common/src/lib.rs
+++ b/iceoryx2-bb/threadsafe/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate iceoryx2_bb_loggers;

--- a/iceoryx2-bb/threadsafe/tests-common/src/trigger_queue_tests.rs
+++ b/iceoryx2-bb/threadsafe/tests-common/src/trigger_queue_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use core::time::Duration;
 
 use iceoryx2_bb_concurrency::atomic::AtomicU64;

--- a/iceoryx2-bb/trait-tests/tests-common/src/lib.rs
+++ b/iceoryx2-bb/trait-tests/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![no_std]
 
 extern crate alloc;

--- a/iceoryx2-bb/trait-tests/tests-common/src/relocatable_container_tests.rs
+++ b/iceoryx2-bb/trait-tests/tests-common/src/relocatable_container_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing_macros::tests;
 
 #[tests(

--- a/iceoryx2-bb/trait-tests/tests-common/src/semantic_string_tests.rs
+++ b/iceoryx2-bb/trait-tests/tests-common/src/semantic_string_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 extern crate iceoryx2_bb_loggers;
 
 use alloc::vec;

--- a/iceoryx2-cal/conformance-tests/tests-common/src/lib.rs
+++ b/iceoryx2-cal/conformance-tests/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(clippy::alloc_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]

--- a/iceoryx2-cal/tests-common/src/lib.rs
+++ b/iceoryx2-cal/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;

--- a/iceoryx2-tunnel/zenoh/tests/event_discovery_tests.rs
+++ b/iceoryx2-tunnel/zenoh/tests/event_discovery_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing::instantiate_conformance_tests_with_module;
 
 use iceoryx2::service::ipc::Service as Ipc;

--- a/iceoryx2-tunnel/zenoh/tests/event_propagation_tests.rs
+++ b/iceoryx2-tunnel/zenoh/tests/event_propagation_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing::instantiate_conformance_tests_with_module;
 
 use iceoryx2::service::ipc::Service as Ipc;

--- a/iceoryx2-tunnel/zenoh/tests/publish_subscribe_discovery_tests.rs
+++ b/iceoryx2-tunnel/zenoh/tests/publish_subscribe_discovery_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing::instantiate_conformance_tests_with_module;
 
 use iceoryx2::service::ipc::Service as Ipc;

--- a/iceoryx2-tunnel/zenoh/tests/publish_subscribe_propagation_tests.rs
+++ b/iceoryx2-tunnel/zenoh/tests/publish_subscribe_propagation_tests.rs
@@ -10,8 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
-
 use iceoryx2_bb_testing::instantiate_conformance_tests_with_module;
 
 use iceoryx2::service::ipc::Service as Ipc;

--- a/iceoryx2/conformance-tests/tests-common/src/lib.rs
+++ b/iceoryx2/conformance-tests/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(clippy::alloc_instead_of_core)]
 #![warn(clippy::std_instead_of_alloc)]

--- a/iceoryx2/tests-common/src/lib.rs
+++ b/iceoryx2/tests-common/src/lib.rs
@@ -10,7 +10,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#![allow(clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The PR updates the `inventory` crate and removes the `disallowed_types` suppression from tests

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1491

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
