### PR TITLE
[#280] Remove rule suppressions from clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,29 +10,15 @@ performance-*,
 portability-*,
 readability-*,
 
--modernize-use-nodiscard, 
 -performance-avoid-endl,
 
--readability-convert-member-functions-to-static, 
--misc-unused-parameters,
--misc-header-include-cycle,
--performance-move-const-arg,
--hicpp-move-const-arg,
--bugprone-easily-swappable-parameters,
 -misc-include-cleaner,
 -cppcoreguidelines-rvalue-reference-param-not-moved,
--modernize-concat-nested-namespaces,
 -readability-else-after-return,
 '
 
-# TODO: remove the following rule surpressions as soon as the C++ stubs are implemented
-# -readability-convert-member-functions-to-static, 
-# -misc-unused-parameters,
-# -performance-move-const-arg,
-# -hicpp-move-const-arg,
-# -misc-header-include-cycle, # TODO: caused by iceoryx inl structure, see duration.hpp
-# -bugprone-easily-swappable-parameters, # TODO: requires maybe a little refactoring with strong types
-# -misc-include-cleaner, # TODO: would be nice to have but we must be able to surpress it for certain include files
+# NOTE
+# * it would be nice to not suppress 'misc-include-cleaner' but we must be able to suppress it at least for certain include files
 
 
 WarningsAsErrors:     '' # Treat all Checks from above as errors

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -113,6 +113,8 @@
 -->
 * Remove clippy workaround
   [#223](https://github.com/eclipse-iceoryx/iceoryx2/issues/223)
+* Remove rule suppression in clang-tidy
+  [#280](https://github.com/eclipse-iceoryx/iceoryx2/issues/280)
 * Remove support for Bazel Workspaces
   [#1263](https://github.com/eclipse-iceoryx/iceoryx2/issues/1263)
 * Adjust test names to naming convention

--- a/examples/c/blackboard/src/blackboard_complex_key.h
+++ b/examples/c/blackboard/src/blackboard_complex_key.h
@@ -30,6 +30,7 @@ struct BlackboardKey {
 bool key_cmp(const void* lhs, const void* rhs) {
     const struct BlackboardKey LHS = *((const struct BlackboardKey*) lhs);
     const struct BlackboardKey RHS = *((const struct BlackboardKey*) rhs);
+    // NOLINTNEXTLINE(readability-implicit-bool-conversion) false positive
     return LHS.x == RHS.x && LHS.y == RHS.y && LHS.z == RHS.z;
 }
 

--- a/examples/c/discovery/src/main.c
+++ b/examples/c/discovery/src/main.c
@@ -13,7 +13,7 @@
 #include "iox2/iceoryx2.h"
 #include <stdio.h>
 
-iox2_callback_progression_e list_callback(const iox2_static_config_t* static_details, void* callback_context) {
+static iox2_callback_progression_e list_callback(const iox2_static_config_t* static_details, void* callback_context) {
     (void) callback_context;
     printf("Found Service: %s, ServiceID: %s\n", static_details->name, static_details->id);
     return iox2_callback_progression_e_CONTINUE;

--- a/examples/c/domains/src/discovery.c
+++ b/examples/c/domains/src/discovery.c
@@ -13,7 +13,7 @@
 #include "iox2/iceoryx2.h"
 #include <stdio.h>
 
-iox2_callback_progression_e list_callback(const iox2_static_config_t* static_details, void* callback_context) {
+static iox2_callback_progression_e list_callback(const iox2_static_config_t* static_details, void* callback_context) {
     (void) callback_context;
     printf("Found Service: %s, ServiceID: %s\n", static_details->name, static_details->id);
     return iox2_callback_progression_e_CONTINUE;

--- a/examples/c/event_multiplexing/src/notifier.c
+++ b/examples/c/event_multiplexing/src/notifier.c
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 
-const int BASE_10 = 10;
+static const int BASE_10 = 10;
 
 #if defined(_WIN32) || defined(WIN32) || defined(__WIN32__) || defined(_WIN64)
 #include <windows.h>

--- a/examples/c/event_multiplexing/src/wait.c
+++ b/examples/c/event_multiplexing/src/wait.c
@@ -27,7 +27,7 @@ struct CallbackContext {
 
 
 // the function that is called when a listener has received an event
-iox2_callback_progression_e on_event(iox2_waitset_attachment_id_h attachment_id, void* context) {
+static iox2_callback_progression_e on_event(iox2_waitset_attachment_id_h attachment_id, void* context) {
     struct CallbackContext* ctx = (struct CallbackContext*) context;
 
     iox2_event_id_t event_id;

--- a/examples/c/service_types/src/ipc_threadsafe_subscriber.c
+++ b/examples/c/service_types/src/ipc_threadsafe_subscriber.c
@@ -68,7 +68,7 @@ void drop_res(struct res* const value) { // NOLINT
     }
 }
 
-void* background_thread(void* unused) {
+static void* background_thread(void* unused) {
     (void) unused;
 
     while (iox2_node_wait(&example.node, 1, 0) == IOX2_OK) {

--- a/examples/c/service_types/src/local_pubsub.c
+++ b/examples/c/service_types/src/local_pubsub.c
@@ -99,7 +99,7 @@ void drop_res(struct res* const value) { // NOLINT
     }
 }
 
-void* background_thread(void* unused) {
+static void* background_thread(void* unused) {
     (void) unused;
 
     // Another node is created inside this thread to communicate with the main thread

--- a/examples/cxx/complex_data_types/src/complex_data_types.cpp
+++ b/examples/cxx/complex_data_types/src/complex_data_types.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <utility>
 
+namespace {
 struct ComplexData {
     iox2::bb::StaticString<4> name;           // NOLINT
     iox2::bb::StaticVector<uint64_t, 4> data; // NOLINT
@@ -29,6 +30,7 @@ struct ComplexDataType {
     iox2::bb::StaticVector<uint64_t, 4> vec_of_data;                 // NOLINT
     iox2::bb::StaticVector<ComplexData, 404857> vec_of_complex_data; // NOLINT
 };
+} // namespace
 
 constexpr iox2::bb::Duration CYCLE_TIME = iox2::bb::Duration::from_secs(1);
 

--- a/examples/cxx/event_multiplexing/src/wait.cpp
+++ b/examples/cxx/event_multiplexing/src/wait.cpp
@@ -76,8 +76,10 @@ auto main(int argc, char** argv) -> int {
     // NOLINTNEXTLINE(misc-const-correctness) false positive
     std::map<WaitSetAttachmentId<ServiceType::Ipc>, ServiceNameListenerPair> listeners;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) fine in the example
     listeners.emplace(WaitSetAttachmentId<ServiceType::Ipc>::from_guard(guards.unchecked_access()[0]),
                       ServiceNameListenerPair { service_name_1, std::move(listener_1) });
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) fine in the example
     listeners.emplace(WaitSetAttachmentId<ServiceType::Ipc>::from_guard(guards.unchecked_access()[1]),
                       ServiceNameListenerPair { service_name_2, std::move(listener_2) });
 

--- a/examples/cxx/event_multiplexing/src/wait.cpp
+++ b/examples/cxx/event_multiplexing/src/wait.cpp
@@ -18,10 +18,12 @@
 #include "iox2/iceoryx2.hpp"
 #include "parse_args.hpp"
 
+namespace {
 struct ServiceNameListenerPair {
     iox2::ServiceName service_name;
     iox2::Listener<iox2::ServiceType::Ipc> listener;
 };
+} // namespace
 
 auto main(int argc, char** argv) -> int {
     using namespace iox2;

--- a/iceoryx2-bb/cxx/include/iox2/bb/layout.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/bb/layout.hpp
@@ -98,6 +98,7 @@ inline auto Layout::round_up_to(const uint64_t value, const uint64_t multiple) -
     return (value % multiple == 0) ? value : multiple * (value / multiple + 1);
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters) private ctor, only used internally
 inline Layout::Layout(const uint64_t size, const uint64_t align)
     : m_size { size }
     , m_align { align } {

--- a/iceoryx2-bb/cxx/include/iox2/bb/layout.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/bb/layout.hpp
@@ -95,7 +95,7 @@ inline auto Layout::is_power_of_two(const uint64_t value) -> bool {
 }
 
 inline auto Layout::round_up_to(const uint64_t value, const uint64_t multiple) -> uint64_t {
-    return (value % multiple == 0) ? value : multiple * (value / multiple + 1);
+    return (value % multiple == 0) ? value : multiple * ((value / multiple) + 1);
 }
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters) private ctor, only used internally

--- a/iceoryx2-bb/cxx/include/iox2/bb/slice.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/bb/slice.hpp
@@ -103,7 +103,7 @@ Slice<T>::Slice(T* data, uint64_t number_of_elements)
 
 template <typename T>
 auto Slice<T>::number_of_bytes() const -> uint64_t {
-    return (sizeof(ValueType) * m_number_of_elements + alignof(ValueType) - 1) & ~(alignof(ValueType) - 1);
+    return ((sizeof(ValueType) * m_number_of_elements) + alignof(ValueType) - 1) & ~(alignof(ValueType) - 1);
 }
 
 template <typename T>

--- a/iceoryx2-bb/cxx/include/iox2/legacy/detail/expected.inl
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/detail/expected.inl
@@ -16,6 +16,7 @@
 #define IOX2_BB_VOCABULARY_EXPECTED_INL
 
 #include "iox2/bb/detail/assertions.hpp"
+// NOLINTNEXTLINE(misc-header-include-cycle) false positive; cycle prevented by include guards
 #include "iox2/legacy/expected.hpp"
 
 namespace iox2 {

--- a/iceoryx2-bb/cxx/include/iox2/legacy/detail/log/logstream.inl
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/detail/log/logstream.inl
@@ -16,6 +16,7 @@
 #ifndef IOX2_BB_REPORTING_LOG_LOGSTREAM_INL
 #define IOX2_BB_REPORTING_LOG_LOGSTREAM_INL
 
+// NOLINTNEXTLINE(misc-header-include-cycle) false positive; cycle prevented by include guards
 #include "iox2/legacy/log/logstream.hpp"
 
 #include <string>

--- a/iceoryx2-bb/cxx/include/iox2/legacy/detail/uninitialized_array.inl
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/detail/uninitialized_array.inl
@@ -15,6 +15,7 @@
 #ifndef IOX2_BB_CONTAINER_UNINITIALIZED_ARRAY_INL
 #define IOX2_BB_CONTAINER_UNINITIALIZED_ARRAY_INL
 
+// NOLINTNEXTLINE(misc-header-include-cycle) false positive; cycle prevented by include guards
 #include "iox2/legacy/uninitialized_array.hpp"
 
 namespace iox2 {

--- a/iceoryx2-bb/cxx/tests/src/duration_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/duration_tests.cpp
@@ -129,7 +129,7 @@ TEST(Duration, construct_duration_with_nanoseconds_max_value) {
     constexpr uint64_t MAX_NANOSECONDS_FOR_CTOR { std::numeric_limits<DurationAccessor::NanosecondsT>::max() };
     constexpr uint64_t EXPECTED_SECONDS = SECONDS + (MAX_NANOSECONDS_FOR_CTOR / NANOSECS_PER_SECOND);
     constexpr uint64_t REMAINING_NANOSECONDS = MAX_NANOSECONDS_FOR_CTOR % NANOSECS_PER_SECOND;
-    constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS { ((EXPECTED_SECONDS) *NANOSECS_PER_SECOND)
+    constexpr uint64_t EXPECTED_DURATION_IN_NANOSECONDS { (EXPECTED_SECONDS * NANOSECS_PER_SECOND)
                                                           + REMAINING_NANOSECONDS };
 
     auto sut = create_duration(SECONDS, MAX_NANOSECONDS_FOR_CTOR);

--- a/iceoryx2-bb/cxx/tests/src/duration_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/duration_tests.cpp
@@ -1727,7 +1727,7 @@ TEST(Duration, log_streaming_operator) {
         IOX2_LOGSTREAM_MOCK(logger_mock) << 0_s;
     }
     ASSERT_THAT(logger_mock.logs.size(), Eq(1U));
-    EXPECT_THAT(logger_mock.logs[0].message, StrEq("0s 0ns"));
+    EXPECT_THAT(logger_mock.logs.at(0).message, StrEq("0s 0ns"));
     logger_mock.logs.clear();
 
     {
@@ -1735,7 +1735,7 @@ TEST(Duration, log_streaming_operator) {
         IOX2_LOGSTREAM_MOCK(logger_mock) << less_than_one_second;
     }
     ASSERT_THAT(logger_mock.logs.size(), Eq(1U));
-    EXPECT_THAT(logger_mock.logs[0].message, StrEq("0s 42ns"));
+    EXPECT_THAT(logger_mock.logs.at(0).message, StrEq("0s 42ns"));
     logger_mock.logs.clear();
 
     {
@@ -1743,7 +1743,7 @@ TEST(Duration, log_streaming_operator) {
         IOX2_LOGSTREAM_MOCK(logger_mock) << more_than_one_second;
     }
     ASSERT_THAT(logger_mock.logs.size(), Eq(1U));
-    EXPECT_THAT(logger_mock.logs[0].message, StrEq("13s 73037042ns"));
+    EXPECT_THAT(logger_mock.logs.at(0).message, StrEq("13s 73037042ns"));
     logger_mock.logs.clear();
 }
 

--- a/iceoryx2-bb/cxx/tests/src/path_and_file_verifier_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/path_and_file_verifier_tests.cpp
@@ -100,8 +100,8 @@ TEST(PathAndFileVerifier, is_valid_file_name__valid_letter_combinations_are_vali
             const uint32_t index = static_cast<uint32_t>(i) % COMBINATION_CAPACITY;
 
             // index is always in the range of [0, COMBINATION_CAPACITY] since we calculate % COMBINATION_CAPACITY
-            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index,readability-identifier-length)
-            auto& s = combinations[index];
+            // NOLINTNEXTLINE(readability-identifier-length)
+            auto& s = combinations.at(index);
             s.append(1, static_cast<char>(i));
 
             EXPECT_TRUE(
@@ -266,16 +266,16 @@ TEST(
         // test
         std::string invalid_character_front;
         invalid_character_front.resize(1);
-        invalid_character_front[0] = static_cast<char>(i);
+        invalid_character_front.at(0) = static_cast<char>(i);
         invalid_character_front += valid_path1 + valid_path2;
 
         std::string invalid_character_middle = valid_path1;
         invalid_character_middle.resize(invalid_character_middle.size() + 1);
-        invalid_character_middle[invalid_character_middle.size() - 1] = static_cast<char>(i);
+        invalid_character_middle.at(invalid_character_middle.size() - 1) = static_cast<char>(i);
 
         std::string invalid_character_end = valid_path1 + valid_path2;
         invalid_character_end.resize(invalid_character_end.size() + 1);
-        invalid_character_end[invalid_character_end.size() - 1] = static_cast<char>(i);
+        invalid_character_end.at(invalid_character_end.size() - 1) = static_cast<char>(i);
 
         const auto invalid_character_front_test =
             *StaticString<FILE_PATH_LENGTH>::from_utf8_null_terminated_unchecked(invalid_character_front.c_str());
@@ -438,6 +438,7 @@ TEST(PathAndFileVerifier,
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay,hicpp-no-array-decay)
     for (const auto separator : platform::IOX2_PATH_SEPARATORS) {
         auto sut = *StaticString<FILE_PATH_LENGTH>::from_utf8(" ");
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
         sut.unchecked_access()[0] = separator;
         EXPECT_TRUE(does_end_with_path_separator(sut));
     }

--- a/iceoryx2-bb/cxx/tests/src/semantic_string_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/semantic_string_tests.cpp
@@ -43,7 +43,7 @@ struct TestValues {
     static const std::vector<std::string> ADD_VALID_CHARS_TO_CREATE_INVALID_CONTENT_AT_END;
 };
 
-// NOLINTBEGIN(cert-err58-cpp): Ignore "initialization with static storage duration may throw an exception that cannot be caught" in tests
+// NOLINTBEGIN(cert-err58-cpp,bugprone-throwing-static-initialization): Ignore "initialization with static storage duration may throw an exception that cannot be caught" in tests
 
 ///////////////////
 // START: FileName
@@ -163,7 +163,7 @@ const std::vector<std::string> TestValues<Path>::ADD_VALID_CHARS_TO_CREATE_INVAL
 // END: Path
 ///////////////////
 
-// NOLINTEND(cert-err58-cpp)
+// NOLINTEND(cert-err58-cpp,bugprone-throwing-static-initialization)
 
 template <typename T>
 class SemanticStringFixture : public Test {

--- a/iceoryx2-bb/cxx/tests/src/semantic_string_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/semantic_string_tests.cpp
@@ -167,7 +167,7 @@ const std::vector<std::string> TestValues<Path>::ADD_VALID_CHARS_TO_CREATE_INVAL
 
 template <typename T>
 class SemanticStringFixture : public Test {
-  public:
+  protected:
     void SetUp() override {
         EXPECT_FALSE(TestValues<T>::VALID_VALUES.empty());
         EXPECT_FALSE(TestValues<T>::TOO_LONG_CONTENT_VALUES.empty());
@@ -180,6 +180,7 @@ class SemanticStringFixture : public Test {
         // have only invalid characters or only invalid content or neither of both
     }
 
+  public:
     using SutType = T;
     // NOLINTBEGIN(misc-non-private-member-variables-in-classes)
     StaticString<SutType::capacity()> greater_value_str =

--- a/iceoryx2-bb/cxx/tests/src/slice_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/slice_tests.cpp
@@ -33,6 +33,8 @@ TEST(SliceTest, const_correctness_is_maintained) {
 
     auto elements = std::array<DummyData, SLICE_MAX_LENGTH> {};
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) fine in the tests
+
     auto mutable_slice = MutableSlice<DummyData>(elements.data(), SLICE_MAX_LENGTH);
     ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(mutable_slice.begin())>>::value);
     ASSERT_FALSE(std::is_const<std::remove_pointer_t<decltype(mutable_slice.end())>>::value);
@@ -57,6 +59,8 @@ TEST(SliceTest, const_correctness_is_maintained) {
     ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(const_immutable_slice.end())>>::value);
     ASSERT_TRUE(std::is_const<std::remove_pointer_t<decltype(const_immutable_slice.data())>>::value);
     ASSERT_TRUE(std::is_const<std::remove_reference_t<decltype(const_immutable_slice[0])>>::value);
+
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 TEST(SliceTest, can_iterate_mutable_slice) {

--- a/iceoryx2-bb/cxx/tests/src/static_function_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/static_function_tests.cpp
@@ -147,12 +147,6 @@ auto free_function_with_copyable_arg(const Arg& arg) -> int32_t {
 
 class StaticFunctionFixture : public Test {
   public:
-    void SetUp() override {
-    }
-
-    void TearDown() override {
-    }
-
     static auto static_function(int32_t num) -> int32_t {
         return num + 1;
     }

--- a/iceoryx2-bb/cxx/tests/src/static_string_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/static_string_tests.cpp
@@ -111,10 +111,12 @@ TEST(StaticString, from_utf8_works_up_to_capacity) {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers) capacity has no significance for this test
 template <typename T, typename U = decltype(iox2::bb::StaticString<99>::from_utf8(std::declval<T&&>()))>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) not relevant for the test
 constexpr auto can_call_from_utf8_with(T&& /* unused */) -> std::true_type {
     return {};
 }
 template <typename T, typename = std::enable_if_t<!std::is_array<std::remove_reference_t<T>>::value, bool>>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) not relevant for the test
 constexpr auto can_call_from_utf8_with(T&& /* unused */) -> std::false_type {
     return {};
 }
@@ -264,6 +266,7 @@ TEST(StaticString, construction_from_smaller_capacity_copies_string_contents) {
 template <uint64_t TargetCapacity,
           typename T,
           typename U = decltype(iox2::bb::StaticString<TargetCapacity>(std::declval<T&&>()))>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) not relevant for the test
 constexpr auto can_construct_from(T&& /* unused */) -> std::true_type {
     return {};
 }
@@ -271,6 +274,7 @@ constexpr auto can_construct_from(T&& /* unused */) -> std::true_type {
 template <uint64_t TargetCapacity,
           typename T,
           typename = std::enable_if_t<(std::remove_reference_t<T>::capacity() > TargetCapacity), bool>>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) not relevant for the test
 constexpr auto can_construct_from(T&& /* unused */) -> std::false_type {
     return {};
 }
@@ -308,6 +312,7 @@ TEST(StaticString, assignment_from_smaller_capacity_returns_reference_to_self) {
 template <uint64_t TargetCapacity,
           typename T,
           typename U = decltype(std::declval<iox2::bb::StaticString<TargetCapacity>>() = std::declval<T&&>())>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) not relevant for the test
 constexpr auto can_assign_from(T&& /* unused */) -> std::true_type {
     return {};
 }
@@ -315,6 +320,7 @@ constexpr auto can_assign_from(T&& /* unused */) -> std::true_type {
 template <uint64_t TargetCapacity,
           typename T,
           typename = std::enable_if_t<(std::remove_reference_t<T>::capacity() > TargetCapacity), bool>>
+// NOLINTNEXTLINE(cppcoreguidelines-missing-std-forward) not relevant for the test
 constexpr auto can_assign_from(T&& /* unused */) -> std::false_type {
     return {};
 }

--- a/iceoryx2-bb/cxx/tests/src/static_string_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/static_string_tests.cpp
@@ -187,6 +187,7 @@ TEST(StaticString, copy_constructor_copies_string_contents) {
 TEST(StaticString, move_constructor_copies_string_contents) {
     constexpr uint64_t const STRING_SIZE = 5;
     auto test_string = *iox2::bb::StaticString<STRING_SIZE>::from_utf8("ABCD");
+    // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg) move is required for the test
     iox2::bb::StaticString<STRING_SIZE> const sut { std::move(test_string) };
     ASSERT_EQ(sut.size(), 4);
     EXPECT_STREQ(sut.unchecked_access().c_str(), "ABCD");
@@ -232,6 +233,7 @@ TEST(StaticString, move_assignment_copies_string_contents) {
     auto test_string = *iox2::bb::StaticString<STRING_SIZE>::from_utf8("ABCD");
     auto sut = *iox2::bb::StaticString<STRING_SIZE>::from_utf8("EFGHI");
     EXPECT_STREQ(sut.unchecked_access().c_str(), "EFGHI");
+    // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg) move is required for the test
     sut = std::move(test_string);
     ASSERT_EQ(sut.size(), 4);
     ASSERT_EQ(sut.unchecked_access()[4], '\0');
@@ -243,6 +245,7 @@ TEST(StaticString, move_assignment_returns_reference_to_self) {
     constexpr uint64_t const STRING_SIZE = 5;
     auto test_string = *iox2::bb::StaticString<STRING_SIZE>::from_utf8("ABCD");
     auto sut = *iox2::bb::StaticString<STRING_SIZE>::from_utf8("EFGHI");
+    // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg) move is required for the test
     ASSERT_EQ(&(sut = std::move(test_string)), &sut);
 }
 

--- a/iceoryx2-bb/cxx/tests/src/static_string_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/static_string_tests.cpp
@@ -216,6 +216,7 @@ TEST(StaticString, copy_assignment_does_not_change_value_on_self_assignment) {
     constexpr uint64_t const STRING_SIZE = 5;
     auto sut = *iox2::bb::StaticString<STRING_SIZE>::from_utf8("ABCD");
     auto* sut_again_but_we_confuse_the_compiler = &sut;
+    // NOLINTNEXTLINE(bugprone-multi-level-implicit-pointer-conversion) intended for the test
     iox2::bb::testing::opaque_use(static_cast<void*>(&sut_again_but_we_confuse_the_compiler));
     ASSERT_EQ(sut.size(), 4);
     ASSERT_STREQ(sut.unchecked_access().c_str(), "ABCD");

--- a/iceoryx2-bb/cxx/tests/src/static_string_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/static_string_tests.cpp
@@ -39,6 +39,8 @@ static_assert(std::is_standard_layout<iox2::bb::StaticString<G_ARBITRARY_CAPACIT
 static_assert(iox2::bb::StaticString<G_ARBITRARY_CAPACITY>::capacity() == G_ARBITRARY_CAPACITY,
               "Capacity must be determined by template argument");
 
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) fine to use in tests
+
 TEST(StaticString, default_constructor_initializes_to_empty) {
     constexpr uint64_t const STRING_SIZE = 5;
     iox2::bb::StaticString<STRING_SIZE> const sut;
@@ -1107,4 +1109,7 @@ TEST(StaticString,
     EXPECT_STREQ(sut.unchecked_access().c_str(), "He");
     ASSERT_TRUE(free_space_is_all_zeroes(sut));
 }
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
+
 } // namespace

--- a/iceoryx2-bb/cxx/tests/src/static_vector_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/static_vector_tests.cpp
@@ -34,6 +34,8 @@ int32_t const G_TEST_ARRAY[G_TEST_ARRAY_SIZE] = { 4, 9, 77, 32, -5 };
 static_assert(std::is_standard_layout<iox2::bb::StaticVector<int32_t, G_TEST_ARRAY_SIZE>>::value,
               "StaticVector must be standard layout");
 
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) fine to use in tests
+
 TEST(StaticVector, default_constructor_initializes_to_empty) {
     iox2::bb::StaticVector<int32_t, G_TEST_ARRAY_SIZE> const sut;
     ASSERT_TRUE(sut.empty());
@@ -1355,5 +1357,7 @@ TEST(StaticVector, ostream_insertion_calls_ostream_inserter_for_values) {
     ASSERT_TRUE(sstr);
     EXPECT_EQ(sstr.str(), "StaticVector::<5> { m_size: 5, m_data: [ 7, 8, 9, 10, 11 ] }");
 }
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 
 } // namespace

--- a/iceoryx2-bb/cxx/tests/src/static_vector_tests.cpp
+++ b/iceoryx2-bb/cxx/tests/src/static_vector_tests.cpp
@@ -1314,7 +1314,7 @@ TEST(StaticVector, ostream_insertion_converts_contents_to_string) {
 }
 } // namespace
 
-// NOTE: the class needs to be outside to the anonymous namespace, else MSVC is not able to find the ostream operator
+// NOLINTNEXTLINE(misc-use-internal-linkage) the class needs to be outside to the anonymous namespace, else MSVC is not able to find the ostream operator
 class StaticVectorePrintable {
     static int32_t s_print_count;
 

--- a/iceoryx2-bb/cxx/tests/src/testing/observable.cpp
+++ b/iceoryx2-bb/cxx/tests/src/testing/observable.cpp
@@ -86,7 +86,7 @@ void DetectLeakedObservablesFixture::TearDown() {
     }
 }
 
-auto DetectLeakedObservablesFixture::has_leaked_observables() const -> bool {
+auto DetectLeakedObservablesFixture::has_leaked_observables() -> bool {
     return Observable::s_counter.total_instances != 0;
 }
 

--- a/iceoryx2-bb/cxx/tests/src/testing/observable.hpp
+++ b/iceoryx2-bb/cxx/tests/src/testing/observable.hpp
@@ -64,13 +64,14 @@ class DetectLeakedObservablesFixture : public ::testing::Test {
     auto operator=(DetectLeakedObservablesFixture const&) -> DetectLeakedObservablesFixture& = delete;
     auto operator=(DetectLeakedObservablesFixture&&) -> DetectLeakedObservablesFixture& = delete;
 
-    void SetUp() override;
-    void TearDown() override;
-
     /// Checks whether there are currently any active instances of Observable that await destruction.
     static auto has_leaked_observables() -> bool;
     /// Do not perform the check for leaks after this test.
     void defuse_leak_check();
+
+  protected:
+    void SetUp() override;
+    void TearDown() override;
 };
 
 // A fixture that checks all Observable counters against a set of expected values after the completion of a test.
@@ -87,11 +88,12 @@ class VerifyAllObservableInteractionsFixture : public ::testing::Test {
     auto operator=(VerifyAllObservableInteractionsFixture const&) -> VerifyAllObservableInteractionsFixture& = delete;
     auto operator=(VerifyAllObservableInteractionsFixture&&) -> VerifyAllObservableInteractionsFixture& = delete;
 
-    void SetUp() override;
-    void TearDown() override;
-
     // Retrieves the set of expected counter values that will be used for the check after this test.
     auto expected_count() -> Observable::Counters&;
+
+  protected:
+    void SetUp() override;
+    void TearDown() override;
 };
 
 } // namespace testing

--- a/iceoryx2-bb/cxx/tests/src/testing/observable.hpp
+++ b/iceoryx2-bb/cxx/tests/src/testing/observable.hpp
@@ -68,7 +68,7 @@ class DetectLeakedObservablesFixture : public ::testing::Test {
     void TearDown() override;
 
     /// Checks whether there are currently any active instances of Observable that await destruction.
-    auto has_leaked_observables() const -> bool;
+    static auto has_leaked_observables() -> bool;
     /// Do not perform the check for leaks after this test.
     void defuse_leak_check();
 };

--- a/iceoryx2-cxx/include/iox2/active_request.hpp
+++ b/iceoryx2-cxx/include/iox2/active_request.hpp
@@ -130,7 +130,7 @@ inline auto ActiveRequest<Service, RequestPayload, RequestUserHeader, ResponsePa
     ActiveRequest&& rhs) noexcept -> ActiveRequest& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/client.hpp
+++ b/iceoryx2-cxx/include/iox2/client.hpp
@@ -124,7 +124,7 @@ inline auto Client<Service, RequestPayload, RequestUserHeader, ResponsePayload, 
     Client&& rhs) noexcept -> Client& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/entry_handle.hpp
+++ b/iceoryx2-cxx/include/iox2/entry_handle.hpp
@@ -98,7 +98,7 @@ template <ServiceType S, typename KeyType, typename ValueType>
 inline auto EntryHandle<S, KeyType, ValueType>::operator=(EntryHandle&& rhs) noexcept -> EntryHandle& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/entry_handle_mut.hpp
+++ b/iceoryx2-cxx/include/iox2/entry_handle_mut.hpp
@@ -73,7 +73,7 @@ template <ServiceType S, typename KeyType, typename ValueType>
 inline auto EntryHandleMut<S, KeyType, ValueType>::operator=(EntryHandleMut&& rhs) noexcept -> EntryHandleMut& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/listener.hpp
+++ b/iceoryx2-cxx/include/iox2/listener.hpp
@@ -114,7 +114,7 @@ template <ServiceType S>
 inline auto Listener<S>::operator=(Listener&& rhs) noexcept -> Listener& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/pending_response.hpp
+++ b/iceoryx2-cxx/include/iox2/pending_response.hpp
@@ -130,7 +130,7 @@ inline auto PendingResponse<Service, RequestPayload, RequestUserHeader, Response
     PendingResponse&& rhs) noexcept -> PendingResponse& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/port_factory_blackboard.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_blackboard.hpp
@@ -110,7 +110,7 @@ inline auto PortFactoryBlackboard<S, KeyType>::operator=(PortFactoryBlackboard&&
     -> PortFactoryBlackboard& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/port_factory_blackboard.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_blackboard.hpp
@@ -131,10 +131,13 @@ inline auto PortFactoryBlackboard<S, KeyType>::name() const -> ServiceNameView {
 template <ServiceType S, typename KeyType>
 inline auto PortFactoryBlackboard<S, KeyType>::service_hash() const -> ServiceHash {
     iox2::legacy::UninitializedArray<char, IOX2_SERVICE_HASH_LENGTH> buffer;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
     iox2_port_factory_blackboard_service_hash(&m_handle, &buffer[0], IOX2_SERVICE_HASH_LENGTH);
 
     return ServiceHash(iox2::bb::StaticString<IOX2_SERVICE_HASH_LENGTH>::from_utf8_null_terminated_unchecked_truncated(
-        &buffer[0], IOX2_SERVICE_HASH_LENGTH));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
+        &buffer[0],
+        IOX2_SERVICE_HASH_LENGTH));
 }
 
 template <ServiceType S, typename KeyType>

--- a/iceoryx2-cxx/include/iox2/port_factory_publish_subscribe.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_publish_subscribe.hpp
@@ -108,7 +108,7 @@ inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::operator=(PortF
     -> PortFactoryPublishSubscribe& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/port_factory_publish_subscribe.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_publish_subscribe.hpp
@@ -129,10 +129,13 @@ inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::name() const ->
 template <ServiceType S, typename Payload, typename UserHeader>
 inline auto PortFactoryPublishSubscribe<S, Payload, UserHeader>::service_hash() const -> ServiceHash {
     iox2::legacy::UninitializedArray<char, IOX2_SERVICE_HASH_LENGTH> buffer;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
     iox2_port_factory_pub_sub_service_hash(&m_handle, &buffer[0], IOX2_SERVICE_HASH_LENGTH);
 
     return ServiceHash(iox2::bb::StaticString<IOX2_SERVICE_HASH_LENGTH>::from_utf8_null_terminated_unchecked_truncated(
-        &buffer[0], IOX2_SERVICE_HASH_LENGTH));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
+        &buffer[0],
+        IOX2_SERVICE_HASH_LENGTH));
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-cxx/include/iox2/port_factory_request_response.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_request_response.hpp
@@ -111,7 +111,7 @@ PortFactoryRequestResponse<Service, RequestPayload, RequestUserHeader, ResponseP
     PortFactoryRequestResponse&& rhs) noexcept -> PortFactoryRequestResponse& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/port_factory_request_response.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_request_response.hpp
@@ -149,10 +149,13 @@ inline auto
 PortFactoryRequestResponse<Service, RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader>::
     service_hash() const -> ServiceHash {
     iox2::legacy::UninitializedArray<char, IOX2_SERVICE_HASH_LENGTH> buffer;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
     iox2_port_factory_request_response_service_hash(&m_handle, &buffer[0], IOX2_SERVICE_HASH_LENGTH);
 
     return ServiceHash(iox2::bb::StaticString<IOX2_SERVICE_HASH_LENGTH>::from_utf8_null_terminated_unchecked_truncated(
-        &buffer[0], IOX2_SERVICE_HASH_LENGTH));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
+        &buffer[0],
+        IOX2_SERVICE_HASH_LENGTH));
 }
 
 template <ServiceType Service,

--- a/iceoryx2-cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-cxx/include/iox2/publisher.hpp
@@ -133,7 +133,7 @@ template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Publisher<S, Payload, UserHeader>::operator=(Publisher&& rhs) noexcept -> Publisher& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/reader.hpp
+++ b/iceoryx2-cxx/include/iox2/reader.hpp
@@ -80,7 +80,7 @@ template <ServiceType S, typename KeyType>
 inline auto Reader<S, KeyType>::operator=(Reader&& rhs) noexcept -> Reader& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/response.hpp
+++ b/iceoryx2-cxx/include/iox2/response.hpp
@@ -73,7 +73,7 @@ template <ServiceType Service, typename ResponsePayload, typename ResponseUserHe
 inline auto Response<Service, ResponsePayload, ResponseUserHeader>::operator=(Response&& rhs) noexcept -> Response& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/server.hpp
+++ b/iceoryx2-cxx/include/iox2/server.hpp
@@ -84,7 +84,7 @@ Server<Service, RequestPayload, RequestHeader, ResponsePayload, ResponseHeader>:
     -> Server& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/service_hash.hpp
+++ b/iceoryx2-cxx/include/iox2/service_hash.hpp
@@ -20,7 +20,7 @@ namespace iox2 {
 class ServiceHash {
   public:
     /// Returns the maximum string length of a [`ServiceHash`]
-    auto max_number_of_characters() -> uint64_t;
+    static auto max_number_of_characters() -> uint64_t;
 
     /// Returns the string value of the [`ServiceHash`]
     auto c_str() const -> const char*;

--- a/iceoryx2-cxx/include/iox2/subscriber.hpp
+++ b/iceoryx2-cxx/include/iox2/subscriber.hpp
@@ -72,7 +72,7 @@ template <ServiceType S, typename Payload, typename UserHeader>
 inline auto Subscriber<S, Payload, UserHeader>::operator=(Subscriber&& rhs) noexcept -> Subscriber& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/include/iox2/writer.hpp
+++ b/iceoryx2-cxx/include/iox2/writer.hpp
@@ -72,7 +72,7 @@ template <ServiceType S, typename KeyType>
 inline auto Writer<S, KeyType>::operator=(Writer&& rhs) noexcept -> Writer& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/attribute_set.cpp
+++ b/iceoryx2-cxx/src/attribute_set.cpp
@@ -50,12 +50,19 @@ auto AttributeSetView::key_value(const Attribute::Key& key, const uint64_t idx) 
     iox2::legacy::UninitializedArray<char, Attribute::Value::capacity()> buffer;
     bool has_value = false;
     iox2_attribute_set_key_value(
-        m_handle, key.unchecked_access().c_str(), idx, &buffer[0], Attribute::Value::capacity(), &has_value);
+        m_handle,
+        key.unchecked_access().c_str(),
+        idx,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
+        &buffer[0],
+        Attribute::Value::capacity(),
+        &has_value);
 
     if (!has_value) {
         return bb::NULLOPT;
     }
 
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
     auto value = Attribute::Value::from_utf8_null_terminated_unchecked(&buffer[0]);
     if (!value.has_value()) {
         return bb::NULLOPT;
@@ -127,6 +134,7 @@ auto AttributeSet::number_of_attributes() const -> uint64_t {
 }
 
 auto AttributeSet::operator[](const uint64_t index) const -> AttributeView {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) required to implement 'operator[]'
     return m_view[index];
 }
 
@@ -151,6 +159,7 @@ void AttributeSet::iter_key_values(
 auto operator<<(std::ostream& stream, const iox2::AttributeSetView& value) -> std::ostream& {
     stream << "AttributeSetView { ";
     for (uint64_t idx = 0; idx < value.number_of_attributes(); ++idx) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index is checked in for loop
         auto attribute = value[idx];
         stream << attribute;
     }
@@ -160,6 +169,7 @@ auto operator<<(std::ostream& stream, const iox2::AttributeSetView& value) -> st
 auto operator<<(std::ostream& stream, const iox2::AttributeSet& value) -> std::ostream& {
     stream << "AttributeSet { ";
     for (uint64_t idx = 0; idx < value.number_of_attributes(); ++idx) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index is checked in for loop
         auto attribute = value[idx];
         stream << attribute;
     }

--- a/iceoryx2-cxx/src/attribute_set.cpp
+++ b/iceoryx2-cxx/src/attribute_set.cpp
@@ -90,8 +90,8 @@ AttributeSet::AttributeSet(iox2_attribute_set_h handle)
 }
 
 AttributeSet::AttributeSet(AttributeSet&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) }
-    , m_view { std::move(rhs.m_view) } {
+    : m_handle { rhs.m_handle }
+    , m_view { rhs.m_view } {
     rhs.m_handle = nullptr;
     rhs.m_view.m_handle = nullptr;
 }
@@ -99,8 +99,8 @@ AttributeSet::AttributeSet(AttributeSet&& rhs) noexcept
 auto AttributeSet::operator=(AttributeSet&& rhs) noexcept -> AttributeSet& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
-        m_view = std::move(rhs.m_view);
+        m_handle = rhs.m_handle;
+        m_view = rhs.m_view;
 
         rhs.m_handle = nullptr;
         rhs.m_view.m_handle = nullptr;

--- a/iceoryx2-cxx/src/attribute_specifier.cpp
+++ b/iceoryx2-cxx/src/attribute_specifier.cpp
@@ -19,7 +19,7 @@ AttributeSpecifier::AttributeSpecifier() {
 }
 
 AttributeSpecifier::AttributeSpecifier(AttributeSpecifier&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 
@@ -30,7 +30,7 @@ AttributeSpecifier::~AttributeSpecifier() {
 auto AttributeSpecifier::operator=(AttributeSpecifier&& rhs) noexcept -> AttributeSpecifier& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/attribute_verifier.cpp
+++ b/iceoryx2-cxx/src/attribute_verifier.cpp
@@ -20,7 +20,7 @@ AttributeVerifier::AttributeVerifier() {
 }
 
 AttributeVerifier::AttributeVerifier(AttributeVerifier&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 
@@ -38,7 +38,7 @@ AttributeVerifier::~AttributeVerifier() {
 auto AttributeVerifier::operator=(AttributeVerifier&& rhs) noexcept -> AttributeVerifier& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/client_details.cpp
+++ b/iceoryx2-cxx/src/client_details.cpp
@@ -18,7 +18,7 @@ ClientDetailsView::ClientDetailsView(iox2_client_details_ptr handle)
 }
 
 ClientDetailsView::ClientDetailsView(ClientDetailsView&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/src/config.cpp
+++ b/iceoryx2-cxx/src/config.cpp
@@ -50,7 +50,7 @@ Config::Config(const Config& rhs) {
 }
 
 Config::Config(Config&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/src/file_descriptor.cpp
+++ b/iceoryx2-cxx/src/file_descriptor.cpp
@@ -54,7 +54,7 @@ FileDescriptor::FileDescriptor(FileDescriptor&& rhs) noexcept {
 auto FileDescriptor::operator=(FileDescriptor&& rhs) noexcept -> FileDescriptor& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/header_publish_subscribe.cpp
+++ b/iceoryx2-cxx/src/header_publish_subscribe.cpp
@@ -32,7 +32,7 @@ auto HeaderPublishSubscribe::operator=(HeaderPublishSubscribe&& rhs) noexcept ->
     if (this != &rhs) {
         drop();
 
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/header_request_response.cpp
+++ b/iceoryx2-cxx/src/header_request_response.cpp
@@ -21,7 +21,7 @@ auto RequestHeader::operator=(RequestHeader&& rhs) noexcept -> RequestHeader& {
     if (this != &rhs) {
         drop();
 
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -57,7 +57,7 @@ auto ResponseHeader::operator=(ResponseHeader&& rhs) noexcept -> ResponseHeader&
     if (this != &rhs) {
         drop();
 
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/listener_details.cpp
+++ b/iceoryx2-cxx/src/listener_details.cpp
@@ -18,7 +18,7 @@ ListenerDetailsView::ListenerDetailsView(iox2_listener_details_ptr handle)
 }
 
 ListenerDetailsView::ListenerDetailsView(ListenerDetailsView&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/src/node.cpp
+++ b/iceoryx2-cxx/src/node.cpp
@@ -23,7 +23,7 @@ Node<T>::Node(iox2_node_h handle)
 
 template <ServiceType T>
 Node<T>::Node(Node&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 
@@ -31,7 +31,7 @@ template <ServiceType T>
 auto Node<T>::operator=(Node&& rhs) noexcept -> Node& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/node_details.cpp
+++ b/iceoryx2-cxx/src/node_details.cpp
@@ -14,7 +14,7 @@
 
 namespace iox2 {
 NodeDetails::NodeDetails(iox2::bb::FileName executable, NodeName name, Config config)
-    : m_executable { std::move(executable) }
+    : m_executable { executable }
     , m_node_name { std::move(name) }
     , m_config { std::move(config) } {
 }

--- a/iceoryx2-cxx/src/node_id.cpp
+++ b/iceoryx2-cxx/src/node_id.cpp
@@ -26,14 +26,14 @@ NodeId::NodeId(const NodeId& rhs) {
 }
 
 NodeId::NodeId(NodeId&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 
 auto NodeId::operator=(NodeId&& rhs) noexcept -> NodeId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/node_name.cpp
+++ b/iceoryx2-cxx/src/node_name.cpp
@@ -54,7 +54,7 @@ NodeName::NodeName(NodeName&& rhs) noexcept {
 auto NodeName::operator=(NodeName&& rhs) noexcept -> NodeName& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/notifier.cpp
+++ b/iceoryx2-cxx/src/notifier.cpp
@@ -27,7 +27,7 @@ template <ServiceType S>
 auto Notifier<S>::operator=(Notifier&& rhs) noexcept -> Notifier& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/notifier_details.cpp
+++ b/iceoryx2-cxx/src/notifier_details.cpp
@@ -18,7 +18,7 @@ NotifierDetailsView::NotifierDetailsView(iox2_notifier_details_ptr handle)
 }
 
 NotifierDetailsView::NotifierDetailsView(NotifierDetailsView&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/src/port_factory_event.cpp
+++ b/iceoryx2-cxx/src/port_factory_event.cpp
@@ -36,7 +36,7 @@ template <ServiceType S>
 auto PortFactoryEvent<S>::operator=(PortFactoryEvent&& rhs) noexcept -> PortFactoryEvent& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/port_factory_event.cpp
+++ b/iceoryx2-cxx/src/port_factory_event.cpp
@@ -60,10 +60,13 @@ auto PortFactoryEvent<S>::name() const -> ServiceNameView {
 template <ServiceType S>
 auto PortFactoryEvent<S>::service_hash() const -> ServiceHash {
     iox2::legacy::UninitializedArray<char, IOX2_SERVICE_HASH_LENGTH> buffer;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
     iox2_port_factory_event_service_hash(&m_handle, &buffer[0], IOX2_SERVICE_HASH_LENGTH);
 
     return ServiceHash(iox2::bb::StaticString<IOX2_SERVICE_HASH_LENGTH>::from_utf8_null_terminated_unchecked_truncated(
-        &buffer[0], IOX2_SERVICE_HASH_LENGTH));
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) index 0 is guaranteed to be valid
+        &buffer[0],
+        IOX2_SERVICE_HASH_LENGTH));
 }
 
 template <ServiceType S>

--- a/iceoryx2-cxx/src/publisher_details.cpp
+++ b/iceoryx2-cxx/src/publisher_details.cpp
@@ -18,7 +18,7 @@ PublisherDetailsView::PublisherDetailsView(iox2_publisher_details_ptr handle)
 }
 
 PublisherDetailsView::PublisherDetailsView(PublisherDetailsView&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/src/reader_details.cpp
+++ b/iceoryx2-cxx/src/reader_details.cpp
@@ -18,7 +18,7 @@ ReaderDetailsView::ReaderDetailsView(iox2_reader_details_ptr handle)
 }
 
 ReaderDetailsView::ReaderDetailsView(ReaderDetailsView&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/src/server_details.cpp
+++ b/iceoryx2-cxx/src/server_details.cpp
@@ -18,7 +18,7 @@ ServerDetailsView::ServerDetailsView(iox2_server_details_ptr handle)
 }
 
 ServerDetailsView::ServerDetailsView(ServerDetailsView&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/src/service_name.cpp
+++ b/iceoryx2-cxx/src/service_name.cpp
@@ -51,7 +51,7 @@ ServiceName::ServiceName(ServiceName&& rhs) noexcept {
 auto ServiceName::operator=(ServiceName&& rhs) noexcept -> ServiceName& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/static_config.cpp
+++ b/iceoryx2-cxx/src/static_config.cpp
@@ -23,14 +23,14 @@ StaticConfig::StaticConfig(iox2_static_config_t value)
 }
 
 StaticConfig::StaticConfig(StaticConfig&& rhs) noexcept
-    : m_value { std::move(rhs.m_value) } {
+    : m_value { rhs.m_value } {
     rhs.m_value.attributes = nullptr;
 }
 
 auto StaticConfig::operator=(StaticConfig&& rhs) noexcept -> StaticConfig& {
     if (this != &rhs) {
         drop();
-        m_value = std::move(rhs.m_value);
+        m_value = rhs.m_value;
         rhs.m_value.attributes = nullptr;
     }
     return *this;

--- a/iceoryx2-cxx/src/subscriber_details.cpp
+++ b/iceoryx2-cxx/src/subscriber_details.cpp
@@ -18,7 +18,7 @@ SubscriberDetailsView::SubscriberDetailsView(iox2_subscriber_details_ptr handle)
 }
 
 SubscriberDetailsView::SubscriberDetailsView(SubscriberDetailsView&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/src/unique_port_id.cpp
+++ b/iceoryx2-cxx/src/unique_port_id.cpp
@@ -20,7 +20,7 @@ UniquePublisherId::UniquePublisherId(UniquePublisherId&& rhs) noexcept {
 auto UniquePublisherId::operator=(UniquePublisherId&& rhs) noexcept -> UniquePublisherId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -66,7 +66,7 @@ UniqueSubscriberId::UniqueSubscriberId(UniqueSubscriberId&& rhs) noexcept {
 auto UniqueSubscriberId::operator=(UniqueSubscriberId&& rhs) noexcept -> UniqueSubscriberId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -112,7 +112,7 @@ UniqueNotifierId::UniqueNotifierId(UniqueNotifierId&& rhs) noexcept {
 auto UniqueNotifierId::operator=(UniqueNotifierId&& rhs) noexcept -> UniqueNotifierId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -158,7 +158,7 @@ UniqueListenerId::UniqueListenerId(UniqueListenerId&& rhs) noexcept {
 auto UniqueListenerId::operator=(UniqueListenerId&& rhs) noexcept -> UniqueListenerId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -204,7 +204,7 @@ UniqueClientId::UniqueClientId(UniqueClientId&& rhs) noexcept {
 auto UniqueClientId::operator=(UniqueClientId&& rhs) noexcept -> UniqueClientId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -250,7 +250,7 @@ UniqueServerId::UniqueServerId(UniqueServerId&& rhs) noexcept {
 auto UniqueServerId::operator=(UniqueServerId&& rhs) noexcept -> UniqueServerId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -296,7 +296,7 @@ UniqueReaderId::UniqueReaderId(UniqueReaderId&& rhs) noexcept {
 auto UniqueReaderId::operator=(UniqueReaderId&& rhs) noexcept -> UniqueReaderId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -342,7 +342,7 @@ UniqueWriterId::UniqueWriterId(UniqueWriterId&& rhs) noexcept {
 auto UniqueWriterId::operator=(UniqueWriterId&& rhs) noexcept -> UniqueWriterId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/waitset.cpp
+++ b/iceoryx2-cxx/src/waitset.cpp
@@ -35,7 +35,7 @@ template <ServiceType S>
 auto WaitSetAttachmentId<S>::operator=(WaitSetAttachmentId&& rhs) noexcept -> WaitSetAttachmentId& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -122,7 +122,7 @@ template <ServiceType S>
 auto WaitSetGuard<S>::operator=(WaitSetGuard&& rhs) noexcept -> WaitSetGuard& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 
@@ -200,7 +200,7 @@ template <ServiceType S>
 auto WaitSet<S>::operator=(WaitSet&& rhs) noexcept -> WaitSet& {
     if (this != &rhs) {
         drop();
-        m_handle = std::move(rhs.m_handle);
+        m_handle = rhs.m_handle;
         rhs.m_handle = nullptr;
     }
 

--- a/iceoryx2-cxx/src/writer_details.cpp
+++ b/iceoryx2-cxx/src/writer_details.cpp
@@ -18,7 +18,7 @@ WriterDetailsView::WriterDetailsView(iox2_writer_details_ptr handle)
 }
 
 WriterDetailsView::WriterDetailsView(WriterDetailsView&& rhs) noexcept
-    : m_handle { std::move(rhs.m_handle) } {
+    : m_handle { rhs.m_handle } {
     rhs.m_handle = nullptr;
 }
 

--- a/iceoryx2-cxx/tests/src/attribute_tests.cpp
+++ b/iceoryx2-cxx/tests/src/attribute_tests.cpp
@@ -21,6 +21,8 @@
 namespace {
 using namespace iox2;
 
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) fine to use in tests
+
 TEST(AttributeVerifier, require_is_listed_in_attributes) {
     auto key = *Attribute::Key::from_utf8("some_key");
     auto value = *Attribute::Value::from_utf8("oh my god, its a value");
@@ -194,4 +196,7 @@ TEST(AttributeSet, to_owned_works) {
     ASSERT_THAT(attributes_owned[0].value(), Eq(value_1));
     ASSERT_THAT(attributes_owned[1].value(), Eq(value_2));
 }
+
+// NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
+
 } // namespace

--- a/iceoryx2-cxx/tests/src/log_tests.cpp
+++ b/iceoryx2-cxx/tests/src/log_tests.cpp
@@ -81,6 +81,7 @@ TEST(Log, custom_logger_works) {
 
     ASSERT_THAT(log_buffer.size(), Eq(6));
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) indices are guaranteed to be valid
     ASSERT_TRUE(log_buffer.unchecked_access()[0].is_equal(LogLevel::Trace, "hello", "world"));
     ASSERT_TRUE(log_buffer.unchecked_access()[1].is_equal(LogLevel::Debug, "goodbye", "hypnotoad"));
     ASSERT_TRUE(log_buffer.unchecked_access()[2].is_equal(LogLevel::Info, "Who is looking for freedom?", "The Hoff!"));
@@ -88,6 +89,7 @@ TEST(Log, custom_logger_works) {
     ASSERT_TRUE(log_buffer.unchecked_access()[4].is_equal(
         LogLevel::Error, "Bluemchen should record a single with", "The almighty Hypnotoad"));
     ASSERT_TRUE(log_buffer.unchecked_access()[5].is_equal(LogLevel::Fatal, "It is the end", "my beloved toad."));
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 TEST(Log, can_set_and_get_log_level) {

--- a/iceoryx2-cxx/tests/src/service_blackboard_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_blackboard_tests.cpp
@@ -1701,7 +1701,7 @@ TYPED_TEST(ServiceBlackboardTest, simple_communication_with_key_struct_works) {
     ASSERT_THAT(*entry_handle_1.get(), Eq(-3));
     ASSERT_THAT(*entry_handle_2.get(), Eq(3));
 
-    entry_handle_mut_1.update_with_copy((VALUE_1));
+    entry_handle_mut_1.update_with_copy(VALUE_1);
     ASSERT_THAT(*entry_handle_1.get(), Eq(VALUE_1));
     ASSERT_THAT(*entry_handle_2.get(), Eq(3));
 

--- a/iceoryx2-cxx/tests/src/service_blackboard_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_blackboard_tests.cpp
@@ -850,6 +850,7 @@ TYPED_TEST(ServiceBlackboardTest, write_and_read_different_value_types_works) {
 
     struct Groovy {
         Groovy() = default;
+        // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
         Groovy(bool a, uint32_t b, int64_t c)
             : m_a { a }
             , m_b { b }
@@ -1649,7 +1650,7 @@ TYPED_TEST(ServiceBlackboardTest, list_keys_works) {
 constexpr uint64_t const STRING_CAPACITY = 25;
 struct Foo {
     Foo() = default;
-    // NOLINTNEXTLINE(readability-identifier-length), come on, its a test
+    // NOLINTNEXTLINE(readability-identifier-length, bugprone-easily-swappable-parameters), come on, its a test
     Foo(uint32_t a, int16_t b, uint8_t c, const bb::StaticString<STRING_CAPACITY>& d)
         : m_a { a }
         , m_b { b }

--- a/iceoryx2-cxx/tests/src/service_blackboard_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_blackboard_tests.cpp
@@ -831,12 +831,12 @@ TYPED_TEST(ServiceBlackboardTest, communication_with_max_reader_and_writer_handl
     }
 
     for (uint64_t i = 0; i < MAX_HANDLES; ++i) {
-        entry_handles_mut[i].update_with_copy(VALUE);
+        entry_handles_mut.at(i).update_with_copy(VALUE);
         for (uint64_t j = 0; j < i + 1; ++j) {
-            ASSERT_THAT(*entry_handles[j].get(), Eq(VALUE));
+            ASSERT_THAT(*entry_handles.at(j).get(), Eq(VALUE));
         }
         for (uint64_t j = i + 1; j < MAX_HANDLES; ++j) {
-            ASSERT_THAT(*entry_handles[j].get(), Eq(j));
+            ASSERT_THAT(*entry_handles.at(j).get(), Eq(j));
         }
     }
 }
@@ -1474,6 +1474,8 @@ TYPED_TEST(ServiceBlackboardTest, create_with_attributes_sets_attributes) {
     auto attributes_create = service_create.attributes();
     auto attributes_open = service_open.attributes();
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) indices are checked
+
     ASSERT_THAT(attributes_create.number_of_attributes(), Eq(1));
     ASSERT_THAT(attributes_create[0].key(), Eq(key));
     ASSERT_THAT(attributes_create[0].value(), Eq(value));
@@ -1481,6 +1483,8 @@ TYPED_TEST(ServiceBlackboardTest, create_with_attributes_sets_attributes) {
     ASSERT_THAT(attributes_open.number_of_attributes(), Eq(1));
     ASSERT_THAT(attributes_open[0].key(), Eq(key));
     ASSERT_THAT(attributes_open[0].value(), Eq(value));
+
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 TYPED_TEST(ServiceBlackboardTest, open_fails_when_attributes_are_incompatible) {
@@ -1619,11 +1623,11 @@ TYPED_TEST(ServiceBlackboardTest, list_keys_works) {
     std::vector<uint64_t> keys { 0, 1, 2, 3, 4 };
     auto service = node.service_builder(service_name)
                        .template blackboard_creator<uint64_t>()
-                       .template add<uint64_t>(keys[0], 0)
-                       .template add<uint64_t>(keys[1], 0)
-                       .template add<uint64_t>(keys[2], 0)
-                       .template add<uint64_t>(keys[3], 0)
-                       .template add<uint64_t>(keys[4], 0)
+                       .template add<uint64_t>(keys.at(0), 0)
+                       .template add<uint64_t>(keys.at(1), 0)
+                       .template add<uint64_t>(keys.at(2), 0)
+                       .template add<uint64_t>(keys.at(3), 0)
+                       .template add<uint64_t>(keys.at(4), 0)
                        .create()
                        .value();
 
@@ -1644,7 +1648,7 @@ TYPED_TEST(ServiceBlackboardTest, list_keys_works) {
         return CallbackProgression::Stop;
     });
     ASSERT_EQ(listed_keys.size(), 1);
-    ASSERT_TRUE(std::find(keys.begin(), keys.end(), listed_keys[0]) != keys.end());
+    ASSERT_TRUE(std::find(keys.begin(), keys.end(), listed_keys.at(0)) != keys.end());
 }
 
 constexpr uint64_t const STRING_CAPACITY = 25;
@@ -1732,8 +1736,8 @@ TYPED_TEST(ServiceBlackboardTest, list_keys_with_key_struct_works) {
                             Foo(2, -3, 0, bb::StaticString<STRING_CAPACITY>::from_utf8("hatschuu").value()) };
     auto service = node.service_builder(service_name)
                        .template blackboard_creator<Foo>()
-                       .template add<int32_t>(keys[0], -3)
-                       .template add<uint32_t>(keys[1], 3)
+                       .template add<int32_t>(keys.at(0), -3)
+                       .template add<uint32_t>(keys.at(1), 3)
                        .create()
                        .value();
 
@@ -1754,7 +1758,7 @@ TYPED_TEST(ServiceBlackboardTest, list_keys_with_key_struct_works) {
         return CallbackProgression::Stop;
     });
     ASSERT_EQ(listed_keys.size(), 1);
-    ASSERT_TRUE(std::find(keys.begin(), keys.end(), listed_keys[0]) != keys.end());
+    ASSERT_TRUE(std::find(keys.begin(), keys.end(), listed_keys.at(0)) != keys.end());
 }
 
 TYPED_TEST(ServiceBlackboardTest, new_value_can_be_written_using_value_mut) {

--- a/iceoryx2-cxx/tests/src/service_event_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_event_tests.cpp
@@ -443,6 +443,8 @@ TYPED_TEST(ServiceEventTest, create_with_attributes_sets_attributes) {
     auto attributes_create = service_create.attributes();
     auto attributes_open = service_open.attributes();
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) indices are checked
+
     ASSERT_THAT(attributes_create.number_of_attributes(), Eq(1));
     ASSERT_THAT(attributes_create[0].key(), Eq(key));
     ASSERT_THAT(attributes_create[0].value(), Eq(value));
@@ -450,6 +452,8 @@ TYPED_TEST(ServiceEventTest, create_with_attributes_sets_attributes) {
     ASSERT_THAT(attributes_open.number_of_attributes(), Eq(1));
     ASSERT_THAT(attributes_open[0].key(), Eq(key));
     ASSERT_THAT(attributes_open[0].value(), Eq(value));
+
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 TYPED_TEST(ServiceEventTest, open_fails_when_attributes_are_incompatible) {

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -1025,6 +1025,8 @@ TYPED_TEST(ServicePublishSubscribeTest, create_with_attributes_sets_attributes) 
     auto attributes_create = service_create.attributes();
     auto attributes_open = service_open.attributes();
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) indices are checked
+
     ASSERT_THAT(attributes_create.number_of_attributes(), Eq(1));
     ASSERT_THAT(attributes_create[0].key(), Eq(key));
     ASSERT_THAT(attributes_create[0].value(), Eq(value));
@@ -1032,6 +1034,8 @@ TYPED_TEST(ServicePublishSubscribeTest, create_with_attributes_sets_attributes) 
     ASSERT_THAT(attributes_open.number_of_attributes(), Eq(1));
     ASSERT_THAT(attributes_open[0].key(), Eq(key));
     ASSERT_THAT(attributes_open[0].value(), Eq(value));
+
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 TYPED_TEST(ServicePublishSubscribeTest, open_fails_when_attributes_are_incompatible) {

--- a/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
@@ -1072,6 +1072,8 @@ TYPED_TEST(ServiceRequestResponseTest, create_with_attributes_sets_attributes) {
     auto attributes_create = service_create.attributes();
     auto attributes_open = service_open.attributes();
 
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access) indices are checked
+
     ASSERT_THAT(attributes_create.number_of_attributes(), Eq(1));
     ASSERT_THAT(attributes_create[0].key(), Eq(key));
     ASSERT_THAT(attributes_create[0].value(), Eq(value));
@@ -1079,6 +1081,8 @@ TYPED_TEST(ServiceRequestResponseTest, create_with_attributes_sets_attributes) {
     ASSERT_THAT(attributes_open.number_of_attributes(), Eq(1));
     ASSERT_THAT(attributes_open[0].key(), Eq(key));
     ASSERT_THAT(attributes_open[0].value(), Eq(value));
+
+    // NOLINTEND(cppcoreguidelines-pro-bounds-avoid-unchecked-container-access)
 }
 
 TYPED_TEST(ServiceRequestResponseTest, open_fails_when_attributes_are_incompatible) {

--- a/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
@@ -748,6 +748,7 @@ TYPED_TEST(ServiceRequestResponseTest, write_payload_works) {
 
     auto request_uninit = sut_client.loan_uninit().value();
     uint64_t request_payload = 3;
+    // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg) required for test
     auto request = request_uninit.write_payload(std::move(request_payload));
     EXPECT_THAT(request.payload(), Eq(request_payload));
     auto pending_response = send(std::move(request)).value();
@@ -758,6 +759,7 @@ TYPED_TEST(ServiceRequestResponseTest, write_payload_works) {
 
     uint64_t response_payload = 4;
     auto response_uninit = active_request->loan_uninit().value();
+    // NOLINTNEXTLINE(hicpp-move-const-arg,performance-move-const-arg) required for test
     auto response = response_uninit.write_payload(std::move(response_payload));
     EXPECT_THAT(response.payload(), Eq(response_payload));
     send(std::move(response)).value();

--- a/iceoryx2-cxx/tests/src/test.hpp
+++ b/iceoryx2-cxx/tests/src/test.hpp
@@ -37,7 +37,7 @@ using ServiceTypes = ::testing::Types<ServiceTypeIpc, ServiceTypeLocal>;
 inline auto generate_service_name() -> ServiceName {
     static std::atomic<uint64_t> COUNTER { 0 };
     const auto now = std::chrono::system_clock::now().time_since_epoch().count();
-    const auto random_number = rand(); // NOLINT(cert-msc30-c,cert-msc50-cpp)
+    const auto random_number = rand(); // NOLINT(cert-msc30-c,cert-msc50-cpp, misc-predictable-rand)
     return ServiceName::create((std::string("test_") + std::to_string(COUNTER.fetch_add(1)) + "_" + std::to_string(now)
                                 + "_" + std::to_string(random_number))
                                    .c_str())

--- a/iceoryx2-cxx/tests/src/waitset_tests.cpp
+++ b/iceoryx2-cxx/tests/src/waitset_tests.cpp
@@ -310,8 +310,8 @@ TYPED_TEST(WaitSetTest, triggering_everything_works) {
 
     auto result = sut.wait_and_process_once([&](auto attachment_id) -> CallbackProgression {
         for (uint64_t idx = 0; idx < guards.size(); ++idx) {
-            if (attachment_id.has_event_from(guards[idx])) {
-                was_triggered[idx] = true;
+            if (attachment_id.has_event_from(guards.at(idx))) {
+                was_triggered.at(idx) = true;
                 break;
             }
         }

--- a/iceoryx2-pal/posix/src/c/socket_macros.c
+++ b/iceoryx2-pal/posix/src/c/socket_macros.c
@@ -23,39 +23,39 @@
 #include <sys/select.h>
 #include <sys/socket.h>
 
-size_t iceoryx2_cmsg_space(const size_t len) {
+static size_t iceoryx2_cmsg_space(const size_t len) {
     return CMSG_SPACE(len);
 }
 
-struct cmsghdr* iceoryx2_cmsg_firsthdr(const struct msghdr* hdr) {
+static struct cmsghdr* iceoryx2_cmsg_firsthdr(const struct msghdr* hdr) {
     return CMSG_FIRSTHDR(hdr);
 }
 
-struct cmsghdr* iceoryx2_cmsg_nxthdr(struct msghdr* hdr, struct cmsghdr* sub) {
+static struct cmsghdr* iceoryx2_cmsg_nxthdr(struct msghdr* hdr, struct cmsghdr* sub) {
     return CMSG_NXTHDR(hdr, sub);
 }
 
-size_t iceoryx2_cmsg_len(const size_t len) {
+static size_t iceoryx2_cmsg_len(const size_t len) {
     return CMSG_LEN(len);
 }
 
-unsigned char* iceoryx2_cmsg_data(struct cmsghdr* cmsg) {
+static unsigned char* iceoryx2_cmsg_data(struct cmsghdr* cmsg) {
     return CMSG_DATA(cmsg);
 }
 
-void iceoryx2_fd_clr(const int fd, fd_set* set) {
+static void iceoryx2_fd_clr(const int fd, fd_set* set) {
     FD_CLR(fd, set);
 }
 
-int iceoryx2_fd_isset(const int fd, const fd_set* set) {
+static int iceoryx2_fd_isset(const int fd, const fd_set* set) {
     return FD_ISSET(fd, set);
 }
 
-void iceoryx2_fd_set(const int fd, fd_set* set) {
+static void iceoryx2_fd_set(const int fd, fd_set* set) {
     FD_SET(fd, set);
 }
 
-void iceoryx2_fd_zero(fd_set* set) {
+static void iceoryx2_fd_zero(fd_set* set) {
     FD_ZERO(set);
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

I thought this was easy to close but it still was not a mowed lawn.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #280 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
