### PR TITLE
fix(event): validate lifecycle event IDs against event_id_max_value at create and open time

### DIFF
--- a/iceoryx2/conformance-tests/src/service_event.rs
+++ b/iceoryx2/conformance-tests/src/service_event.rs
@@ -1298,6 +1298,63 @@ pub mod service_event {
             format!("{}", EventCreateError::InsufficientPermissions), eq "EventCreateError::InsufficientPermissions");
         assert_that!(
             format!("{}", EventCreateError::IsBeingCreatedByAnotherInstance), eq "EventCreateError::IsBeingCreatedByAnotherInstance");
+        assert_that!(
+            format!("{}", EventCreateError::EventIdExceedsMaxSupportedValue), eq "EventCreateError::EventIdExceedsMaxSupportedValue");
+    }
+
+    // Regression test for #1488: lifecycle event IDs exceeding event_id_max_value must be
+    // rejected at service creation time and detected at open time, rather than silently
+    // accepted and only failing at notify_with_custom_event_id call time.
+    #[conformance_test]
+    pub fn create_fails_when_lifecycle_event_id_exceeds_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
+        // notifier_created_event exceeds max
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_created_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+
+        // notifier_dropped_event exceeds max
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_dropped_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+
+        // notifier_dead_event exceeds max
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_dead_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+
+        // lifecycle event IDs at or below max are accepted
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_created_event(EventId::new(MAX))
+            .notifier_dropped_event(EventId::new(MAX - 1))
+            .notifier_dead_event(EventId::new(0))
+            .create();
+        assert_that!(sut, is_ok);
     }
 
     #[conformance_test]

--- a/iceoryx2/src/service/builder/event.rs
+++ b/iceoryx2/src/service/builder/event.rs
@@ -119,6 +119,9 @@ pub enum EventCreateError {
     HangsInCreation,
     /// The process has insufficient permissions to create the [`Service`].
     InsufficientPermissions,
+    /// A lifecycle event id (`notifier_created_event`, `notifier_dropped_event`, or
+    /// `notifier_dead_event`) exceeds the configured `event_id_max_value`.
+    EventIdExceedsMaxSupportedValue,
 }
 
 impl core::fmt::Display for EventCreateError {
@@ -476,6 +479,25 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
 
         let msg = "Unable to create event service";
 
+        {
+            let settings = self.base.service_config.event();
+            let max = settings.event_id_max_value;
+            for (label, opt_id) in [
+                ("notifier_created_event", settings.notifier_created_event.as_option_ref().copied()),
+                ("notifier_dropped_event", settings.notifier_dropped_event.as_option_ref().copied()),
+                ("notifier_dead_event", settings.notifier_dead_event.as_option_ref().copied()),
+            ] {
+                if let Some(id) = opt_id {
+                    if id > max {
+                        fail!(from self,
+                            with EventCreateError::EventIdExceedsMaxSupportedValue,
+                            "{} since the {} value {} exceeds event_id_max_value {}.",
+                            msg, label, id, max);
+                    }
+                }
+            }
+        }
+
         match self.base.is_service_available(msg)? {
             None => {
                 let service_tag = self
@@ -671,6 +693,34 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
             fail!(from self, with EventOpenError::IncompatibleDeadline,
                 "{} since the deadline is {:?} but a deadline of {:?} is required.",
                 msg, existing_settings.deadline, required_settings.deadline);
+        }
+
+        // Verify that the existing service's lifecycle event IDs are within its own
+        // event_id_max_value bounds.  A service whose lifecycle events exceed its own max
+        // would cause every Notifier creation to fail with EventIdOutOfBounds at emit time —
+        // a silent accept that only surfaces later.  Catch it here instead.
+        let max_event_id = existing_settings.event_id_max_value;
+        for (label, opt_id) in [
+            (
+                "notifier_created_event",
+                existing_settings.notifier_created_event.as_option_ref().copied(),
+            ),
+            (
+                "notifier_dropped_event",
+                existing_settings.notifier_dropped_event.as_option_ref().copied(),
+            ),
+            (
+                "notifier_dead_event",
+                existing_settings.notifier_dead_event.as_option_ref().copied(),
+            ),
+        ] {
+            if let Some(id) = opt_id {
+                if id > max_event_id {
+                    fail!(from self, with EventOpenError::DoesNotSupportRequestedMaxEventId,
+                        "{} since the stored {} value {} exceeds the service's event_id_max_value {}.",
+                        msg, label, id, max_event_id);
+                }
+            }
         }
 
         Ok(*existing_settings)


### PR DESCRIPTION
## Summary

Closes #1488

When a service was created with `notifier_created_event`, `notifier_dropped_event`,
or `notifier_dead_event` set to a value exceeding `event_id_max_value`, the service
builder silently accepted the invalid configuration. The error only surfaced later
when a Notifier tried to emit the lifecycle event and `notify_with_custom_event_id`
returned `EventIdOutOfBounds` — at a point far removed from the misconfiguration.

This PR adds two guard points:

**1. Create path (`create_impl`):** before persisting the static config, verify that
each lifecycle event ID (if set) does not exceed `event_id_max_value`. Returns the
new `EventCreateError::EventIdExceedsMaxSupportedValue` if violated.

**2. Open path (`verify_service_configuration`):** after all existing compatibility
checks, verify that the existing service's stored lifecycle event IDs do not exceed
its own `event_id_max_value`. Returns the existing
`EventOpenError::DoesNotSupportRequestedMaxEventId` if violated, catching any service
that was persisted in an invalid state before this fix.

## Files changed

- `iceoryx2/src/service/builder/event.rs`
  - New `EventCreateError::EventIdExceedsMaxSupportedValue` variant
  - Create-path validation block in `create_impl`
  - Open-path validation block at end of `verify_service_configuration`
- `iceoryx2/conformance-tests/src/service_event.rs`
  - New conformance test `create_fails_when_lifecycle_event_id_exceeds_max_event_id`
  - `create_error_display_works` extended with new variant

## Test plan

- [ ] `cargo test -p iceoryx2-conformance-tests create_fails_when_lifecycle_event_id_exceeds_max_event_id`
- [ ] `cargo test -p iceoryx2-conformance-tests create_error_display_works`
- [ ] Full conformance test suite `cargo test -p iceoryx2-conformance-tests`

*AI-assisted — authored with Claude, reviewed by Komada.*