### PR TITLE
fix(python): divide __slice_len by sizeof(T) to get element count in payload()

### DIFF
--- a/iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py
+++ b/iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py
@@ -27,7 +27,10 @@ def payload(self: Any) -> Any:
     assert self.__payload_type_details is not None
     if get_origin(self.__payload_type_details) is Slice:
         (contained_type,) = get_args(self.__payload_type_details)
-        return Slice(self.payload_ptr, self.__slice_len, contained_type)
+        # __slice_len is the raw payload size in bytes; divide by the element
+        # size to obtain the element count expected by Slice. (fix for #1533)
+        number_of_elements = self.__slice_len // ctypes.sizeof(contained_type)
+        return Slice(self.payload_ptr, number_of_elements, contained_type)
 
     return ctypes.cast(self.payload_ptr, ctypes.POINTER(self.__payload_type_details))
 

--- a/iceoryx2-ffi/python/tests/service_publish_subscribe_tests.py
+++ b/iceoryx2-ffi/python/tests/service_publish_subscribe_tests.py
@@ -363,3 +363,49 @@ def test_history_is_delivered_with_update_connections(
         assert received_sample.payload().contents.data == 85 + i
 
     assert not subscriber.has_samples()
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_slice_payload_element_count_is_correct_for_multi_byte_types(
+    service_type: iox2.ServiceType,
+) -> None:
+    """Regression test for #1533: payload() must return element count, not byte count.
+
+    When the slice element type has sizeof > 1, __slice_len returns the raw byte
+    count from Rust.  The Python payload() function must divide by sizeof(T) to
+    obtain the number of elements; otherwise Slice.len() would report N*sizeof(T)
+    instead of N.
+    """
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+
+    service_name = iox2.testing.generate_service_name()
+    service = (
+        node.service_builder(service_name)
+        .publish_subscribe(iox2.Slice[ctypes.c_uint32])
+        .create()
+    )
+
+    number_of_elements = 3
+    publisher = (
+        service.publisher_builder()
+        .initial_max_slice_len(number_of_elements)
+        .create()
+    )
+    subscriber = service.subscriber_builder().create()
+
+    sample_uninit = publisher.loan_slice_uninit(number_of_elements)
+    arr_type = ctypes.c_uint32 * number_of_elements
+    arr = arr_type(10, 20, 30)
+    ctypes.memmove(sample_uninit.payload_ptr, arr, ctypes.sizeof(arr))
+    sample_uninit.assume_init().send()
+
+    received_sample = subscriber.receive()
+    assert received_sample is not None
+
+    received_slice = received_sample.payload()
+    # Must be element count (3), not byte count (3 * sizeof(c_uint32) = 12).
+    assert received_slice.len() == number_of_elements
+    assert received_slice[0] == 10
+    assert received_slice[1] == 20
+    assert received_slice[2] == 30


### PR DESCRIPTION
## Summary

Closes #1533

The Rust FFI layer's `__slice_len` property returns the raw **byte length** of the
payload buffer (`v.payload().len()` on `&[u8]`). The Python `payload()` function in
`publish_subscribe_extensions.py` was passing this byte count directly to `Slice()`
as the element count.

For single-byte element types (`c_uint8`) this happened to be correct. For any
element type wider than one byte (e.g. `c_uint32`, `c_int64`, a struct), `Slice.len()`
would report `N * sizeof(T)` instead of `N`.

**Fix:** one line in `payload()`:

```python
# Before
return Slice(self.payload_ptr, self.__slice_len, contained_type)

# After
number_of_elements = self.__slice_len // ctypes.sizeof(contained_type)
return Slice(self.payload_ptr, number_of_elements, contained_type)
```

## Files changed

- `iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py`
  - Divide `__slice_len` by `ctypes.sizeof(contained_type)` before passing to `Slice`
- `iceoryx2-ffi/python/tests/service_publish_subscribe_tests.py`
  - New regression test `test_slice_payload_element_count_is_correct_for_multi_byte_types`
    publishes a `Slice[c_uint32]` of 3 elements and asserts `Slice.len() == 3` (not 12)

## Test plan

- [ ] `pytest iceoryx2-ffi/python/tests/service_publish_subscribe_tests.py::test_slice_payload_element_count_is_correct_for_multi_byte_types`
- [ ] Full Python test suite

*AI-assisted — authored with Claude, reviewed by Komada.*