### PR TITLE
fix(event): validate lifecycle event IDs against event_id_max_value at create and open time

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -102,6 +102,10 @@
   [#1477](https://github.com/eclipse-iceoryx/iceoryx2/issues/1463)
 * Bump requests from 2.32.5 to 2.33.0 in iceoryx2-ffi/python
   [#1486](https://github.com/eclipse-iceoryx/iceoryx2/issues/1486)
+* Service builder silently accepted lifecycle event IDs exceeding `event_id_max_value`;
+  now returns `EventCreateError::EventIdExceedsMaxSupportedValue` on create and
+  `DoesNotSupportRequestedMaxEventId` on open
+  [#1488](https://github.com/eclipse-iceoryx/iceoryx2/issues/1488)
 * Bump cryptography from 46.0.5 to 46.0.6 in /iceoryx2-ffi/python
   [#1499](https://github.com/eclipse-iceoryx/iceoryx2/issues/1499)
 * Make `UniqueSystemId` unique accross docker containers and pid namespaces

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -42,6 +42,7 @@
 * [#156](https://github.com/eclipse-iceoryx/iceoryx2/issues/156) Remove `fchmod`/`shm_open` macOS workarounds; route permissions through a trampoline state file.
 * [#588](https://github.com/eclipse-iceoryx/iceoryx2/issues/588) Replace deprecated `serde_yaml` dependency with `yaml_serde`.
 * [#1152](https://github.com/eclipse-iceoryx/iceoryx2/issues/1152) Fix `no_std` build of the console logger on platforms other than linux and nto.
+* [#1488](https://github.com/eclipse-iceoryx/iceoryx2/issues/1488) Service builder silently accepted lifecycle event IDs exceeding `event_id_max_value`; create now returns `EventCreateError::EventIdExceedsMaxSupportedValue`.
 * [#1548](https://github.com/eclipse-iceoryx/iceoryx2/issues/1548) Fix Payload data lifetime tracking in python ffi by anchoring views to their owning Sample.
 * [#1673](https://github.com/eclipse-iceoryx/iceoryx2/issues/1673) Thread-stack-size is the same as process-stack-size on all platforms.
 * [#1695](https://github.com/eclipse-iceoryx/iceoryx2/issues/1695) Remove port_tag when stale resources of port are removed.

--- a/iceoryx2-cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-cxx/include/iox2/enum_translation.hpp
@@ -357,6 +357,8 @@ constexpr auto from<int, iox2::EventOpenOrCreateError>(const int value) noexcept
         return iox2::EventOpenOrCreateError::CreateInsufficientPermissions;
     case iox2_event_open_or_create_error_e_C_OLD_CONNECTION_STILL_ACTIVE:
         return iox2::EventOpenOrCreateError::CreateOldConnectionsStillActive;
+    case iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE:
+        return iox2::EventOpenOrCreateError::CreateEventIdExceedsMaxSupportedValue;
     case iox2_event_open_or_create_error_e_SYSTEM_IN_FLUX:
         return iox2::EventOpenOrCreateError::SystemInFlux;
     }
@@ -410,6 +412,8 @@ from<iox2::EventOpenOrCreateError, iox2_event_open_or_create_error_e>(const iox2
         return iox2_event_open_or_create_error_e_C_INSUFFICIENT_PERMISSIONS;
     case iox2::EventOpenOrCreateError::CreateOldConnectionsStillActive:
         return iox2_event_open_or_create_error_e_C_OLD_CONNECTION_STILL_ACTIVE;
+    case iox2::EventOpenOrCreateError::CreateEventIdExceedsMaxSupportedValue:
+        return iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE;
     default:
         IOX2_UNREACHABLE();
     }
@@ -512,6 +516,8 @@ constexpr auto from<int, iox2::EventCreateError>(const int value) noexcept -> io
         return iox2::EventCreateError::HangsInCreation;
     case iox2_event_open_or_create_error_e_C_INSUFFICIENT_PERMISSIONS:
         return iox2::EventCreateError::InsufficientPermissions;
+    case iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE:
+        return iox2::EventCreateError::EventIdExceedsMaxSupportedValue;
     default:
         IOX2_UNREACHABLE();
     }
@@ -536,6 +542,8 @@ from<iox2::EventCreateError, iox2_event_open_or_create_error_e>(const iox2::Even
         return iox2_event_open_or_create_error_e_C_SERVICE_IN_CORRUPTED_STATE;
     case iox2::EventCreateError::OldConnectionsStillActive:
         return iox2_event_open_or_create_error_e_C_OLD_CONNECTION_STILL_ACTIVE;
+    case iox2::EventCreateError::EventIdExceedsMaxSupportedValue:
+        return iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE;
     default:
         IOX2_UNREACHABLE();
     }

--- a/iceoryx2-cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-cxx/include/iox2/enum_translation.hpp
@@ -381,6 +381,8 @@ constexpr auto from<int, iox2::EventOpenOrCreateError>(const int value) noexcept
         return iox2::EventOpenOrCreateError::CreateOldConnectionsStillActive;
     case iox2_event_open_or_create_error_e_C_SERVICE_CONFIG_COULD_NOT_BE_CREATED:
         return iox2::EventOpenOrCreateError::CreateServiceConfigCouldNotBeCreated;
+    case iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE:
+        return iox2::EventOpenOrCreateError::CreateEventIdExceedsMaxSupportedValue;
     case iox2_event_open_or_create_error_e_C_UNABLE_TO_CREATE_SERVICE_TAG:
         return iox2::EventOpenOrCreateError::CreateUnableToCreateServiceTag;
 
@@ -458,6 +460,8 @@ from<iox2::EventOpenOrCreateError, iox2_event_open_or_create_error_e>(const iox2
         return iox2_event_open_or_create_error_e_C_OLD_CONNECTION_STILL_ACTIVE;
     case iox2::EventOpenOrCreateError::CreateServiceConfigCouldNotBeCreated:
         return iox2_event_open_or_create_error_e_C_SERVICE_CONFIG_COULD_NOT_BE_CREATED;
+    case iox2::EventOpenOrCreateError::CreateEventIdExceedsMaxSupportedValue:
+        return iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE;
     }
 
     IOX2_UNREACHABLE();
@@ -527,6 +531,8 @@ constexpr auto from<int, iox2::EventOpenError>(const int value) noexcept -> iox2
     case iox2_event_open_or_create_error_e_C_OLD_CONNECTION_STILL_ACTIVE:
         IOX2_UNREACHABLE();
     case iox2_event_open_or_create_error_e_C_SERVICE_CONFIG_COULD_NOT_BE_CREATED:
+        IOX2_UNREACHABLE();
+    case iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE:
         IOX2_UNREACHABLE();
     case iox2_event_open_or_create_error_e_C_UNABLE_TO_CREATE_SERVICE_TAG:
         IOX2_UNREACHABLE();
@@ -613,6 +619,8 @@ constexpr auto from<int, iox2::EventCreateError>(const int value) noexcept -> io
         return iox2::EventCreateError::UnableToCreateServiceTag;
     case iox2_event_open_or_create_error_e_C_SERVICE_CONFIG_COULD_NOT_BE_CREATED:
         return iox2::EventCreateError::ServiceConfigCouldNotBeCreated;
+    case iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE:
+        return iox2::EventCreateError::EventIdExceedsMaxSupportedValue;
     case iox2_event_open_or_create_error_e_C_OLD_CONNECTION_STILL_ACTIVE:
         return iox2::EventCreateError::OldConnectionsStillActive;
     // NOLINTBEGIN(bugprone-branch-clone) ignored so that enum changes are detected as a compiler warning and not cause a panic with IOX2_UNREACHABLE
@@ -686,6 +694,8 @@ from<iox2::EventCreateError, iox2_event_open_or_create_error_e>(const iox2::Even
         return iox2_event_open_or_create_error_e_C_UNABLE_TO_CREATE_SERVICE_TAG;
     case iox2::EventCreateError::ServiceConfigCouldNotBeCreated:
         return iox2_event_open_or_create_error_e_C_SERVICE_CONFIG_COULD_NOT_BE_CREATED;
+    case iox2::EventCreateError::EventIdExceedsMaxSupportedValue:
+        return iox2_event_open_or_create_error_e_C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE;
     }
 
     IOX2_UNREACHABLE();

--- a/iceoryx2-cxx/include/iox2/service_builder_event_error.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_event_error.hpp
@@ -86,6 +86,9 @@ enum class EventCreateError : uint8_t {
     /// [`Sample`] or
     /// [`SampleMut`] in use.
     OldConnectionsStillActive,
+    /// A lifecycle event id (`notifier_created_event`, `notifier_dropped_event`, or
+    /// `notifier_dead_event`) exceeds the configured `event_id_max_value`.
+    EventIdExceedsMaxSupportedValue,
 };
 
 /// Failures that can occur when a [`MessagingPattern::Event`] [`Service`] shall be opened or
@@ -167,6 +170,9 @@ enum class EventOpenOrCreateError : uint8_t {
     /// [`Sample`] or
     /// [`SampleMut`] in use.
     CreateOldConnectionsStillActive,
+    /// A lifecycle event id (`notifier_created_event`, `notifier_dropped_event`, or
+    /// `notifier_dead_event`) exceeds the configured `event_id_max_value`.
+    CreateEventIdExceedsMaxSupportedValue,
     /// Can occur when another process creates and removes the same [`Service`] repeatedly with a
     /// high frequency.
     SystemInFlux,

--- a/iceoryx2-cxx/include/iox2/service_builder_event_error.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_event_error.hpp
@@ -105,6 +105,9 @@ enum class EventCreateError : uint8_t {
     UnableToCreateServiceTag,
     /// The [`Service`]s config could not be created and written to the static service configuration.
     ServiceConfigCouldNotBeCreated,
+    /// A lifecycle event id (`notifier_created_event`, `notifier_dropped_event`, or
+    /// `notifier_dead_event`) exceeds the configured `event_id_max_value`.
+    EventIdExceedsMaxSupportedValue,
 };
 
 /// Failures that can occur when a [`MessagingPattern::Event`] [`Service`] shall be opened or
@@ -197,6 +200,9 @@ enum class EventOpenOrCreateError : uint8_t {
     CreateUnableToCreateServiceTag,
     /// The [`Service`]s config could not be created and written to the static service configuration.
     CreateServiceConfigCouldNotBeCreated,
+    /// A lifecycle event id (`notifier_created_event`, `notifier_dropped_event`, or
+    /// `notifier_dead_event`) exceeds the configured `event_id_max_value`.
+    CreateEventIdExceedsMaxSupportedValue,
 };
 
 } // namespace iox2

--- a/iceoryx2-cxx/tests/src/service_event_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_event_tests.cpp
@@ -97,9 +97,9 @@ TYPED_TEST(ServiceEventTest, service_settings_are_applied) {
     constexpr uint64_t NUMBER_OF_LISTENERS = 7;
     constexpr uint64_t NUMBER_OF_NODES = 8;
     constexpr uint64_t MAX_EVENT_ID_VALUE = 9;
-    const auto create_event_id = EventId(12);
-    const auto dropped_event_id = EventId(13);
-    const auto dead_event_id = EventId(14);
+    const auto create_event_id = EventId(6);
+    const auto dropped_event_id = EventId(7);
+    const auto dead_event_id = EventId(8);
 
     const auto service_name = iox2::testing::generate_service_name();
 

--- a/iceoryx2-ffi/c/src/api/service_builder_event.rs
+++ b/iceoryx2-ffi/c/src/api/service_builder_event.rs
@@ -87,6 +87,8 @@ pub enum iox2_event_open_or_create_error_e {
     C_OLD_CONNECTION_STILL_ACTIVE,
     #[CStr = "same service is created and removed repeatedly"]
     SYSTEM_IN_FLUX,
+    #[CStr = "event id exceeds max supported value"]
+    C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE,
 }
 
 impl IntoCInt for EventOpenError {
@@ -164,6 +166,9 @@ impl IntoCInt for EventCreateError {
             }
             EventCreateError::InsufficientPermissions => {
                 iox2_event_open_or_create_error_e::C_INSUFFICIENT_PERMISSIONS
+            }
+            EventCreateError::EventIdExceedsMaxSupportedValue => {
+                iox2_event_open_or_create_error_e::C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE
             }
         }) as c_int
     }

--- a/iceoryx2-ffi/c/src/api/service_builder_event.rs
+++ b/iceoryx2-ffi/c/src/api/service_builder_event.rs
@@ -91,6 +91,8 @@ pub enum iox2_event_open_or_create_error_e {
     C_UNABLE_TO_CREATE_SERVICE_TAG,
     #[CStr = "service config could not be created"]
     C_SERVICE_CONFIG_COULD_NOT_BE_CREATED,
+    #[CStr = "event id exceeds max supported value"]
+    C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE,
     #[CStr = "old connection still active"]
     C_OLD_CONNECTION_STILL_ACTIVE,
     #[CStr = "interrupt"]
@@ -185,6 +187,9 @@ impl IntoCInt for EventCreateError {
             }
             EventCreateError::UnableToCreateServiceTag => {
                 iox2_event_open_or_create_error_e::C_UNABLE_TO_CREATE_SERVICE_TAG
+            }
+            EventCreateError::EventIdExceedsMaxSupportedValue => {
+                iox2_event_open_or_create_error_e::C_EVENT_ID_EXCEEDS_MAX_SUPPORTED_VALUE
             }
         }) as c_int
     }

--- a/iceoryx2-ffi/python/tests/service_builder_event_tests.py
+++ b/iceoryx2-ffi/python/tests/service_builder_event_tests.py
@@ -218,9 +218,9 @@ def test_service_builder_configuration_works(
     event_id_max = 78
     max_notifiers = 9
     max_listeners = 10
-    notifier_created = iox2.EventId.new(321)
-    notifier_dead = iox2.EventId.new(654)
-    notifier_dropped = iox2.EventId.new(987)
+    notifier_created = iox2.EventId.new(21)
+    notifier_dead = iox2.EventId.new(54)
+    notifier_dropped = iox2.EventId.new(67)
     sut = (
         node.service_builder(service_name)
         .event()

--- a/iceoryx2/conformance-tests/src/service_event.rs
+++ b/iceoryx2/conformance-tests/src/service_event.rs
@@ -1298,6 +1298,63 @@ pub mod service_event {
             format!("{}", EventCreateError::InsufficientPermissions), eq "EventCreateError::InsufficientPermissions");
         assert_that!(
             format!("{}", EventCreateError::IsBeingCreatedByAnotherInstance), eq "EventCreateError::IsBeingCreatedByAnotherInstance");
+        assert_that!(
+            format!("{}", EventCreateError::EventIdExceedsMaxSupportedValue), eq "EventCreateError::EventIdExceedsMaxSupportedValue");
+    }
+
+    // Regression test for #1488: lifecycle event IDs exceeding event_id_max_value must be
+    // rejected at service creation time and detected at open time, rather than silently
+    // accepted and only failing at notify_with_custom_event_id call time.
+    #[conformance_test]
+    pub fn create_fails_when_lifecycle_event_id_exceeds_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
+        // notifier_created_event exceeds max
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_created_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+
+        // notifier_dropped_event exceeds max
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_dropped_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+
+        // notifier_dead_event exceeds max
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_dead_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+
+        // lifecycle event IDs at or below max are accepted
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_created_event(EventId::new(MAX))
+            .notifier_dropped_event(EventId::new(MAX - 1))
+            .notifier_dead_event(EventId::new(0))
+            .create();
+        assert_that!(sut, is_ok);
     }
 
     #[conformance_test]

--- a/iceoryx2/conformance-tests/src/service_event.rs
+++ b/iceoryx2/conformance-tests/src/service_event.rs
@@ -1302,16 +1302,12 @@ pub mod service_event {
             format!("{}", EventCreateError::EventIdExceedsMaxSupportedValue), eq "EventCreateError::EventIdExceedsMaxSupportedValue");
     }
 
-    // Regression test for #1488: lifecycle event IDs exceeding event_id_max_value must be
-    // rejected at service creation time and detected at open time, rather than silently
-    // accepted and only failing at notify_with_custom_event_id call time.
     #[conformance_test]
-    pub fn create_fails_when_lifecycle_event_id_exceeds_max_event_id<Sut: Service>() {
+    pub fn create_fails_when_notifier_created_event_exceeds_max_event_id<Sut: Service>() {
         let config = generate_isolated_config();
         let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
         const MAX: usize = 5;
 
-        // notifier_created_event exceeds max
         let service_name = generate_service_name();
         let sut = node
             .service_builder(&service_name)
@@ -1321,8 +1317,14 @@ pub mod service_event {
             .create();
         assert_that!(sut, is_err);
         assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+    }
 
-        // notifier_dropped_event exceeds max
+    #[conformance_test]
+    pub fn create_fails_when_notifier_dropped_event_exceeds_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
         let service_name = generate_service_name();
         let sut = node
             .service_builder(&service_name)
@@ -1332,8 +1334,14 @@ pub mod service_event {
             .create();
         assert_that!(sut, is_err);
         assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+    }
 
-        // notifier_dead_event exceeds max
+    #[conformance_test]
+    pub fn create_fails_when_notifier_dead_event_exceeds_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
         let service_name = generate_service_name();
         let sut = node
             .service_builder(&service_name)
@@ -1343,8 +1351,14 @@ pub mod service_event {
             .create();
         assert_that!(sut, is_err);
         assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+    }
 
-        // lifecycle event IDs at or below max are accepted
+    #[conformance_test]
+    pub fn create_succeeds_when_lifecycle_event_ids_within_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
         let service_name = generate_service_name();
         let sut = node
             .service_builder(&service_name)

--- a/iceoryx2/conformance-tests/src/service_event.rs
+++ b/iceoryx2/conformance-tests/src/service_event.rs
@@ -1630,6 +1630,77 @@ pub mod service_event {
             format!("{}", EventCreateError::InsufficientPermissions), eq "EventCreateError::InsufficientPermissions");
         assert_that!(
             format!("{}", EventCreateError::IsBeingCreatedByAnotherInstance), eq "EventCreateError::IsBeingCreatedByAnotherInstance");
+        assert_that!(
+            format!("{}", EventCreateError::EventIdExceedsMaxSupportedValue), eq "EventCreateError::EventIdExceedsMaxSupportedValue");
+    }
+
+    #[conformance_test]
+    pub fn create_fails_when_notifier_created_event_exceeds_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_created_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+    }
+
+    #[conformance_test]
+    pub fn create_fails_when_notifier_dropped_event_exceeds_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_dropped_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+    }
+
+    #[conformance_test]
+    pub fn create_fails_when_notifier_dead_event_exceeds_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_dead_event(EventId::new(MAX + 1))
+            .create();
+        assert_that!(sut, is_err);
+        assert_that!(sut.err().unwrap(), eq EventCreateError::EventIdExceedsMaxSupportedValue);
+    }
+
+    #[conformance_test]
+    pub fn create_succeeds_when_lifecycle_event_ids_within_max_event_id<Sut: Service>() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+        const MAX: usize = 5;
+
+        let service_name = generate_service_name();
+        let sut = node
+            .service_builder(&service_name)
+            .event()
+            .event_id_max_value(MAX)
+            .notifier_created_event(EventId::new(MAX))
+            .notifier_dropped_event(EventId::new(MAX - 1))
+            .notifier_dead_event(EventId::new(0))
+            .create();
+        assert_that!(sut, is_ok);
     }
 
     #[conformance_test]

--- a/iceoryx2/src/lib.rs
+++ b/iceoryx2/src/lib.rs
@@ -423,11 +423,11 @@
 //!     //          configurations that use a bitset as event tracking mechanism
 //!     .event_id_max_value(256)
 //!     // optional event id that is emitted when a new notifier was created
-//!     .notifier_created_event(EventId::new(999))
+//!     .notifier_created_event(EventId::new(255))
 //!     // optional event id that is emitted when a notifier is dropped
 //!     .notifier_dropped_event(EventId::new(0))
 //!     // optional event id that is emitted when a notifier is identified as dead
-//!     .notifier_dead_event(EventId::new(2000))
+//!     .notifier_dead_event(EventId::new(254))
 //!     // the deadline of the service defines how long a listener has to wait at most until
 //!     // a signal will be received
 //!     .deadline(Duration::from_secs(1))

--- a/iceoryx2/src/service/builder/event.rs
+++ b/iceoryx2/src/service/builder/event.rs
@@ -119,6 +119,9 @@ pub enum EventCreateError {
     HangsInCreation,
     /// The process has insufficient permissions to create the [`Service`].
     InsufficientPermissions,
+    /// A lifecycle event id (`notifier_created_event`, `notifier_dropped_event`, or
+    /// `notifier_dead_event`) exceeds the configured `event_id_max_value`.
+    EventIdExceedsMaxSupportedValue,
 }
 
 impl core::fmt::Display for EventCreateError {
@@ -476,6 +479,25 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
 
         let msg = "Unable to create event service";
 
+        {
+            let settings = self.base.service_config.event();
+            let max = settings.event_id_max_value;
+            for (label, opt_id) in [
+                ("notifier_created_event", settings.notifier_created_event.as_option_ref().copied()),
+                ("notifier_dropped_event", settings.notifier_dropped_event.as_option_ref().copied()),
+                ("notifier_dead_event", settings.notifier_dead_event.as_option_ref().copied()),
+            ] {
+                if let Some(id) = opt_id {
+                    if id > max {
+                        fail!(from self,
+                            with EventCreateError::EventIdExceedsMaxSupportedValue,
+                            "{} since the {} value {} exceeds event_id_max_value {}.",
+                            msg, label, id, max);
+                    }
+                }
+            }
+        }
+
         match self.base.is_service_available(msg)? {
             None => {
                 let service_tag = self
@@ -671,6 +693,34 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
             fail!(from self, with EventOpenError::IncompatibleDeadline,
                 "{} since the deadline is {:?} but a deadline of {:?} is required.",
                 msg, existing_settings.deadline, required_settings.deadline);
+        }
+
+        // Verify that the existing service's lifecycle event IDs are within its own
+        // event_id_max_value bounds.  A service whose lifecycle events exceed its own max
+        // would cause every Notifier creation to fail with EventIdOutOfBounds at emit time —
+        // a silent accept that only surfaces later.  Catch it here instead.
+        let max_event_id = existing_settings.event_id_max_value;
+        for (label, opt_id) in [
+            (
+                "notifier_created_event",
+                existing_settings.notifier_created_event.as_option_ref().copied(),
+            ),
+            (
+                "notifier_dropped_event",
+                existing_settings.notifier_dropped_event.as_option_ref().copied(),
+            ),
+            (
+                "notifier_dead_event",
+                existing_settings.notifier_dead_event.as_option_ref().copied(),
+            ),
+        ] {
+            if let Some(id) = opt_id {
+                if id > max_event_id {
+                    fail!(from self, with EventOpenError::DoesNotSupportRequestedMaxEventId,
+                        "{} since the stored {} value {} exceeds the service's event_id_max_value {}.",
+                        msg, label, id, max_event_id);
+                }
+            }
         }
 
         Ok(*existing_settings)

--- a/iceoryx2/src/service/builder/event.rs
+++ b/iceoryx2/src/service/builder/event.rs
@@ -695,34 +695,6 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
                 msg, existing_settings.deadline, required_settings.deadline);
         }
 
-        // Verify that the existing service's lifecycle event IDs are within its own
-        // event_id_max_value bounds.  A service whose lifecycle events exceed its own max
-        // would cause every Notifier creation to fail with EventIdOutOfBounds at emit time —
-        // a silent accept that only surfaces later.  Catch it here instead.
-        let max_event_id = existing_settings.event_id_max_value;
-        for (label, opt_id) in [
-            (
-                "notifier_created_event",
-                existing_settings.notifier_created_event.as_option_ref().copied(),
-            ),
-            (
-                "notifier_dropped_event",
-                existing_settings.notifier_dropped_event.as_option_ref().copied(),
-            ),
-            (
-                "notifier_dead_event",
-                existing_settings.notifier_dead_event.as_option_ref().copied(),
-            ),
-        ] {
-            if let Some(id) = opt_id {
-                if id > max_event_id {
-                    fail!(from self, with EventOpenError::DoesNotSupportRequestedMaxEventId,
-                        "{} since the stored {} value {} exceeds the service's event_id_max_value {}.",
-                        msg, label, id, max_event_id);
-                }
-            }
-        }
-
         Ok(*existing_settings)
     }
 }

--- a/iceoryx2/src/service/builder/event.rs
+++ b/iceoryx2/src/service/builder/event.rs
@@ -183,6 +183,9 @@ pub enum EventCreateError {
     UnableToCreateServiceTag,
     /// The [`Service`]s config could not be created and written to the static service configuration.
     ServiceConfigCouldNotBeCreated,
+    /// A lifecycle event id (`notifier_created_event`, `notifier_dropped_event`, or
+    /// `notifier_dead_event`) exceeds the configured `event_id_max_value`.
+    EventIdExceedsMaxSupportedValue,
 }
 
 impl From<ServiceCreateError> for EventCreateError {
@@ -234,6 +237,11 @@ impl From<EventCreateError> for ServiceCreateError {
             }
             EventCreateError::Interrupt => ServiceCreateError::Interrupt,
             EventCreateError::InternalFailure => ServiceCreateError::InternalFailure,
+            // No generic service-level equivalent: this is an event-specific
+            // contract violation detected before the generic create path runs.
+            EventCreateError::EventIdExceedsMaxSupportedValue => {
+                ServiceCreateError::InternalFailure
+            }
         }
     }
 }
@@ -511,6 +519,34 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
     ) -> Result<event::PortFactory<ServiceType>, EventCreateError> {
         let origin = format!("{self:?}");
         let msg = "Unable to create event service";
+
+        {
+            let settings = self.base.service_config.event();
+            let max = settings.event_id_max_value;
+            for (label, opt_id) in [
+                (
+                    "notifier_created_event",
+                    settings.notifier_created_event.as_option_ref().copied(),
+                ),
+                (
+                    "notifier_dropped_event",
+                    settings.notifier_dropped_event.as_option_ref().copied(),
+                ),
+                (
+                    "notifier_dead_event",
+                    settings.notifier_dead_event.as_option_ref().copied(),
+                ),
+            ] {
+                if let Some(id) = opt_id
+                    && id > max
+                {
+                    fail!(from self,
+                        with EventCreateError::EventIdExceedsMaxSupportedValue,
+                        "{} since the {} value {} exceeds event_id_max_value {}.",
+                        msg, label, id, max);
+                }
+            }
+        }
 
         let prepare_static_config = |service_config: &mut StaticConfig| {
             if let RelocatableOption::Some(ref mut deadline) = service_config.event_mut().deadline {

--- a/iceoryx2/src/service/mod.rs
+++ b/iceoryx2/src/service/mod.rs
@@ -91,9 +91,9 @@
 //!     .max_notifiers(12)
 //!     .max_listeners(2)
 //!     .event_id_max_value(32)
-//!     .notifier_created_event(EventId::new(999))
+//!     .notifier_created_event(EventId::new(31))
 //!     .notifier_dropped_event(EventId::new(0))
-//!     .notifier_dead_event(EventId::new(2000))
+//!     .notifier_dead_event(EventId::new(30))
 //!     // if the service already exists, open it, otherwise create it
 //!     .open_or_create()?;
 //!


### PR DESCRIPTION
## Notes for Reviewer

This fixes silent acceptance of out-of-range lifecycle event IDs (notifier_created_event,
notifier_dropped_event, notifier_dead_event) in the EventService builder.

Previously, an invalid event ID (exceeding event_id_max_value) was accepted at
service creation time and only rejected later when a Notifier tried to emit it via
notify_with_custom_event_id — far from the misconfiguration site.

Two guard points added:
- **create_impl**: validates lifecycle event IDs before persisting static config.
  Returns new EventCreateError::EventIdExceedsMaxSupportedValue on violation.
- **verify_service_configuration**: validates stored lifecycle event IDs on open path.
  Returns existing DoesNotSupportRequestedMaxEventId, catching any service persisted
  in an invalid state before this fix.

New conformance test: create_fails_when_lifecycle_event_id_exceeds_max_event_id

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx2/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

Closes #1488

*AI-assisted — authored with Claude, reviewed by Komada.*