### PR TITLE
[#280] Revert some changes regarding 'misc-use-internal-linkage'

### DIFF
--- a/iceoryx2-pal/posix/src/c/socket_macros.c
+++ b/iceoryx2-pal/posix/src/c/socket_macros.c
@@ -23,40 +23,46 @@
 #include <sys/select.h>
 #include <sys/socket.h>
 
-static size_t iceoryx2_cmsg_space(const size_t len) {
+// NOLINTBEGIN(misc-use-internal-linkage) we want this functions to be found by the linker and used externally;
+// the linker on FreeBSD is more strict and complains about missing symbols if the functions are static;
+// another workaround would be to add a C header with the signatures, but to keep it simple, we just suppress clang-tidy
+
+size_t iceoryx2_cmsg_space(const size_t len) {
     return CMSG_SPACE(len);
 }
 
-static struct cmsghdr* iceoryx2_cmsg_firsthdr(const struct msghdr* hdr) {
+struct cmsghdr* iceoryx2_cmsg_firsthdr(const struct msghdr* hdr) {
     return CMSG_FIRSTHDR(hdr);
 }
 
-static struct cmsghdr* iceoryx2_cmsg_nxthdr(struct msghdr* hdr, struct cmsghdr* sub) {
+struct cmsghdr* iceoryx2_cmsg_nxthdr(struct msghdr* hdr, struct cmsghdr* sub) {
     return CMSG_NXTHDR(hdr, sub);
 }
 
-static size_t iceoryx2_cmsg_len(const size_t len) {
+size_t iceoryx2_cmsg_len(const size_t len) {
     return CMSG_LEN(len);
 }
 
-static unsigned char* iceoryx2_cmsg_data(struct cmsghdr* cmsg) {
+unsigned char* iceoryx2_cmsg_data(struct cmsghdr* cmsg) {
     return CMSG_DATA(cmsg);
 }
 
-static void iceoryx2_fd_clr(const int fd, fd_set* set) {
+void iceoryx2_fd_clr(const int fd, fd_set* set) {
     FD_CLR(fd, set);
 }
 
-static int iceoryx2_fd_isset(const int fd, const fd_set* set) {
+int iceoryx2_fd_isset(const int fd, const fd_set* set) {
     return FD_ISSET(fd, set);
 }
 
-static void iceoryx2_fd_set(const int fd, fd_set* set) {
+void iceoryx2_fd_set(const int fd, fd_set* set) {
     FD_SET(fd, set);
 }
 
-static void iceoryx2_fd_zero(fd_set* set) {
+void iceoryx2_fd_zero(fd_set* set) {
     FD_ZERO(set);
 }
+
+// NOLINTEND(misc-use-internal-linkage)
 
 #endif


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

It seems some of the fixes clang-tidy suggested, broke FreeBSD. With hindsight, it is clear that the hint was wrong.

The CI build for FreeBSD with this branch -> https://github.com/eclipse-iceoryx/iceoryx2/actions/runs/24419059570/job/71337661432

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #280 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
