### PR TITLE
[WIP] [DO NOT REVIEW] [#1556] Propagate 'InterruptedBySinal' errors up in the stack as distinct error

### DIFF
--- a/iceoryx2-cal/src/zero_copy_connection/common.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/common.rs
@@ -29,7 +29,8 @@ pub mod details {
         safely_overflowing_index_queue::RelocatableSafelyOverflowingIndexQueue,
     };
     use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
-    use iceoryx2_bb_posix::adaptive_wait::AdaptiveWaitBuilder;
+    use iceoryx2_bb_posix::adaptive_wait::{AdaptiveWaitBuilder, AdaptiveWaitError};
+    use iceoryx2_bb_posix::clock::NanosleepError;
     use iceoryx2_bb_posix::file::AccessMode;
     use iceoryx2_log::{fail, fatal_panic};
 
@@ -748,7 +749,13 @@ pub mod details {
                         && is_connected
                         && has_valid_channel_state
                 }) {
-                    fail!(from self, with ZeroCopySendError::InternalError,
+                    let error = match e {
+                        AdaptiveWaitError::NanosleepError(NanosleepError::InterruptedBySignal(
+                            _,
+                        )) => ZeroCopySendError::InterruptedBySignal,
+                        _ => ZeroCopySendError::InternalError,
+                    };
+                    fail!(from self, with error,
                         "{msg} {ptr:?} via channel {channel_id:?} since the adaptive wait failed. [{e:?}]");
                 }
 

--- a/iceoryx2-cal/src/zero_copy_connection/mod.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/mod.rs
@@ -79,6 +79,7 @@ pub enum ZeroCopySendError {
     UsedChunkListFull,
     NoConnectedReceiver,
     ChannelIsClosed,
+    InterruptedBySignal,
     InternalError,
 }
 

--- a/iceoryx2-cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-cxx/include/iox2/enum_translation.hpp
@@ -1670,6 +1670,8 @@ constexpr auto from<int, iox2::SendError>(const int value) noexcept -> iox2::Sen
         return iox2::SendError::LoanErrorInternalFailure;
     case iox2_send_error_e_CONNECTION_ERROR:
         return iox2::SendError::ConnectionError;
+    case iox2_send_error_e_INTERRUPTED_BY_SIGNAL:
+        return iox2::SendError::InterruptedBySignal;
     case iox2_send_error_e_INTERNAL_ERROR:
         return iox2::SendError::InternalError;
     }
@@ -1694,6 +1696,8 @@ constexpr auto from<iox2::SendError, iox2_send_error_e>(const iox2::SendError va
         return iox2_send_error_e_LOAN_ERROR_INTERNAL_FAILURE;
     case iox2::SendError::ConnectionError:
         return iox2_send_error_e_CONNECTION_ERROR;
+    case iox2::SendError::InterruptedBySignal:
+        return iox2_send_error_e_INTERRUPTED_BY_SIGNAL;
     case iox2::SendError::InternalError:
         return iox2_send_error_e_INTERNAL_ERROR;
     }
@@ -1799,6 +1803,8 @@ constexpr auto from<int, iox2::RequestSendError>(const int value) noexcept -> io
         return iox2::RequestSendError::LoanErrorInternalFailure;
     case iox2_request_send_error_e_CONNECTION_ERROR:
         return iox2::RequestSendError::ConnectionError;
+    case iox2_request_send_error_e_INTERRUPTED_BY_SIGNAL:
+        return iox2::RequestSendError::InterruptedBySignal;
     case iox2_request_send_error_e_INTERNAL_ERROR:
         return iox2::RequestSendError::InternalError;
     }
@@ -1826,6 +1832,8 @@ constexpr auto from<iox2::RequestSendError, iox2_request_send_error_e>(const iox
         return iox2_request_send_error_e_LOAN_ERROR_INTERNAL_FAILURE;
     case iox2::RequestSendError::ConnectionError:
         return iox2_request_send_error_e_CONNECTION_ERROR;
+    case iox2::RequestSendError::InterruptedBySignal:
+        return iox2_request_send_error_e_INTERRUPTED_BY_SIGNAL;
     case iox2::RequestSendError::InternalError:
         return iox2_request_send_error_e_INTERNAL_ERROR;
     }

--- a/iceoryx2-cxx/include/iox2/port_error.hpp
+++ b/iceoryx2-cxx/include/iox2/port_error.hpp
@@ -55,6 +55,8 @@ enum class SendError : uint8_t {
     LoanErrorInternalFailure,
     /// A failure occurred while establishing a connection to the ports counterpart port.
     ConnectionError,
+    /// A signal was raised and interrupted a system call.
+    InterruptedBySignal,
     /// An internal mechanisms failed and the data could not be delivered to all receivers.
     InternalError
 };
@@ -98,6 +100,8 @@ enum class RequestSendError : uint8_t {
     LoanErrorInternalFailure,
     /// A failure occurred while establishing a connection to the ports counterpart port.
     ConnectionError,
+    /// A signal was raised and interrupted a system call.
+    InterruptedBySignal,
     /// An internal mechanisms failed and the data could not be delivered to all receivers.
     InternalError,
 };

--- a/iceoryx2-ffi/c/src/api/publisher.rs
+++ b/iceoryx2-ffi/c/src/api/publisher.rs
@@ -46,6 +46,7 @@ pub enum iox2_send_error_e {
     LOAN_ERROR_EXCEEDS_MAX_LOAN_SIZE,
     LOAN_ERROR_INTERNAL_FAILURE,
     CONNECTION_ERROR,
+    INTERRUPTED_BY_SIGNAL,
     INTERNAL_ERROR,
 }
 
@@ -69,6 +70,7 @@ impl IntoCInt for SendError {
             SendError::LoanError(LoanError::InternalFailure) => {
                 iox2_send_error_e::LOAN_ERROR_INTERNAL_FAILURE
             }
+            SendError::InterruptedBySignal => iox2_send_error_e::INTERRUPTED_BY_SIGNAL,
             SendError::ConnectionError(_) => iox2_send_error_e::CONNECTION_ERROR,
         }) as c_int
     }

--- a/iceoryx2-ffi/c/src/api/request_mut.rs
+++ b/iceoryx2-ffi/c/src/api/request_mut.rs
@@ -44,6 +44,7 @@ pub enum iox2_request_send_error_e {
     LOAN_ERROR_EXCEEDS_MAX_LOAN_SIZE,
     LOAN_ERROR_INTERNAL_FAILURE,
     CONNECTION_ERROR,
+    INTERRUPTED_BY_SIGNAL,
     EXCEEDS_MAX_ACTIVE_REQUESTS,
     INTERNAL_ERROR,
 }
@@ -71,6 +72,9 @@ impl IntoCInt for RequestSendError {
             }
             RequestSendError::SendError(SendError::ConnectionError(_)) => {
                 iox2_request_send_error_e::CONNECTION_ERROR
+            }
+            RequestSendError::SendError(SendError::InterruptedBySignal) => {
+                iox2_request_send_error_e::INTERRUPTED_BY_SIGNAL
             }
             RequestSendError::ExceedsMaxActiveRequests => {
                 iox2_request_send_error_e::EXCEEDS_MAX_ACTIVE_REQUESTS

--- a/iceoryx2/src/port/details/sender.rs
+++ b/iceoryx2/src/port/details/sender.rs
@@ -211,6 +211,10 @@ impl<Service: service::Service> Sender<Service> {
                                     offset, connection.receiver_port_id);
                     }
                 },
+                Err(ZeroCopySendError::InterruptedBySignal) => {
+                    fail!(from self, with SendError::InterruptedBySignal,
+                         "{msg} a signal was raised and interrupted a system call.");
+                }
                 Ok(overflow) => {
                     self.borrow_sample(offset);
                     number_of_recipients += 1;

--- a/iceoryx2/src/port/mod.rs
+++ b/iceoryx2/src/port/mod.rs
@@ -112,6 +112,8 @@ pub enum SendError {
     LoanError(LoanError),
     /// A failure occurred while establishing a connection to the ports counterpart port.
     ConnectionError(ConnectionFailure),
+    /// A signal was raised and interrupted a system call.
+    InterruptedBySignal,
     /// An internal mechanisms failed and the data could not be delivered to all receivers.
     InternalError,
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] Add sensible notes for the reviewer
* [ ] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [ ] Commits messages are according to this [guideline][commit-guidelines]
    * [ ] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1556 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
