### PR TITLE
feat: add Zeroable derive macro

### DIFF
--- a/iceoryx2-bb/derive-macros/src/lib.rs
+++ b/iceoryx2-bb/derive-macros/src/lib.rs
@@ -348,5 +348,71 @@ pub fn zero_copy_send_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
+/// Implements the [`iceoryx2_bb_elementary_traits::zeroable::Zeroable`] trait when all
+/// fields of the struct implement it.
+///
+/// ```
+/// use iceoryx2_bb_derive_macros::Zeroable;
+/// use iceoryx2_bb_elementary_traits::zeroable::Zeroable;
+///
+/// #[derive(Zeroable)]
+/// struct MyStruct {
+///     value_1: u64,
+///     value_2: u32,
+///     value_3: [u8; 16],
+/// }
+///
+/// let zeroed = MyStruct::new_zeroed();
+/// ```
+#[proc_macro_derive(Zeroable)]
+pub fn zeroable_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let zeroable_check = match input.data {
+        Data::Struct(ref data_struct) => match data_struct.fields {
+            Fields::Named(ref fields_named) => {
+                let field_checks = fields_named.named.iter().map(|f| {
+                    let field_name = &f.ident;
+                    quote! {
+                        Zeroable::__is_zeroable(&self.#field_name);
+                    }
+                });
+
+                quote! {
+                    fn __is_zeroable(&self) {
+                        #(#field_checks)*
+                    }
+                }
+            }
+            Fields::Unnamed(ref fields_unnamed) => {
+                let field_checks = fields_unnamed.unnamed.iter().enumerate().map(|(i, _)| {
+                    let index = syn::Index::from(i);
+                    quote! {
+                        Zeroable::__is_zeroable(&self.#index);
+                    }
+                });
+
+                quote! {
+                    fn __is_zeroable(&self) {
+                        #(#field_checks)*
+                    }
+                }
+            }
+            Fields::Unit => quote! {},
+        },
+        _ => unimplemented!(),
+    };
+
+    let expanded = quote! {
+        unsafe impl #impl_generics Zeroable for #name #ty_generics #where_clause {
+            #zeroable_check
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
 #[cfg(doctest)]
 mod zero_copy_send_compile_tests;

--- a/iceoryx2-bb/derive-macros/tests-common/src/lib.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/lib.rs
@@ -16,3 +16,4 @@ extern crate iceoryx2_bb_loggers;
 
 pub mod placement_default_tests;
 pub mod zero_copy_send_tests;
+pub mod zeroable_tests;

--- a/iceoryx2-bb/derive-macros/tests-common/src/zeroable_tests.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/zeroable_tests.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2_bb_derive_macros::Zeroable;
+use iceoryx2_bb_elementary_traits::zeroable::Zeroable;
+use iceoryx2_bb_testing::assert_that;
+use iceoryx2_bb_testing_macros::test;
+
+fn is_zeroable<T: Zeroable>(_: &T) -> bool {
+    true
+}
+
+#[derive(Zeroable)]
+struct NamedTestStruct {
+    _val1: u64,
+    _val2: u32,
+    _val3: [u8; 16],
+}
+
+#[derive(Zeroable)]
+struct UnnamedTestStruct(u64, u32);
+
+#[derive(Zeroable)]
+struct UnitTestStruct;
+
+#[derive(Zeroable)]
+struct GenericTestStruct<T: Zeroable> {
+    _val1: T,
+    _val2: u64,
+}
+
+#[test]
+fn zeroable_derive_works_for_named_struct() {
+    let sut = NamedTestStruct::new_zeroed();
+    assert_that!(is_zeroable(&sut), eq true);
+}
+
+#[test]
+fn zeroable_derive_works_for_unnamed_struct() {
+    let sut = UnnamedTestStruct::new_zeroed();
+    assert_that!(is_zeroable(&sut), eq true);
+}
+
+#[test]
+fn zeroable_derive_works_for_unit_struct() {
+    let sut = UnitTestStruct::new_zeroed();
+    assert_that!(is_zeroable(&sut), eq true);
+}
+
+#[test]
+fn zeroable_derive_works_for_generic_struct() {
+    let sut = GenericTestStruct::<u32>::new_zeroed();
+    assert_that!(is_zeroable(&sut), eq true);
+}

--- a/iceoryx2-bb/elementary-traits/src/zeroable.rs
+++ b/iceoryx2-bb/elementary-traits/src/zeroable.rs
@@ -23,6 +23,11 @@ pub unsafe trait Zeroable: core::marker::Sized {
     fn new_zeroed() -> Self {
         unsafe { core::mem::zeroed() }
     }
+
+    #[doc(hidden)]
+    /// used as dummy call in the derive macro to ensure at compile-time that all fields of
+    /// a struct implement Zeroable
+    fn __is_zeroable(&self) {}
 }
 
 unsafe impl Zeroable for usize {}


### PR DESCRIPTION
## Summary

This PR adds a `#[derive(Zeroable)]` macro for the `Zeroable` trait from `iceoryx2-bb-elementary-traits`, as requested in #1547.

I noticed that `PlacementDefault` and `ZeroCopySend` already have derive macros, but `Zeroable` was still missing. Since `Zeroable` is an unsafe trait and manually implementing it for composite structs is error-prone (a new field could easily be overlooked), a derive macro makes this safer by verifying all fields at compile time.

## Changes

- **`iceoryx2-bb/elementary-traits/src/zeroable.rs`**: Added a `#[doc(hidden)]` `__is_zeroable(&self)` method to the `Zeroable` trait. This follows the same pattern as `ZeroCopySend::__is_zero_copy_send()` — a dummy method used by the derive macro to generate compile-time field checks.

- **`iceoryx2-bb/derive-macros/src/lib.rs`**: Implemented the `Zeroable` derive proc macro supporting named structs, tuple structs, unit structs, and generics. For each field, it generates a `Zeroable::__is_zeroable(&self.field)` call that triggers a compile error if a field's type doesn't implement `Zeroable`.

- **`iceoryx2-bb/derive-macros/tests-common/src/zeroable_tests.rs`**: Added tests covering named, unnamed, unit, and generic struct variants.

## Test plan

- [x] `cargo check -p iceoryx2-bb-derive-macros` passes
- [x] `cargo check -p iceoryx2-bb-derive-macros-tests-common` passes
- [x] `cargo test -p iceoryx2-bb-derive-macros` passes (all 22 existing + new doctests)
- [ ] CI runs on this PR

Relates to #1547