### PR TITLE
[#1547] Add Zeroable and PlainOldDataWithoutPadding derives

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -41,6 +41,10 @@
   [#1496](https://github.com/eclipse-iceoryx/iceoryx2/issues/1496)
 * Enable override of preallocated data chunks for sender ports
   [#1551](https://github.com/eclipse-iceoryx/iceoryx2/issues/1551)
+* Add `Zeroable` and `PlainOldDataWithoutPadding` derive macros that generate
+  the trait impl and enforce all invariants (`#[repr(C)]`, no padding, field
+  bounds) at compile time
+  [#1547](https://github.com/eclipse-iceoryx/iceoryx2/issues/1547)
 
 ### Bugfixes
 

--- a/iceoryx2-bb/derive-macros/src/lib.rs
+++ b/iceoryx2-bb/derive-macros/src/lib.rs
@@ -348,5 +348,181 @@ pub fn zero_copy_send_derive(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
+/// Implements the [`iceoryx2_bb_elementary_traits::zeroable::Zeroable`] trait
+/// when all fields of the struct also implement it. Rejects enums, unions, and
+/// structs whose fields violate the `Zeroable` invariant at compile time.
+///
+/// ```
+/// use iceoryx2_bb_derive_macros::Zeroable;
+/// use iceoryx2_bb_elementary_traits::zeroable::Zeroable;
+///
+/// #[derive(Zeroable)]
+/// struct MyStruct {
+///     val1: u64,
+///     val2: [u8; 16],
+/// }
+///
+/// let v = MyStruct::new_zeroed();
+/// assert_eq!(v.val1, 0);
+/// ```
+///
+#[proc_macro_derive(Zeroable)]
+pub fn zeroable_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let impl_body = match &ast.data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields) => {
+                let calls = fields.named.iter().map(|field| {
+                    let name = &field.ident;
+                    quote! { Zeroable::__is_zeroable(&self.#name); }
+                });
+                quote! {
+                    fn __is_zeroable(&self) {
+                        #(#calls)*
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let calls = fields.unnamed.iter().enumerate().map(|(i, _)| {
+                    let idx = syn::Index::from(i);
+                    quote! { Zeroable::__is_zeroable(&self.#idx); }
+                });
+                quote! {
+                    fn __is_zeroable(&self) {
+                        #(#calls)*
+                    }
+                }
+            }
+            Fields::Unit => quote! {},
+        },
+        _ => panic!("`#[derive(Zeroable)]` can only be used on structs"),
+    };
+
+    let expanded = quote! {
+        unsafe impl #impl_generics Zeroable for #name #ty_generics #where_clause {
+            #impl_body
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
+/// Implements the [`iceoryx2_bb_elementary_traits::plain_old_data_without_padding::PlainOldDataWithoutPadding`]
+/// trait when the struct is annotated with `#[repr(C)]`, has no padding
+/// between or after its fields, and every field also implements the trait.
+/// Rejects enums, unions, layouts with padding, and supertrait violations
+/// (`Copy`, `Zeroable`, `ZeroCopySend`, `'static`) at compile time.
+///
+/// ```
+/// use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+/// use iceoryx2_bb_elementary_traits::plain_old_data_without_padding::PlainOldDataWithoutPadding;
+/// use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
+/// use iceoryx2_bb_elementary_traits::zeroable::Zeroable;
+///
+/// #[repr(C)]
+/// #[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+/// struct MyPodStruct {
+///     val1: u64,
+///     val2: [u8; 16],
+/// }
+///
+/// fn needs_pod<T: PlainOldDataWithoutPadding>(_: &T) {}
+/// needs_pod(&MyPodStruct { val1: 0, val2: [0; 16] });
+/// ```
+///
+#[proc_macro_derive(PlainOldDataWithoutPadding)]
+pub fn plain_old_data_without_padding_derive(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    // reject enum/union, collect field accessors + field types
+    let (field_accessors, field_types): (Vec<_>, Vec<_>) = match &ast.data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields) => fields
+                .named
+                .iter()
+                .map(|field| {
+                    let ident = &field.ident;
+                    let ty = &field.ty;
+                    (quote! { #ident }, ty)
+                })
+                .unzip(),
+            Fields::Unnamed(fields) => fields
+                .unnamed
+                .iter()
+                .enumerate()
+                .map(|(i, field)| {
+                    let idx = syn::Index::from(i);
+                    let ty = &field.ty;
+                    (quote! { #idx }, ty)
+                })
+                .unzip(),
+            Fields::Unit => (Vec::new(), Vec::new()),
+        },
+        _ => panic!("`#[derive(PlainOldDataWithoutPadding)]` can only be used on structs"),
+    };
+
+    // verify #[repr(C)]
+    let has_repr_c = ast.attrs.iter().any(|a| {
+        a.path().is_ident("repr")
+            && a.parse_args::<syn::Meta>()
+                .ok()
+                .map(|m| m.path().is_ident("C"))
+                .unwrap_or(false)
+    });
+    if !has_repr_c {
+        panic!(
+            "`#[derive(PlainOldDataWithoutPadding)]` requires the type to be annotated with #[repr(C)]"
+        );
+    }
+
+    // padding check via const assert
+    let size_check = if field_types.is_empty() {
+        quote! {
+            assert!(
+                ::core::mem::size_of::<#name #ty_generics>() == 0,
+                "PlainOldDataWithoutPadding: unit struct must have size 0"
+            );
+        }
+    } else {
+        quote! {
+            assert!(
+                ::core::mem::size_of::<#name #ty_generics>()
+                    == 0usize #( + ::core::mem::size_of::<#field_types>() )*,
+                "PlainOldDataWithoutPadding: struct has padding bytes"
+            );
+        }
+    };
+
+    // dummy-call body to verify each field is PoD
+    let call_body = field_accessors.iter().map(|acc| {
+        quote! { PlainOldDataWithoutPadding::__is_pod(&self.#acc); }
+    });
+
+    let expanded = quote! {
+        const _: () = { #size_check };
+
+        unsafe impl #impl_generics PlainOldDataWithoutPadding
+            for #name #ty_generics #where_clause
+        {
+            fn __is_pod(&self) {
+                #(#call_body)*
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}
+
 #[cfg(doctest)]
 mod zero_copy_send_compile_tests;
+
+#[cfg(doctest)]
+mod zeroable_compile_tests;
+
+#[cfg(doctest)]
+mod plain_old_data_without_padding_compile_tests;

--- a/iceoryx2-bb/derive-macros/src/plain_old_data_without_padding_compile_tests.rs
+++ b/iceoryx2-bb/derive-macros/src/plain_old_data_without_padding_compile_tests.rs
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// === Requirement 3: must be `#[repr(C)]` ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+///
+/// #[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+/// struct NoReprC {
+///     a: u64,
+///     b: u64,
+/// }
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_without_repr_c() {}
+
+/// === Requirement 2: must not have padding between members ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+///
+/// // `u8` at offset 0 followed by `u32` forces 3 bytes of padding
+/// #[repr(C)]
+/// #[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+/// struct InternalPadding {
+///     a: u8,
+///     b: u32,
+/// }
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_for_struct_with_internal_padding() {}
+
+/// === Requirement 2: must not have trailing padding ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+///
+/// // Fields sum to 5 bytes but alignment bumps struct size to 8 (3 bytes trailing pad)
+/// #[repr(C)]
+/// #[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+/// struct TrailingPadding {
+///     a: u32,
+///     b: u8,
+/// }
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_for_struct_with_trailing_padding() {}
+
+/// === Supertrait bound: must implement `Copy` ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+///
+/// #[repr(C)]
+/// #[derive(Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+/// struct NoCopy {
+///     a: u64,
+/// }
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_for_non_copy_struct() {}
+
+/// === Requirement 4: every member must implement `PlainOldDataWithoutPadding` ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+///
+/// #[repr(C)]
+/// #[derive(Copy, Clone, Zeroable, ZeroCopySend)]
+/// struct MissingPodDerive { x: u32 }
+///
+/// #[repr(C)]
+/// #[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+/// struct WithNonPodField {
+///     a: u64,
+///     b: MissingPodDerive,
+/// }
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_for_struct_with_non_pod_field() {}
+
+/// === Enum rejection ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::PlainOldDataWithoutPadding;
+///
+/// #[repr(C)]
+/// #[derive(PlainOldDataWithoutPadding)]
+/// enum Kind {
+///     A,
+///     B,
+/// }
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_for_enum() {}
+
+/// === Union rejection ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::PlainOldDataWithoutPadding;
+///
+/// #[repr(C)]
+/// #[derive(Copy, Clone, PlainOldDataWithoutPadding)]
+/// union MyUnion {
+///     a: u64,
+///     b: u64,
+/// }
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_for_union() {}
+
+/// === References violate the `'static` supertrait bound ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+///
+/// #[repr(C)]
+/// #[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+/// struct WithReference<'a> {
+///     a: u64,
+///     b: &'a u64,
+/// }
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_for_struct_with_reference() {}
+
+/// === Tuple struct variants of the above ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+///
+/// // tuple struct with internal padding: u8 followed by u32
+/// #[repr(C)]
+/// #[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+/// struct PaddedTuple(u8, u32);
+/// ```
+#[cfg(doctest)]
+fn pod_derive_does_not_work_for_tuple_struct_with_padding() {}

--- a/iceoryx2-bb/derive-macros/src/zeroable_compile_tests.rs
+++ b/iceoryx2-bb/derive-macros/src/zeroable_compile_tests.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// === Enum / union rejection ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::Zeroable;
+///
+/// #[derive(Zeroable)]
+/// enum Color {
+///     Red,
+///     Blue,
+/// }
+/// ```
+#[cfg(doctest)]
+fn zeroable_derive_does_not_work_for_enum() {}
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::Zeroable;
+///
+/// #[derive(Zeroable)]
+/// union MyUnion {
+///     a: u32,
+///     b: u64,
+/// }
+/// ```
+#[cfg(doctest)]
+fn zeroable_derive_does_not_work_for_union() {}
+
+/// === Structs containing a non-Zeroable field ===
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::Zeroable;
+///
+/// #[derive(Zeroable)]
+/// struct NamedStructWithNonZeroField {
+///     a: u32,
+///     b: core::num::NonZeroU32,
+/// }
+/// ```
+#[cfg(doctest)]
+fn zeroable_derive_does_not_work_for_named_struct_with_non_zeroable_field() {}
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::Zeroable;
+///
+/// #[derive(Zeroable)]
+/// struct TupleStructWithNonZeroField(u32, core::num::NonZeroU32);
+/// ```
+#[cfg(doctest)]
+fn zeroable_derive_does_not_work_for_tuple_struct_with_non_zeroable_field() {}
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::Zeroable;
+/// use iceoryx2_bb_elementary_traits::zeroable::Zeroable;
+///
+/// #[derive(Zeroable)]
+/// struct StructWithReference {
+///     a: u32,
+///     b: &'static u32,
+/// }
+///
+/// // Force monomorphization so the impl's where-bound is actually checked
+/// fn assert_zeroable<T: Zeroable>() {}
+/// assert_zeroable::<StructWithReference>();
+/// ```
+#[cfg(doctest)]
+fn zeroable_derive_does_not_work_for_struct_with_reference_field() {}
+
+/// ``` compile_fail
+/// use iceoryx2_bb_derive_macros::Zeroable;
+///
+/// struct NonZeroable;
+///
+/// #[derive(Zeroable)]
+/// struct StructWithNonZeroableType {
+///     a: u32,
+///     b: NonZeroable,
+/// }
+/// ```
+#[cfg(doctest)]
+fn zeroable_derive_does_not_work_for_struct_with_non_zeroable_typed_field() {}

--- a/iceoryx2-bb/derive-macros/tests-common/src/lib.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/lib.rs
@@ -15,4 +15,6 @@
 extern crate iceoryx2_bb_loggers;
 
 pub mod placement_default_tests;
+pub mod plain_old_data_without_padding_tests;
 pub mod zero_copy_send_tests;
+pub mod zeroable_tests;

--- a/iceoryx2-bb/derive-macros/tests-common/src/plain_old_data_without_padding_tests.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/plain_old_data_without_padding_tests.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2_bb_derive_macros::{PlainOldDataWithoutPadding, ZeroCopySend, Zeroable};
+use iceoryx2_bb_elementary_traits::plain_old_data_without_padding::PlainOldDataWithoutPadding;
+use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
+use iceoryx2_bb_elementary_traits::zeroable::Zeroable;
+use iceoryx2_bb_testing::assert_that;
+use iceoryx2_bb_testing_macros::test;
+
+fn is_pod<T: PlainOldDataWithoutPadding>(_: &T) -> bool {
+    true
+}
+
+fn is_zeroable<T: Zeroable>(_: &T) -> bool {
+    true
+}
+
+fn is_copy<T: Copy>(_: &T) -> bool {
+    true
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+struct NamedPodStruct {
+    value1: u64,
+    value2: u64,
+    value3: u64,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+struct UnnamedPodStruct(u64, u32, u32);
+
+#[repr(C)]
+#[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+struct ArrayFieldPodStruct {
+    data: [u8; 16],
+    count: u64,
+}
+
+// Nested: the inner struct must also be PlainOldDataWithoutPadding.
+#[repr(C)]
+#[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+struct InnerPodStruct {
+    a: u32,
+    b: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Zeroable, ZeroCopySend, PlainOldDataWithoutPadding)]
+struct NestedPodStruct {
+    inner: InnerPodStruct,
+    trailing: u64,
+}
+
+#[test]
+fn pod_derive_for_named_struct_satisfies_all_trait_bounds() {
+    let v = NamedPodStruct {
+        value1: 1,
+        value2: 2,
+        value3: 3,
+    };
+
+    assert_that!(is_pod(&v), eq true);
+    assert_that!(is_zeroable(&v), eq true);
+    assert_that!(is_copy(&v), eq true);
+    assert_that!(core::mem::size_of::<NamedPodStruct>(), eq 24);
+}
+
+#[test]
+fn pod_derive_for_tuple_struct_satisfies_trait_bound() {
+    let v = UnnamedPodStruct(1, 2, 3);
+
+    assert_that!(is_pod(&v), eq true);
+    assert_that!(core::mem::size_of::<UnnamedPodStruct>(), eq 16);
+}
+
+#[test]
+fn pod_derive_with_array_field_satisfies_trait_bound() {
+    let v = ArrayFieldPodStruct {
+        data: [0; 16],
+        count: 0,
+    };
+
+    assert_that!(is_pod(&v), eq true);
+    assert_that!(core::mem::size_of::<ArrayFieldPodStruct>(), eq 24);
+}
+
+#[test]
+fn pod_derive_for_nested_struct_satisfies_trait_bound() {
+    let v = NestedPodStruct {
+        inner: InnerPodStruct { a: 1, b: 2 },
+        trailing: 3,
+    };
+
+    assert_that!(is_pod(&v), eq true);
+    assert_that!(
+        core::mem::size_of::<NestedPodStruct>(),
+        eq core::mem::size_of::<InnerPodStruct>() + core::mem::size_of::<u64>()
+    );
+}
+
+#[test]
+fn pod_derive_implies_zeroable_via_new_zeroed() {
+    let v = NamedPodStruct::new_zeroed();
+
+    assert_that!(v.value1, eq 0);
+    assert_that!(v.value2, eq 0);
+    assert_that!(v.value3, eq 0);
+}

--- a/iceoryx2-bb/derive-macros/tests-common/src/zeroable_tests.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/zeroable_tests.rs
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2_bb_derive_macros::Zeroable;
+use iceoryx2_bb_elementary_traits::zeroable::Zeroable;
+use iceoryx2_bb_testing::assert_that;
+use iceoryx2_bb_testing_macros::test;
+
+fn is_zeroable<T: Zeroable>(_: &T) -> bool {
+    true
+}
+
+#[derive(Zeroable)]
+struct NamedTestStruct {
+    value1: u64,
+    value2: u32,
+    value3: u8,
+    value4: [u8; 8],
+    value5: bool,
+}
+
+#[derive(Zeroable)]
+struct UnnamedTestStruct(u64, u32, u8, [u8; 4]);
+
+#[derive(Zeroable)]
+struct NestedTestStruct {
+    inner: NamedTestStruct,
+    extra: u64,
+}
+
+#[derive(Zeroable)]
+struct GenericNamedTestStruct<T1, T2>
+where
+    T1: Zeroable,
+    T2: Zeroable,
+{
+    value1: T1,
+    value2: T2,
+}
+
+#[derive(Zeroable)]
+struct GenericUnnamedTestStruct<T1, T2>(T1, T2)
+where
+    T1: Zeroable,
+    T2: Zeroable;
+
+#[test]
+fn zeroable_derive_for_named_struct_produces_all_zero_fields() {
+    let v = NamedTestStruct::new_zeroed();
+
+    assert_that!(v.value1, eq 0);
+    assert_that!(v.value2, eq 0);
+    assert_that!(v.value3, eq 0);
+    assert_that!(v.value4, eq [0u8; 8]);
+    assert_that!(v.value5, eq false);
+    assert_that!(is_zeroable(&v), eq true);
+}
+
+#[test]
+fn zeroable_derive_for_tuple_struct_produces_all_zero_fields() {
+    let v = UnnamedTestStruct::new_zeroed();
+
+    assert_that!(v.0, eq 0);
+    assert_that!(v.1, eq 0);
+    assert_that!(v.2, eq 0);
+    assert_that!(v.3, eq [0u8; 4]);
+    assert_that!(is_zeroable(&v), eq true);
+}
+
+#[test]
+fn zeroable_derive_for_nested_struct_zeroes_all_inner_fields() {
+    let v = NestedTestStruct::new_zeroed();
+
+    assert_that!(v.inner.value1, eq 0);
+    assert_that!(v.inner.value2, eq 0);
+    assert_that!(v.inner.value3, eq 0);
+    assert_that!(v.inner.value4, eq [0u8; 8]);
+    assert_that!(v.inner.value5, eq false);
+    assert_that!(v.extra, eq 0);
+    assert_that!(is_zeroable(&v), eq true);
+}
+
+#[test]
+fn zeroable_derive_for_generic_named_struct_works() {
+    type SutType = GenericNamedTestStruct<u64, u32>;
+    let v = SutType::new_zeroed();
+
+    assert_that!(v.value1, eq 0);
+    assert_that!(v.value2, eq 0);
+    assert_that!(is_zeroable(&v), eq true);
+}
+
+#[test]
+fn zeroable_derive_for_generic_tuple_struct_works() {
+    type SutType = GenericUnnamedTestStruct<u64, [u8; 8]>;
+    let v = SutType::new_zeroed();
+
+    assert_that!(v.0, eq 0);
+    assert_that!(v.1, eq [0u8; 8]);
+    assert_that!(is_zeroable(&v), eq true);
+}

--- a/iceoryx2-bb/elementary-traits/src/plain_old_data_without_padding.rs
+++ b/iceoryx2-bb/elementary-traits/src/plain_old_data_without_padding.rs
@@ -24,6 +24,10 @@ use crate::{zero_copy_send::ZeroCopySend, zeroable::Zeroable};
 pub unsafe trait PlainOldDataWithoutPadding:
     ZeroCopySend + Zeroable + Copy + 'static
 {
+    #[doc(hidden)]
+    /// used as dummy call in the derive macro to ensure at compile-time that all fields of
+    /// a struct implement PlainOldDataWithoutPadding
+    fn __is_pod(&self) {}
 }
 
 unsafe impl PlainOldDataWithoutPadding for usize {}

--- a/iceoryx2-bb/elementary-traits/src/zeroable.rs
+++ b/iceoryx2-bb/elementary-traits/src/zeroable.rs
@@ -23,6 +23,11 @@ pub unsafe trait Zeroable: core::marker::Sized {
     fn new_zeroed() -> Self {
         unsafe { core::mem::zeroed() }
     }
+
+    #[doc(hidden)]
+    /// used as dummy call in the derive macro to ensure at compile-time that all fields of
+    /// a struct implement Zeroable
+    fn __is_zeroable(&self) {}
 }
 
 unsafe impl Zeroable for usize {}


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This commit introduces two proc-macro derives that automate the impls and enforce each invariant at compile time:

  - `#[derive(Zeroable)]` verifies every field implements `Zeroable` through a bound in the generated impl.
  - `#[derive(PlainOldDataWithoutPadding)]` additionally checks `#[repr(C)]`, asserts `size_of::<Self>()` equals the sum of field sizes (rejecting any padding), and requires each field to implement the trait.

Both derives reject enums and unions. Test coverage includes named, unnamed, nested, and generic structs with runtime assertions, plus compile_fail doctests for every violation (missing repr(C), padding, non-Copy, non-PoD field, enum, union, reference field, tuple padding).

- Padding detection uses a `const _: () = assert!(size_of::<Self>()  == sum_of_field_sizes);` assertion that triggers at monomorphization.
- The PoD derive does NOT auto-derive `Copy`, `Zeroable`, or  `ZeroCopySend`; users must list them explicitly.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References
<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1547 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
