### PR TITLE
[#1567] Fix aligment of 'variant' alternatives

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -120,6 +120,8 @@
   [#1515](https://github.com/eclipse-iceoryx/iceoryx2/issues/1515)
 * Fix build error in `iceoryx2-pal-posix` with bindgen
   [#1560](https://github.com/eclipse-iceoryx/iceoryx2/issues/1560)
+* Fix alignment of the `variant` alternatives
+  [#1567](https://github.com/eclipse-iceoryx/iceoryx2/issues/1567)
 
 ### Refactoring
 

--- a/iceoryx2-bb/cxx/include/iox2/legacy/expected.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/expected.hpp
@@ -231,7 +231,7 @@ class IOX2_NO_DISCARD expected final {
     explicit operator bool() const noexcept;
 
     /// @brief  returns true if the expected contains a value type and false if it is an error type
-    /// @return bool which contains true if the expected contains an error
+    /// @return bool which contains true if the expected contains a value type and false if it is an error type
     bool has_value() const noexcept;
 
     /// @brief  returns true if the expected contains an error otherwise false

--- a/iceoryx2-bb/cxx/include/iox2/legacy/variant.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/variant.hpp
@@ -64,20 +64,6 @@ struct in_place_type {
 /// @endcode
 static constexpr uint64_t INVALID_VARIANT_INDEX { std::numeric_limits<uint64_t>::max() };
 
-namespace detail {
-/// template recursion stopper for maximum size calculation
-template <std::size_t S = 0>
-constexpr std::size_t maxSize() noexcept {
-    return S;
-}
-
-/// calculate maximum size of supplied types
-template <typename T, typename... Args>
-constexpr std::size_t maxSize() noexcept {
-    return (sizeof(T) > maxSize<Args...>()) ? sizeof(T) : maxSize<Args...>();
-}
-} // namespace detail
-
 /// @brief Variant implementation from the C++17 standard with C++11. The
 ///         interface is inspired by the C++17 standard but it has changes in
 ///         get and emplace since we are not allowed to throw exceptions.
@@ -115,7 +101,7 @@ template <typename... Types>
 class variant final {
   private:
     /// @brief contains the largest size of the elements
-    static constexpr uint64_t TYPE_SIZE { detail::maxSize<Types...>() };
+    static constexpr uint64_t TYPE_SIZE { std::max({ sizeof(Types)... }) };
     /// @brief contains the largest alignment of the elements
     static constexpr uint64_t TYPE_ALIGNMENT { std::max({ alignof(Types)... }) };
 

--- a/iceoryx2-bb/cxx/include/iox2/legacy/variant.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/variant.hpp
@@ -20,6 +20,7 @@
 
 #include "iox2/legacy/detail/variant_internal.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <iostream>
 #include <limits>
@@ -113,8 +114,10 @@ constexpr std::size_t maxSize() noexcept {
 template <typename... Types>
 class variant final {
   private:
-    /// @brief contains the size of the largest element
+    /// @brief contains the largest size of the elements
     static constexpr uint64_t TYPE_SIZE { detail::maxSize<Types...>() };
+    /// @brief contains the largest alignment of the elements
+    static constexpr uint64_t TYPE_ALIGNMENT { std::max({ alignof(Types)... }) };
 
   public:
     /// @brief the default constructor constructs a variant which does not contain
@@ -288,7 +291,7 @@ class variant final {
 
   private:
     // AXIVION Next Construct AutosarC++19_03-A9.6.1 : false positive. internal::byte_t is a type alias for uint8_t
-    struct alignas(Types...) storage_t {
+    struct alignas(TYPE_ALIGNMENT) storage_t {
         // AXIVION Next Construct AutosarC++19_03-M0.1.3 : data provides the actual storage and is accessed via m_storage since &m_storage.data = &m_storage
         // AXIVION Next Construct AutosarC++19_03-A18.1.1 : safe access is guaranteed since the c-array is wrapped inside the variant class
         // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays)

--- a/iceoryx2-bb/cxx/tests/CMakeLists.txt
+++ b/iceoryx2-bb/cxx/tests/CMakeLists.txt
@@ -93,6 +93,7 @@ target_sources(iceoryx2-bb-cxx-tests
     ${PROJECT_SOURCE_DIR}/src/legacy/moduletests/test_utility_convert.cpp
     ${PROJECT_SOURCE_DIR}/src/legacy/moduletests/test_utility_deprecation_marker.cpp
     ${PROJECT_SOURCE_DIR}/src/legacy/moduletests/test_vocabulary_expected.cpp
+    ${PROJECT_SOURCE_DIR}/src/legacy/moduletests/test_vocabulary_variant.cpp
 )
 target_include_directories(iceoryx2-bb-cxx-tests
     PRIVATE ${PROJECT_SOURCE_DIR}/src

--- a/iceoryx2-bb/cxx/tests/src/legacy/moduletests/test_vocabulary_variant.cpp
+++ b/iceoryx2-bb/cxx/tests/src/legacy/moduletests/test_vocabulary_variant.cpp
@@ -655,4 +655,14 @@ TEST_F(variant_Test, TwoVariantsWithUnequalValueAreUnequal) {
     EXPECT_FALSE(sut1 == sut2);
 }
 
+TEST_F(variant_Test, VariantUsesMaxAlignment) {
+    ::testing::Test::RecordProperty("TEST_ID", "f49bc937-0aca-4be7-bb40-b4e0d4cc50d0");
+
+    struct alignas(16) Foo { };
+
+    using SUT = iox2::legacy::variant<char, Foo, bool>;
+
+    ASSERT_THAT(alignof(SUT), alignof(Foo));
+}
+
 } // namespace


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The alignment of the `variant` alternatives was not set correctly. This PR fixes the issue.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1567 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
