### PR TITLE
[#262] Enable all tests on 32 bit

### DIFF
--- a/.github/workflows/reuse_x86_32.yml
+++ b/.github/workflows/reuse_x86_32.yml
@@ -100,8 +100,8 @@ jobs:
                 -DCMAKE_INSTALL_PREFIX=target/ff/cc/install \
                 -DBUILD_EXAMPLES=ON \
                 -DBUILD_TESTING=ON \
-                -DCMAKE_C_FLAGS="-m32 -malign-double" \
-                -DCMAKE_CXX_FLAGS="-m32 -malign-double" \
+                -DCMAKE_C_FLAGS="-m32" \
+                -DCMAKE_CXX_FLAGS="-m32" \
                 -DRUST_BUILD_ARTIFACT_PATH="${{ github.workspace }}/target/i686-unknown-linux-gnu/${{ inputs.profile }}" \
                 ${{ steps.set-build-flags.outputs.cmake-build-type }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
@@ -116,8 +116,7 @@ jobs:
         run: target/ff/cc/build/tests/iceoryx2-c-tests
 
       - name: Run C++ language binding tests
-        # TODO: [#262] the skipped tests trigger an unaligned pointer access
-        run: target/ff/cc/build/tests/iceoryx2-cxx-tests --gtest_filter="-ServiceTest/*.list_works:ServiceTest/*.list_works_with_attributes:ServiceTest/*.details_works"
+        run: target/ff/cc/build/tests/iceoryx2-cxx-tests
 
       - name: Build C language binding examples in out-of-tree configuration
         shell: bash
@@ -126,8 +125,8 @@ jobs:
           cmake -S examples/c \
                 -B target/ff/out-of-tree-c \
                 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/target/ff/cc/install \
-                -DCMAKE_C_FLAGS="-m32 -malign-double" \
-                -DCMAKE_CXX_FLAGS="-m32 -malign-double" \
+                -DCMAKE_C_FLAGS="-m32" \
+                -DCMAKE_CXX_FLAGS="-m32" \
                 ${{ steps.set-build-flags.outputs.cmake-build-type }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
@@ -139,8 +138,8 @@ jobs:
           cmake -S examples/cxx \
                 -B target/ff/out-of-tree-cxx \
                 -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ff/cc/install" \
-                -DCMAKE_C_FLAGS="-m32 -malign-double" \
-                -DCMAKE_CXX_FLAGS="-m32 -malign-double" \
+                -DCMAKE_C_FLAGS="-m32" \
+                -DCMAKE_CXX_FLAGS="-m32" \
                 ${{ steps.set-build-flags.outputs.cmake-build-type }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -49,6 +49,8 @@
     conflicts when merging.
 -->
 
+* Enable all tests for 32 bit after `#1567` fixed the unaligned pointer access
+  [#262](https://github.com/eclipse-iceoryx/iceoryx2/issues/262)
 * Publisher, Client, Server no longer deadlocks with
   UnableToDeliveryStrategy::Block when the other side disconnects
   [#314](https://github.com/eclipse-iceoryx/iceoryx2/issues/314)

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -582,7 +582,7 @@ TYPED_TEST(ServicePublishSubscribeTest, setting_service_properties_works) {
     constexpr uint64_t HISTORY_SIZE = 13;
     constexpr uint64_t SUBSCRIBER_MAX_BUFFER_SIZE = 14;
     constexpr uint64_t SUBSCRIBER_MAX_BORROWED_SAMPLES = 15;
-    constexpr uint64_t PAYLOAD_ALIGNMENT = 4;
+    constexpr uint64_t PAYLOAD_ALIGNMENT = alignof(uint64_t) * 2;
 
     const auto service_name = iox2_testing::generate_service_name();
 
@@ -608,7 +608,7 @@ TYPED_TEST(ServicePublishSubscribeTest, setting_service_properties_works) {
     ASSERT_THAT(static_config.subscriber_max_buffer_size(), Eq(SUBSCRIBER_MAX_BUFFER_SIZE));
     ASSERT_THAT(static_config.subscriber_max_borrowed_samples(), Eq(SUBSCRIBER_MAX_BORROWED_SAMPLES));
     ASSERT_THAT(static_config.message_type_details().payload().size(), Eq(sizeof(uint64_t)));
-    ASSERT_THAT(static_config.message_type_details().payload().alignment(), Eq(alignof(uint64_t)));
+    ASSERT_THAT(static_config.message_type_details().payload().alignment(), Eq(PAYLOAD_ALIGNMENT));
     ASSERT_THAT(static_config.message_type_details().payload().type_name(), StrEq("u64"));
 
     auto subscriber = service.subscriber_builder().create().value();
@@ -616,6 +616,24 @@ TYPED_TEST(ServicePublishSubscribeTest, setting_service_properties_works) {
 
     auto subscriber_2 = service.subscriber_builder().buffer_size(1).create().value();
     ASSERT_THAT(subscriber_2.buffer_size(), Eq(1));
+}
+
+TYPED_TEST(ServicePublishSubscribeTest, setting_service_properties_incorrect_alignment_is_corrected) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint64_t PAYLOAD_ALIGNMENT = alignof(uint64_t) / 2;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name)
+                       .template publish_subscribe<uint64_t>()
+                       .payload_alignment(PAYLOAD_ALIGNMENT)
+                       .create()
+                       .value();
+
+    auto static_config = service.static_config();
+
+    ASSERT_THAT(static_config.message_type_details().payload().alignment(), Eq(alignof(uint64_t)));
 }
 
 TYPED_TEST(ServicePublishSubscribeTest, safe_overflow_can_be_set) {

--- a/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
@@ -831,8 +831,8 @@ TYPED_TEST(ServiceRequestResponseTest, setting_service_properties_works) {
     constexpr uint64_t MAX_RESPONSE_BUFFER_SIZE = 4;
     constexpr uint64_t MAX_BORROWED_RESPONSES = 5;
     constexpr uint64_t MAX_LOANED_REQUESTS = 3;
-    constexpr uint64_t REQUEST_PAYLOAD_ALIGNMENT = 4;
-    constexpr uint64_t RESPONSE_PAYLOAD_ALIGNMENT = 8;
+    constexpr uint64_t REQUEST_PAYLOAD_ALIGNMENT = alignof(uint64_t) * 2;
+    constexpr uint64_t RESPONSE_PAYLOAD_ALIGNMENT = alignof(uint64_t) * 4;
 
     const auto service_name = iox2_testing::generate_service_name();
 
@@ -860,10 +860,10 @@ TYPED_TEST(ServiceRequestResponseTest, setting_service_properties_works) {
     ASSERT_THAT(static_config.max_clients(), Eq(NUMBER_OF_CLIENTS));
     ASSERT_THAT(static_config.max_servers(), Eq(NUMBER_OF_SERVERS));
     ASSERT_THAT(static_config.request_message_type_details().payload().size(), Eq(sizeof(uint64_t)));
-    ASSERT_THAT(static_config.request_message_type_details().payload().alignment(), Eq(alignof(uint64_t)));
+    ASSERT_THAT(static_config.request_message_type_details().payload().alignment(), Eq(REQUEST_PAYLOAD_ALIGNMENT));
     ASSERT_THAT(static_config.request_message_type_details().payload().type_name(), StrEq("u64"));
     ASSERT_THAT(static_config.response_message_type_details().payload().size(), Eq(sizeof(uint64_t)));
-    ASSERT_THAT(static_config.response_message_type_details().payload().alignment(), Eq(alignof(uint64_t)));
+    ASSERT_THAT(static_config.response_message_type_details().payload().alignment(), Eq(RESPONSE_PAYLOAD_ALIGNMENT));
     ASSERT_THAT(static_config.response_message_type_details().payload().type_name(), StrEq("u64"));
     ASSERT_THAT(static_config.has_safe_overflow_for_requests(), Eq(false));
     ASSERT_THAT(static_config.has_safe_overflow_for_responses(), Eq(false));
@@ -872,6 +872,28 @@ TYPED_TEST(ServiceRequestResponseTest, setting_service_properties_works) {
     ASSERT_THAT(static_config.max_borrowed_responses_per_pending_responses(), Eq(MAX_BORROWED_RESPONSES));
     ASSERT_THAT(static_config.max_loaned_requests(), Eq(MAX_LOANED_REQUESTS));
     ASSERT_THAT(static_config.does_support_fire_and_forget_requests(), Eq(false));
+}
+
+
+TYPED_TEST(ServiceRequestResponseTest, setting_service_properties_incorrect_alignment_is_corrected) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint64_t REQUEST_PAYLOAD_ALIGNMENT = alignof(uint64_t) / 2;
+    constexpr uint64_t RESPONSE_PAYLOAD_ALIGNMENT = alignof(uint64_t) / 2;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name)
+                       .template request_response<uint64_t, uint64_t>()
+                       .request_payload_alignment(REQUEST_PAYLOAD_ALIGNMENT)
+                       .response_payload_alignment(RESPONSE_PAYLOAD_ALIGNMENT)
+                       .create()
+                       .value();
+
+    auto static_config = service.static_config();
+
+    ASSERT_THAT(static_config.request_message_type_details().payload().alignment(), Eq(alignof(uint64_t)));
+    ASSERT_THAT(static_config.response_message_type_details().payload().alignment(), Eq(alignof(uint64_t)));
 }
 
 TYPED_TEST(ServiceRequestResponseTest, open_fails_with_incompatible_client_requirement) {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

After #1568 fixed the alignment issue with the `variant`, the 32 bit build also passed all tests, except a test for request response. But that test was wrong for 32 bit and this PR also adjusted the payload alignment tests.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #262

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
