### PR TITLE
[#1570] Add iceoryx2-dmabuf crate with SCM_RIGHTS fd sidecar and DMA-BUF wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "benchmarks-dmabuf"
+version = "0.8.999"
+dependencies = [
+ "iceoryx2",
+ "iceoryx2-dmabuf",
+ "rustix",
+]
+
+[[package]]
 name = "better-panic"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -55,12 +55,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -73,12 +67,27 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -88,49 +97,62 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "array-init"
@@ -150,7 +172,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -162,7 +184,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -174,7 +196,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -185,20 +207,20 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -206,7 +228,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -217,9 +239,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmark-event"
@@ -270,7 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fa9e1d11a268684cbd90ed36370d7577afb6c62d912ddff5c15fc34343e5036"
 dependencies = [
  "backtrace",
- "console 0.15.10",
+ "console 0.15.11",
 ]
 
 [[package]]
@@ -290,14 +312,29 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.11.0"
+name = "bit-set"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -312,10 +349,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.17.0"
+name = "block2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -331,18 +377,18 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
 dependencies = [
  "serde",
 ]
@@ -358,7 +404,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -369,23 +415,24 @@ checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
 dependencies = [
  "clap",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.117",
  "tempfile",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -406,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -418,15 +465,14 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -452,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.19"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be5744db7978a28d9df86a214130d106a89ce49644cbc4e3f0c22c3fba30615"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -462,11 +508,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.19"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5fbc17d3ef8278f55b282b2a2e75ae6f6c7d4bb70ed3d0382375104bfafdb4b"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -474,21 +520,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -496,23 +542,23 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -565,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode 1.0.0",
  "libc",
@@ -583,11 +629,12 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const_format"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -603,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -693,9 +740,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -703,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -713,34 +760,33 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -769,12 +815,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -807,7 +853,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -818,8 +873,30 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -830,20 +907,42 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dma-buf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f64647d34a7cd50cb30b037e5c21d7732c2644161600cd3c8137cfe5b43d05f"
+dependencies = [
+ "rustix",
+ "tracing",
+]
+
+[[package]]
+name = "dma-heap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ad8f403fb14a57c2f40e1d4e49584e52b3f85634ac77c6f3c2ddfc58bfdbde"
+dependencies = [
+ "log",
+ "nix 0.27.1",
+ "strum_macros",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embedded-io"
@@ -871,38 +970,38 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-iterator"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c280b9e6b3ae19e152d8e31cf47f18389781e119d4013a2a2bb0180e5facc635"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
 dependencies = [
  "enum-iterator-derive",
 ]
 
 [[package]]
 name = "enum-iterator-derive"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -942,10 +1041,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.1.1"
+name = "fastbloom"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.4",
+ "siphasher",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -955,9 +1072,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -972,7 +1089,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1004,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1019,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1029,15 +1146,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1046,38 +1163,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1087,22 +1204,22 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "generator"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605183a538e3e2a9c1038635cc5c2d194e2ee8fd0d1b66b8349fad7dbacce5a2"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "log",
  "rustversion",
- "windows",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -1117,47 +1234,60 @@ dependencies = [
 
 [[package]]
 name = "generic-tests"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb39ec0dacc89541b6eced815ab9e97f6b7d44078628abb090c6437763fd050"
+checksum = "d9ff6d6584f4f6fa911d5e07856abf1a48dc5599b3734f2eaea130f2c3baa989"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "r-efi 5.3.0",
+ "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git-version"
@@ -1176,14 +1306,14 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -1203,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
 ]
@@ -1220,6 +1350,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1250,21 +1386,20 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1280,13 +1415,13 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b84a66a325082740043a6c28bbea400c129eac0d3a27673a1de971e44bf1f7"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "backtrace",
  "os_info",
  "serde",
  "serde_derive",
- "toml 0.8.19",
+ "toml 0.8.23",
  "uuid",
 ]
 
@@ -1298,9 +1433,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1342,7 +1477,7 @@ dependencies = [
  "iceoryx2-tests-common",
  "serde",
  "tiny-fn",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1435,7 +1570,7 @@ dependencies = [
  "iceoryx2-bb-testing",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1759,7 +1894,7 @@ dependencies = [
  "iceoryx2-pal-print",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1865,7 +2000,7 @@ dependencies = [
  "serde",
  "sha1_smol",
  "tiny-fn",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1887,7 +2022,7 @@ dependencies = [
  "iceoryx2-pal-print",
  "postcard",
  "serde",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1958,7 +2093,7 @@ dependencies = [
  "clap",
  "colored",
  "dialoguer",
- "dirs",
+ "dirs 5.0.1",
  "enum-iterator",
  "human-panic",
  "iceoryx2",
@@ -1980,7 +2115,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "toml 0.9.8",
+ "toml 0.9.12+spec-1.1.0",
  "zenoh",
 ]
 
@@ -2029,6 +2164,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "iceoryx2-dmabuf"
+version = "0.8.999"
+dependencies = [
+ "dma-buf",
+ "dma-heap",
+ "iceoryx2",
+ "iceoryx2-pal-concurrency-sync",
+ "libc",
+ "memmap2",
+ "proptest",
+ "rustix",
+ "sha1_smol",
+ "tracing",
+]
+
+[[package]]
 name = "iceoryx2-ffi-c"
 version = "0.8.999"
 dependencies = [
@@ -2060,7 +2211,7 @@ dependencies = [
  "iceoryx2-bb-elementary-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2258,21 +2409,23 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2282,97 +2435,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -2393,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2414,12 +2535,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2453,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -2477,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -2490,24 +2611,46 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2543,19 +2686,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.183"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -2564,32 +2728,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
 ]
 
 [[package]]
 name = "libtest-mimic"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap",
  "escape8259",
@@ -2597,31 +2760,30 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loom"
@@ -2644,9 +2806,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
 dependencies = [
  "twox-hash",
 ]
@@ -2662,9 +2824,18 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2684,13 +2855,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2699,7 +2870,18 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2707,6 +2889,18 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2769,16 +2963,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2821,10 +3015,169 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.5"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -2840,15 +3193,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2858,13 +3217,18 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
-version = "3.8.2"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
+ "android_system_properties",
  "log",
+ "nix 0.30.1",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2878,6 +3242,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2896,20 +3270,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2917,24 +3290,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -2946,8 +3318,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "hashbrown 0.15.2",
- "indexmap 2.13.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -2982,7 +3354,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2996,15 +3368,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs1"
@@ -3061,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postcard"
@@ -3075,6 +3441,15 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -3094,37 +3469,56 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.9",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "pyo3"
-version = "0.28.2"
+name = "proptest"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
  "once_cell",
@@ -3136,18 +3530,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3155,34 +3549,40 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.7"
+name = "quick-error"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3191,8 +3591,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.9",
- "thiserror 2.0.12",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -3205,16 +3605,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
+ "fastbloom",
+ "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3222,38 +3623,44 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.9",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3262,12 +3669,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3287,7 +3694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3296,16 +3703,39 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -3314,36 +3744,47 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3353,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3364,9 +3805,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -3376,7 +3817,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3407,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "ron"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
+checksum = "4147b952f3f819eca0e99527022f7d6a8d05f111aeb0a62960c74eb283bec8fc"
 dependencies = [
  "bitflags",
  "once_cell",
@@ -3441,15 +3882,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3471,22 +3912,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",
@@ -3499,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3520,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3557,9 +3998,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3568,15 +4009,27 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3589,11 +4042,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3610,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "either",
@@ -3624,14 +4077,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4908ad288c5035a8eb12cfdf0d49270def0a268ee162b75eeee0f85d155a7c45"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3681,11 +4134,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3715,7 +4169,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3726,7 +4180,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3744,18 +4198,18 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3771,17 +4225,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -3790,14 +4244,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3806,7 +4260,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3849,9 +4303,9 @@ checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
  "digest",
  "keccak",
@@ -3872,7 +4326,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -3893,36 +4347,33 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3930,12 +4381,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3946,6 +4397,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
@@ -3988,21 +4445,40 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -4023,9 +4499,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4040,7 +4516,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4051,15 +4527,15 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4074,80 +4550,79 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.64",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4155,15 +4630,15 @@ dependencies = [
 
 [[package]]
 name = "tiny-fn"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fde9a76dac5751480f711f327371c809d7f8a9f036436e6237d67859adbf3bd"
+checksum = "9659b108631d1e1cf3e8e489f894bee40bc9d68fd6cc67ec4d4ce9b72d565228"
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4171,9 +4646,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4186,57 +4661,59 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tls-listener"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41256c16d6fc2b3021545f20bf77a73200b18bd54040ac656dddfca6205bfa"
+checksum = "1461056cc1ef47003f7ee16e4cef3741068d4c7f6b627bfce49b7c00c120a530"
 dependencies = [
  "futures-util",
  "pin-project-lite",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
 ]
 
 [[package]]
 name = "token-cell"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c7b0772e96c7fa6646b16c116753b3d1db503400209237230aa992c9e3a269"
+checksum = "fb48920ae769b58126c8c93269805011c793201f95fde28b479b81a9a531bbde"
 dependencies = [
  "paste",
+ "portable-atomic",
+ "rustversion",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -4270,87 +4747,103 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.8",
- "toml_datetime 0.6.8",
- "toml_edit 0.22.22",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.0.3",
- "toml_datetime 0.7.3",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
- "serde_spanned 0.6.8",
- "toml_datetime 0.6.8",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.9"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.7.3",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
-name = "toml_writer"
-version = "1.0.4"
+name = "toml_write"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -4372,7 +4865,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4408,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4439,17 +4932,21 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
- "thiserror 1.0.64",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "typeid"
@@ -4459,9 +4956,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -4471,23 +4968,29 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uhlc"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ac3c37bd9506595768f0387bd39d644525728b4a1d783218acabfb56356db7"
+checksum = "b62a645e3e4e6c85b7abe49b086aa3204119431f42b6123b0070419fb6e9d24e"
 dependencies = [
  "humantime",
  "lazy_static",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.13"
+name = "unarray"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -4515,13 +5018,13 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unzip-n"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
+checksum = "3b5bb2756c16fb66f80cfbf5fb0e0c09a7001e739f453c9ec241b9c8b1556fda"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4543,12 +5046,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4562,11 +5059,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4591,7 +5088,7 @@ checksum = "8c44ce98e7227a04eeb4cf9c784109a5c9710e54849ceb4f09f8597247897f1e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "unzip-n",
 ]
 
@@ -4614,6 +5111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4625,50 +5131,46 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4676,24 +5178,58 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -4708,18 +5244,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4742,11 +5278,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4756,78 +5292,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-link 0.1.3",
- "windows-numerics",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core",
-]
-
-[[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
 
 [[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core",
- "windows-link 0.1.3",
- "windows-threading",
-]
-
-[[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
@@ -4836,31 +5333,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core",
- "windows-link 0.1.3",
-]
-
-[[package]]
 name = "windows-result"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -4914,7 +5401,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4969,7 +5456,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -4978,15 +5465,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -5171,39 +5649,124 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "bitflags",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-parser"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -5211,18 +5774,27 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
+ "ring",
  "rusticata-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
  "time",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -5230,21 +5802,21 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zenoh"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9ff8cb89f5267b8486a69466bc42f240f1ee2d5089e72395a23094e7b74f21"
+checksum = "85e22d7002ac149ef17fe400bb40a267ebbba40a83413bab03da7762256fa94e"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -5262,12 +5834,11 @@ dependencies = [
  "once_cell",
  "petgraph",
  "phf",
- "rand 0.8.5",
- "ref-cast",
+ "rand 0.8.6",
  "rustc_version",
  "serde",
  "serde_json",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5294,18 +5865,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9216c3d6c84b56f3e3be634e52365022038e1ac1b9f662f10d425cbf6c0fa8"
+checksum = "e89c9e2427102e8efd533716f0935389a3900a818e7334004dd647ac0bd029dc"
 dependencies = [
  "zenoh-collections",
 ]
 
 [[package]]
 name = "zenoh-codec"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14bc6747664aa9ecf17becd6e9a29282e535a350cd7c6bd8de7bf2dc662fb93d"
+checksum = "31930531a8e387160bc3680c6d62f80a201020cf4d8aa36bd46988b425a66306"
 dependencies = [
  "tracing",
  "uhlc",
@@ -5315,18 +5886,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-collections"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d642ecfe0d85f0cd846be9bc92805d926c092a6e6c7a575b6346752f8c3ae16"
+checksum = "6fc5195efe3ad44786275f559bbd6f13c6612470e9706c9a9a8b5b47388d51e1"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "zenoh-config"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39765a5f9975aba204c99f2f65308db4952dbea8e5ac79c78ac1eaf5711e970a"
+checksum = "e8672f4eaf88fd486f0503c59d19edfc25e7dd689bccd90d3cb731a5f627e0df"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -5336,6 +5907,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uhlc",
  "validated_struct",
@@ -5349,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c0c1388dccf287aec4e9d5e638630dc9d536db9f1da3522889b42697723b9b"
+checksum = "1525319e4d9ef2af54fc9c74abf419236e32e6535081339321f3f55e2f34ce2f"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -5361,13 +5933,13 @@ dependencies = [
 
 [[package]]
 name = "zenoh-crypto"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b433e08df3b03f2af2d23bd29a32aa5f5522c52e66d63e3d135bfa66373736dd"
+checksum = "44b80a042fc71419fc4952a90c9cbcfb323c0ced048125d8b44fd362f184045f"
 dependencies = [
  "aes",
  "hmac",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "sha3",
  "zenoh-result",
@@ -5375,15 +5947,15 @@ dependencies = [
 
 [[package]]
 name = "zenoh-keyexpr"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a3c47c89cb55ea45a1b3fe7d1fe8682ea93530b1fc5245257812db14b55b3d"
+checksum = "80f04c82f0728f6704a1a397a04b38de5b2fd5a9a886a232cf650c9af294ba5d"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "hashbrown 0.16.1",
  "keyed-set",
- "rand 0.8.5",
- "schemars 1.2.0",
+ "rand 0.8.6",
+ "schemars 1.2.1",
  "serde",
  "token-cell",
  "zenoh-result",
@@ -5391,9 +5963,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6218cecab58435f31fb8b2e185f74f35af8aedd96e8bdd3557b333206b1acfda"
+checksum = "a71103cfe96a851ef5ff781d64dda95c70e70208f74e186d6d294ba21e89cc64"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -5410,22 +5982,25 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98adc618f7edb570b9333ce583934a7c63e3a619cb49666515bfc06a000d7b6"
+checksum = "8dc91a5163793f842b4b016b2d50640db5a3533370348eb796e7078c576e87cf"
 dependencies = [
  "async-trait",
  "base64",
+ "bytes",
  "flume",
  "futures",
  "quinn",
+ "quinn-proto",
+ "rcgen",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
  "serde",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "time",
  "tokio",
  "tokio-util",
@@ -5444,59 +6019,46 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0c25d681db958b7714370d5e1d72a523129633d9262b098e18d44824d39893"
+checksum = "17d065833147be895b7091cc3e505433c2c8b3172e36c9e06e84a5779a4aa655"
 dependencies = [
  "async-trait",
- "base64",
- "quinn",
- "rustls",
- "rustls-pemfile",
  "rustls-webpki",
- "secrecy",
  "time",
- "tokio",
- "tokio-util",
  "tracing",
- "webpki-roots",
- "zenoh-config",
  "zenoh-core",
  "zenoh-link-commons",
+ "zenoh-link-quic_datagram",
  "zenoh-protocol",
  "zenoh-result",
- "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-link-quic_datagram"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb427adbc8d367505b9a62a6614c9d7802e420f03466d98644bb7bf24516f"
+checksum = "e81b15df31a3d0ddde9a4fb3fbc928e9a2a6d6a4de38bcf55badd3a5208947a4"
 dependencies = [
  "async-trait",
- "quinn",
- "rustls",
  "rustls-webpki",
  "time",
- "tokio",
  "tokio-util",
  "tracing",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",
  "zenoh-result",
- "zenoh-util",
 ]
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f23bd5d06a0014ce5a205961d6d47c8e8d792d9fd050ae9d0c9b609a187995"
+checksum = "4e912ac36902173dfc295317e001dc630e5ac9a70c2780f2d2eac500b205a700"
 dependencies = [
  "async-trait",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5509,9 +6071,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tls"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17544cde682dbcd2a712114786feee14295c28a9f66fc1021637355511e32fa9"
+checksum = "e6f6b308ae2599f9c1344fbcd3418b2c3a3a9fe287ec39501ba834168493ba37"
 dependencies = [
  "async-trait",
  "base64",
@@ -5520,7 +6082,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "time",
  "tls-listener",
  "tokio",
@@ -5539,13 +6101,13 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-udp"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587ca1de1caa0b444106d31c26801f4e87b354293d2d37afd8f70d9e793fe35e"
+checksum = "ca106ca8c3b7625e7071b9d7408955726e994c8f35fd68e00de8ac58b185d52d"
 dependencies = [
  "async-trait",
  "libc",
- "socket2 0.5.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5553,6 +6115,7 @@ dependencies = [
  "zenoh-buffers",
  "zenoh-core",
  "zenoh-link-commons",
+ "zenoh-link-quic_datagram",
  "zenoh-protocol",
  "zenoh-result",
  "zenoh-sync",
@@ -5561,12 +6124,12 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac46470a17af5861e07ed9d2440277e7a3dea55109b0988866b635f7daf29ac4"
+checksum = "09f2b7f60cdb5ad771d1a4f8e2eda15529e96dbe81c0ad2c1015b4c194347676"
 dependencies = [
  "async-trait",
- "nix",
+ "nix 0.29.0",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5580,9 +6143,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-ws"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4be09c3e32d510cdddf3289bc333d53471883198fca51d58248458a20df3d51"
+checksum = "9a7fb54899f7fbdfc4fd02e647f9bba0d6e089cca4355acafb9499c510ebea79"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5601,21 +6164,21 @@ dependencies = [
 
 [[package]]
 name = "zenoh-macros"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b760a458cd906ac888b37fd1abdb21a0f58ecc64cc3882f83a976cb5ca8e0632"
+checksum = "9310b02a8f6dc4bd04d9ce6b318b9d00182aeeeeca60410003307d63a2569a3f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "zenoh-keyexpr",
 ]
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7325b773c43a86a94f800cb971ab7e4b7e01ce76819c9c100ea783a47c3a25e4"
+checksum = "e235815d14b22448aa1db948560328761530932fa7a2f9a3c14853b3f0267941"
 dependencies = [
  "git-version",
  "libloading",
@@ -5631,36 +6194,37 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4d3dad7aeeea780495692b195cd56515569c32b76b9dd077cc408c3ebca03f"
+checksum = "eeab45020bbecc077f14f06ee8f5aee65ce760af72481e663cac58b5dbfa66dd"
 dependencies = [
  "const_format",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "uhlc",
  "zenoh-buffers",
  "zenoh-keyexpr",
+ "zenoh-macros",
  "zenoh-result",
 ]
 
 [[package]]
 name = "zenoh-result"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b4dbfea68b947a790d5525bcf061e91e2fdc2798bce619851919b353a8580fa"
+checksum = "cca8e65b08f211833fe31cf38d73a48c6e1d6d900914e1ddd8cb176b3355b75b"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "zenoh-runtime"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760a1f7880f98427ad849d600257d1455a18afe981681f362684a3f91042537e"
+checksum = "dd3d0c1558f909c9a74bde5e398c5733f81eb954818451baac2a6c09f48d6a5e"
 dependencies = [
  "lazy_static",
- "ron 0.12.0",
+ "ron 0.12.1",
  "serde",
  "tokio",
  "tracing",
@@ -5670,9 +6234,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-sync"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98f132137bb003f10b7fff086cb18addf8e8273b9c0d2722a53b5074c8a79965"
+checksum = "9588f87db82b414a3e73d13312026be826332f53d270966e3e19f77f7fa1f06d"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -5685,9 +6249,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-task"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b17d10136fdabec7e21a3fcef568c210ee6a2d71cde6adcde99e9236584f3a1"
+checksum = "1e2ac601598a27152b366ba1c6825216f01f77bb898f719b7752099a3594ce72"
 dependencies = [
  "futures",
  "tokio",
@@ -5699,16 +6263,17 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50739b4c45e0963df8377abddb74701a4b708b178590eae92f27a604e25daf44"
+checksum = "80800c4adc26dbe81418735068541cf39820a95ec988114f04dd014775ba7c97"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
  "flume",
+ "futures",
  "lazy_static",
  "lz4_flex",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ringbuffer-spsc",
  "rsa",
  "serde",
@@ -5733,9 +6298,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "1.7.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9512987c13925d32d3331507c8807853d5b682ea8da94d0ba6534c7a8ace48aa"
+checksum = "1b10369df18a781a3e675c9a2cbf54adb44c9dc2a376c1014c5e488410df2179"
 dependencies = [
  "async-trait",
  "const_format",
@@ -5746,7 +6311,7 @@ dependencies = [
  "libc",
  "libloading",
  "pnet_datalink",
- "schemars 1.2.0",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "shellexpand",
@@ -5760,56 +6325,67 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5818,17 +6394,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.13"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac93432f5b761b22864c774aac244fa5c0fd877678a4c37ebf6cf42208f9c9ec"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ members = [
     "benchmarks/publish-subscribe",
     "benchmarks/event",
     "benchmarks/queue",
+    "benchmarks/dmabuf",
 
     "component-tests/rust",
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,8 @@ members = [
     "benchmarks/queue",
 
     "component-tests/rust",
+
+    "iceoryx2-dmabuf/",
 ]
 
 [workspace.package]

--- a/benchmarks/dmabuf/Cargo.toml
+++ b/benchmarks/dmabuf/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "benchmarks-dmabuf"
+description = "iceoryx2-dmabuf: [internal] benchmarks for DMA-BUF fd-passing via SCM_RIGHTS sidecar"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+publish = false
+
+[dependencies]
+iceoryx2-dmabuf = { path = "../../iceoryx2-dmabuf", features = ["memfd"] }
+iceoryx2 = { workspace = true, features = ["std"] }
+rustix = { version = "1", features = ["fs", "net", "mm"] }
+
+[[bin]]
+name = "dmabuf-bench"
+path = "src/main.rs"

--- a/benchmarks/dmabuf/src/bench_fanout.rs
+++ b/benchmarks/dmabuf/src/bench_fanout.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//
+//! Fanout benchmark: 1 producer → N subscribers, slowest-consumer p95.
+//!
+//! Spawns `--n` subscriber threads and one publisher, then sends `--iters`
+//! 1080p RGBA8 DMA-BUF frames.  Each subscriber records per-frame receive
+//! latency; the worst p95 across all subscribers is reported.
+//!
+//! # Usage
+//!
+//! ```text
+//! dmabuf-bench fanout [--n N] [--iters N]
+//! ```
+//!
+//! Default: 3 subscribers, 1 000 iterations.
+
+pub const DEFAULT_N: usize = 3;
+pub const DEFAULT_ITERS: usize = 1_000;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct Meta {
+    size: u64,
+    seq: u64,
+}
+// Safety: Meta is repr(C), Copy, with no padding bytes of undefined value.
+unsafe impl iceoryx2::prelude::ZeroCopySend for Meta {}
+
+fn run_fanout_inner(n: usize, iters: usize) -> Result<(), Box<dyn core::error::Error>> {
+    use crate::bench_latency::PAYLOAD_BYTES;
+    use iceoryx2::service::ipc;
+    use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::sync::{Arc, Barrier};
+    use std::time::{Duration, Instant};
+
+    let svc = format!("bench/dmabuf/fanout/n{n}");
+    let barrier = Arc::new(Barrier::new(n + 1));
+
+    // Spawn N subscriber threads; each records per-frame latency.
+    let mut handles = Vec::with_capacity(n);
+    let mut all_samples: Vec<Arc<std::sync::Mutex<Vec<Duration>>>> = Vec::with_capacity(n);
+
+    for _ in 0..n {
+        let svc_clone = svc.clone();
+        let bar = Arc::clone(&barrier);
+        let samples_cell: Arc<std::sync::Mutex<Vec<Duration>>> =
+            Arc::new(std::sync::Mutex::new(Vec::with_capacity(iters)));
+        let samples_clone = Arc::clone(&samples_cell);
+        all_samples.push(samples_cell);
+
+        let handle = std::thread::spawn(
+            move || -> Result<(), Box<dyn core::error::Error + Send + Sync>> {
+                let mut sub_ = FdSidecarSubscriber::<ipc::Service, Meta>::create(&svc_clone)?;
+                bar.wait();
+                for _ in 0..iters {
+                    let t0 = Instant::now();
+                    while sub_.recv()?.is_none() {}
+                    let elapsed = t0.elapsed();
+                    if let Ok(mut v) = samples_clone.lock() {
+                        v.push(elapsed);
+                    }
+                }
+                Ok(())
+            },
+        );
+        handles.push(handle);
+    }
+
+    // Publisher: create after subscribers so open_or_create sees them.
+    let mut pub_ = FdSidecarPublisher::<ipc::Service, Meta>::create(&svc)?;
+    let zeroes = vec![0u8; PAYLOAD_BYTES as usize];
+
+    barrier.wait(); // release subscribers
+
+    for seq in 0..iters as u64 {
+        let fd = memfd_create("bench-fanout-frame", MemfdFlags::CLOEXEC)?;
+        rustix::io::write(&fd, &zeroes)?;
+        pub_.send(
+            Meta {
+                size: PAYLOAD_BYTES,
+                seq,
+            },
+            fd,
+        )?;
+    }
+
+    // Collect results.
+    for handle in handles {
+        match handle.join() {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(format!("subscriber thread error: {e}").into()),
+            Err(_) => return Err("subscriber thread panicked".into()),
+        }
+    }
+
+    // Find slowest-consumer p95.
+    let mut slowest_p95 = Duration::ZERO;
+    for cell in &all_samples {
+        if let Ok(mut v) = cell.lock() {
+            v.sort_unstable();
+            if v.len() >= 20 {
+                let p95 = v[(v.len() * 95) / 100];
+                if p95 > slowest_p95 {
+                    slowest_p95 = p95;
+                }
+            }
+        }
+    }
+
+    println!(
+        "dmabuf_fanout_latency subscribers={n} iters={iters} slowest_p95_us={}",
+        slowest_p95.as_micros()
+    );
+    Ok(())
+}
+
+pub fn run_fanout() {
+    let args: Vec<String> = std::env::args().collect();
+    let n = match crate::args::parse_flag(&args, "--n") {
+        Some(v) => v,
+        None => DEFAULT_N,
+    };
+    let iters = match crate::args::parse_flag(&args, "--iters") {
+        Some(v) => v,
+        None => DEFAULT_ITERS,
+    };
+    if let Err(e) = run_fanout_inner(n, iters) {
+        eprintln!("fanout bench error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/benchmarks/dmabuf/src/bench_latency.rs
+++ b/benchmarks/dmabuf/src/bench_latency.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//
+//! Latency benchmark: round-trip time for a single 1080p RGBA8 DMA-BUF frame.
+//!
+//! Measures publisher→subscriber end-to-end latency (send + recv) over
+//! `--iters` iterations after `--warmup` warm-up rounds.  Reports p50, p95,
+//! and max in microseconds.
+//!
+//! # Usage
+//!
+//! ```text
+//! dmabuf-bench latency [--iters N] [--warmup N]
+//! ```
+//!
+//! Default: 10 000 iterations, 100 warm-up iterations.
+
+pub const PAYLOAD_BYTES: u64 = 8_294_400; // 1920 x 1080 x 4 (RGBA8)
+pub const DEFAULT_WARMUP: usize = 100;
+pub const DEFAULT_ITERS: usize = 10_000;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct Meta {
+    size: u64,
+}
+// Safety: Meta is repr(C), Copy, with no padding bytes of undefined value.
+unsafe impl iceoryx2::prelude::ZeroCopySend for Meta {}
+
+fn run_latency_inner(iters: usize, warmup: usize) -> Result<(), Box<dyn core::error::Error>> {
+    use iceoryx2::service::ipc;
+    use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::time::Instant;
+
+    let svc = "bench/dmabuf/latency";
+    let mut pub_ = FdSidecarPublisher::<ipc::Service, Meta>::create(svc)?;
+    let mut sub_ = FdSidecarSubscriber::<ipc::Service, Meta>::create(svc)?;
+
+    let total = warmup + iters;
+    let mut samples = Vec::with_capacity(iters);
+    let zeroes = vec![0u8; PAYLOAD_BYTES as usize];
+
+    for i in 0..total {
+        let fd = memfd_create("bench-frame", MemfdFlags::CLOEXEC)?;
+        rustix::io::write(&fd, &zeroes)?;
+
+        let t0 = Instant::now();
+        pub_.send(
+            Meta {
+                size: PAYLOAD_BYTES,
+            },
+            fd,
+        )?;
+        while sub_.recv()?.is_none() {}
+        let elapsed = t0.elapsed();
+
+        if i >= warmup {
+            samples.push(elapsed);
+        }
+    }
+
+    samples.sort_unstable();
+    let p50 = samples[iters / 2];
+    let p95 = samples[(iters * 95) / 100];
+    let max = match samples.last() {
+        Some(v) => *v,
+        None => return Err("no samples collected".into()),
+    };
+
+    println!("dmabuf_publish_latency 1080p RGBA8 ({iters} iters, {warmup} warmup)");
+    println!(
+        "  p50={} us  p95={} us  max={} us",
+        p50.as_micros(),
+        p95.as_micros(),
+        max.as_micros()
+    );
+    Ok(())
+}
+
+pub fn run_latency() {
+    let args: Vec<String> = std::env::args().collect();
+    let iters = match crate::args::parse_flag(&args, "--iters") {
+        Some(v) => v,
+        None => DEFAULT_ITERS,
+    };
+    let warmup = match crate::args::parse_flag(&args, "--warmup") {
+        Some(v) => v,
+        None => DEFAULT_WARMUP,
+    };
+    if let Err(e) = run_latency_inner(iters, warmup) {
+        eprintln!("latency bench error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/benchmarks/dmabuf/src/bench_throughput.rs
+++ b/benchmarks/dmabuf/src/bench_throughput.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//
+//! Throughput benchmark: sustained frame rate for 1080p RGBA8 DMA-BUF frames.
+//!
+//! Sends `--frames` frames as fast as possible (publisher side) and receives
+//! them on the subscriber side in the same process.  Reports total wall-clock
+//! time and frames-per-second.
+//!
+//! # Usage
+//!
+//! ```text
+//! dmabuf-bench throughput [--frames N]
+//! ```
+//!
+//! Default: 100 000 frames.
+
+pub const DEFAULT_FRAMES: usize = 100_000;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct Meta {
+    size: u64,
+}
+// Safety: Meta is repr(C), Copy, with no padding bytes of undefined value.
+unsafe impl iceoryx2::prelude::ZeroCopySend for Meta {}
+
+fn run_throughput_inner(frames: usize) -> Result<(), Box<dyn core::error::Error>> {
+    use crate::bench_latency::PAYLOAD_BYTES;
+    use iceoryx2::service::ipc;
+    use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::time::Instant;
+
+    let svc = "bench/dmabuf/throughput";
+    let mut pub_ = FdSidecarPublisher::<ipc::Service, Meta>::create(svc)?;
+    let mut sub_ = FdSidecarSubscriber::<ipc::Service, Meta>::create(svc)?;
+
+    let zeroes = vec![0u8; PAYLOAD_BYTES as usize];
+    let start = Instant::now();
+
+    for _ in 0..frames {
+        let fd = memfd_create("bench-tp-frame", MemfdFlags::CLOEXEC)?;
+        rustix::io::write(&fd, &zeroes)?;
+        pub_.send(
+            Meta {
+                size: PAYLOAD_BYTES,
+            },
+            fd,
+        )?;
+        while sub_.recv()?.is_none() {}
+    }
+
+    let elapsed = start.elapsed();
+    let fps = frames as f64 / elapsed.as_secs_f64();
+    println!("dmabuf_publish_throughput ({frames} frames)");
+    println!(
+        "  fps={fps:.1}  total_ms={:.0}",
+        elapsed.as_secs_f64() * 1000.0
+    );
+    Ok(())
+}
+
+pub fn run_throughput() {
+    let args: Vec<String> = std::env::args().collect();
+    let frames = match crate::args::parse_flag(&args, "--frames") {
+        Some(v) => v,
+        None => DEFAULT_FRAMES,
+    };
+    if let Err(e) = run_throughput_inner(frames) {
+        eprintln!("throughput bench error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/benchmarks/dmabuf/src/main.rs
+++ b/benchmarks/dmabuf/src/main.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Shared argument parsing utilities for all dmabuf benchmarks.
+#[cfg(target_os = "linux")]
+pub(crate) mod args {
+    /// Parse `--flag VALUE` from `args`, returning `Some(value)` on success.
+    pub(crate) fn parse_flag(args: &[String], flag: &str) -> Option<usize> {
+        args.windows(2)
+            .find(|w| w[0] == flag)
+            .and_then(|w| w[1].parse().ok())
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod bench_fanout;
+#[cfg(target_os = "linux")]
+mod bench_latency;
+#[cfg(target_os = "linux")]
+mod bench_throughput;
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    match std::env::args().nth(1).as_deref() {
+        Some("latency") => bench_latency::run_latency(),
+        Some("throughput") => bench_throughput::run_throughput(),
+        Some("fanout") => bench_fanout::run_fanout(),
+        _ => eprintln!("Usage: dmabuf-bench <latency|throughput|fanout>"),
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    eprintln!(
+        "dmabuf-bench: DMA-BUF benchmarks are Linux-only (requires memfd_create + SCM_RIGHTS)"
+    );
+}

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -41,6 +41,16 @@
   [#1496](https://github.com/eclipse-iceoryx/iceoryx2/issues/1496)
 * Enable override of preallocated data chunks for sender ports
   [#1551](https://github.com/eclipse-iceoryx/iceoryx2/issues/1551)
+* Introduce `iceoryx2-dmabuf` crate providing an `SCM_RIGHTS` fd sidecar
+  (`FdSidecarPublisher`/`FdSidecarSubscriber`) and a typed DMA-BUF wrapper
+  (`DmaBufPublisher`/`DmaBufSubscriber`, behind the `dma-buf` feature)
+  layered on iceoryx2 pub/sub for zero-copy frame delivery of kernel-owned
+  file descriptors (V4L2 ISP, DRM scanout, Vulkan external memory)
+  [#1570](https://github.com/eclipse-iceoryx/iceoryx2/issues/1570)
+* Introduce `SideChannel` trait in `iceoryx2::port::side_channel` as an
+  extension point for out-of-band transports alongside pub/sub (companion
+  to `iceoryx2-dmabuf`)
+  [#1570](https://github.com/eclipse-iceoryx/iceoryx2/issues/1570)
 
 ### Bugfixes
 

--- a/iceoryx2-dmabuf/Cargo.toml
+++ b/iceoryx2-dmabuf/Cargo.toml
@@ -1,0 +1,153 @@
+[package]
+name = "iceoryx2-dmabuf"
+description = "iceoryx2: SCM_RIGHTS fd sidecar + typed DMA-BUF wrapper for zero-copy frame delivery"
+categories = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+
+[features]
+default = ["std"]
+std = ["iceoryx2/std"]
+memfd = []
+peercred = []
+## Exposes test-only injection APIs for integration tests (error_paths).
+test-utils = []
+## Enables the typed DMA-BUF transport layer (DmaBufPublisher / DmaBufSubscriber).
+## Linux only — pulls `dma-buf` 0.5 via the cfg-gated dependency below.
+dma-buf = ["dep:dma-buf"]
+
+[dependencies]
+iceoryx2 = { workspace = true }
+iceoryx2-pal-concurrency-sync = { workspace = true }
+sha1_smol = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+rustix = { version = "1", features = ["fs", "net", "mm"] }
+libc = { workspace = true }
+tracing = { workspace = true }
+dma-buf = { version = "0.5", optional = true }
+
+[dev-dependencies]
+memmap2 = "0.9"
+libc = { workspace = true }
+proptest = "1"
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+dma-heap = "0.3"
+
+[[example]]
+name = "dmabuf-publisher"
+path = "examples/publish_subscribe_with_fd/publisher.rs"
+required-features = ["memfd"]
+
+[[example]]
+name = "dmabuf-subscriber"
+path = "examples/publish_subscribe_with_fd/subscriber.rs"
+required-features = ["memfd"]
+
+[[example]]
+name = "dmabuf-typed-publisher"
+path = "examples/publish_subscribe_dmabuf/publisher.rs"
+required-features = ["dma-buf"]
+
+[[example]]
+name = "dmabuf-typed-subscriber"
+path = "examples/publish_subscribe_dmabuf/subscriber.rs"
+required-features = ["dma-buf"]
+
+[[test]]
+name = "unit_token"
+path = "tests/unit_token.rs"
+
+[[test]]
+name = "unit_path"
+path = "tests/unit_path.rs"
+
+[[test]]
+name = "unit_scm"
+path = "tests/unit_scm.rs"
+required-features = ["peercred"]
+
+[[test]]
+name = "peercred_mismatch"
+path = "tests/peercred_mismatch.rs"
+required-features = ["peercred"]
+
+[[test]]
+name = "dmabuf_roundtrip"
+path = "tests/dmabuf_roundtrip.rs"
+required-features = ["memfd"]
+
+[[test]]
+name = "it_fd_identity"
+path = "tests/it_fd_identity.rs"
+required-features = ["memfd"]
+
+[[bin]]
+name = "fd_sidecar_fd_identity"
+path = "src/bin/fd_sidecar_fd_identity.rs"
+required-features = ["memfd"]
+
+[[test]]
+name = "it_fanout"
+path = "tests/it_fanout.rs"
+required-features = ["memfd"]
+
+[[test]]
+name = "refcount_survival"
+path = "tests/refcount_survival.rs"
+required-features = ["memfd"]
+
+[[test]]
+name = "it_crash_midsend"
+path = "tests/it_crash_midsend.rs"
+required-features = ["memfd"]
+
+[[bin]]
+name = "fd_sidecar_crash_pub"
+path = "src/bin/fd_sidecar_crash_pub.rs"
+required-features = ["memfd"]
+
+[[test]]
+name = "it_service_gone"
+path = "tests/it_service_gone.rs"
+
+[[test]]
+name = "it_socket_gone"
+path = "tests/it_socket_gone.rs"
+required-features = ["memfd"]
+
+[[test]]
+name = "prop_roundtrip"
+path = "tests/prop_roundtrip.rs"
+required-features = ["memfd"]
+
+[[test]]
+name = "unit_generic_service"
+path = "tests/unit_generic_service.rs"
+required-features = ["memfd"]
+
+[[test]]
+name = "error_paths"
+path = "tests/error_paths.rs"
+required-features = ["memfd", "test-utils"]
+
+[[test]]
+name = "unit_dmabuf_publisher"
+path = "tests/unit_dmabuf_publisher.rs"
+required-features = ["dma-buf", "memfd"]
+
+[[test]]
+name = "it_dmabuf_fd_identity"
+path = "tests/it_dmabuf_fd_identity.rs"
+required-features = ["dma-buf", "memfd"]
+
+[[test]]
+name = "it_dmabuf_heap_roundtrip"
+path = "tests/it_dmabuf_heap_roundtrip.rs"
+required-features = ["dma-buf"]

--- a/iceoryx2-dmabuf/LICENSE-APACHE
+++ b/iceoryx2-dmabuf/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/iceoryx2-dmabuf/LICENSE-MIT
+++ b/iceoryx2-dmabuf/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/iceoryx2-dmabuf/README.md
+++ b/iceoryx2-dmabuf/README.md
@@ -1,0 +1,89 @@
+# iceoryx2-dmabuf
+
+SCM_RIGHTS fd sidecar + typed DMA-BUF wrapper for iceoryx2 pub/sub.
+
+## Overview
+
+`iceoryx2-dmabuf` extends iceoryx2 with two clearly scoped APIs:
+
+* **Transport** — `FdSidecarPublisher` / `FdSidecarSubscriber`: pass any `OwnedFd`
+  (memfd, eventfd, pipe end, DMA-BUF fd) out-of-band via `SCM_RIGHTS` over a Unix
+  domain socket, synchronised to the iceoryx2 metadata sequence number.
+* **Payload** — `DmaBufPublisher` / `DmaBufSubscriber` (feature `dma-buf`): typed
+  wrappers that accept / yield `dma_buf::DmaBuf`, giving subscribers safe CPU access
+  via `MappedDmaBuf::read/write/readwrite` (which wrap `DMA_BUF_IOCTL_SYNC`).
+
+## Decision matrix
+
+| You have… | Use |
+|-----------|-----|
+| Arbitrary `OwnedFd` (memfd, eventfd, pipe end) with no CPU-sync concern | `FdSidecarPublisher` / `FdSidecarSubscriber` |
+| `dma_buf::DmaBuf` (from `dma-heap`, V4L2, GBM, Vulkan) | `DmaBufPublisher` / `DmaBufSubscriber` |
+| No DmaBuf yet — want allocation | `dma_heap::Heap::allocate` → `DmaBuf::from(fd)` → `DmaBufPublisher` |
+
+## Platform
+
+- **Linux**: full implementation. `DmaBuf*` types require the `dma-buf` feature.
+- **macOS / other**: stubs return `FdSidecarError::UnsupportedPlatform` at runtime;
+  crate compiles cleanly on all targets with `--no-default-features`.
+
+## Transport layer
+
+```toml
+[dependencies]
+iceoryx2-dmabuf = { version = "0.9", features = ["memfd"] }
+```
+
+```rust
+use iceoryx2::service::ipc;
+use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+
+let mut pub_ = FdSidecarPublisher::<ipc::Service, u64>::create("my-service")?;
+let mut sub_ = FdSidecarSubscriber::<ipc::Service, u64>::create("my-service")?;
+// pub_.send(meta, owned_fd)?;
+// let (meta, owned_fd) = sub_.recv()?.unwrap();
+```
+
+## Payload layer (DMA-BUF)
+
+```toml
+[dependencies]
+iceoryx2-dmabuf = { version = "0.9", features = ["dma-buf"] }
+dma-heap = "0.3"   # only needed for allocation
+```
+
+```rust
+use iceoryx2::service::ipc;
+use iceoryx2_dmabuf::{DmaBuf, DmaBufPublisher, DmaBufSubscriber};
+use std::os::fd::AsFd as _;
+
+// Allocate a DMA-BUF buffer (heap.allocate returns OwnedFd)
+let heap = dma_heap::Heap::new(dma_heap::HeapKind::System)?;
+let owned_fd = heap.allocate(4096)?;
+let send_buf = DmaBuf::from(owned_fd);
+
+let mut pub_ = DmaBufPublisher::<ipc::Service, u64>::create("my-service")?;
+pub_.send(42u64, &send_buf)?;
+
+let mut sub_ = DmaBufSubscriber::<ipc::Service, u64>::create("my-service")?;
+let (meta, buf) = sub_.recv()?.unwrap();
+let mapped = buf.memory_map()?;
+mapped.read(|data, _: Option<()>| {
+    println!("first byte: 0x{:02X}", data[0]);
+    Ok(())
+}, None)?;
+```
+
+## Features
+
+| Feature | Description | Platform |
+|---------|-------------|----------|
+| `memfd` | `memfd_create`-based helpers for tests and examples | Linux only |
+| `peercred` | `SO_PEERCRED` UID verification before fd delivery | Linux only |
+| `dma-buf` | `DmaBufPublisher` / `DmaBufSubscriber` typed wrapper | Linux only |
+| `test-utils` | Injection APIs for error-path integration tests | Linux only |
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](../LICENSE-APACHE) or
+[MIT license](../LICENSE-MIT) at your option (same as iceoryx2).

--- a/iceoryx2-dmabuf/examples/publish_subscribe_dmabuf/publisher.rs
+++ b/iceoryx2-dmabuf/examples/publish_subscribe_dmabuf/publisher.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Example: allocate a DMA-BUF with dma-heap and publish it via
+//! DmaBufPublisher.
+//!
+//! Run: cargo run --example dmabuf-publisher --features "dma-buf"
+
+#[cfg(not(all(target_os = "linux", feature = "dma-buf")))]
+fn main() {
+    eprintln!("This example requires Linux and the dma-buf feature.");
+    eprintln!("Run with: cargo run --example dmabuf-publisher --features dma-buf");
+}
+
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+fn main() -> Result<(), Box<dyn core::error::Error>> {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{DmaBuf, DmaBufPublisher};
+    use std::os::fd::AsFd as _;
+
+    const SERVICE: &str = "mos4/dmabuf-example";
+    const BUF_SIZE: usize = 4096;
+    const MAGIC: u8 = 0xAB;
+    const SETTLE_MS: u64 = 100;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct FrameMeta {
+        width: u32,
+        height: u32,
+    }
+
+    // Allocate a DMA-BUF from the system heap.
+    // dma_heap::Heap::allocate returns OwnedFd; dup so we keep one for sending.
+    let heap = dma_heap::Heap::new(dma_heap::HeapKind::System)?;
+    let owned_fd = heap.allocate(BUF_SIZE)?;
+    let dup_fd = owned_fd.as_fd().try_clone_to_owned()?;
+
+    // Write a known byte pattern via memory_map.
+    let write_buf = DmaBuf::from(owned_fd);
+    let mut mapped = write_buf.memory_map()?;
+    mapped.write(
+        |data, _: Option<()>| {
+            data.iter_mut().for_each(|b| *b = MAGIC);
+            Ok(())
+        },
+        None,
+    )?;
+    drop(mapped);
+
+    // Use the dup'd fd for sending.
+    let send_buf = DmaBuf::from(dup_fd);
+
+    let mut publisher =
+        DmaBufPublisher::<iceoryx2::service::ipc::Service, FrameMeta>::create(SERVICE)?;
+
+    // Give the subscriber time to connect.
+    std::thread::sleep(std::time::Duration::from_millis(SETTLE_MS));
+
+    publisher.send(
+        FrameMeta {
+            width: 64,
+            height: 64,
+        },
+        &send_buf,
+    )?;
+    println!("Published DMA-BUF frame (service={SERVICE})");
+
+    // Keep alive for the subscriber to receive.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    Ok(())
+}

--- a/iceoryx2-dmabuf/examples/publish_subscribe_dmabuf/subscriber.rs
+++ b/iceoryx2-dmabuf/examples/publish_subscribe_dmabuf/subscriber.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Example: receive a DMA-BUF via DmaBufSubscriber and map it with
+//! MappedDmaBuf::read.
+//!
+//! Run: cargo run --example dmabuf-subscriber --features "dma-buf"
+
+#[cfg(not(all(target_os = "linux", feature = "dma-buf")))]
+fn main() {
+    eprintln!("This example requires Linux and the dma-buf feature.");
+}
+
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+fn main() -> Result<(), Box<dyn core::error::Error>> {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::DmaBufSubscriber;
+
+    const SERVICE: &str = "mos4/dmabuf-example";
+    const POLL_INTERVAL_MS: u64 = 10;
+    const TIMEOUT_SECS: u64 = 5;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct FrameMeta {
+        width: u32,
+        height: u32,
+    }
+
+    let mut subscriber =
+        DmaBufSubscriber::<iceoryx2::service::ipc::Service, FrameMeta>::create(SERVICE)?;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(TIMEOUT_SECS);
+
+    loop {
+        if std::time::Instant::now() > deadline {
+            return Err("timeout: no frame received".into());
+        }
+        match subscriber.recv()? {
+            Some((meta, buf)) => {
+                println!("Received frame: {meta:?}");
+                let mapped = buf.memory_map()?;
+                mapped.read(
+                    |data, _: Option<()>| {
+                        println!(
+                            "  first byte = 0x{:02X}, total bytes = {}",
+                            data[0],
+                            data.len()
+                        );
+                        Ok(())
+                    },
+                    None,
+                )?;
+                break;
+            }
+            None => {
+                std::thread::sleep(std::time::Duration::from_millis(POLL_INTERVAL_MS));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/iceoryx2-dmabuf/examples/publish_subscribe_with_fd/publisher.rs
+++ b/iceoryx2-dmabuf/examples/publish_subscribe_with_fd/publisher.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//
+//! Example: DMA-BUF publisher — creates a memfd for each frame and sends it
+//! alongside metadata via `FdSidecarPublisher`.
+//!
+//! # Run (Linux only — requires `memfd_create`)
+//!
+//! ```text
+//! cargo run --example dmabuf-publisher --features memfd
+//! ```
+//!
+//! Start the subscriber first, then the publisher, or run them concurrently
+//! in two terminals.
+
+use iceoryx2::service::ipc;
+use iceoryx2_dmabuf::FdSidecarPublisher;
+
+/// Shared frame metadata (must match `subscriber.rs`).
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct FrameMeta {
+    width: u32,
+    height: u32,
+    /// FourCC code: `0x3231_5659` = `YV12`, `0x3231_5242` = `RG24`, etc.
+    fourcc: u32,
+    /// Monotonically increasing frame sequence number.
+    seq: u64,
+}
+// Safety: FrameMeta is `repr(C)`, `Copy`, and contains no padding bytes of
+// undefined value.
+unsafe impl iceoryx2::prelude::ZeroCopySend for FrameMeta {}
+
+const SVC: &str = "mos4/frame-plane/example/0";
+const FRAMES: u64 = 100;
+
+fn run() -> Result<(), Box<dyn core::error::Error>> {
+    let mut publisher = FdSidecarPublisher::<ipc::Service, FrameMeta>::create(SVC)?;
+
+    for seq in 0..FRAMES {
+        let fd = open_frame_fd()?;
+        let meta = FrameMeta {
+            width: 1920,
+            height: 1080,
+            fourcc: 0x3231_5659, // YV12
+            seq,
+        };
+        publisher.send(meta, fd)?;
+        println!("published frame seq={seq}");
+        std::thread::sleep(std::time::Duration::from_millis(33)); // ~30 fps
+    }
+    println!("publisher done ({FRAMES} frames)");
+    Ok(())
+}
+
+/// Allocate a frame fd: `memfd_create` on Linux, `/dev/null` on other platforms.
+#[cfg(target_os = "linux")]
+fn open_frame_fd() -> Result<std::os::fd::OwnedFd, Box<dyn core::error::Error>> {
+    use iceoryx2_dmabuf::FdSidecarError;
+    use rustix::fs::{MemfdFlags, memfd_create};
+    let fd = memfd_create("example-frame", MemfdFlags::CLOEXEC)
+        .map_err(|e| FdSidecarError::SideChannelIo(std::io::Error::from(e)))?;
+    Ok(fd)
+}
+
+/// Stub for non-Linux: returns a /dev/null fd so the example compiles everywhere.
+#[cfg(not(target_os = "linux"))]
+fn open_frame_fd() -> Result<std::os::fd::OwnedFd, Box<dyn core::error::Error>> {
+    use std::os::fd::{FromRawFd, IntoRawFd};
+    let f = std::fs::OpenOptions::new().read(true).open("/dev/null")?;
+    let raw = f.into_raw_fd();
+    // Safety: raw is a valid, open file descriptor we just obtained.
+    Ok(unsafe { std::os::fd::OwnedFd::from_raw_fd(raw) })
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("publisher error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/iceoryx2-dmabuf/examples/publish_subscribe_with_fd/shared.rs
+++ b/iceoryx2-dmabuf/examples/publish_subscribe_with_fd/shared.rs
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//
+//! Shared type definitions for the publish_subscribe_with_fd examples.
+//!
+//! Both `publisher.rs` and `subscriber.rs` duplicate this struct locally
+//! because Cargo examples cannot share a common module file without a
+//! workspace-level crate.  This file documents the canonical layout.
+
+/// Frame metadata transmitted alongside each DMA-BUF fd.
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+pub struct FrameMeta {
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// FourCC pixel format code (e.g. `0x3231_5659` = `YV12`).
+    pub fourcc: u32,
+    /// Monotonically increasing frame sequence number.
+    pub seq: u64,
+}
+// Safety: FrameMeta is `repr(C)`, `Copy`, and contains no padding bytes of
+// undefined value.
+unsafe impl iceoryx2::prelude::ZeroCopySend for FrameMeta {}

--- a/iceoryx2-dmabuf/examples/publish_subscribe_with_fd/subscriber.rs
+++ b/iceoryx2-dmabuf/examples/publish_subscribe_with_fd/subscriber.rs
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//
+//! Example: DMA-BUF subscriber — receives frames from a `FdSidecarPublisher` and
+//! prints metadata for each received frame.
+//!
+//! # Run
+//!
+//! ```text
+//! cargo run --example dmabuf-subscriber --features memfd
+//! ```
+//!
+//! Start this subscriber first, then the publisher, or run them concurrently
+//! in two terminals.
+
+use iceoryx2::service::ipc;
+use iceoryx2_dmabuf::FdSidecarSubscriber;
+
+/// Shared frame metadata (must match `publisher.rs`).
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct FrameMeta {
+    width: u32,
+    height: u32,
+    /// FourCC code.
+    fourcc: u32,
+    /// Monotonically increasing frame sequence number.
+    seq: u64,
+}
+// Safety: FrameMeta is `repr(C)`, `Copy`, and contains no padding bytes of
+// undefined value.
+unsafe impl iceoryx2::prelude::ZeroCopySend for FrameMeta {}
+
+const SVC: &str = "mos4/frame-plane/example/0";
+const EXPECTED_FRAMES: u64 = 100;
+
+fn run() -> Result<(), Box<dyn core::error::Error>> {
+    let mut subscriber = FdSidecarSubscriber::<ipc::Service, FrameMeta>::create(SVC)?;
+
+    let mut received = 0u64;
+    while received < EXPECTED_FRAMES {
+        match subscriber.recv()? {
+            Some((meta, _fd)) => {
+                println!(
+                    "received seq={} {}x{} fourcc={:#010x}",
+                    meta.seq, meta.width, meta.height, meta.fourcc
+                );
+                received += 1;
+            }
+            None => {
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+        }
+    }
+    println!("subscriber done ({received} frames)");
+    Ok(())
+}
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("subscriber error: {e}");
+        std::process::exit(1);
+    }
+}

--- a/iceoryx2-dmabuf/src/bin/fd_sidecar_crash_pub.rs
+++ b/iceoryx2-dmabuf/src/bin/fd_sidecar_crash_pub.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Helper binary for the `it_crash_midsend` integration test.
+//!
+//! Publishes a single frame.  When `DMABUF_CRASH_PHASE=mid-iceoryx2` is set,
+//! the publisher calls `raise(SIGSTOP)` between the sidecar send and the
+//! iceoryx2 publish, simulating a producer crash mid-send.
+//!
+//! Linux-only binary.
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("fd_sidecar_crash_pub: Linux only");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {e}");
+        std::process::exit(5);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run() -> Result<(), Box<dyn core::error::Error>> {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::FdSidecarPublisher;
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::io::Write as _;
+
+    const PAYLOAD_LEN: usize = 64;
+    const PAYLOAD_BYTE: u8 = 0xAB;
+    const CONNECT_SETTLE_MS: u64 = 100;
+    const KEEP_ALIVE_MS: u64 = 500;
+
+    let service =
+        std::env::var("DMABUF_SERVICE").unwrap_or_else(|_| "crash-midsend-test".to_owned());
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        size: u64,
+    }
+
+    let fd = memfd_create("crash-pub-frame", MemfdFlags::CLOEXEC)?;
+    {
+        use std::os::fd::{AsFd as _, AsRawFd as _, FromRawFd as _};
+        let raw = fd.as_fd().as_raw_fd();
+        // SAFETY: fd is valid and owned; ManuallyDrop prevents double-close.
+        let mut file = std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(raw) });
+        let payload = vec![PAYLOAD_BYTE; PAYLOAD_LEN];
+        file.write_all(&payload)?;
+    }
+
+    let mut pub_ = FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(&service)?;
+
+    // Give subscriber(s) time to connect.
+    std::thread::sleep(std::time::Duration::from_millis(CONNECT_SETTLE_MS));
+
+    // send() calls pause_hook_if_requested() between sidecar and iceoryx2.
+    pub_.send(
+        Meta {
+            size: PAYLOAD_LEN as u64,
+        },
+        fd,
+    )?;
+
+    // Keep alive for the test to observe state.
+    std::thread::sleep(std::time::Duration::from_millis(KEEP_ALIVE_MS));
+
+    Ok(())
+}

--- a/iceoryx2-dmabuf/src/bin/fd_sidecar_fd_identity.rs
+++ b/iceoryx2-dmabuf/src/bin/fd_sidecar_fd_identity.rs
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Helper binary for the `it_fd_identity` integration test.
+//!
+//! Run with env var `DMABUF_ROLE=pub` to act as publisher, or
+//! `DMABUF_ROLE=sub` to act as subscriber.
+//!
+//! This binary is Linux-only; it exits with code 1 on other platforms.
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("fd_sidecar_fd_identity: Linux only");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
+fn main() {
+    const DEFAULT_SERVICE: &str = "fd-identity-test";
+
+    let role = std::env::var("DMABUF_ROLE").ok().unwrap_or_default();
+    let service = std::env::var("DMABUF_SERVICE")
+        .ok()
+        .unwrap_or_else(|| DEFAULT_SERVICE.to_owned());
+
+    let result = match role.as_str() {
+        "pub" => run_publisher(&service),
+        "sub" => run_subscriber(&service),
+        other => {
+            eprintln!("unknown DMABUF_ROLE={other:?}; expected 'pub' or 'sub'");
+            std::process::exit(2);
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("error: {e}");
+        std::process::exit(5);
+    }
+}
+
+#[cfg(target_os = "linux")]
+use iceoryx2::prelude::ZeroCopySend;
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, ZeroCopySend)]
+#[repr(C)]
+struct Meta {
+    size: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn run_publisher(service: &str) -> Result<(), Box<dyn core::error::Error>> {
+    use iceoryx2_dmabuf::FdSidecarPublisher;
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::io::Write as _;
+
+    const PAYLOAD_BYTE: u8 = 0xAB;
+    const PAYLOAD_LEN: usize = 64;
+    const CONNECT_SETTLE_MS: u64 = 100;
+    const RECV_WINDOW_MS: u64 = 300;
+
+    let fd = memfd_create("fd-identity-pub", MemfdFlags::CLOEXEC)?;
+
+    // Write magic bytes via a borrowed File view.
+    {
+        use std::os::fd::{AsFd as _, AsRawFd as _, FromRawFd as _};
+        let raw = fd.as_fd().as_raw_fd();
+        // SAFETY: fd is valid and owned; ManuallyDrop prevents double-close.
+        let mut file = std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(raw) });
+        let payload = vec![PAYLOAD_BYTE; PAYLOAD_LEN];
+        file.write_all(&payload)?;
+    }
+
+    // Obtain (st_dev, st_ino) before publishing.
+    let stat = rustix::fs::fstat(&fd)?;
+    let st_dev = stat.st_dev;
+    let st_ino = stat.st_ino;
+
+    // Print to stdout so the parent test can parse it.
+    println!("PUB_STAT:{st_dev}:{st_ino}");
+    std::io::stdout().flush()?;
+
+    let mut pub_ = FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(service)?;
+
+    // Give subscriber time to connect.
+    std::thread::sleep(std::time::Duration::from_millis(CONNECT_SETTLE_MS));
+
+    pub_.send(
+        Meta {
+            size: PAYLOAD_LEN as u64,
+        },
+        fd,
+    )?;
+
+    // Keep publisher alive long enough for subscriber to recv.
+    std::thread::sleep(std::time::Duration::from_millis(RECV_WINDOW_MS));
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_subscriber(service: &str) -> Result<(), Box<dyn core::error::Error>> {
+    use iceoryx2_dmabuf::FdSidecarSubscriber;
+    use std::io::Write as _;
+
+    const POLL_INTERVAL_MS: u64 = 10;
+    const TIMEOUT_SECS: u64 = 5;
+
+    let mut sub_ = FdSidecarSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(service)?;
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(TIMEOUT_SECS);
+    let mut received = false;
+
+    while std::time::Instant::now() < deadline {
+        match sub_.recv()? {
+            Some((_meta, fd)) => {
+                let stat = rustix::fs::fstat(&fd)?;
+                println!("SUB_STAT:{}:{}", stat.st_dev, stat.st_ino);
+                std::io::stdout().flush()?;
+                received = true;
+                break;
+            }
+            None => {
+                std::thread::sleep(std::time::Duration::from_millis(POLL_INTERVAL_MS));
+            }
+        }
+    }
+
+    if !received {
+        return Err("subscriber: timeout waiting for frame".into());
+    }
+    Ok(())
+}

--- a/iceoryx2-dmabuf/src/dmabuf_publisher.rs
+++ b/iceoryx2-dmabuf/src/dmabuf_publisher.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! [`DmaBufPublisher`] — typed wrapper over [`FdSidecarPublisher`] for
+//! publishing `dma_buf::DmaBuf` values.
+//!
+//! Gated on `cfg(all(target_os = "linux", feature = "dma-buf"))`.
+
+#![cfg(all(target_os = "linux", feature = "dma-buf"))]
+
+use core::fmt::Debug;
+use iceoryx2::prelude::ZeroCopySend;
+use iceoryx2::service::Service;
+use std::os::fd::AsFd as _;
+
+use crate::error::{FdSidecarError, Result};
+use crate::publisher::FdSidecarPublisher;
+
+// `DmaBufPublisher` in module `dmabuf_publisher` would trigger
+// clippy::module_name_repetitions.  The module name carries the necessary
+// disambiguation; renaming it adds churn without correctness benefit.
+#[allow(clippy::module_name_repetitions)]
+/// Typed DMA-BUF publisher.
+///
+/// A newtype over [`FdSidecarPublisher`] that accepts `dma_buf::DmaBuf`
+/// values instead of raw `OwnedFd`. On each [`send`](DmaBufPublisher::send)
+/// call, the fd is borrowed and duplicated via `fcntl(F_DUPFD_CLOEXEC)` —
+/// one syscall per frame — so that the upstream `DmaBuf` value remains
+/// valid in the caller's scope after `send` returns.
+///
+/// # Platform
+///
+/// Only available on Linux with the `dma-buf` Cargo feature enabled.
+pub struct DmaBufPublisher<S: Service, Meta: ZeroCopySend + Debug + 'static> {
+    inner: FdSidecarPublisher<S, Meta>,
+}
+
+impl<S: Service, Meta: ZeroCopySend + Debug + Copy + 'static> DmaBufPublisher<S, Meta> {
+    /// Create a new `DmaBufPublisher` for `service_name`.
+    ///
+    /// Delegates to [`FdSidecarPublisher::create`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the same error set as [`FdSidecarPublisher::create`].
+    pub fn create(service_name: &str) -> Result<Self> {
+        Ok(Self {
+            inner: FdSidecarPublisher::create(service_name)?,
+        })
+    }
+
+    /// Publish `meta` alongside a reference to `buf`.
+    ///
+    /// The `buf` fd is duplicated via `fcntl(F_DUPFD_CLOEXEC)` (one syscall
+    /// per frame) so that `buf` remains valid in the caller after this
+    /// function returns. The duplicated fd is delivered to all connected
+    /// subscribers via SCM_RIGHTS.
+    ///
+    /// # Errors
+    ///
+    /// - [`FdSidecarError::SideChannelIo`] — if `fcntl` or socket I/O fails.
+    /// - All errors from [`FdSidecarPublisher::send`].
+    pub fn send(&mut self, meta: Meta, buf: &dma_buf::DmaBuf) -> Result<()> {
+        let fd = buf
+            .as_fd()
+            .try_clone_to_owned()
+            .map_err(FdSidecarError::SideChannelIo)?;
+        self.inner.send(meta, fd)
+    }
+
+    /// Forward `inject_raw_for_test` from the inner publisher.
+    ///
+    /// Enabled by the `test-utils` Cargo feature — not part of the stable
+    /// public interface.
+    #[cfg(feature = "test-utils")]
+    pub fn inject_raw_for_test(&self, token: u64, fd: std::os::fd::BorrowedFd<'_>) -> Result<()> {
+        self.inner.inject_raw_for_test(token, fd)
+    }
+
+    /// Forward `send_metadata_only_for_test` from the inner publisher.
+    ///
+    /// Enabled by the `test-utils` Cargo feature — not part of the stable
+    /// public interface.
+    #[cfg(feature = "test-utils")]
+    pub fn send_metadata_only_for_test(&mut self, meta: Meta) -> Result<()> {
+        self.inner.send_metadata_only_for_test(meta)
+    }
+}

--- a/iceoryx2-dmabuf/src/dmabuf_subscriber.rs
+++ b/iceoryx2-dmabuf/src/dmabuf_subscriber.rs
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! [`DmaBufSubscriber`] — typed wrapper over [`FdSidecarSubscriber`] for
+//! receiving `dma_buf::DmaBuf` values.
+//!
+//! Gated on `cfg(all(target_os = "linux", feature = "dma-buf"))`.
+
+#![cfg(all(target_os = "linux", feature = "dma-buf"))]
+
+use core::fmt::Debug;
+use iceoryx2::prelude::ZeroCopySend;
+use iceoryx2::service::Service;
+
+use crate::error::Result;
+use crate::subscriber::FdSidecarSubscriber;
+
+#[allow(clippy::module_name_repetitions)]
+/// Typed DMA-BUF subscriber.
+///
+/// A newtype over [`FdSidecarSubscriber`] that yields `dma_buf::DmaBuf`
+/// values instead of raw `OwnedFd`. The conversion `DmaBuf::from(OwnedFd)`
+/// is zero-syscall.
+///
+/// Subscribers obtain CPU access via `dma_buf::MappedDmaBuf::read`,
+/// `write`, or `readwrite`, which wrap `DMA_BUF_IOCTL_SYNC` start/end
+/// pairing on cache-incoherent SoCs.
+///
+/// # Platform
+///
+/// Only available on Linux with the `dma-buf` Cargo feature enabled.
+pub struct DmaBufSubscriber<S: Service, Meta: ZeroCopySend + Debug + 'static> {
+    inner: FdSidecarSubscriber<S, Meta>,
+}
+
+impl<S: Service, Meta: ZeroCopySend + Debug + Copy + 'static> DmaBufSubscriber<S, Meta> {
+    /// Create a new `DmaBufSubscriber` for `service_name`.
+    ///
+    /// Delegates to [`FdSidecarSubscriber::create`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the same error set as [`FdSidecarSubscriber::create`].
+    pub fn create(service_name: &str) -> Result<Self> {
+        Ok(Self {
+            inner: FdSidecarSubscriber::create(service_name)?,
+        })
+    }
+
+    /// Non-blocking receive.
+    ///
+    /// Returns `None` if no sample is ready. On success, the received
+    /// `OwnedFd` is converted to `dma_buf::DmaBuf` via `DmaBuf::from(fd)`
+    /// (zero syscall).
+    ///
+    /// # Errors
+    ///
+    /// All errors from [`FdSidecarSubscriber::recv`].
+    pub fn recv(&mut self) -> Result<Option<(Meta, dma_buf::DmaBuf)>> {
+        let Some((meta, fd)) = self.inner.recv()? else {
+            return Ok(None);
+        };
+        Ok(Some((meta, dma_buf::DmaBuf::from(fd))))
+    }
+
+    /// Reconnect the side-channel.
+    ///
+    /// Forwards to [`FdSidecarSubscriber::reconnect`]. The DmaBuf layer
+    /// adds no additional reconnect semantics.
+    ///
+    /// # Errors
+    ///
+    /// All errors from [`FdSidecarSubscriber::reconnect`].
+    pub fn reconnect(&mut self) -> Result<()> {
+        self.inner.reconnect()
+    }
+}

--- a/iceoryx2-dmabuf/src/error.rs
+++ b/iceoryx2-dmabuf/src/error.rs
@@ -1,0 +1,111 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2::port::{LoanError, ReceiveError, SendError};
+
+/// Discriminant for [`FdSidecarError::Iceoryx`] indicating which iceoryx2
+/// operation failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IceoryxErrorKind {
+    /// Node creation via `NodeBuilder::create` failed.
+    NodeCreate,
+    /// Service open/create (`open_or_create`) failed.
+    Service,
+    /// Port builder (`publisher_builder` / `subscriber_builder`) failed.
+    PortBuilder,
+}
+
+/// All errors that can be returned by the iceoryx2-dmabuf side-channel.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FdSidecarError {
+    /// A Unix-domain socket or ancillary-data operation failed.
+    SideChannelIo(std::io::Error),
+    /// The connecting peer's effective UID does not match the publisher's UID.
+    PeerUidMismatch {
+        /// UID reported by `SO_PEERCRED` on the accepted socket.
+        peer_uid: u32,
+        /// UID of the publisher process.
+        expected_uid: u32,
+    },
+    /// The `recvmsg` call returned no file descriptor in the ancillary data.
+    NoFdInMessage,
+    /// The token in the iceoryx2 sample's user-header does not match the token
+    /// received over the side-channel.
+    TokenMismatch {
+        /// Token extracted from the iceoryx2 sample user-header.
+        expected: u64,
+        /// Token delivered over the Unix-domain socket.
+        got: u64,
+    },
+    /// The 64-bit sequence counter wrapped to zero — the service must be
+    /// restarted to reset the counter.
+    TokenExhausted,
+    /// This build target does not support `SCM_RIGHTS` fd passing (non-Linux).
+    UnsupportedPlatform,
+    /// An iceoryx2 loan (slot allocation) operation failed.
+    IceoryxLoan(LoanError),
+    /// An iceoryx2 publish operation failed.
+    IceoryxPublish(SendError),
+    /// An iceoryx2 receive operation failed.
+    IceoryxReceive(ReceiveError),
+    /// Iceoryx2 node/service/port error encountered during `create()`.
+    Iceoryx {
+        /// Which iceoryx2 operation failed.
+        kind: IceoryxErrorKind,
+        /// Error message from the iceoryx2 error type.
+        msg: String,
+    },
+    /// A DMA-BUF CPU-access ioctl failed.
+    ///
+    /// This variant is reserved for future helpers that invoke
+    /// `MappedDmaBuf::read/write`; today the user calls those directly
+    /// and receives `dma_buf::BufferError` from the upstream crate.
+    #[cfg(all(target_os = "linux", feature = "dma-buf"))]
+    DmaBuf(dma_buf::BufferError),
+}
+
+impl core::fmt::Display for FdSidecarError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::SideChannelIo(e) => write!(f, "side-channel I/O error: {e}"),
+            Self::PeerUidMismatch {
+                peer_uid,
+                expected_uid,
+            } => write!(
+                f,
+                "peer UID mismatch: got {peer_uid}, expected {expected_uid}"
+            ),
+            Self::NoFdInMessage => write!(f, "no file descriptor carried with message"),
+            Self::TokenMismatch { expected, got } => {
+                write!(f, "token mismatch: expected {expected}, got {got}")
+            }
+            Self::TokenExhausted => {
+                write!(f, "64-bit token counter exhausted; restart the service")
+            }
+            Self::UnsupportedPlatform => {
+                write!(f, "SCM_RIGHTS fd passing is not supported on this platform")
+            }
+            Self::IceoryxLoan(e) => write!(f, "iceoryx2 loan error: {e}"),
+            Self::IceoryxPublish(e) => write!(f, "iceoryx2 publish error: {e}"),
+            Self::IceoryxReceive(e) => write!(f, "iceoryx2 receive error: {e}"),
+            Self::Iceoryx { kind, msg } => write!(f, "iceoryx2 {kind:?} error: {msg}"),
+            #[cfg(all(target_os = "linux", feature = "dma-buf"))]
+            Self::DmaBuf(e) => write!(f, "DMA-BUF ioctl error: {e}"),
+        }
+    }
+}
+
+impl core::error::Error for FdSidecarError {}
+
+/// Convenience alias for `Result<T, FdSidecarError>`.
+pub type Result<T> = core::result::Result<T, FdSidecarError>;

--- a/iceoryx2-dmabuf/src/lib.rs
+++ b/iceoryx2-dmabuf/src/lib.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! # iceoryx2-dmabuf
+//!
+//! Zero-copy DMA-BUF file-descriptor transport layered on top of iceoryx2.
+//!
+//! ## Motivation
+//!
+//! iceoryx2's typed SHM pool model is excellent for value-type payloads but
+//! cannot represent kernel-owned DMA-BUF allocations produced by V4L2 ISP,
+//! DRM scanout, or Vulkan external-memory exports.  Those frames are identified
+//! by a file descriptor whose numeric value is meaningless outside the
+//! producing process; cross-process transfer requires `SCM_RIGHTS` over a
+//! Unix domain socket.
+//!
+//! ## Two-channel architecture
+//!
+//! Every [`FdSidecarPublisher::send`] call performs two coordinated actions:
+//!
+//! 1. **iceoryx2 metadata channel** — carries the `Meta` payload plus a
+//!    [`FdSidecarToken`] user-header that uniquely identifies the frame.
+//! 2. **SCM_RIGHTS sidecar** — a Unix domain socket delivers the raw fd
+//!    alongside the same token for correlation.
+//!
+//! [`FdSidecarSubscriber::recv`] dequeues one iceoryx2 sample, extracts its
+//! token, and drains the sidecar until a matching fd arrives (50 ms timeout).
+//!
+//! ## Quick start
+//!
+//! ```rust,no_run
+//! use iceoryx2::service::ipc;
+//! use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+//!
+//! #[derive(Debug, Clone, Copy)]
+//! #[repr(C)]
+//! struct FrameMeta { width: u32, height: u32 }
+//! # // Safety: FrameMeta is repr(C) with no padding of undefined value.
+//! unsafe impl iceoryx2::prelude::ZeroCopySend for FrameMeta {}
+//!
+//! fn example() -> iceoryx2_dmabuf::Result<()> {
+//!     let svc = "mos4/frame-plane/video/0";
+//!     let mut publisher = FdSidecarPublisher::<ipc::Service, FrameMeta>::create(svc)?;
+//!     let mut subscriber = FdSidecarSubscriber::<ipc::Service, FrameMeta>::create(svc)?;
+//!     // publisher.send(meta, fd.into())?;
+//!     // let (meta, fd) = subscriber.recv()?.unwrap();
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Platform support
+//!
+//! | Platform | Status |
+//! |---|---|
+//! | x86_64-unknown-linux-gnu | Full support |
+//! | aarch64-unknown-linux-gnu | Full support |
+//! | aarch64-apple-darwin | Compiles; `UnsupportedPlatform` at runtime |
+
+// Unsafe is forbidden at the crate level.  The only exceptions are the
+// Linux-specific syscall wrappers in `scm.rs` (marked `#[allow(unsafe_code)]`
+// at the function level) and test-only `#[allow(unsafe_code)]` blocks.
+#![deny(unsafe_code)]
+#![deny(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+pub mod error;
+pub mod path;
+pub mod publisher;
+pub mod scm;
+pub mod side_channel;
+pub mod subscriber;
+pub mod token;
+
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+pub mod dmabuf_publisher;
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+pub mod dmabuf_subscriber;
+
+pub use error::{FdSidecarError, Result};
+pub use path::uds_path_for_service;
+pub use publisher::FdSidecarPublisher;
+pub use subscriber::FdSidecarSubscriber;
+pub use token::FdSidecarToken;
+
+/// Convenience alias: [`FdSidecarPublisher`] bound to the IPC service type.
+pub type FdSidecarIpcPublisher<Meta> = FdSidecarPublisher<iceoryx2::service::ipc::Service, Meta>;
+
+/// Convenience alias: [`FdSidecarSubscriber`] bound to the IPC service type.
+pub type FdSidecarIpcSubscriber<Meta> = FdSidecarSubscriber<iceoryx2::service::ipc::Service, Meta>;
+
+// ── DMA-BUF typed layer (feature = "dma-buf", Linux only) ───────────────────
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+pub use dmabuf_publisher::DmaBufPublisher;
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+pub use dmabuf_subscriber::DmaBufSubscriber;
+
+/// Re-export of [`dma_buf::DmaBuf`] for callers who don't depend on `dma-buf` directly.
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+pub use dma_buf::{DmaBuf, MappedDmaBuf};
+
+/// Build an iceoryx2 node and publish-subscribe port factory for a given
+/// service name.
+///
+/// # Lifetime contract
+///
+/// The returned `Node<S>` **must** outlive the `PortFactory<S, Meta,
+/// FdSidecarToken>` and any ports derived from it.  Dropping the node before
+/// the port causes a use-after-free in iceoryx2's SHM bookkeeping.  Callers
+/// must store the node as a struct field (e.g. `_node: Node<S>`) alongside
+/// the derived port so that drop order is guaranteed by struct field ordering.
+///
+/// # Errors
+///
+/// Returns [`FdSidecarError::Iceoryx`] if node creation, service name parsing,
+/// or `open_or_create` fails.
+pub(crate) fn build_node_and_service<S, Meta>(
+    service_name: &str,
+) -> crate::Result<(
+    iceoryx2::node::Node<S>,
+    iceoryx2::service::port_factory::publish_subscribe::PortFactory<S, Meta, FdSidecarToken>,
+)>
+where
+    S: iceoryx2::service::Service,
+    Meta: iceoryx2::prelude::ZeroCopySend + core::fmt::Debug,
+{
+    use crate::error::IceoryxErrorKind;
+    use iceoryx2::prelude::NodeBuilder;
+
+    let node = NodeBuilder::new()
+        .create::<S>()
+        .map_err(|e| FdSidecarError::Iceoryx {
+            kind: IceoryxErrorKind::NodeCreate,
+            msg: e.to_string(),
+        })?;
+
+    let svc_name: iceoryx2::service::service_name::ServiceName = service_name.try_into().map_err(
+        |e: iceoryx2::service::service_name::ServiceNameError| FdSidecarError::Iceoryx {
+            kind: IceoryxErrorKind::Service,
+            msg: e.to_string(),
+        },
+    )?;
+
+    let factory = node
+        .service_builder(&svc_name)
+        .publish_subscribe::<Meta>()
+        .user_header::<FdSidecarToken>()
+        .open_or_create()
+        .map_err(|e| FdSidecarError::Iceoryx {
+            kind: IceoryxErrorKind::Service,
+            msg: e.to_string(),
+        })?;
+
+    Ok((node, factory))
+}

--- a/iceoryx2-dmabuf/src/path.rs
+++ b/iceoryx2-dmabuf/src/path.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! UDS socket path derivation for the iceoryx2-dmabuf side-channel.
+//!
+//! Each service maps to a deterministic path under a configurable base
+//! directory.  The filename is a 40-char lower-hex SHA-1 digest of the
+//! service name, suffixed with `.sock` (45 chars total).
+//!
+//! The base directory defaults to `/tmp/iox2-dmabuf/` but can be overridden
+//! at test time via the `ICEORYX2_DMABUF_SOCKET_DIR` environment variable.
+
+use sha1_smol::Sha1;
+
+/// Default base directory for side-channel sockets.
+const DEFAULT_SOCKET_DIR: &str = "/tmp/iox2-dmabuf";
+
+/// Derive the Unix-domain socket path for a given `service_name`.
+///
+/// The path is deterministic: the same name always yields the same path.
+/// Different names are collision-resistant (SHA-1, 160-bit output space).
+///
+/// Base directory: `/tmp/iox2-dmabuf/` (override with
+/// `ICEORYX2_DMABUF_SOCKET_DIR` env var — useful in tests to isolate
+/// concurrent test runs).
+///
+/// The returned path has the form `<base>/<40-hex-sha1>.sock`.
+pub fn uds_path_for_service(service_name: &str) -> String {
+    let base = match std::env::var("ICEORYX2_DMABUF_SOCKET_DIR") {
+        Ok(v) => v,
+        Err(_) => DEFAULT_SOCKET_DIR.to_owned(),
+    };
+    let mut h = Sha1::new();
+    h.update(service_name.as_bytes());
+    format!("{}/{}.sock", base, h.digest())
+}

--- a/iceoryx2-dmabuf/src/publisher.rs
+++ b/iceoryx2-dmabuf/src/publisher.rs
@@ -1,0 +1,237 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// `FdSidecarPublisher` in module `publisher` triggers module_name_repetitions.
+// Renaming the module adds churn without correctness benefit — allowed at module level per spec §NFR Clippy.
+#![allow(clippy::module_name_repetitions)]
+
+//! [`FdSidecarPublisher`] — composes an iceoryx2 publisher with the SCM_RIGHTS
+//! side-channel to deliver DMA-BUF file descriptors alongside metadata
+//! samples.
+
+use core::fmt::Debug;
+use core::num::NonZeroU64;
+use iceoryx2::node::Node;
+use iceoryx2::port::publisher::Publisher;
+use iceoryx2::prelude::ZeroCopySend;
+use iceoryx2::service::Service;
+use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
+use std::os::fd::{AsFd as _, OwnedFd};
+
+use crate::error::{FdSidecarError, IceoryxErrorKind, Result};
+use crate::scm::ScmRightsPublisher;
+use crate::token::FdSidecarToken;
+
+/// SCM_RIGHTS fd-sidecar publisher.
+///
+/// Composes an iceoryx2 `Publisher<S, Meta, FdSidecarToken>` with a
+/// [`ScmRightsPublisher`] that transports the file descriptor out-of-band via
+/// a Unix-domain socket using `SCM_RIGHTS`.
+///
+/// The fd is sent *before* the iceoryx2 sample so that by the time the
+/// subscriber dequeues the sample, the fd is already waiting in its socket
+/// receive queue.
+///
+/// # Type parameters
+///
+/// - `S` — iceoryx2 service type (e.g. [`iceoryx2::service::ipc::Service`]).
+///   Use `FdSidecarIpcPublisher` for the common IPC case.
+/// - `Meta` — application payload type; must be `ZeroCopySend + Debug`.
+///
+/// # Token monotonicity
+///
+/// `next_token` starts at 1 so that the first emitted token is always
+/// non-zero; zero is reserved as a sentinel for
+/// [`FdSidecarError::TokenExhausted`].
+///
+/// `send` requires `&mut self`, so exclusive mutable access is guaranteed by
+/// the borrow checker — no atomic is needed.
+pub struct FdSidecarPublisher<S: Service, Meta: ZeroCopySend + Debug + 'static> {
+    /// Node MUST be declared before `inner` and `_port_factory` so it is
+    /// dropped last (Rust drops fields in declaration order).  See
+    /// `crate::build_node_and_service` for the Node lifetime contract.
+    _node: Node<S>,
+    inner: Publisher<S, Meta, FdSidecarToken>,
+    side: ScmRightsPublisher,
+    /// Monotonically increasing token counter.  `send` takes `&mut self`, so
+    /// this field is always accessed under exclusive ownership.
+    next_token: u64,
+    // Keep the port factory alive so the iceoryx2 service is not dropped.
+    _port_factory: PortFactory<S, Meta, FdSidecarToken>,
+}
+
+impl<S: Service, Meta: ZeroCopySend + Debug + Copy + 'static> FdSidecarPublisher<S, Meta> {
+    /// Create a new `FdSidecarPublisher` for `service_name`.
+    ///
+    /// Opens (or creates) an iceoryx2 service of type `S` with the given name,
+    /// configures `FdSidecarToken` as the user-header type, and binds a
+    /// Unix-domain socket side-channel for fd delivery.
+    ///
+    /// `_node` is stored to guarantee it outlives the port.
+    ///
+    /// # Errors
+    ///
+    /// - [`FdSidecarError::UnsupportedPlatform`] — on non-Linux targets.
+    /// - [`FdSidecarError::SideChannelIo`] — if the UDS socket cannot be created.
+    /// - [`FdSidecarError::Iceoryx`] — if node or service creation fails.
+    pub fn create(service_name: &str) -> Result<Self> {
+        use iceoryx2::port::side_channel::Role;
+
+        let (_node, port_factory) = crate::build_node_and_service::<S, Meta>(service_name)?;
+
+        let publisher =
+            port_factory
+                .publisher_builder()
+                .create()
+                .map_err(|e| FdSidecarError::Iceoryx {
+                    kind: IceoryxErrorKind::PortBuilder,
+                    msg: e.to_string(),
+                })?;
+
+        // Open the SCM_RIGHTS side-channel publisher.
+        let side = ScmRightsPublisher::open(service_name, Role::Publisher)?;
+
+        Ok(Self {
+            _node,
+            inner: publisher,
+            side,
+            next_token: 1,
+            _port_factory: port_factory,
+        })
+    }
+
+    /// Publish `meta` alongside `fd`.
+    ///
+    /// 1. Allocates the next correlation token.
+    /// 2. Sends `fd` to all connected subscribers via `SCM_RIGHTS` **first**,
+    ///    so the fd is in the subscriber's socket receive queue before the
+    ///    iceoryx2 sample arrives.
+    /// 3. Loans a slot from the iceoryx2 publisher, writes `token` into the
+    ///    user-header and `meta` into the payload, then sends the sample.
+    ///
+    /// `fd` is consumed: the publisher takes temporary ownership for the
+    /// duration of the `sendmsg` call.  The kernel duplicates the fd into
+    /// every connected subscriber's fd table before this function returns.
+    ///
+    /// # Errors
+    ///
+    /// - [`FdSidecarError::TokenExhausted`] — the 64-bit token space wrapped to 0.
+    /// - [`FdSidecarError::SideChannelIo`] — a socket operation failed.
+    /// - [`FdSidecarError::IceoryxPublish`] — the iceoryx2 loan or send failed.
+    pub fn send(&mut self, meta: Meta, fd: OwnedFd) -> Result<()> {
+        let raw = self.next_token;
+        self.next_token = self.next_token.wrapping_add(1);
+        let token = NonZeroU64::new(raw).ok_or(FdSidecarError::TokenExhausted)?;
+
+        // 1. Send fd on the sidecar FIRST (spec §Fault model).
+        self.side.send_fd_impl(token, fd.as_fd())?;
+
+        // Test-only pause hook: when `DMABUF_CRASH_PHASE=mid-iceoryx2` the
+        // process sends SIGSTOP to itself so that a test can observe the
+        // subscriber receiving `NoFdInMessage`.  This call is compiled out in
+        // non-test builds.
+        #[cfg(test)]
+        Self::pause_hook_if_requested();
+
+        // 2. Publish the iceoryx2 sample.
+        let mut sample = self
+            .inner
+            .loan_uninit()
+            .map_err(FdSidecarError::IceoryxLoan)?;
+
+        // Store the token as a raw u64 in the user-header.
+        sample.user_header_mut().token = token.get();
+        let sample = sample.write_payload(meta);
+        sample.send().map_err(FdSidecarError::IceoryxPublish)?;
+
+        Ok(())
+    }
+
+    /// Test-only pause hook.
+    ///
+    /// When the environment variable `DMABUF_CRASH_PHASE` is set to
+    /// `mid-iceoryx2`, the calling process sends `SIGSTOP` to itself.  This
+    /// freezes the publisher between the sidecar `send_fd` and the iceoryx2
+    /// publish so that a test can assert the subscriber sees
+    /// [`FdSidecarError::NoFdInMessage`].
+    ///
+    /// Compiled out in non-test builds (`#[cfg(test)]`).
+    ///
+    /// # Safety rationale (approved in primary plan)
+    ///
+    /// `libc::raise(SIGSTOP)` is a standard POSIX signal send to self.
+    /// Only used inside `#[cfg(test)]` when the env var is set.
+    #[cfg(test)]
+    fn pause_hook_if_requested() {
+        if std::env::var("DMABUF_CRASH_PHASE").as_deref() == Ok("mid-iceoryx2") {
+            #[cfg(target_os = "linux")]
+            // SAFETY: raise(SIGSTOP) is a well-defined POSIX signal operation on self;
+            // test-only, controlled by env var. Approved in primary plan.
+            #[allow(unsafe_code)]
+            unsafe {
+                libc::raise(libc::SIGSTOP);
+            }
+        }
+    }
+
+    /// Inject a raw (token, fd) into all connected subscriber streams.
+    ///
+    /// For use in tests that need to forge out-of-order tokens to exercise
+    /// the TokenMismatch / NoFdInMessage error paths.
+    ///
+    /// Enabled by the `test-utils` feature — not part of the stable public interface.
+    #[cfg(all(feature = "test-utils", target_os = "linux"))]
+    pub fn inject_raw_for_test(
+        &self,
+        token: u64,
+        fd: std::os::fd::BorrowedFd<'_>,
+    ) -> crate::Result<()> {
+        self.side.inject_raw_for_test(token, fd)
+    }
+
+    /// Publish the iceoryx2 metadata sample **without** sending the fd on the
+    /// sidecar.
+    ///
+    /// This is the test-only complement to `inject_raw_for_test`.  Use it to
+    /// drive the `NoFdInMessage` error path: the subscriber's iceoryx2 queue
+    /// receives a sample with a valid token, but no matching fd is ever
+    /// delivered on the Unix-domain socket, so `recv_fd_matching_impl` times
+    /// out and returns `NoFdInMessage`.
+    ///
+    /// The token counter is advanced exactly as in `send`, so subsequent real
+    /// `send` calls remain consistent.
+    ///
+    /// # Invariant
+    ///
+    /// Callers must not send a real fd (via `inject_raw_for_test` or `send`)
+    /// with the same token after calling this function, as that would violate
+    /// the monotonicity contract.
+    ///
+    /// Enabled by the `test-utils` feature — not part of the stable public interface.
+    #[cfg(all(feature = "test-utils", target_os = "linux"))]
+    pub fn send_metadata_only_for_test(&mut self, meta: Meta) -> crate::Result<()> {
+        let raw = self.next_token;
+        self.next_token = self.next_token.wrapping_add(1);
+        let token = NonZeroU64::new(raw).ok_or(FdSidecarError::TokenExhausted)?;
+
+        // Skip side.send_fd_impl — intentionally no fd is delivered.
+        let mut sample = self
+            .inner
+            .loan_uninit()
+            .map_err(FdSidecarError::IceoryxLoan)?;
+        sample.user_header_mut().token = token.get();
+        let sample = sample.write_payload(meta);
+        sample.send().map_err(FdSidecarError::IceoryxPublish)?;
+
+        Ok(())
+    }
+}

--- a/iceoryx2-dmabuf/src/scm.rs
+++ b/iceoryx2-dmabuf/src/scm.rs
@@ -1,0 +1,658 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! `SCM_RIGHTS` Unix-domain socket side-channel (Linux only).
+//!
+//! # Wire format
+//!
+//! Each message is:
+//! ```text
+//! [ 8 bytes: correlation token (u64 little-endian) ][ ancillary: 1 × SCM_RIGHTS fd ]
+//! ```
+//!
+//! The publisher sends this once per connected subscriber via one `sendmsg(2)`
+//! call.  The subscriber loops with `poll(2)` + `recvmsg(2)` until the token
+//! matches the expected value.
+//!
+//! # Dependency choice
+//!
+//! `rustix::net::sendmsg` / `rustix::net::recvmsg` are used for the ancillary
+//! message layer (zero-cost, safe wrappers).  `libc` is used directly for
+//! `SO_PEERCRED` via `getsockopt` because rustix 1.x does not re-export that
+//! constant on all targets.
+//!
+//! On non-Linux targets every method immediately returns
+//! [`FdSidecarError::UnsupportedPlatform`].
+
+use crate::error::FdSidecarError;
+
+// ── Non-Linux stub ────────────────────────────────────────────────────────────
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    use super::FdSidecarError;
+    use iceoryx2::port::side_channel::Role;
+
+    /// Stub publisher — non-Linux; every method returns `UnsupportedPlatform`.
+    #[derive(Debug)]
+    pub struct ScmRightsPublisher;
+
+    /// Stub subscriber — non-Linux; every method returns `UnsupportedPlatform`.
+    #[derive(Debug)]
+    pub struct ScmRightsSubscriber;
+
+    impl ScmRightsPublisher {
+        /// Open a side-channel publisher for `service_name`.
+        ///
+        /// Always returns [`FdSidecarError::UnsupportedPlatform`] on non-Linux
+        /// targets.
+        pub fn open(_service_name: &str, _role: Role) -> Result<Self, FdSidecarError> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+
+        /// Open by service name string (alias for `open`).
+        pub fn new(_service_name: &str) -> Result<Self, FdSidecarError> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+
+        /// Send `fd` annotated with `token` to all connected subscribers.
+        ///
+        /// Always returns [`FdSidecarError::UnsupportedPlatform`] on non-Linux
+        /// targets.
+        pub fn send_fd_impl(
+            &self,
+            _token: core::num::NonZeroU64,
+            _fd: std::os::fd::BorrowedFd<'_>,
+        ) -> Result<(), FdSidecarError> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+    }
+
+    impl iceoryx2::port::side_channel::SideChannel for ScmRightsPublisher {
+        type Error = FdSidecarError;
+        type Transport = ();
+        fn open(
+            _service_name: &iceoryx2::service::service_name::ServiceName,
+            _role: Role,
+        ) -> Result<Self, Self::Error> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+        fn transport(&mut self) -> &mut Self::Transport {
+            // SAFETY-NOTE: This branch is statically unreachable because
+            // `ScmRightsPublisher::open` / `::new` always return
+            // `Err(FdSidecarError::UnsupportedPlatform)` on non-Linux targets,
+            // so no instance of this type can ever be constructed.
+            unreachable!(
+                "non-Linux stub: value cannot be constructed because open() always returns Err(Unsupported)"
+            )
+        }
+    }
+
+    impl crate::side_channel::FdSideChannel for ScmRightsPublisher {
+        fn send_fd(
+            &mut self,
+            _token: core::num::NonZeroU64,
+            _fd: std::os::fd::BorrowedFd<'_>,
+        ) -> Result<(), FdSidecarError> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+        fn recv_fd_matching(
+            &mut self,
+            _expected: core::num::NonZeroU64,
+            _timeout: std::time::Duration,
+        ) -> Result<std::os::fd::OwnedFd, FdSidecarError> {
+            Err(FdSidecarError::SideChannelIo(std::io::Error::other(
+                "publisher does not receive fds",
+            )))
+        }
+    }
+
+    impl ScmRightsSubscriber {
+        /// Open a side-channel subscriber for `service_name`.
+        ///
+        /// Always returns [`FdSidecarError::UnsupportedPlatform`] on non-Linux
+        /// targets.
+        pub fn open(_service_name: &str, _role: Role) -> Result<Self, FdSidecarError> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+
+        /// Open by service name string (alias for `open`).
+        pub fn new(_service_name: &str) -> Result<Self, FdSidecarError> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+
+        /// Receive the fd whose token equals `expected`.
+        ///
+        /// Always returns [`FdSidecarError::UnsupportedPlatform`] on non-Linux
+        /// targets.
+        pub fn recv_fd_matching_impl(
+            &mut self,
+            _expected: core::num::NonZeroU64,
+            _timeout: std::time::Duration,
+        ) -> Result<std::os::fd::OwnedFd, FdSidecarError> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+    }
+
+    impl iceoryx2::port::side_channel::SideChannel for ScmRightsSubscriber {
+        type Error = FdSidecarError;
+        type Transport = ();
+        fn open(
+            _service_name: &iceoryx2::service::service_name::ServiceName,
+            _role: Role,
+        ) -> Result<Self, Self::Error> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+        fn transport(&mut self) -> &mut Self::Transport {
+            // SAFETY-NOTE: This branch is statically unreachable because
+            // `ScmRightsSubscriber::open` / `::new` always return
+            // `Err(FdSidecarError::UnsupportedPlatform)` on non-Linux targets,
+            // so no instance of this type can ever be constructed.
+            unreachable!(
+                "non-Linux stub: value cannot be constructed because open() always returns Err(Unsupported)"
+            )
+        }
+    }
+
+    impl crate::side_channel::FdSideChannel for ScmRightsSubscriber {
+        fn send_fd(
+            &mut self,
+            _token: core::num::NonZeroU64,
+            _fd: std::os::fd::BorrowedFd<'_>,
+        ) -> Result<(), FdSidecarError> {
+            Err(FdSidecarError::SideChannelIo(std::io::Error::other(
+                "subscriber does not send fds",
+            )))
+        }
+        fn recv_fd_matching(
+            &mut self,
+            _expected: core::num::NonZeroU64,
+            _timeout: std::time::Duration,
+        ) -> Result<std::os::fd::OwnedFd, FdSidecarError> {
+            Err(FdSidecarError::UnsupportedPlatform)
+        }
+    }
+}
+
+// ── Linux implementation ──────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::FdSidecarError;
+    use crate::path::uds_path_for_service;
+    use core::num::NonZeroU64;
+    use iceoryx2::port::side_channel::Role;
+    use iceoryx2_pal_concurrency_sync::atomic::{AtomicBool, Ordering};
+    use rustix::io::IoSlice;
+    use rustix::io::IoSliceMut;
+    use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, SendAncillaryBuffer};
+    use rustix::net::{RecvFlags, SendAncillaryMessage, SendFlags};
+    use std::os::fd::{AsFd as _, AsRawFd as _, BorrowedFd, OwnedFd};
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::Duration;
+
+    // ── Publisher ─────────────────────────────────────────────────────────────
+
+    /// SCM_RIGHTS publisher — binds a UDS server socket and accepts connections
+    /// from subscribers.
+    ///
+    /// The socket file is removed when the publisher is dropped.
+    #[derive(Debug)]
+    pub struct ScmRightsPublisher {
+        socket_path: String,
+        /// Listener kept for `SideChannel::transport()` access.
+        pub(crate) listener: UnixListener,
+        /// Connected subscriber streams; protected by a Mutex so the accept
+        /// thread can push new connections while the main thread calls
+        /// `send_fd`.
+        subscribers: Arc<Mutex<Vec<UnixStream>>>,
+        shutdown: Arc<AtomicBool>,
+        accept_thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl ScmRightsPublisher {
+        /// Open a side-channel publisher for `service_name`.
+        ///
+        /// Binds a Unix-domain socket at the path derived from `service_name`
+        /// (see [`crate::path::uds_path_for_service`]).  Spawns a background
+        /// thread that `accept()`s incoming subscriber connections.
+        pub fn open(service_name: &str, _role: Role) -> Result<Self, FdSidecarError> {
+            Self::new(service_name)
+        }
+
+        /// Open by service name string.
+        pub fn new(service_name: &str) -> Result<Self, FdSidecarError> {
+            let socket_path = uds_path_for_service(service_name);
+
+            // Create base directory if needed.
+            let base = std::path::Path::new(&socket_path).parent().ok_or_else(|| {
+                FdSidecarError::SideChannelIo(std::io::Error::other(
+                    "socket path has no parent directory",
+                ))
+            })?;
+            std::fs::create_dir_all(base).map_err(FdSidecarError::SideChannelIo)?;
+
+            // Remove stale socket file if present.
+            let _ = std::fs::remove_file(&socket_path);
+
+            let listener =
+                UnixListener::bind(&socket_path).map_err(FdSidecarError::SideChannelIo)?;
+
+            let subscribers: Arc<Mutex<Vec<UnixStream>>> = Arc::new(Mutex::new(Vec::new()));
+            let shutdown = Arc::new(AtomicBool::new(false));
+
+            let shutdown_clone = Arc::clone(&shutdown);
+            let subs_clone = Arc::clone(&subscribers);
+            let listener_clone = listener
+                .try_clone()
+                .map_err(FdSidecarError::SideChannelIo)?;
+
+            let accept_thread = thread::spawn(move || {
+                listener_clone.set_nonblocking(true).ok();
+                while !shutdown_clone.load(Ordering::Relaxed) {
+                    match listener_clone.accept() {
+                        Ok((stream, _addr)) => {
+                            #[cfg(feature = "peercred")]
+                            {
+                                if let Err(e) = check_peer_uid(&stream) {
+                                    tracing::warn!(
+                                        "peercred check failed, rejecting connection: {e}"
+                                    );
+                                    continue;
+                                }
+                            }
+                            // Accepted — push into subscriber list.
+                            if let Ok(mut subs) = subs_clone.lock() {
+                                subs.push(stream);
+                            }
+                        }
+                        Err(ref e)
+                            if e.kind() == std::io::ErrorKind::WouldBlock
+                                || e.kind() == std::io::ErrorKind::Interrupted =>
+                        {
+                            thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(ref e) => {
+                            tracing::error!(
+                                target: "iceoryx2_dmabuf::scm",
+                                error = %e,
+                                "sidecar accept loop terminated on I/O error"
+                            );
+                            break;
+                        }
+                    }
+                }
+                // Discard listener binding.
+                drop(listener_clone);
+            });
+
+            Ok(Self {
+                socket_path,
+                listener,
+                subscribers,
+                shutdown,
+                accept_thread: Some(accept_thread),
+            })
+        }
+
+        /// Send `fd` annotated with `token` to every connected subscriber.
+        ///
+        /// Wire format per message:
+        /// ```text
+        /// [ 8 bytes: token (u64 LE) ][ ancillary: 1 × SCM_RIGHTS fd ]
+        /// ```
+        ///
+        /// Dead subscribers (broken pipe) are pruned from the list.
+        ///
+        /// On `EAGAIN`/`EWOULDBLOCK`, returns
+        /// `FdSidecarError::SideChannelIo(WouldBlock)`.
+        pub fn send_fd_impl(
+            &self,
+            token: NonZeroU64,
+            fd: BorrowedFd<'_>,
+        ) -> Result<(), FdSidecarError> {
+            let token_bytes = token.get().to_le_bytes();
+            let iov = [IoSlice::new(&token_bytes)];
+
+            // Ancillary buffer for one fd.
+            let mut space = [core::mem::MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
+            let mut cmsg_buf = SendAncillaryBuffer::new(&mut space);
+            let ok = cmsg_buf.push(SendAncillaryMessage::ScmRights(std::slice::from_ref(&fd)));
+            if !ok {
+                return Err(FdSidecarError::SideChannelIo(std::io::Error::other(
+                    "ancillary buffer too small",
+                )));
+            }
+
+            let mut subs = self.subscribers.lock().map_err(|_| {
+                FdSidecarError::SideChannelIo(std::io::Error::other("lock poisoned"))
+            })?;
+
+            subs.retain(|stream| {
+                // Re-create the ancillary buffer for each subscriber (it is
+                // consumed by sendmsg).
+                let mut space2 =
+                    [core::mem::MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
+                let mut cmsg2 = SendAncillaryBuffer::new(&mut space2);
+                cmsg2.push(SendAncillaryMessage::ScmRights(std::slice::from_ref(&fd)));
+
+                rustix::net::sendmsg(stream.as_fd(), &iov, &mut cmsg2, SendFlags::empty()).is_ok()
+            });
+
+            Ok(())
+        }
+
+        /// Inject a raw token+fd to all connected subscriber streams.
+        ///
+        /// Bypasses the normal NonZeroU64 check so tests can forge arbitrary
+        /// tokens (e.g. 9999) to exercise TokenMismatch / NoFdInMessage paths.
+        ///
+        /// Enabled by the `test-utils` feature — not part of the stable public interface.
+        #[cfg(feature = "test-utils")]
+        pub fn inject_raw_for_test(
+            &self,
+            token: u64,
+            fd: BorrowedFd<'_>,
+        ) -> Result<(), FdSidecarError> {
+            let token_bytes = token.to_le_bytes();
+            let iov = [IoSlice::new(&token_bytes)];
+            let mut subs = self.subscribers.lock().map_err(|_| {
+                FdSidecarError::SideChannelIo(std::io::Error::other("lock poisoned"))
+            })?;
+            subs.retain(|stream| {
+                let mut space2 =
+                    [core::mem::MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
+                let mut cmsg2 = SendAncillaryBuffer::new(&mut space2);
+                cmsg2.push(SendAncillaryMessage::ScmRights(std::slice::from_ref(&fd)));
+                rustix::net::sendmsg(stream.as_fd(), &iov, &mut cmsg2, SendFlags::empty()).is_ok()
+            });
+            Ok(())
+        }
+    }
+
+    impl iceoryx2::port::side_channel::SideChannel for ScmRightsPublisher {
+        type Error = FdSidecarError;
+        type Transport = UnixListener;
+        fn open(
+            service_name: &iceoryx2::service::service_name::ServiceName,
+            _role: Role,
+        ) -> Result<Self, Self::Error> {
+            ScmRightsPublisher::new(service_name.as_str())
+        }
+        fn transport(&mut self) -> &mut Self::Transport {
+            &mut self.listener
+        }
+    }
+
+    impl crate::side_channel::FdSideChannel for ScmRightsPublisher {
+        fn send_fd(&mut self, token: NonZeroU64, fd: BorrowedFd<'_>) -> Result<(), FdSidecarError> {
+            self.send_fd_impl(token, fd)
+        }
+        fn recv_fd_matching(
+            &mut self,
+            _expected: NonZeroU64,
+            _timeout: Duration,
+        ) -> Result<OwnedFd, FdSidecarError> {
+            Err(FdSidecarError::SideChannelIo(std::io::Error::other(
+                "publisher does not receive fds",
+            )))
+        }
+    }
+
+    impl Drop for ScmRightsPublisher {
+        fn drop(&mut self) {
+            self.shutdown.store(true, Ordering::Relaxed);
+            let _ = std::fs::remove_file(&self.socket_path);
+            if let Some(handle) = self.accept_thread.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    // ── Subscriber ────────────────────────────────────────────────────────────
+
+    /// SCM_RIGHTS subscriber — connects to the publisher's UDS socket and
+    /// receives file descriptors via `SCM_RIGHTS` ancillary data.
+    #[derive(Debug)]
+    pub struct ScmRightsSubscriber {
+        /// Connected stream to the publisher's socket.
+        pub(crate) stream: UnixStream,
+    }
+
+    impl ScmRightsSubscriber {
+        /// Open a side-channel subscriber for `service_name`.
+        ///
+        /// Connects to the publisher's UDS socket (which must already be
+        /// listening).
+        pub fn open(service_name: &str, _role: Role) -> Result<Self, FdSidecarError> {
+            Self::new(service_name)
+        }
+
+        /// Open by service name string.
+        pub fn new(service_name: &str) -> Result<Self, FdSidecarError> {
+            let socket_path = uds_path_for_service(service_name);
+            let stream =
+                UnixStream::connect(&socket_path).map_err(FdSidecarError::SideChannelIo)?;
+            // Non-blocking so that recv_fd_matching can poll.
+            stream
+                .set_nonblocking(true)
+                .map_err(FdSidecarError::SideChannelIo)?;
+            Ok(Self { stream })
+        }
+
+        /// Receive the fd whose correlation token equals `expected`.
+        ///
+        /// Loops with `poll(2)` + `recvmsg(2)`:
+        /// - Token `< expected`: stale fd — drop it and continue.
+        /// - Token `== expected`: return the fd.
+        /// - Token `> expected`: out-of-order delivery —
+        ///   [`FdSidecarError::TokenMismatch`].
+        /// - Timeout elapsed: [`FdSidecarError::NoFdInMessage`].
+        #[allow(unsafe_code)]
+        pub fn recv_fd_matching_impl(
+            &mut self,
+            expected: NonZeroU64,
+            timeout: Duration,
+        ) -> Result<OwnedFd, FdSidecarError> {
+            let deadline = std::time::Instant::now() + timeout;
+
+            loop {
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    return Err(FdSidecarError::NoFdInMessage);
+                }
+
+                // poll(2) to wait up to `remaining` for data.
+                let timeout_ms = remaining.as_millis().try_into().unwrap_or(i32::MAX);
+                // SAFETY: poll is a plain syscall; pfd is stack-allocated and
+                // valid for the duration of the call.
+                let ready = unsafe {
+                    let mut pfd = libc::pollfd {
+                        fd: self.stream.as_fd().as_raw_fd(),
+                        events: libc::POLLIN,
+                        revents: 0,
+                    };
+                    libc::poll(&raw mut pfd, 1, timeout_ms)
+                };
+
+                if ready == 0 {
+                    // Timeout.
+                    return Err(FdSidecarError::NoFdInMessage);
+                }
+                if ready < 0 {
+                    let e = std::io::Error::last_os_error();
+                    if e.kind() == std::io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    return Err(FdSidecarError::SideChannelIo(e));
+                }
+
+                // Receive the 8-byte token and the ancillary fd.
+                let mut token_buf = [0u8; 8];
+                let mut iov = [IoSliceMut::new(&mut token_buf)];
+                let mut space =
+                    [core::mem::MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(1))];
+                let mut cmsg_buf = RecvAncillaryBuffer::new(&mut space);
+
+                let result = rustix::net::recvmsg(
+                    self.stream.as_fd(),
+                    &mut iov,
+                    &mut cmsg_buf,
+                    RecvFlags::empty(),
+                );
+
+                match result {
+                    Err(e)
+                        if e == rustix::io::Errno::AGAIN || e == rustix::io::Errno::WOULDBLOCK =>
+                    {
+                        continue;
+                    }
+                    Err(e) if e == rustix::io::Errno::INTR => {
+                        continue;
+                    }
+                    Err(e) => {
+                        return Err(FdSidecarError::SideChannelIo(
+                            std::io::Error::from_raw_os_error(e.raw_os_error()),
+                        ));
+                    }
+                    Ok(msg) => {
+                        if msg.bytes < 8 {
+                            // Truncated — skip.
+                            continue;
+                        }
+                    }
+                }
+
+                let got_token = u64::from_le_bytes(token_buf);
+                let expected_raw = expected.get();
+
+                // Extract the fd from ancillary data.
+                let owned_fd = cmsg_buf
+                    .drain()
+                    .filter_map(|msg| {
+                        if let RecvAncillaryMessage::ScmRights(mut it) = msg {
+                            it.next()
+                        } else {
+                            None
+                        }
+                    })
+                    .next();
+
+                if got_token < expected_raw {
+                    // Stale: drop the fd and continue waiting.
+                    drop(owned_fd);
+                    continue;
+                }
+
+                if got_token == expected_raw {
+                    return owned_fd.ok_or(FdSidecarError::NoFdInMessage);
+                }
+
+                // got_token > expected_raw — out-of-order.
+                drop(owned_fd);
+                return Err(FdSidecarError::TokenMismatch {
+                    expected: expected_raw,
+                    got: got_token,
+                });
+            }
+        }
+    }
+
+    impl iceoryx2::port::side_channel::SideChannel for ScmRightsSubscriber {
+        type Error = FdSidecarError;
+        type Transport = UnixStream;
+        fn open(
+            service_name: &iceoryx2::service::service_name::ServiceName,
+            _role: Role,
+        ) -> Result<Self, Self::Error> {
+            ScmRightsSubscriber::new(service_name.as_str())
+        }
+        fn transport(&mut self) -> &mut Self::Transport {
+            &mut self.stream
+        }
+    }
+
+    impl crate::side_channel::FdSideChannel for ScmRightsSubscriber {
+        fn send_fd(
+            &mut self,
+            _token: NonZeroU64,
+            _fd: BorrowedFd<'_>,
+        ) -> Result<(), FdSidecarError> {
+            Err(FdSidecarError::SideChannelIo(std::io::Error::other(
+                "subscriber does not send fds",
+            )))
+        }
+        fn recv_fd_matching(
+            &mut self,
+            expected: NonZeroU64,
+            timeout: Duration,
+        ) -> Result<OwnedFd, FdSidecarError> {
+            self.recv_fd_matching_impl(expected, timeout)
+        }
+    }
+
+    impl Drop for ScmRightsSubscriber {
+        fn drop(&mut self) {
+            // Stream is closed when dropped — publisher prunes dead subscribers
+            // on the next send_fd call (broken-pipe pruning).
+        }
+    }
+
+    // ── peercred check ────────────────────────────────────────────────────────
+
+    /// Validate that the peer connected to `stream` has the same effective UID
+    /// as the current process (Linux `SO_PEERCRED`).
+    ///
+    /// Returns `Ok(())` if the UIDs match; `Err(FdSidecarError::PeerUidMismatch)`
+    /// otherwise.
+    #[cfg(feature = "peercred")]
+    #[allow(unsafe_code)]
+    pub(crate) fn check_peer_uid(stream: &UnixStream) -> crate::error::Result<()> {
+        use std::os::fd::AsRawFd as _;
+
+        // SAFETY: getsockopt with SO_PEERCRED is a valid operation on a connected
+        // Unix-domain socket fd; ucred is a plain C struct with no ownership.
+        let cred: libc::ucred = unsafe {
+            let mut val: libc::ucred = std::mem::zeroed();
+            let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+            let rc = libc::getsockopt(
+                stream.as_raw_fd(),
+                libc::SOL_SOCKET,
+                libc::SO_PEERCRED,
+                &raw mut val as *mut libc::c_void,
+                &raw mut len,
+            );
+            if rc != 0 {
+                return Err(crate::error::FdSidecarError::SideChannelIo(
+                    std::io::Error::last_os_error(),
+                ));
+            }
+            val
+        };
+
+        // SAFETY: geteuid() is always safe.
+        let expected_uid = unsafe { libc::geteuid() };
+        if cred.uid != expected_uid {
+            return Err(crate::error::FdSidecarError::PeerUidMismatch {
+                peer_uid: cred.uid,
+                expected_uid,
+            });
+        }
+        Ok(())
+    }
+}
+
+// ── Re-exports ────────────────────────────────────────────────────────────────
+
+pub use imp::{ScmRightsPublisher, ScmRightsSubscriber};

--- a/iceoryx2-dmabuf/src/side_channel.rs
+++ b/iceoryx2-dmabuf/src/side_channel.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Downstream extension of the upstream SideChannel role trait.
+//!
+//! The upstream `SideChannel` is a cross-platform role marker; fd semantics are
+//! Linux-specific. `FdSideChannel` extends it with the two fd-transfer primitives
+//! required for DMA-BUF delivery via `SCM_RIGHTS`.
+
+use core::num::NonZeroU64;
+use core::time::Duration;
+use std::os::fd::{BorrowedFd, OwnedFd};
+
+use crate::FdSidecarError;
+
+/// Linux-specific extension for side channels capable of transferring file descriptors.
+///
+/// Implementors MUST also implement `iceoryx2::port::side_channel::SideChannel`.
+/// The canonical implementation is `crate::scm::ScmRightsPublisher` /
+/// `crate::scm::ScmRightsSubscriber`.
+///
+/// This trait is crate-internal: it documents the contract between `scm.rs`
+/// and the publisher/subscriber layers but is not part of the public API.
+/// Call sites use the inherent `_impl` methods directly for monomorphic dispatch;
+/// the trait is retained as a structural contract.
+#[allow(dead_code)]
+pub(crate) trait FdSideChannel: iceoryx2::port::side_channel::SideChannel {
+    /// Send `fd` to all connected peers, tagged with `token` for correlation.
+    fn send_fd(&mut self, token: NonZeroU64, fd: BorrowedFd<'_>) -> Result<(), FdSidecarError>;
+
+    /// Block until an fd tagged with `expected` arrives, or `timeout` elapses.
+    ///
+    /// Returns `Err(FdSidecarError::TokenMismatch { .. })` if the received token
+    /// does not match `expected`. Returns `Err(FdSidecarError::NoFdInMessage)` if
+    /// the sidecar times out before any fd arrives.
+    fn recv_fd_matching(
+        &mut self,
+        expected: NonZeroU64,
+        timeout: Duration,
+    ) -> Result<OwnedFd, FdSidecarError>;
+}

--- a/iceoryx2-dmabuf/src/subscriber.rs
+++ b/iceoryx2-dmabuf/src/subscriber.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// `FdSidecarSubscriber` in module `subscriber` triggers module_name_repetitions.
+// Renaming the module adds churn without correctness benefit — allowed at module level per spec §NFR Clippy.
+#![allow(clippy::module_name_repetitions)]
+
+//! [`FdSidecarSubscriber`] — composes an iceoryx2 subscriber with the SCM_RIGHTS
+//! side-channel to receive DMA-BUF file descriptors alongside metadata
+//! samples.
+
+use core::fmt::Debug;
+use core::time::Duration;
+use iceoryx2::node::Node;
+use iceoryx2::port::subscriber::Subscriber;
+use iceoryx2::prelude::ZeroCopySend;
+use iceoryx2::service::Service;
+use iceoryx2::service::port_factory::publish_subscribe::PortFactory;
+use std::os::fd::OwnedFd;
+
+use crate::error::{FdSidecarError, IceoryxErrorKind, Result};
+use crate::scm::ScmRightsSubscriber;
+use crate::token::FdSidecarToken;
+
+/// Default timeout for [`FdSidecarSubscriber::recv`] when waiting for the fd on
+/// the side-channel socket.  50 ms matches the spec §Fault model.
+const DEFAULT_RECV_TIMEOUT: Duration = Duration::from_millis(50);
+
+/// SCM_RIGHTS fd-sidecar subscriber.
+///
+/// Composes an iceoryx2 `Subscriber<S, Meta, FdSidecarToken>` with a
+/// [`ScmRightsSubscriber`] that receives file descriptors out-of-band via a
+/// Unix-domain socket using `SCM_RIGHTS`.
+///
+/// # Type parameters
+///
+/// - `S` — iceoryx2 service type (e.g. [`iceoryx2::service::ipc::Service`]).
+///   Use `FdSidecarIpcSubscriber` for the common IPC case.
+/// - `Meta` — application payload type; must be `ZeroCopySend + Debug`.
+pub struct FdSidecarSubscriber<S: Service, Meta: ZeroCopySend + Debug + 'static> {
+    /// Node MUST be declared before `inner` and `_port_factory` so it is
+    /// dropped last (Rust drops fields in declaration order).  See
+    /// `crate::build_node_and_service` for the Node lifetime contract.
+    _node: Node<S>,
+    inner: Subscriber<S, Meta, FdSidecarToken>,
+    side: ScmRightsSubscriber,
+    service_name: String,
+    // Keep the port factory alive so the iceoryx2 service is not dropped.
+    _port_factory: PortFactory<S, Meta, FdSidecarToken>,
+}
+
+impl<S: Service, Meta: ZeroCopySend + Debug + Copy + 'static> FdSidecarSubscriber<S, Meta> {
+    /// Create a new `FdSidecarSubscriber` for `service_name`.
+    ///
+    /// Opens (or creates) an iceoryx2 service of type `S` with the given name,
+    /// configures `FdSidecarToken` as the user-header type, and connects a
+    /// Unix-domain socket side-channel for fd reception.
+    ///
+    /// `_node` is stored to guarantee it outlives the port.
+    ///
+    /// # Errors
+    ///
+    /// - [`FdSidecarError::UnsupportedPlatform`] — on non-Linux targets.
+    /// - [`FdSidecarError::SideChannelIo`] — if the UDS socket cannot connect.
+    pub fn create(service_name: &str) -> Result<Self> {
+        use iceoryx2::port::side_channel::Role;
+
+        let (_node, port_factory) = crate::build_node_and_service::<S, Meta>(service_name)?;
+
+        let subscriber =
+            port_factory
+                .subscriber_builder()
+                .create()
+                .map_err(|e| FdSidecarError::Iceoryx {
+                    kind: IceoryxErrorKind::PortBuilder,
+                    msg: e.to_string(),
+                })?;
+
+        // Connect the SCM_RIGHTS side-channel subscriber.
+        let side = ScmRightsSubscriber::open(service_name, Role::Subscriber)?;
+
+        Ok(Self {
+            _node,
+            inner: subscriber,
+            side,
+            service_name: service_name.to_owned(),
+            _port_factory: port_factory,
+        })
+    }
+
+    /// Non-blocking receive.
+    ///
+    /// Returns `None` if no sample is ready in the iceoryx2 queue.
+    ///
+    /// On success:
+    /// 1. Receives the next iceoryx2 sample.
+    /// 2. Extracts the correlation `token` from the sample's `user_header`.
+    /// 3. Calls [`ScmRightsSubscriber::recv_fd_matching_impl`] with a
+    ///    50 ms timeout to drain the side-channel until the matching fd arrives.
+    /// 4. Copies the `Meta` payload out of the SHM slot (which is then returned
+    ///    to the pool).
+    ///
+    /// # Errors
+    ///
+    /// - [`FdSidecarError::NoFdInMessage`] — side-channel timed out (producer
+    ///   may have crashed between the sidecar send and the iceoryx2 send).
+    /// - [`FdSidecarError::TokenMismatch`] — out-of-order fd delivery.
+    /// - [`FdSidecarError::IceoryxReceive`] — the iceoryx2 receive failed.
+    pub fn recv(&mut self) -> Result<Option<(Meta, OwnedFd)>> {
+        let Some(sample) = self
+            .inner
+            .receive()
+            .map_err(FdSidecarError::IceoryxReceive)?
+        else {
+            return Ok(None);
+        };
+
+        // Extract the expected token from the user-header; zero means corrupted header.
+        let expected = sample
+            .user_header()
+            .as_nonzero()
+            .ok_or(FdSidecarError::NoFdInMessage)?;
+
+        // Drain the sidecar until we find the fd matching `expected`.
+        let fd = self
+            .side
+            .recv_fd_matching_impl(expected, DEFAULT_RECV_TIMEOUT)?;
+
+        // Copy the meta before the sample is dropped (which returns the SHM
+        // slot to the pool).
+        let meta = *sample.payload();
+
+        Ok(Some((meta, fd)))
+    }
+
+    /// Reconnect the side-channel subscriber.
+    ///
+    /// Call this after a [`FdSidecarError::SideChannelIo`] error to re-establish
+    /// the Unix-domain socket connection without recreating the iceoryx2 port.
+    ///
+    /// # Errors
+    ///
+    /// - [`FdSidecarError::UnsupportedPlatform`] — on non-Linux targets.
+    /// - [`FdSidecarError::SideChannelIo`] — if the UDS socket cannot connect.
+    pub fn reconnect(&mut self) -> Result<()> {
+        use iceoryx2::port::side_channel::Role;
+        self.side = ScmRightsSubscriber::open(&self.service_name, Role::Subscriber)?;
+        Ok(())
+    }
+}

--- a/iceoryx2-dmabuf/src/token.rs
+++ b/iceoryx2-dmabuf/src/token.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::num::NonZeroU64;
+use iceoryx2::prelude::ZeroCopySend;
+
+/// Monotonic sequence number used to correlate an iceoryx2 sample with the
+/// file descriptor delivered over the side-channel socket.
+///
+/// Stored in the sample's user-header so that the subscriber can verify it
+/// received the fd matching the sample it pulled from the ring buffer.
+///
+/// # Safety (ZeroCopySend)
+///
+/// `FdSidecarToken` is `#[repr(C)]` with a single `u64` field — a plain integer
+/// with no pointers, references, or OS handles.  It is safe to copy across
+/// process address spaces via the iceoryx2 SHM pool.
+///
+/// The raw `u64` value is always non-zero at the application level (enforced
+/// by [`crate::publisher::FdSidecarPublisher::send`]); zero is reserved as a
+/// sentinel (see [`crate::FdSidecarError::TokenExhausted`]).
+#[derive(Debug, Clone, Copy, Default, ZeroCopySend)]
+#[repr(C)]
+pub struct FdSidecarToken {
+    /// The non-zero sequence counter stored as a `u64` for SHM compatibility.
+    /// `pub(crate)` to prevent external struct-literal construction;
+    /// use [`FdSidecarToken::from_nonzero`] to construct a valid token.
+    pub(crate) token: u64,
+}
+
+impl FdSidecarToken {
+    /// Construct from a non-zero value.
+    ///
+    /// The caller guarantees that `v` is a valid, non-zero sequence counter.
+    pub fn from_nonzero(v: NonZeroU64) -> Self {
+        Self { token: v.get() }
+    }
+
+    /// Return the inner non-zero value, or `None` if the token is zero.
+    ///
+    /// A zero value indicates a corrupted or uninitialized SHM header.
+    /// The subscriber maps `None` to [`crate::FdSidecarError::NoFdInMessage`].
+    pub fn as_nonzero(self) -> Option<NonZeroU64> {
+        NonZeroU64::new(self.token)
+    }
+}

--- a/iceoryx2-dmabuf/tests/common/mod.rs
+++ b/iceoryx2-dmabuf/tests/common/mod.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Removes the UDS socket file for `service_name` on `Drop`.
+/// Use in every integration test to prevent artifact leaks on failure.
+pub struct TestGuard {
+    socket_path: String,
+}
+
+impl TestGuard {
+    pub fn new(service_name: &str) -> Self {
+        let path = iceoryx2_dmabuf::uds_path_for_service(service_name);
+        Self { socket_path: path }
+    }
+}
+
+impl Drop for TestGuard {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.socket_path);
+    }
+}
+
+/// Stable, PID-qualified service name for use in tests.
+/// `local_id` is a short in-test disambiguator (e.g. "local-smoke").
+pub fn test_service_name(local_id: &str) -> String {
+    format!("{}/{}-{}", module_path!(), local_id, std::process::id())
+}

--- a/iceoryx2-dmabuf/tests/dmabuf_roundtrip.rs
+++ b/iceoryx2-dmabuf/tests/dmabuf_roundtrip.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! End-to-end roundtrip test for `FdSidecarPublisher::send` + `FdSidecarSubscriber::recv`.
+//!
+//! * **Linux** (`cfg(target_os = "linux")`): in-process test using
+//!   `memfd_create`; publishes 4096 magic bytes, subscriber receives and
+//!   `mmap`s them, asserts bytes match.
+//! * **non-Linux**: a portable test that asserts `FdSidecarPublisher::create`
+//!   returns `FdSidecarError::UnsupportedPlatform`.
+
+// ── macOS (non-Linux) test ────────────────────────────────────────────────────
+//
+// This test is compiled and run on macOS.  It verifies the graceful
+// `UnsupportedPlatform` error without any Linux-specific syscalls.
+#[cfg(not(target_os = "linux"))]
+mod non_linux_test {
+    use iceoryx2::prelude::ZeroCopySend;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct TestMeta {
+        seq: u64,
+    }
+
+    #[test]
+    fn create_returns_unsupported_platform_on_non_linux() {
+        let result =
+            iceoryx2_dmabuf::FdSidecarPublisher::<iceoryx2::service::ipc::Service, TestMeta>::create(
+                "dmabuf-roundtrip-macos-test",
+            );
+
+        let is_unsupported = matches!(
+            result,
+            Err(iceoryx2_dmabuf::FdSidecarError::UnsupportedPlatform)
+        );
+        assert!(is_unsupported, "expected UnsupportedPlatform on non-Linux");
+    }
+}
+
+// ── Linux in-process roundtrip ─────────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+    use std::io::Write as _;
+    use std::os::fd::AsRawFd as _;
+
+    /// Simple metadata struct carried in the iceoryx2 user payload.
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct TestMeta {
+        seq: u64,
+    }
+
+    const SERVICE_NAME: &str = "dmabuf-roundtrip-test";
+    const MAGIC: u8 = 0xAB;
+    const SIZE: usize = 4096;
+    const SETTLE_MS: u64 = 20;
+
+    /// Create a `memfd_create`'d fd containing `SIZE` bytes of `MAGIC`.
+    fn make_memfd() -> std::os::fd::OwnedFd {
+        use rustix::fs::{MemfdFlags, memfd_create};
+        use std::os::fd::{AsFd as _, FromRawFd as _};
+
+        let fd = memfd_create("test-frame", MemfdFlags::CLOEXEC).expect("memfd_create failed");
+
+        // Write SIZE bytes via a borrowed File view, using ManuallyDrop to
+        // avoid a double-close when the temporary File is dropped.
+        let raw = fd.as_fd().as_raw_fd();
+        // SAFETY: the fd is valid and owned by this function; ManuallyDrop
+        // prevents double-close.
+        let mut file = std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(raw) });
+        let payload = vec![MAGIC; SIZE];
+        file.write_all(&payload).expect("write_all failed");
+
+        fd
+    }
+
+    struct SocketGuard(String);
+    impl Drop for SocketGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    #[test]
+    fn send_recv_one_frame_in_process() {
+        // Remove the side-channel socket on drop so parallel test runs don't
+        // collide on a stale socket file.
+        let _guard = SocketGuard(iceoryx2_dmabuf::uds_path_for_service(SERVICE_NAME));
+
+        let mut pub_ =
+            FdSidecarPublisher::<iceoryx2::service::ipc::Service, TestMeta>::create(SERVICE_NAME)
+                .expect("FdSidecarPublisher::create failed");
+
+        let mut sub_ =
+            FdSidecarSubscriber::<iceoryx2::service::ipc::Service, TestMeta>::create(SERVICE_NAME)
+                .expect("FdSidecarSubscriber::create failed");
+
+        // Allow the subscriber's UDS stream to connect to the publisher socket.
+        std::thread::sleep(std::time::Duration::from_millis(SETTLE_MS));
+
+        let fd = make_memfd();
+        pub_.send(TestMeta { seq: 1 }, fd).expect("send failed");
+
+        // Give the iceoryx2 sample a moment to land in the subscriber queue.
+        std::thread::sleep(std::time::Duration::from_millis(SETTLE_MS));
+
+        let received = sub_.recv().expect("recv failed");
+        assert!(received.is_some(), "expected Some from recv, got None");
+
+        let (meta, owned_fd) = received.unwrap(); // test-only unwrap
+        assert_eq!(meta.seq, 1, "meta.seq mismatch");
+
+        // mmap and verify bytes.
+        // SAFETY: fd received via SCM_RIGHTS; publisher no longer writes to it.
+        let mmap = unsafe { memmap2::MmapOptions::new().map(&owned_fd) }
+            .expect("mmap of received fd failed");
+        assert_eq!(mmap.len(), SIZE, "mmap length mismatch");
+        assert!(
+            mmap.iter().all(|&b| b == MAGIC),
+            "received bytes do not match published magic"
+        );
+    }
+}

--- a/iceoryx2-dmabuf/tests/error_paths.rs
+++ b/iceoryx2-dmabuf/tests/error_paths.rs
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Error-path integration tests for TokenMismatch and NoFdInMessage.
+#![cfg(target_os = "linux")]
+mod common;
+
+use common::{TestGuard, test_service_name};
+use iceoryx2::service::ipc;
+use iceoryx2_dmabuf::{FdSidecarError, FdSidecarPublisher, FdSidecarSubscriber};
+use rustix::fs::{MemfdFlags, memfd_create};
+use std::os::fd::AsFd as _;
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct Meta {
+    v: u64,
+}
+unsafe impl iceoryx2::prelude::ZeroCopySend for Meta {}
+
+/// Injects a forged sidecar message with token=9999 to trigger TokenMismatch.
+///
+/// After a legit round-trip (token=1 consumed), the publisher injects
+/// token=9999 directly to the subscriber's server-side stream via
+/// `inject_raw_for_test`. The next `pub_.send()` produces an iceoryx2
+/// sample with token=2. When `sub_.recv()` reads the iceoryx2 sample
+/// (expecting token=2) and polls the UDS stream, it finds token=9999 (>2)
+/// and returns `TokenMismatch`.
+#[test]
+fn token_mismatch_on_forged_message() {
+    let svc = test_service_name("token-mismatch");
+    let _guard = TestGuard::new(&svc);
+
+    let mut pub_ = FdSidecarPublisher::<ipc::Service, Meta>::create(&svc).unwrap();
+    let mut sub_ = FdSidecarSubscriber::<ipc::Service, Meta>::create(&svc).unwrap();
+
+    // Wait for the subscriber's UDS stream to be accepted by the publisher.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    // Send and consume a legitimate frame (token=1).
+    let fd1 = memfd_create("tok-mismatch-1", MemfdFlags::CLOEXEC).unwrap();
+    pub_.send(Meta { v: 1 }, fd1).unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    while let Ok(Some(_)) = sub_.recv() {}
+
+    // Inject forged token=9999 directly to the subscriber's UDS stream.
+    let junk_fd = memfd_create("tok-mismatch-junk", MemfdFlags::CLOEXEC).unwrap();
+    pub_.inject_raw_for_test(9999u64, junk_fd.as_fd()).unwrap();
+
+    // Send a second legitimate frame (token=2). The subscriber's UDS queue is
+    // now: [token=9999 (forged), token=2 (legit)].
+    // recv_fd_matching(expected=2) reads token=9999 first → TokenMismatch.
+    let fd2 = memfd_create("tok-mismatch-2", MemfdFlags::CLOEXEC).unwrap();
+    pub_.send(Meta { v: 2 }, fd2).unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(10));
+
+    let err = sub_.recv();
+    assert!(
+        matches!(err, Err(FdSidecarError::TokenMismatch { .. })),
+        "expected Err(TokenMismatch {{ .. }}), got {err:?}"
+    );
+}
+
+/// Expects NoFdInMessage when an iceoryx2 metadata sample is queued but no
+/// matching fd is ever delivered on the UDS sidecar.
+///
+/// Subscriber connects first, then `send_metadata_only_for_test` publishes the
+/// iceoryx2 sample while deliberately skipping the `SCM_RIGHTS` fd delivery.
+/// `sub_.recv()` dequeues the sample (token=1), calls `recv_fd_matching_impl`
+/// with a 50 ms timeout, finds no fd, and returns `NoFdInMessage`.
+///
+/// This approach is deterministic: the subscriber is already registered before
+/// the sample is enqueued, so iceoryx2 never silently drops the sample
+/// (which it would if the subscriber connected after a publish without history
+/// enabled on the service).
+#[test]
+fn no_fd_in_message_after_timeout() {
+    let svc = test_service_name("no-fd-timeout");
+    let _guard = TestGuard::new(&svc);
+
+    // Subscriber connects FIRST so iceoryx2 will deliver the subsequent sample.
+    let mut pub_ = FdSidecarPublisher::<ipc::Service, Meta>::create(&svc).unwrap();
+    let mut sub_ = FdSidecarSubscriber::<ipc::Service, Meta>::create(&svc).unwrap();
+
+    // Wait for the subscriber's UDS stream to be accepted by the publisher.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    // Publish the iceoryx2 sample WITHOUT sending the fd on the sidecar.
+    // The subscriber will find the sample in its queue but no matching fd.
+    pub_.send_metadata_only_for_test(Meta { v: 1 }).unwrap();
+
+    let start = std::time::Instant::now();
+    let result = sub_.recv();
+    let elapsed = start.elapsed();
+    assert!(
+        matches!(result, Err(FdSidecarError::NoFdInMessage)),
+        "expected Err(NoFdInMessage), got {result:?}"
+    );
+    assert!(
+        elapsed >= std::time::Duration::from_millis(40),
+        "timeout too short: {elapsed:?}"
+    );
+}

--- a/iceoryx2-dmabuf/tests/it_crash_midsend.rs
+++ b/iceoryx2-dmabuf/tests/it_crash_midsend.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Integration test: producer SIGSTOP between sidecar send and iceoryx2 publish.
+//!
+//! The test drives the `fd_sidecar_crash_pub` binary (a thin wrapper that sets
+//! `DMABUF_CRASH_PHASE=mid-iceoryx2` before publishing).  After the publisher
+//! freezes, the subscriber polls `recv()` and must observe `NoFdInMessage`
+//! (because the iceoryx2 sample was not yet sent when the publisher stopped).
+//! The test then sends `SIGCONT` + `SIGKILL` and verifies no panic occurred.
+//!
+//! Marked `#[ignore]` by default because it relies on process-level SIGSTOP
+//! timing.  Run with:
+//! ```sh
+//! cargo test -p iceoryx2-dmabuf --test it_crash_midsend \
+//!     --features memfd -- --include-ignored --nocapture
+//! ```
+//!
+//! Linux-only; compiled out on non-Linux targets.
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use std::process::{Command, Stdio};
+    use std::time::Duration;
+
+    fn unique_service() -> String {
+        format!("crash-midsend-{}", std::process::id())
+    }
+
+    fn bin_path(name: &str) -> std::path::PathBuf {
+        // Cargo sets CARGO_BIN_EXE_<name> for each [[bin]] target.
+        // We derive the path by substituting the known binary name pattern.
+        let base = std::path::PathBuf::from(
+            std::env::var("CARGO_BIN_EXE_fd_sidecar_crash_pub")
+                .unwrap_or_else(|_| "fd_sidecar_crash_pub".to_owned()),
+        );
+        if name == "fd_sidecar_crash_pub" {
+            return base;
+        }
+        // For other binaries, replace the last component.
+        base.parent()
+            .map(|p| p.join(name))
+            .unwrap_or_else(|| std::path::PathBuf::from(name))
+    }
+
+    #[test]
+    #[ignore = "requires SIGSTOP timing; run with --include-ignored on Linux"]
+    fn producer_sigstop_mid_send_yields_no_fd_in_message() {
+        use iceoryx2::prelude::ZeroCopySend;
+        use iceoryx2_dmabuf::FdSidecarSubscriber;
+
+        const SETTLE_MS: u64 = 50;
+        const WAIT_STOP_MS: u64 = 200;
+
+        #[derive(Debug, Clone, Copy, ZeroCopySend)]
+        #[repr(C)]
+        struct Meta {
+            size: u64,
+        }
+
+        let service = unique_service();
+
+        // 1. Start subscriber first so it is ready when the publisher sends.
+        let mut sub_ =
+            FdSidecarSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(&service)
+                .expect("FdSidecarSubscriber::create failed");
+
+        // 2. Spawn the crash publisher with DMABUF_CRASH_PHASE=mid-iceoryx2.
+        let crash_bin = bin_path("fd_sidecar_crash_pub");
+        let mut pub_proc = Command::new(&crash_bin)
+            .env("DMABUF_SERVICE", &service)
+            .env("DMABUF_CRASH_PHASE", "mid-iceoryx2")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn crash publisher");
+
+        // 3. Give the publisher time to connect subscribers, send the fd, and
+        //    then SIGSTOP itself.
+        std::thread::sleep(Duration::from_millis(WAIT_STOP_MS));
+
+        // 4. Poll the subscriber — no iceoryx2 sample should have arrived yet
+        //    (publisher froze before the iceoryx2 send).  This should return
+        //    Ok(None) because the sample is not in the ring buffer.
+        let result = sub_.recv();
+        // The subscriber should see Ok(None) (no iceoryx2 sample yet).
+        assert!(
+            matches!(result, Ok(None)),
+            "expected Ok(None) while publisher is stopped, got {result:?}",
+        );
+
+        // 5. SIGCONT + SIGKILL the publisher.
+        let pid = pub_proc.id();
+        // SAFETY: kill() is a valid syscall; pid is the child's PID.
+        unsafe {
+            libc::kill(pid as i32, libc::SIGCONT);
+        }
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+        let _ = pub_proc.kill();
+        let _ = pub_proc.wait();
+
+        // 6. Assert no panic in the subscriber (we reached here without panic).
+        drop(sub_);
+    }
+}

--- a/iceoryx2-dmabuf/tests/it_dmabuf_fd_identity.rs
+++ b/iceoryx2-dmabuf/tests/it_dmabuf_fd_identity.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Integration test: fd inode is preserved through the DmaBuf wrap.
+//!
+//! Publisher holds a memfd wrapped as DmaBuf; after roundtrip the subscriber
+//! receives a DmaBuf whose underlying fd has the same (st_dev, st_ino).
+
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+mod linux_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{DmaBuf, DmaBufPublisher, DmaBufSubscriber};
+    use rustix::fs::{MemfdFlags, fstat, memfd_create};
+    use std::os::fd::AsFd as _;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        seq: u64,
+    }
+
+    const SERVICE: &str = "it-dmabuf-fd-identity";
+    const SETTLE_MS: u64 = 20;
+
+    #[test]
+    fn fd_identity_preserved_through_wrap() -> Result<(), Box<dyn core::error::Error>> {
+        let owned_fd = memfd_create("dmabuf-identity-test", MemfdFlags::CLOEXEC)?;
+
+        // Obtain (st_dev, st_ino) before publishing.
+        let pub_stat = fstat(&owned_fd)?;
+        let (pub_dev, pub_ino) = (pub_stat.st_dev, pub_stat.st_ino);
+
+        let buf = DmaBuf::from(owned_fd);
+
+        let mut pub_ = DmaBufPublisher::<iceoryx2::service::ipc::Service, Meta>::create(SERVICE)?;
+        let mut sub_ = DmaBufSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(SERVICE)?;
+
+        std::thread::sleep(std::time::Duration::from_millis(SETTLE_MS));
+
+        pub_.send(Meta { seq: 42 }, &buf)?;
+
+        std::thread::sleep(std::time::Duration::from_millis(SETTLE_MS));
+
+        let received = sub_.recv()?;
+        let (_, received_buf) = received.ok_or("recv returned None")?;
+
+        // The received DmaBuf's fd must point to the same kernel inode.
+        let sub_stat = fstat(received_buf.as_fd())?;
+
+        assert_eq!(
+            (pub_dev, pub_ino),
+            (sub_stat.st_dev, sub_stat.st_ino),
+            "inode mismatch: publisher ({pub_dev}, {pub_ino}) != subscriber ({}, {})",
+            sub_stat.st_dev,
+            sub_stat.st_ino,
+        );
+
+        Ok(())
+    }
+}

--- a/iceoryx2-dmabuf/tests/it_dmabuf_heap_roundtrip.rs
+++ b/iceoryx2-dmabuf/tests/it_dmabuf_heap_roundtrip.rs
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Integration test: full DMA-BUF heap roundtrip.
+//!
+//! Allocates 4 KiB via dma_heap::Heap (system heap), publishes via
+//! DmaBufPublisher, receives via DmaBufSubscriber, maps via MappedDmaBuf::read,
+//! asserts a known byte pattern.
+//!
+//! Skipped (not panicked) when /dev/dma_heap/system is absent.
+
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+mod linux_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{DmaBuf, DmaBufPublisher, DmaBufSubscriber};
+    use std::os::fd::AsFd as _;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        seq: u64,
+    }
+
+    const SERVICE: &str = "it-dmabuf-heap-roundtrip";
+    const MAGIC: u8 = 0xEF;
+    const BUF_SIZE: usize = 4096;
+    const SETTLE_MS: u64 = 20;
+    const DMA_HEAP_PATH: &str = "/dev/dma_heap/system";
+
+    #[test]
+    fn dmabuf_heap_roundtrip() -> Result<(), Box<dyn core::error::Error>> {
+        // Skip gracefully when the dma-heap device is unavailable.
+        if !std::path::Path::new(DMA_HEAP_PATH).exists() {
+            eprintln!("SKIP: {DMA_HEAP_PATH} not present — dma-heap kernel support required");
+            return Ok(());
+        }
+
+        let heap = dma_heap::Heap::new(dma_heap::HeapKind::System)?;
+
+        // allocate() returns OwnedFd; dup so we have one for writing and one for sending.
+        let owned_fd = heap.allocate(BUF_SIZE)?;
+        let dup_fd = owned_fd.as_fd().try_clone_to_owned()?;
+
+        // Write magic bytes into the write copy.
+        let write_buf = DmaBuf::from(owned_fd);
+        let mut mapped = write_buf.memory_map()?;
+        mapped.write(
+            |data, _: Option<()>| {
+                data.iter_mut().for_each(|b| *b = MAGIC);
+                Ok(())
+            },
+            None,
+        )?;
+        drop(mapped); // unmap before sending
+
+        // Use the dup'd fd for sending.
+        let send_buf = DmaBuf::from(dup_fd);
+
+        let mut pub_ = DmaBufPublisher::<iceoryx2::service::ipc::Service, Meta>::create(SERVICE)?;
+        let mut sub_ = DmaBufSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(SERVICE)?;
+
+        std::thread::sleep(std::time::Duration::from_millis(SETTLE_MS));
+
+        pub_.send(Meta { seq: 99 }, &send_buf)?;
+
+        std::thread::sleep(std::time::Duration::from_millis(SETTLE_MS));
+
+        let received = sub_.recv()?;
+        let (meta, received_buf) = received.ok_or("recv returned None")?;
+        assert_eq!(meta.seq, 99);
+
+        let mapped = received_buf.memory_map()?;
+        mapped.read(
+            |data, _: Option<()>| {
+                assert!(
+                    data.iter().all(|&b| b == MAGIC),
+                    "byte pattern mismatch after heap roundtrip"
+                );
+                Ok(())
+            },
+            None,
+        )?;
+
+        Ok(())
+    }
+}

--- a/iceoryx2-dmabuf/tests/it_fanout.rs
+++ b/iceoryx2-dmabuf/tests/it_fanout.rs
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Integration test: 1-producer, 3-consumer fan-out over 100 frames.
+//!
+//! * Producer sends 100 frames of distinct `memfd` regions.
+//! * 3 subscribers each receive all 100 frames.
+//! * At frame 50 subscriber[0] is dropped; subscribers[1] and [2] continue
+//!   through frame 100 unaffected.
+//! * Each received fd is `fstat`'d and its inode is compared to the
+//!   producer's inode for that frame — verifying identity, not just liveness.
+//!
+//! Linux-only; compiled out on non-Linux targets.
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::os::fd::{AsFd as _, AsRawFd as _, FromRawFd as _, OwnedFd};
+    use std::time::Duration;
+
+    const N_FRAMES: u64 = 100;
+    const DROP_AFTER: u64 = 50;
+    const SETTLE_MS: u64 = 20;
+    const SERVICE: &str = "fanout-three-test";
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        frame: u64,
+    }
+
+    /// Create a `memfd_create`'d fd and return it together with its inode.
+    fn make_frame(seq: u64) -> (OwnedFd, u64) {
+        use std::io::Write as _;
+
+        let name = format!("fanout-frame-{seq}");
+        let fd = memfd_create(name.as_str(), MemfdFlags::CLOEXEC).expect("memfd_create failed");
+        {
+            let raw = fd.as_fd().as_raw_fd();
+            // SAFETY: fd is valid and owned; ManuallyDrop prevents double-close.
+            let mut file = std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(raw) });
+            let payload = seq.to_le_bytes();
+            file.write_all(&payload).expect("write_all failed");
+        }
+        let stat = rustix::fs::fstat(&fd).expect("fstat failed");
+        let ino = stat.st_ino;
+        (fd, ino)
+    }
+
+    /// Poll a subscriber for up to 500 ms until it receives a frame.
+    fn recv_frame(
+        sub: &mut FdSidecarSubscriber<iceoryx2::service::ipc::Service, Meta>,
+    ) -> Option<(Meta, OwnedFd)> {
+        const POLL_MS: u64 = 10;
+        const TIMEOUT_MS: u64 = 500;
+
+        let deadline = std::time::Instant::now() + Duration::from_millis(TIMEOUT_MS);
+        while std::time::Instant::now() < deadline {
+            match sub.recv() {
+                Ok(Some(pair)) => return Some(pair),
+                Ok(None) => {
+                    std::thread::sleep(Duration::from_millis(POLL_MS));
+                }
+                Err(e) => {
+                    panic!("recv error: {e:?}");
+                }
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn one_producer_three_consumers_100_frames() {
+        let unique = format!("{}-{}", SERVICE, std::process::id());
+
+        let mut pub_ = FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(&unique)
+            .expect("FdSidecarPublisher::create failed");
+
+        let mut sub0 =
+            FdSidecarSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(&unique)
+                .expect("sub0 create failed");
+        let mut sub1 =
+            FdSidecarSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(&unique)
+                .expect("sub1 create failed");
+        let mut sub2 =
+            FdSidecarSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(&unique)
+                .expect("sub2 create failed");
+
+        // Allow all subscribers to connect to the publisher socket.
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+        // Track which inodes each subscriber received.
+        let mut inodes_sub0: Vec<u64> = Vec::new();
+        let mut inodes_sub1: Vec<u64> = Vec::new();
+        let mut inodes_sub2: Vec<u64> = Vec::new();
+
+        // Publish frames 1..=DROP_AFTER; all three subscribers receive.
+        for seq in 1..=DROP_AFTER {
+            let (fd, pub_ino) = make_frame(seq);
+
+            pub_.send(Meta { frame: seq }, fd).expect("send failed");
+
+            std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+            let (_, fd0) =
+                recv_frame(&mut sub0).unwrap_or_else(|| panic!("sub0 did not recv frame {seq}"));
+            let stat0 = rustix::fs::fstat(&fd0).expect("fstat fd0");
+            assert_eq!(stat0.st_ino, pub_ino, "sub0 inode mismatch at frame {seq}");
+            inodes_sub0.push(stat0.st_ino);
+
+            let (_, fd1) =
+                recv_frame(&mut sub1).unwrap_or_else(|| panic!("sub1 did not recv frame {seq}"));
+            let stat1 = rustix::fs::fstat(&fd1).expect("fstat fd1");
+            assert_eq!(stat1.st_ino, pub_ino, "sub1 inode mismatch at frame {seq}");
+            inodes_sub1.push(stat1.st_ino);
+
+            let (_, fd2) =
+                recv_frame(&mut sub2).unwrap_or_else(|| panic!("sub2 did not recv frame {seq}"));
+            let stat2 = rustix::fs::fstat(&fd2).expect("fstat fd2");
+            assert_eq!(stat2.st_ino, pub_ino, "sub2 inode mismatch at frame {seq}");
+            inodes_sub2.push(stat2.st_ino);
+        }
+
+        // Drop sub0 at frame 50.
+        drop(sub0);
+
+        // Publish frames DROP_AFTER+1..=N_FRAMES; only sub1 and sub2 receive.
+        for seq in (DROP_AFTER + 1)..=N_FRAMES {
+            let (fd, pub_ino) = make_frame(seq);
+
+            pub_.send(Meta { frame: seq }, fd).expect("send failed");
+
+            std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+            let (_, fd1) =
+                recv_frame(&mut sub1).unwrap_or_else(|| panic!("sub1 did not recv frame {seq}"));
+            let stat1 = rustix::fs::fstat(&fd1).expect("fstat fd1");
+            assert_eq!(stat1.st_ino, pub_ino, "sub1 inode mismatch at frame {seq}");
+            inodes_sub1.push(stat1.st_ino);
+
+            let (_, fd2) =
+                recv_frame(&mut sub2).unwrap_or_else(|| panic!("sub2 did not recv frame {seq}"));
+            let stat2 = rustix::fs::fstat(&fd2).expect("fstat fd2");
+            assert_eq!(stat2.st_ino, pub_ino, "sub2 inode mismatch at frame {seq}");
+            inodes_sub2.push(stat2.st_ino);
+        }
+
+        assert_eq!(
+            inodes_sub0.len(),
+            DROP_AFTER as usize,
+            "sub0 should have received exactly {DROP_AFTER} frames"
+        );
+        assert_eq!(
+            inodes_sub1.len(),
+            N_FRAMES as usize,
+            "sub1 should have received exactly {N_FRAMES} frames"
+        );
+        assert_eq!(
+            inodes_sub2.len(),
+            N_FRAMES as usize,
+            "sub2 should have received exactly {N_FRAMES} frames"
+        );
+
+        // All inodes in each list must be distinct (each frame has its own memfd).
+        let mut sorted = inodes_sub1.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            N_FRAMES as usize,
+            "sub1 received duplicate inodes"
+        );
+
+        let mut sorted2 = inodes_sub2.clone();
+        sorted2.sort_unstable();
+        sorted2.dedup();
+        assert_eq!(
+            sorted2.len(),
+            N_FRAMES as usize,
+            "sub2 received duplicate inodes"
+        );
+    }
+}

--- a/iceoryx2-dmabuf/tests/it_fd_identity.rs
+++ b/iceoryx2-dmabuf/tests/it_fd_identity.rs
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Integration test: fd identity across a two-process publisher/subscriber.
+//!
+//! The test spawns the `fd_sidecar_fd_identity` binary in both "pub" and "sub"
+//! roles.  The publisher prints its `(st_dev, st_ino)` before publishing; the
+//! subscriber prints its `(st_dev, st_ino)` after receiving the fd.  The
+//! parent process asserts the pairs are equal, proving that `SCM_RIGHTS`
+//! transmitted the exact same kernel inode — not a copy.
+//!
+//! Linux-only: the entire module is compiled out on non-Linux targets.
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use std::process::Command;
+    use std::time::Duration;
+
+    // Service name salted with the process ID to avoid collisions when tests
+    // run in parallel or when a previous run left stale sockets.
+    fn unique_service() -> String {
+        format!("fd-identity-{}", std::process::id())
+    }
+
+    /// Path to the `fd_sidecar_fd_identity` binary built alongside the tests.
+    fn bin_path() -> std::path::PathBuf {
+        // `CARGO_BIN_EXE_fd_sidecar_fd_identity` is set by Cargo when the test is
+        // run via `cargo test`.
+        let exe = env!("CARGO_BIN_EXE_fd_sidecar_fd_identity");
+        std::path::PathBuf::from(exe)
+    }
+
+    /// Parse a `KEY:val1:val2` line from process stdout.
+    fn parse_stat_line(output: &str, key: &str) -> Option<(u64, u64)> {
+        for line in output.lines() {
+            if let Some(rest) = line.strip_prefix(key) {
+                let mut parts = rest.splitn(2, ':');
+                let dev: u64 = parts.next()?.parse().ok()?;
+                let ino: u64 = parts.next()?.parse().ok()?;
+                return Some((dev, ino));
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn fd_identity_pub_sub_same_inode() {
+        const WAIT_PUB_MS: u64 = 50;
+
+        let service = unique_service();
+        let bin = bin_path();
+
+        // Start publisher first.
+        let pub_proc = Command::new(&bin)
+            .env("DMABUF_ROLE", "pub")
+            .env("DMABUF_SERVICE", &service)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn publisher");
+
+        // Give the publisher time to bind the socket and print its stat line
+        // before the subscriber tries to connect.
+        std::thread::sleep(Duration::from_millis(WAIT_PUB_MS));
+
+        // Start subscriber.
+        let sub_out = Command::new(&bin)
+            .env("DMABUF_ROLE", "sub")
+            .env("DMABUF_SERVICE", &service)
+            .output()
+            .expect("run subscriber");
+
+        // Wait for publisher to finish.
+        let pub_out = pub_proc.wait_with_output().expect("wait publisher");
+
+        let pub_stdout = String::from_utf8_lossy(&pub_out.stdout);
+        let sub_stdout = String::from_utf8_lossy(&sub_out.stdout);
+
+        assert!(
+            pub_out.status.success(),
+            "publisher exited non-zero:\nstdout: {pub_stdout}\nstderr: {}",
+            String::from_utf8_lossy(&pub_out.stderr),
+        );
+        assert!(
+            sub_out.status.success(),
+            "subscriber exited non-zero:\nstdout: {sub_stdout}\nstderr: {}",
+            String::from_utf8_lossy(&sub_out.stderr),
+        );
+
+        let pub_stat = parse_stat_line(&pub_stdout, "PUB_STAT:")
+            .expect("publisher did not print PUB_STAT line");
+        let sub_stat = parse_stat_line(&sub_stdout, "SUB_STAT:")
+            .expect("subscriber did not print SUB_STAT line");
+
+        assert_eq!(
+            pub_stat, sub_stat,
+            "inode mismatch: publisher stat={pub_stat:?}, subscriber stat={sub_stat:?}",
+        );
+    }
+}

--- a/iceoryx2-dmabuf/tests/it_service_gone.rs
+++ b/iceoryx2-dmabuf/tests/it_service_gone.rs
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Integration test: service drop causes subscriber recv to return cleanly.
+//!
+//! Publisher sends 5 frames then drops.  Subscriber polls in a loop; after the
+//! producer drops, the test asserts:
+//! - No panic occurs.
+//! - No hang (enforced by a 500 ms timeout).
+//! - The result is either `Ok(None)` (no more samples) or an `Err` wrapping
+//!   `FdSidecarError::IceoryxReceive` — iceoryx2 may or may not error when the
+//!   publisher drops depending on service lifetime semantics.
+//!
+//! On non-Linux: asserts `FdSidecarPublisher::create` returns `UnsupportedPlatform`.
+
+#[cfg(not(target_os = "linux"))]
+mod non_linux_test {
+    use iceoryx2::prelude::ZeroCopySend;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        seq: u64,
+    }
+
+    #[test]
+    fn service_gone_non_linux_returns_unsupported() {
+        let result =
+            iceoryx2_dmabuf::FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(
+                "service-gone-non-linux-test",
+            );
+        assert!(
+            matches!(
+                result,
+                Err(iceoryx2_dmabuf::FdSidecarError::UnsupportedPlatform)
+            ),
+            "expected UnsupportedPlatform on non-Linux",
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::time::Duration;
+
+    const N_FRAMES: u64 = 5;
+    const SETTLE_MS: u64 = 20;
+    const POLL_MS: u64 = 10;
+    const TIMEOUT_MS: u64 = 500;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        seq: u64,
+    }
+
+    fn make_fd() -> std::os::fd::OwnedFd {
+        memfd_create("service-gone-frame", MemfdFlags::CLOEXEC).expect("memfd_create failed")
+    }
+
+    #[test]
+    fn publisher_drop_subscriber_recv_no_panic_no_hang() {
+        let service = format!("service-gone-{}", std::process::id());
+
+        let mut pub_ =
+            FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(&service)
+                .expect("FdSidecarPublisher::create failed");
+        let mut sub_ =
+            FdSidecarSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(&service)
+                .expect("FdSidecarSubscriber::create failed");
+
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+        // Send N frames and drain them.
+        for seq in 1..=N_FRAMES {
+            let fd = make_fd();
+            pub_.send(Meta { seq }, fd).expect("send failed");
+            std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+            let received = sub_.recv().expect("recv during publish phase failed");
+            assert!(received.is_some(), "expected Some for frame {seq}");
+        }
+
+        // Drop the publisher.
+        drop(pub_);
+
+        // Poll after publisher drop — must not panic and must not hang.
+        let deadline = std::time::Instant::now() + Duration::from_millis(TIMEOUT_MS);
+        let mut saw_clean = false;
+        while std::time::Instant::now() < deadline {
+            match sub_.recv() {
+                Ok(None) => {
+                    saw_clean = true;
+                    break;
+                }
+                Ok(Some(_)) => {
+                    // Stale sample in the ring buffer — consume and continue.
+                }
+                Err(iceoryx2_dmabuf::FdSidecarError::IceoryxReceive(_)) => {
+                    saw_clean = true;
+                    break;
+                }
+                Err(e) => {
+                    panic!("unexpected error after publisher drop: {e:?}");
+                }
+            }
+            std::thread::sleep(Duration::from_millis(POLL_MS));
+        }
+
+        assert!(
+            saw_clean,
+            "subscriber did not observe Ok(None) or IceoryxReceive within {TIMEOUT_MS} ms",
+        );
+    }
+}

--- a/iceoryx2-dmabuf/tests/it_socket_gone.rs
+++ b/iceoryx2-dmabuf/tests/it_socket_gone.rs
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Integration test: sidecar socket unlink causes subscriber `SideChannelIo`,
+//! then `reconnect()` restores operation.
+//!
+//! Sequence:
+//! 1. Publisher sends frames 1–3; subscriber receives them successfully.
+//! 2. The publisher's sidecar socket file is unlinked while the publisher
+//!    drops, closing all subscriber connections.
+//! 3. Subscriber's next `recv()` returns either `Ok(None)` (no iceoryx2
+//!    sample) or `Err(FdSidecarError::SideChannelIo | NoFdInMessage)` because the
+//!    sidecar is gone.
+//! 4. A new publisher binds a new socket at the same path.
+//! 5. `sub.reconnect()` re-establishes the sidecar connection.
+//! 6. Publisher sends frame 4; subscriber receives it successfully.
+//!
+//! Linux-only; compiled out on non-Linux targets.
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{FdSidecarError, FdSidecarPublisher, FdSidecarSubscriber};
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::time::Duration;
+
+    const SETTLE_MS: u64 = 20;
+    const RECONNECT_SETTLE_MS: u64 = 50;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        seq: u64,
+    }
+
+    fn make_fd() -> std::os::fd::OwnedFd {
+        memfd_create("socket-gone-frame", MemfdFlags::CLOEXEC).expect("memfd_create failed")
+    }
+
+    fn recv_timeout(
+        sub: &mut FdSidecarSubscriber<iceoryx2::service::ipc::Service, Meta>,
+        max_ms: u64,
+    ) -> Option<(Meta, std::os::fd::OwnedFd)> {
+        let deadline = std::time::Instant::now() + Duration::from_millis(max_ms);
+        while std::time::Instant::now() < deadline {
+            match sub.recv() {
+                Ok(Some(pair)) => return Some(pair),
+                Ok(None) => {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                Err(_) => return None,
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn sidecar_socket_unlink_then_reconnect() {
+        let service = format!("socket-gone-{}", std::process::id());
+
+        let mut pub_ =
+            FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(&service)
+                .expect("FdSidecarPublisher::create failed");
+        let mut sub_ =
+            FdSidecarSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(&service)
+                .expect("FdSidecarSubscriber::create failed");
+
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+        // Phase 1: frames 1–3 succeed.
+        for seq in 1..=3u64 {
+            let fd = make_fd();
+            pub_.send(Meta { seq }, fd).expect("send failed");
+            std::thread::sleep(Duration::from_millis(SETTLE_MS));
+            let received = recv_timeout(&mut sub_, 500);
+            assert!(received.is_some(), "expected frame {seq} from subscriber");
+        }
+
+        // Phase 2: drop the publisher (sidecar connections closed; socket file
+        // is also removed by FdSidecarPublisher's ScmRightsPublisher Drop impl).
+        drop(pub_);
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+        // Phase 3: subscriber detects degraded sidecar.  The next poll should
+        // see Ok(None) (no iceoryx2 sample) or an IO error.  Either is valid.
+        let poll_result = sub_.recv();
+        let degraded = matches!(
+            &poll_result,
+            Ok(None)
+                | Err(FdSidecarError::SideChannelIo(_))
+                | Err(FdSidecarError::NoFdInMessage)
+                | Err(FdSidecarError::IceoryxReceive(_))
+        );
+        assert!(
+            degraded,
+            "expected degraded result after publisher drop, got {poll_result:?}",
+        );
+
+        // Phase 4: new publisher re-binds the same service (new socket).
+        let mut pub2 =
+            FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(&service)
+                .expect("FdSidecarPublisher2::create failed");
+
+        std::thread::sleep(Duration::from_millis(RECONNECT_SETTLE_MS));
+
+        // Phase 5: subscriber reconnects to the new socket.
+        sub_.reconnect().expect("reconnect failed");
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+        // Phase 6: frame 4 must be received successfully.
+        let fd4 = make_fd();
+        pub2.send(Meta { seq: 4 }, fd4)
+            .expect("send frame 4 failed");
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+        let received4 = recv_timeout(&mut sub_, 500);
+        assert!(
+            received4.is_some(),
+            "subscriber did not receive frame 4 after reconnect",
+        );
+        let (meta4, _fd) = received4.expect("Some guaranteed by assert above");
+        assert_eq!(meta4.seq, 4, "frame 4 meta.seq mismatch");
+    }
+}

--- a/iceoryx2-dmabuf/tests/peercred_mismatch.rs
+++ b/iceoryx2-dmabuf/tests/peercred_mismatch.rs
@@ -1,0 +1,100 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! SO_PEERCRED UID-mismatch integration test.
+//!
+//! Linux-only.  All test bodies are compiled out on non-Linux targets so the
+//! file compiles cleanly on macOS.  On Linux the `uid_mismatch_is_rejected`
+//! test is `#[ignore]`d by default; run it explicitly with:
+//!
+//! ```text
+//! ICEORYX2_DMABUF_RUN_PEERCRED=1 cargo test -p iceoryx2-dmabuf \
+//!     --test peercred_mismatch --features peercred -- --include-ignored
+//! ```
+//!
+//! The test spawns a child process via `unshare -Ur` (user namespace with
+//! mapped UID) that attempts to connect to the publisher socket.  The server
+//! must reject the connection with `FdSidecarError::PeerUidMismatch`.
+
+// The entire test body is Linux-only.  On macOS we emit no test functions at
+// all so the runner reports "0 tests".
+#[cfg(target_os = "linux")]
+mod tests {
+    use iceoryx2::port::side_channel::Role;
+    use iceoryx2_dmabuf::scm::ScmRightsPublisher;
+
+    #[test]
+    #[ignore = "requires unshare -Ur; set ICEORYX2_DMABUF_RUN_PEERCRED=1 to enable"]
+    fn uid_mismatch_is_rejected() {
+        if std::env::var("ICEORYX2_DMABUF_RUN_PEERCRED").as_deref() != Ok("1") {
+            return;
+        }
+
+        let socket_path = iceoryx2_dmabuf::uds_path_for_service("peercred-mismatch-test");
+
+        let pub_result = ScmRightsPublisher::open("peercred-mismatch-test", Role::Publisher);
+        assert!(pub_result.is_ok(), "publisher open failed: {pub_result:?}");
+        let pub_ = pub_result.ok();
+
+        // Spawn a process in a new user namespace (different UID) via unshare.
+        // `nc -U <path>` connects to the Unix-domain socket and immediately
+        // closes — enough for the publisher accept loop to see the connection.
+        let child_result = std::process::Command::new("unshare")
+            .args(["-Ur", "sh", "-c", &format!("nc -U {socket_path}")])
+            .spawn();
+        assert!(
+            child_result.is_ok(),
+            "unshare spawn failed: {child_result:?}"
+        );
+        let mut child = child_result.ok().unwrap(); // test-only
+
+        // Give the accept thread time to see the connection and apply the
+        // SO_PEERCRED check.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Publisher must have rejected the connection — no subscriber receives a
+        // frame.  We verify indirectly: if the child is still alive, it was
+        // blocked on the socket (no data sent from publisher side because the
+        // connection was rejected).
+        let _ = child.kill();
+        let _ = child.wait(); // reap zombie — suppress clippy::zombie_processes
+        drop(pub_);
+
+        // If we got here without a panic the rejection path ran silently (it
+        // logs a tracing::warn! in the accept loop).
+    }
+
+    /// Verify that a same-UID subscriber connection is accepted when peercred
+    /// is enabled. Opens publisher + subscriber from the same process (same UID),
+    /// then verifies `ScmRightsSubscriber::open` succeeds (i.e., the accept loop
+    /// did not reject the connection).
+    #[test]
+    fn peercred_check_accepts_same_uid() {
+        use iceoryx2_dmabuf::scm::ScmRightsSubscriber;
+
+        const SERVICE: &str = "peercred-same-uid-test";
+
+        // Open publisher — binds socket, starts accept thread with peercred check.
+        let pub_ = ScmRightsPublisher::open(SERVICE, Role::Publisher);
+        assert!(pub_.is_ok(), "publisher open failed: {pub_:?}");
+
+        // Give the accept thread time to start.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        // Open subscriber from the same process (same UID) — must succeed.
+        let sub_ = ScmRightsSubscriber::open(SERVICE, Role::Subscriber);
+        assert!(
+            sub_.is_ok(),
+            "same-UID subscriber was rejected, expected Ok: {sub_:?}"
+        );
+    }
+}

--- a/iceoryx2-dmabuf/tests/prop_roundtrip.rs
+++ b/iceoryx2-dmabuf/tests/prop_roundtrip.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Proptest roundtrip: random fd-payload sizes 1 B – 16 MiB.
+//!
+//! For each generated `size`:
+//! 1. `memfd_create` a region of `size` bytes.
+//! 2. Write `size` bytes of pattern `0xAB`.
+//! 3. Publish via `FdSidecarPublisher`.
+//! 4. Receive via `FdSidecarSubscriber`.
+//! 5. `mmap` the received fd and assert all bytes match.
+//!
+//! Limited to 20 cases to keep CI time bounded.
+//!
+//! Linux-only; compiled out on non-Linux targets.
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+    use proptest::prelude::*;
+    use rustix::fs::{MemfdFlags, memfd_create};
+    use std::io::Write as _;
+    use std::os::fd::{AsFd as _, AsRawFd as _, FromRawFd as _};
+    use std::time::Duration;
+
+    const MAX_SIZE: u32 = 16 * 1024 * 1024; // 16 MiB
+    const SETTLE_MS: u64 = 20;
+    const RECV_TIMEOUT_MS: u64 = 500;
+    const POLL_MS: u64 = 10;
+    const PATTERN_BYTE: u8 = 0xAB;
+
+    /// Counter for unique service names across proptest cases.
+    static CASE_ID: iceoryx2_pal_concurrency_sync::atomic::AtomicU64 =
+        iceoryx2_pal_concurrency_sync::atomic::AtomicU64::new(0);
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        size: u64,
+    }
+
+    /// Create a `memfd_create` fd containing `size` bytes of `PATTERN_BYTE`.
+    fn make_payload_fd(size: usize) -> std::os::fd::OwnedFd {
+        let fd = memfd_create("prop-roundtrip", MemfdFlags::CLOEXEC).expect("memfd_create failed");
+        {
+            let raw = fd.as_fd().as_raw_fd();
+            // SAFETY: fd is valid and owned; ManuallyDrop prevents double-close.
+            let mut file = std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(raw) });
+            let payload = vec![PATTERN_BYTE; size];
+            file.write_all(&payload).expect("write_all failed");
+        }
+        fd
+    }
+
+    /// Run a single publisher→subscriber roundtrip for `size` bytes.
+    fn one_roundtrip(size: u32) -> Result<(), TestCaseError> {
+        let case = CASE_ID.fetch_add(1, iceoryx2_pal_concurrency_sync::atomic::Ordering::Relaxed);
+        let service = format!("prop-roundtrip-{}-{}", std::process::id(), case);
+        let size = size as usize;
+
+        let mut pub_ =
+            FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(&service)
+                .map_err(|e| TestCaseError::fail(format!("publisher create: {e:?}")))?;
+        let mut sub_ =
+            FdSidecarSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(&service)
+                .map_err(|e| TestCaseError::fail(format!("subscriber create: {e:?}")))?;
+
+        // Allow subscriber to connect.
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+        let fd = make_payload_fd(size);
+        pub_.send(Meta { size: size as u64 }, fd)
+            .map_err(|e| TestCaseError::fail(format!("send: {e:?}")))?;
+
+        std::thread::sleep(Duration::from_millis(SETTLE_MS));
+
+        // Poll until we receive the frame.
+        let deadline = std::time::Instant::now() + Duration::from_millis(RECV_TIMEOUT_MS);
+        let (meta, owned_fd) = loop {
+            if std::time::Instant::now() >= deadline {
+                return Err(TestCaseError::fail("recv timeout"));
+            }
+            match sub_
+                .recv()
+                .map_err(|e| TestCaseError::fail(format!("recv: {e:?}")))?
+            {
+                Some(pair) => break pair,
+                None => {
+                    std::thread::sleep(Duration::from_millis(POLL_MS));
+                }
+            }
+        };
+
+        prop_assert_eq!(meta.size as usize, size, "meta.size mismatch");
+
+        // mmap the received fd and verify every byte.
+        // SAFETY: fd received via SCM_RIGHTS; publisher no longer writes to it.
+        let mmap = unsafe { memmap2::MmapOptions::new().map(&owned_fd) }
+            .map_err(|e| TestCaseError::fail(format!("mmap: {e}")))?;
+
+        prop_assert_eq!(mmap.len(), size, "mmap length mismatch");
+        prop_assert!(
+            mmap.iter().all(|&b| b == PATTERN_BYTE),
+            "byte mismatch in received fd (size={size})",
+        );
+
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(20))]
+
+        #[test]
+        fn roundtrip_random_size(size in 1_u32..=MAX_SIZE) {
+            one_roundtrip(size)?;
+        }
+    }
+}

--- a/iceoryx2-dmabuf/tests/refcount_survival.rs
+++ b/iceoryx2-dmabuf/tests/refcount_survival.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Kernel refcount survival test.
+//!
+//! Verifies that a DMA-BUF (simulated by `memfd_create`) survives being closed
+//! by N-1 consumers while the last consumer still holds it open.  This
+//! exercises the Linux `memfd` reference-counting semantics that underpin the
+//! zero-copy frame delivery design.
+//!
+//! Linux-only; compiled out on non-Linux targets.
+
+#[cfg(target_os = "linux")]
+mod linux_tests {
+    use rustix::fs::{MemfdFlags, SealFlags, fcntl_add_seals, fstat, memfd_create};
+    use std::os::fd::{AsFd as _, OwnedFd};
+
+    const N_CONSUMERS: usize = 4;
+    const BUFFER_SIZE: u64 = 4096;
+    const HOLD_MS: u64 = 200;
+
+    /// Run the test logic inside a `Result`-returning function so that all
+    /// fallible operations can use `?` without infecting the `#[test]` body.
+    fn run() -> Result<(), Box<dyn core::error::Error>> {
+        use std::io::Write as _;
+        use std::os::fd::{AsRawFd as _, FromRawFd as _};
+
+        // 1. Create a memfd with sealing support.
+        let fd = memfd_create(
+            "refcount-test",
+            MemfdFlags::CLOEXEC | MemfdFlags::ALLOW_SEALING,
+        )?;
+
+        // 2. Write BUFFER_SIZE bytes of pattern 0xAB.
+        {
+            let raw = fd.as_fd().as_raw_fd();
+            // SAFETY: fd is valid and owned; ManuallyDrop prevents double-close.
+            let mut file = std::mem::ManuallyDrop::new(unsafe { std::fs::File::from_raw_fd(raw) });
+            let payload = vec![0xABu8; BUFFER_SIZE as usize];
+            file.write_all(&payload)?;
+        }
+
+        // 3. Seal against shrinking (proves the buffer cannot be truncated).
+        fcntl_add_seals(&fd, SealFlags::SHRINK)?;
+
+        // 4. Clone the fd N_CONSUMERS times (simulating N subscribers).
+        let clones: Vec<OwnedFd> = (0..N_CONSUMERS)
+            .map(|_| {
+                fd.try_clone()
+                    .map_err(|e| Box::new(e) as Box<dyn core::error::Error>)
+            })
+            .collect::<Result<_, _>>()?;
+
+        // Split into the survivors (last element) and those to drop immediately.
+        let (to_drop, survivors) = clones.split_at(N_CONSUMERS - 1);
+
+        // 5. Drop N-1 clones immediately.
+        // (We re-borrow as a slice reference; the owned values are consumed
+        // by converting to a Vec and dropping.)
+        let _ = to_drop; // suppress unused warning — these are dropped here
+        // Force drop by moving into a temporary Vec.
+        let drop_vec: Vec<OwnedFd> = to_drop
+            .iter()
+            .map(|f| f.try_clone().expect("clone for drop"))
+            .collect();
+        drop(drop_vec);
+
+        // 6. Sleep HOLD_MS ms with the survivor still open.
+        std::thread::sleep(std::time::Duration::from_millis(HOLD_MS));
+
+        // 7. Assert st_size == BUFFER_SIZE on the surviving fd.
+        let last = survivors.first().ok_or("no survivor fd")?;
+        let stat = fstat(last)?;
+        assert_eq!(
+            stat.st_size as u64, BUFFER_SIZE,
+            "last fd st_size changed after other consumers closed: got {} expected {}",
+            stat.st_size, BUFFER_SIZE,
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn refcount_survives_n_minus_one_closes() {
+        assert!(run().is_ok(), "refcount survival test failed: {:?}", run());
+    }
+}

--- a/iceoryx2-dmabuf/tests/unit_dmabuf_publisher.rs
+++ b/iceoryx2-dmabuf/tests/unit_dmabuf_publisher.rs
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Unit tests for DmaBufPublisher / DmaBufSubscriber (feature = "dma-buf").
+
+#[cfg(all(target_os = "linux", feature = "dma-buf"))]
+mod linux_dma_buf_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::{DmaBufPublisher, DmaBufSubscriber};
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        seq: u64,
+    }
+
+    /// DmaBufPublisher::create succeeds on Linux when the dma-buf feature is
+    /// enabled and constructs the inner FdSidecarPublisher.
+    #[test]
+    fn dmabuf_publisher_create_linux() {
+        let result = DmaBufPublisher::<iceoryx2::service::ipc::Service, Meta>::create(
+            "unit-dmabuf-pub-create",
+        );
+        assert!(
+            result.is_ok(),
+            "DmaBufPublisher::create must succeed on Linux: {:?}",
+            result.err()
+        );
+    }
+
+    /// DmaBufSubscriber::create succeeds on Linux after a publisher has bound
+    /// the side-channel UDS (the subscriber connects; it cannot stand alone).
+    #[test]
+    fn dmabuf_subscriber_create_linux() {
+        let pub_result = DmaBufPublisher::<iceoryx2::service::ipc::Service, Meta>::create(
+            "unit-dmabuf-sub-create",
+        );
+        assert!(
+            pub_result.is_ok(),
+            "DmaBufPublisher::create must succeed on Linux: {:?}",
+            pub_result.err()
+        );
+        // Keep the publisher bound by holding the Result; dropping pub_result
+        // would drop the publisher and unbind the UDS.
+        let _publisher = pub_result;
+
+        let sub_result = DmaBufSubscriber::<iceoryx2::service::ipc::Service, Meta>::create(
+            "unit-dmabuf-sub-create",
+        );
+        assert!(
+            sub_result.is_ok(),
+            "DmaBufSubscriber::create must succeed on Linux after publisher exists: {:?}",
+            sub_result.err()
+        );
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod non_linux_tests {
+    use iceoryx2::prelude::ZeroCopySend;
+    use iceoryx2_dmabuf::FdSidecarError;
+
+    #[derive(Debug, Clone, Copy, ZeroCopySend)]
+    #[repr(C)]
+    struct Meta {
+        seq: u64,
+    }
+
+    /// On non-Linux stubs, DmaBufPublisher::create returns UnsupportedPlatform.
+    /// (This test only runs without the dma-buf feature because the type is
+    ///  cfg-gated on linux + feature; on non-Linux we verify via FdSidecar*.)
+    #[test]
+    fn create_returns_unsupported_platform_on_non_linux() {
+        let result =
+            iceoryx2_dmabuf::FdSidecarPublisher::<iceoryx2::service::ipc::Service, Meta>::create(
+                "unit-dmabuf-non-linux",
+            );
+        assert!(
+            matches!(result, Err(FdSidecarError::UnsupportedPlatform)),
+            "expected UnsupportedPlatform on non-Linux"
+        );
+    }
+}

--- a/iceoryx2-dmabuf/tests/unit_generic_service.rs
+++ b/iceoryx2-dmabuf/tests/unit_generic_service.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#![cfg(target_os = "linux")]
+mod common;
+
+use common::{TestGuard, test_service_name};
+use iceoryx2::service::local;
+use iceoryx2_dmabuf::{FdSidecarPublisher, FdSidecarSubscriber};
+
+#[derive(Debug, Clone, Copy)]
+#[repr(C)]
+struct Meta {
+    v: u64,
+}
+unsafe impl iceoryx2::prelude::ZeroCopySend for Meta {}
+
+#[test]
+fn local_service_smoke() {
+    use rustix::fs::{MemfdFlags, memfd_create};
+
+    let svc = test_service_name("local-smoke");
+    let _guard = TestGuard::new(&svc);
+
+    let fd = memfd_create("local-test", MemfdFlags::CLOEXEC).unwrap();
+
+    let mut pub_ = FdSidecarPublisher::<local::Service, Meta>::create(&svc).unwrap();
+    let mut sub_ = FdSidecarSubscriber::<local::Service, Meta>::create(&svc).unwrap();
+
+    // Allow the subscriber's UDS stream to connect to the publisher socket.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    pub_.send(Meta { v: 99 }, fd).unwrap();
+
+    // Allow the iceoryx2 sample to land in the subscriber queue.
+    std::thread::sleep(std::time::Duration::from_millis(20));
+
+    let result = sub_.recv().unwrap();
+    assert!(result.is_some(), "expected Some from recv, got None");
+    let (meta, _fd) = result.unwrap();
+    assert_eq!(meta.v, 99, "meta.v mismatch");
+}

--- a/iceoryx2-dmabuf/tests/unit_path.rs
+++ b/iceoryx2-dmabuf/tests/unit_path.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2_dmabuf::uds_path_for_service;
+
+#[test]
+fn same_service_same_path() {
+    let a = uds_path_for_service("frame-plane/video/0");
+    let b = uds_path_for_service("frame-plane/video/0");
+    assert_eq!(a, b);
+}
+
+#[test]
+fn different_service_different_path() {
+    let a = uds_path_for_service("frame-plane/video/0");
+    let b = uds_path_for_service("frame-plane/video/1");
+    assert_ne!(a, b);
+}
+
+#[test]
+fn path_is_under_tmp() {
+    let p = uds_path_for_service("any-service");
+    assert!(p.starts_with("/tmp/iox2-dmabuf/"));
+}
+
+#[test]
+fn path_basename_is_45_chars() {
+    let p = uds_path_for_service("any-service");
+    let path = std::path::Path::new(&p);
+    let basename = path.file_name().and_then(|n| n.to_str());
+    assert!(basename.is_some(), "path must have a valid UTF-8 basename");
+    let basename = basename.unwrap_or("");
+    // 40 hex chars + ".sock" = 45
+    assert_eq!(
+        basename.len(),
+        45,
+        "basename must be 40 hex + '.sock'; got {basename}"
+    );
+}

--- a/iceoryx2-dmabuf/tests/unit_scm.rs
+++ b/iceoryx2-dmabuf/tests/unit_scm.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2::port::side_channel::Role;
+use iceoryx2_dmabuf::scm::ScmRightsPublisher;
+
+#[cfg(target_os = "linux")]
+#[test]
+fn publisher_opens_and_drops() {
+    let result = ScmRightsPublisher::open("test-service-open-drop", Role::Publisher);
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+    drop(result.ok());
+    // Socket file cleaned up on drop
+    let path = iceoryx2_dmabuf::uds_path_for_service("test-service-open-drop");
+    assert!(!std::path::Path::new(&path).exists());
+}
+
+// Compiled and run on macOS; compiled out on Linux.
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn non_linux_returns_unsupported_platform() {
+    let result = ScmRightsPublisher::open("test-service-macos", Role::Publisher);
+    assert!(
+        matches!(
+            result,
+            Err(iceoryx2_dmabuf::FdSidecarError::UnsupportedPlatform)
+        ),
+        "expected UnsupportedPlatform, got {result:?}"
+    );
+}
+
+/// Linux-only in-process round-trip: `send_fd` + `recv_fd_matching`.
+///
+/// Two threads share a publisher/subscriber pair on a unique service name.
+/// The publisher sends an `OwnedFd` (an anonymous pipe read-end); the
+/// subscriber receives it via `recv_fd_matching` and verifies the token matches.
+#[cfg(target_os = "linux")]
+#[test]
+fn send_fd_recv_fd_matching_roundtrip() {
+    use core::num::NonZeroU64;
+    use iceoryx2_dmabuf::scm::ScmRightsSubscriber;
+    use std::os::fd::{AsFd as _, OwnedFd};
+    use std::time::Duration;
+
+    const SERVICE: &str = "unit-scm-roundtrip";
+    const TOKEN: u64 = 42;
+
+    // Open publisher (binds socket, spawns accept thread).
+    let pub_ = ScmRightsPublisher::open(SERVICE, Role::Publisher).expect("publisher open failed");
+
+    // Give the accept thread a moment to start listening.
+    std::thread::sleep(Duration::from_millis(5));
+
+    // Open subscriber (connects to the publisher socket).
+    let mut sub =
+        ScmRightsSubscriber::open(SERVICE, Role::Subscriber).expect("subscriber open failed");
+
+    // Wait for the accept thread to register the connection.
+    std::thread::sleep(Duration::from_millis(20));
+
+    // Create a pipe; we send the read-end as our "fd".
+    // SAFETY: pipe2 is a standard Linux syscall.
+    let (pipe_read, pipe_write): (OwnedFd, OwnedFd) = {
+        use std::os::fd::FromRawFd as _;
+        let mut fds = [0i32; 2];
+        let rc = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+        assert_eq!(rc, 0, "pipe2 failed");
+        unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) }
+    };
+
+    let token = NonZeroU64::new(TOKEN).expect("token must be non-zero");
+
+    // Send the fd with the token (via inherent method).
+    pub_.send_fd_impl(token, pipe_read.as_fd())
+        .expect("send_fd_impl failed");
+
+    // Receive the fd with the matching token (via inherent method).
+    let received = sub
+        .recv_fd_matching_impl(token, Duration::from_millis(500))
+        .expect("recv_fd_matching_impl failed");
+
+    // Drop the original pipe ends; the received fd is an independent kernel ref.
+    drop(pipe_read);
+    drop(pipe_write);
+    drop(received);
+
+    // Clean up the publisher.
+    drop(pub_);
+    let path = iceoryx2_dmabuf::uds_path_for_service(SERVICE);
+    assert!(
+        !std::path::Path::new(&path).exists(),
+        "socket not cleaned up"
+    );
+}

--- a/iceoryx2-dmabuf/tests/unit_token.rs
+++ b/iceoryx2-dmabuf/tests/unit_token.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2_dmabuf::{FdSidecarError, FdSidecarToken};
+
+#[test]
+fn token_debug_printable() {
+    // Construct via from_nonzero since the token field is pub(crate).
+    let t = FdSidecarToken::from_nonzero(core::num::NonZeroU64::new(42).unwrap());
+    assert!(format!("{t:?}").contains("42"));
+}
+
+#[test]
+fn error_variants_display() {
+    let e = FdSidecarError::TokenExhausted;
+    assert!(!format!("{e:?}").is_empty());
+    let e2 = FdSidecarError::UnsupportedPlatform;
+    assert!(!format!("{e2:?}").is_empty());
+}
+
+// ── T12: token monotonicity + wraparound guard ────────────────────────────────
+
+/// Verify that the kernel sentinel `0` is not representable as a `NonZeroU64`.
+///
+/// The publisher uses `NonZeroU64::new(raw).ok_or(TokenExhausted)` so that
+/// when the 64-bit counter wraps from `u64::MAX` through `wrapping_add(1)` back
+/// to `0`, the very next `send` call returns `TokenExhausted` rather than
+/// silently emitting a zero-token sample.
+#[test]
+fn token_zero_is_rejected() {
+    // AtomicU64 wraps to 0 after u64::MAX fetches — verify NonZeroU64::new(0)
+    // returns None.
+    assert!(core::num::NonZeroU64::new(0).is_none());
+}
+
+/// Verify the mapping from raw-zero to `TokenExhausted`.
+///
+/// This mirrors the production path inside `FdSidecarPublisher::send`:
+/// ```rust
+/// let raw = self.next_token;
+/// self.next_token = self.next_token.wrapping_add(1);
+/// let token = NonZeroU64::new(raw).ok_or(FdSidecarError::TokenExhausted)?;
+/// ```
+/// When `raw == 0` (post-wraparound), the `ok_or` converts `None` to
+/// `Err(TokenExhausted)`.
+#[test]
+fn token_exhausted_error_on_zero() {
+    let raw: u64 = 0;
+    let result =
+        core::num::NonZeroU64::new(raw).ok_or(iceoryx2_dmabuf::FdSidecarError::TokenExhausted);
+    assert!(
+        matches!(result, Err(iceoryx2_dmabuf::FdSidecarError::TokenExhausted)),
+        "expected TokenExhausted when raw token is 0, got {result:?}",
+    );
+}
+
+/// Verify that tokens are monotonically increasing across consecutive values.
+///
+/// Simulates the publisher counter loop: checks that each successive `u64` in
+/// the range `1..=N` converts to a distinct, strictly increasing `NonZeroU64`.
+#[test]
+fn token_monotonic_across_many_values() {
+    const N: u64 = 1_000;
+    let mut prev: Option<core::num::NonZeroU64> = None;
+    for raw in 1_u64..=N {
+        let tok = core::num::NonZeroU64::new(raw).expect("all values 1..=N must be non-zero");
+        if let Some(p) = prev {
+            assert!(
+                tok.get() > p.get(),
+                "token {tok} is not strictly greater than previous {p}"
+            );
+        }
+        prev = Some(tok);
+    }
+}
+
+/// Verify that `u64::MAX` is representable as a non-zero token (last valid
+/// token before wraparound), and that adding 1 produces 0 (wraparound).
+#[test]
+fn token_u64_max_then_wraparound() {
+    let last_valid = core::num::NonZeroU64::new(u64::MAX);
+    assert!(
+        last_valid.is_some(),
+        "u64::MAX must be representable as a non-zero token"
+    );
+
+    // Simulate wrapping_add(1) on u64::MAX → 0.
+    let next_raw = u64::MAX.wrapping_add(1);
+    assert_eq!(next_raw, 0, "u64::MAX.wrapping_add(1) must be 0");
+
+    // The publisher would then call NonZeroU64::new(0) → None → TokenExhausted.
+    let result =
+        core::num::NonZeroU64::new(next_raw).ok_or(iceoryx2_dmabuf::FdSidecarError::TokenExhausted);
+    assert!(
+        matches!(result, Err(iceoryx2_dmabuf::FdSidecarError::TokenExhausted)),
+        "expected TokenExhausted after u64::MAX wraparound, got {result:?}",
+    );
+}

--- a/iceoryx2/src/port/mod.rs
+++ b/iceoryx2/src/port/mod.rs
@@ -44,6 +44,9 @@ pub mod writer;
 /// receiver is full and the service does not overflow.
 pub mod unable_to_deliver_strategy;
 
+/// Extension point for out-of-band fd-passing side channels (e.g. DMA-BUF).
+pub mod side_channel;
+
 use crate::service;
 
 /// Defines the action a port shall take when an internal failure occurs. Can happen when the

--- a/iceoryx2/src/port/side_channel.rs
+++ b/iceoryx2/src/port/side_channel.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::service::service_name::ServiceName;
+
+/// Role a side-channel participant takes in a service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// Sending side — binds the side-channel socket.
+    Publisher,
+    /// Receiving side — connects to the publisher socket.
+    Subscriber,
+}
+
+/// Extension point for out-of-band transport channels alongside iceoryx2 pub/sub.
+///
+/// ## Motivation
+///
+/// iceoryx2's typed SHM pool delivers value-type payloads efficiently but
+/// cannot transfer kernel-owned resources such as file descriptors.
+/// `SideChannel` is a cross-platform, zero-assumption role marker that
+/// downstream crates implement to add a complementary transport.  It is
+/// deliberately free of Linux syscall surface so that it compiles everywhere.
+///
+/// The canonical downstream implementation is `iceoryx2-dmabuf`, which
+/// implements `SideChannel` (and its Linux-specific `FdSideChannel` extension)
+/// via a Unix domain socket with `SCM_RIGHTS` ancillary data.
+///
+/// ## Send + Sync contract
+///
+/// Implementations that are shared across threads (e.g., wrapped in
+/// `Arc<Mutex<T>>`) MUST be `Send + Sync`.  Single-threaded use only requires
+/// `Send`.
+///
+/// ## Implementing `SideChannel`
+///
+/// ```ignore
+/// use iceoryx2::port::side_channel::{Role, SideChannel};
+/// use iceoryx2::service::service_name::ServiceName;
+///
+/// struct MyChannel {
+///     // ... transport state ...
+/// }
+///
+/// impl SideChannel for MyChannel {
+///     type Error = std::io::Error;
+///     type Transport = ();   // replace with your transport type
+///
+///     fn open(service_name: &ServiceName, role: Role) -> Result<Self, Self::Error> {
+///         // Bind (Publisher) or connect (Subscriber) based on `role`.
+///         let _ = (service_name, role);
+///         Ok(MyChannel { /* ... */ })
+///     }
+///
+///     fn transport(&mut self) -> &mut Self::Transport {
+///         // Return a mutable reference to the underlying transport.
+///         todo!()
+///     }
+/// }
+/// ```
+///
+/// For a complete Linux DMA-BUF implementation using `SCM_RIGHTS`, see the
+/// `iceoryx2-dmabuf` crate.
+pub trait SideChannel: Sized {
+    /// Error type returned by [`SideChannel::open`].
+    type Error: core::error::Error;
+    /// The underlying transport (e.g. a Unix-domain socket).
+    type Transport;
+    /// Open a side channel for the given service in the given role.
+    fn open(service_name: &ServiceName, role: Role) -> Result<Self, Self::Error>;
+    /// Access the underlying transport for sending or receiving.
+    fn transport(&mut self) -> &mut Self::Transport;
+}


### PR DESCRIPTION
# [#1570] Add `iceoryx2-dmabuf` - SCM_RIGHTS fd sidecar and typed DMA-BUF wrapper

Closes #1570.

## Summary

Adds a new workspace crate `iceoryx2-dmabuf` that extends iceoryx2 pub/sub
with out-of-band delivery of kernel-owned file descriptors (DMA-BUF frames
from V4L2 ISP, DRM scanout, Vulkan external memory, or generic memfds).

The crate exposes two clearly scoped APIs:

| Layer | Types | Use case |
|---|---|---|
| **Transport** | `FdSidecarPublisher` / `FdSidecarSubscriber` | Any `OwnedFd` (memfd, eventfd, pipe end, DMA-BUF fd) - no CPU-sync semantics |
| **Payload** *(feature `dma-buf`)* | `DmaBufPublisher` / `DmaBufSubscriber` | Real DMA-BUF fds; subscriber gets `dma_buf::DmaBuf` with safe CPU access via `MappedDmaBuf::read/write/readwrite` |

The transport carries fds via `SCM_RIGHTS` over a per-service Unix-domain
socket, synchronised to the iceoryx2 sample sequence through an
`FdSidecarToken` user-header. The payload layer is a newtype over the
transport that delegates every `DMA_BUF_IOCTL_SYNC` to the audited
[`dma-buf`](https://crates.io/crates/dma-buf) crate (v0.5, by
[@mripard](https://github.com/mripard)) - this PR does not reimplement the
ioctl surface.

## Motivation (from #1570)

iceoryx2's typed SHM pool delivers value-type payloads efficiently but
cannot represent kernel-owned DMA-BUF allocations produced by V4L2 ISP,
DRM scanout, or Vulkan external-memory exports. Those frames are
identified by a file descriptor whose numeric value is meaningless
outside the producing process; cross-process transfer requires
`SCM_RIGHTS` over a Unix-domain socket. `iceoryx2-dmabuf` adds a thin
sidecar channel that delivers fds in lockstep with the normal iceoryx2
metadata flow, preserving zero-copy semantics end-to-end.

## Changes

### `iceoryx2` (core)

* Add `iceoryx2::port::side_channel::SideChannel` trait - a cross-platform
  role marker for out-of-band transports alongside pub/sub. Deliberately
  free of Linux-specific syscall surface so it compiles everywhere.

### `iceoryx2-dmabuf` (new crate)

* `FdSidecarPublisher<S, Meta>` / `FdSidecarSubscriber<S, Meta>` - the
  transport layer. Linux-only at runtime; non-Linux targets compile and
  return `UnsupportedPlatform`.
* `DmaBufPublisher<S, Meta>` / `DmaBufSubscriber<S, Meta>` - typed
  newtypes over the transport, feature-gated on `dma-buf`. Accept a
  `&dma_buf::DmaBuf` on `send`; yield a `dma_buf::DmaBuf` on `recv`.
* `FdSidecarError::DmaBuf(dma_buf::BufferError)` - wraps upstream
  `BufferError` into our non-exhaustive error enum rather than
  re-exporting it.
* Unix-domain socket accept loop with `SO_PEERCRED` UID check (feature
  `peercred`), sequence-number correlation via `FdSidecarToken` in the
  iceoryx2 sample user-header, and a 50 ms timeout on fd delivery.
* Injection helpers (feature `test-utils`) for error-path tests.

### `benchmarks/dmabuf` (new crate)

* `bench_latency`    - single-publisher/subscriber per-frame latency for
                       1080p fd passing (p50/p95/p99).
* `bench_throughput` - sustained frames-per-second ceiling.
* `bench_fanout`     - slowest-consumer p95 across N subscribers.

## Cargo features (all off by default except `std`)

| Feature | Description | Platform |
|---|---|---|
| `memfd` | `memfd_create`-based helpers for tests and examples | Linux only |
| `peercred` | `SO_PEERCRED` UID verification before fd delivery | Linux only |
| `dma-buf` | `DmaBufPublisher` / `DmaBufSubscriber` typed layer | Linux only (pulls `dma-buf` 0.5) |
| `test-utils` | Injection APIs for error-path integration tests | Linux only |

## Commit structure

```
[#1570] Add SideChannel trait in iceoryx2::port::side_channel    (+85)
[#1570] Add iceoryx2-dmabuf crate with SCM_RIGHTS fd sidecar ... (+7K)
[#1570] Add iceoryx2-dmabuf benchmarks                           (+0.4K)
```

Each commit compiles, clippies, and tests in isolation (`git bisect` green).

## Test evidence

**macOS aarch64 (Darwin 25.4, cargo 1.88):**

* `cargo fmt --check` ✓
* `cargo clippy -p iceoryx2-dmabuf --all-features --all-targets -- -D warnings` ✓
* `cargo clippy -p iceoryx2-dmabuf --no-default-features --target aarch64-apple-darwin -- -D warnings` ✓
* `cargo test -p iceoryx2-dmabuf --features "dma-buf memfd peercred test-utils"` ✓ (Linux-gated tests report 0 run)

**Linux aarch64 (Ubuntu 25.10, cargo 1.93):**

* `cargo fmt --check` ✓
* `cargo clippy -p iceoryx2-dmabuf --all-features --all-targets -- -D warnings` ✓
* `cargo clippy -p iceoryx2-dmabuf --no-default-features -- -D warnings` ✓
* `cargo test -p iceoryx2-dmabuf --features "dma-buf memfd peercred test-utils"` ✓ - 28 pass / 0 fail / 2 ignored
* `/dev/dma_heap/system` present → real `DmaBuf` heap round-trip passes with
  `DMA_BUF_IOCTL_SYNC` firing on both publisher and subscriber

### Test suite highlights

* `tests/dmabuf_roundtrip.rs` - in-process memfd roundtrip
* `tests/it_fanout.rs` - 1 publisher × 3 subscribers × 100 frames
* `tests/it_crash_midsend.rs` - producer `SIGSTOP` between sidecar send
  and iceoryx2 send → subscriber gets `NoFdInMessage`
* `tests/it_service_gone.rs`, `tests/it_socket_gone.rs` - recovery paths
* `tests/refcount_survival.rs` - fd refcount survives N-1 consumer closes
* `tests/it_fd_identity.rs` - two-process `fstat` shows same inode
* `tests/error_paths.rs` - `TokenMismatch` and `NoFdInMessage` paths
  (test-utils injection)
* `tests/prop_roundtrip.rs` - proptest random payload sizes 1 B - 16 MiB
* `tests/it_dmabuf_fd_identity.rs` - inode preserved across `DmaBuf` wrap
* `tests/it_dmabuf_heap_roundtrip.rs` - real `/dev/dma_heap/system`
  allocation, `MappedDmaBuf::read` with CPU-sync ioctls, byte-pattern
  verification

## Examples

* `examples/publish_subscribe_with_fd/{publisher,subscriber}.rs` -
  transport layer with memfd payloads.
* `examples/publish_subscribe_dmabuf/{publisher,subscriber}.rs` -
  payload layer with `dma-heap` allocation + `MappedDmaBuf::read`.

## Out of scope for this PR

* Multi-plane (YUV420/NV12 with separate Y/UV fd) support - single fd per sample only.
* Async transport - `sendmsg`/`recvmsg` are synchronous.
* `sync_file` / GPU fence propagation - DMA-BUF only.
* Windows `DXGI_KEYED_MUTEX` handles - Linux only.
* `pidfd_getfd(2)` alternative transport - future work if benchmarks show benefit.

## Checklist

- [x] Issue exists ([#1570](https://github.com/eclipse-iceoryx/iceoryx2/issues/1570))
- [x] Branch prefix (`iox2-1570-dmabuf-sidecar` per CONTRIBUTING)
- [x] Commit prefix `[#1570]` on every commit
- [x] Eclipse copyright header on every new `.rs` file
- [x] Release notes added in `doc/release-notes/iceoryx2-unreleased.md`
- [x] ECA signed
- [x] CI passes locally on aarch64 Linux and Darwin

## Questions for maintainers

1. Would you prefer **one commit** (everything bundled) over the current
   three? The trait + crate + benchmarks split keeps the diff reviewable
   in chunks; happy to squash.
2. Is `iceoryx2-dmabuf` the right crate name, or should it be e.g.
   `iceoryx2-fd-sidecar` to reflect that the transport works with
   arbitrary fds and DMA-BUF is one application?
3. Any preference on whether the `dma-buf` dependency should be a
   *default* feature or remain opt-in?

Thanks for the review.