### PR TITLE
[#1584] Expose Service::remove() for orphaned static config cleanup

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -45,6 +45,11 @@
   the trait impl and enforce all invariants (`#[repr(C)]`, no padding, field
   bounds) at compile time
   [#1547](https://github.com/eclipse-iceoryx/iceoryx2/issues/1547)
+* Add `Service::remove()` so that orphaned static service configs left behind
+  after an abrupt process termination (e.g. `SIGKILL`) can be cleaned up
+  programmatically (also surfaced via the C and Python FFIs as
+  `iox2_service_remove` and `Service.remove`)
+  [#1584](https://github.com/eclipse-iceoryx/iceoryx2/issues/1584)
 
 ### Bugfixes
 

--- a/iceoryx2-ffi/c/src/api/service.rs
+++ b/iceoryx2-ffi/c/src/api/service.rs
@@ -23,6 +23,7 @@ use iceoryx2::service::{
 };
 use iceoryx2_bb_elementary::CallbackProgression;
 use iceoryx2_bb_elementary_traits::AsCStr;
+use iceoryx2_cal::named_concept::NamedConceptRemoveError;
 use iceoryx2_ffi_macros::CStrRepr;
 
 use crate::{
@@ -142,6 +143,24 @@ pub type iox2_service_list_callback = extern "C" fn(
     *const iox2_static_config_t,
     iox2_callback_context,
 ) -> iox2_callback_progression_e;
+
+#[repr(C)]
+#[derive(Copy, Clone, CStrRepr)]
+pub enum iox2_service_remove_error_e {
+    INSUFFICIENT_PERMISSIONS = IOX2_OK as isize + 1,
+    INTERNAL_ERROR,
+}
+
+impl IntoCInt for NamedConceptRemoveError {
+    fn into_c_int(self) -> c_int {
+        (match self {
+            NamedConceptRemoveError::InsufficientPermissions => {
+                iox2_service_remove_error_e::INSUFFICIENT_PERMISSIONS
+            }
+            NamedConceptRemoveError::InternalError => iox2_service_remove_error_e::INTERNAL_ERROR,
+        }) as c_int
+    }
+}
 
 // END type definition
 
@@ -333,6 +352,73 @@ pub unsafe extern "C" fn iox2_service_list(
     match result {
         Ok(()) => IOX2_OK,
         Err(e) => e.into_c_int(),
+    }
+}
+
+/// Returns a string literal describing the provided [`iox2_service_remove_error_e`].
+///
+/// # Arguments
+///
+/// * `error` - The error value for which a description should be returned
+///
+/// # Returns
+///
+/// A pointer to a null-terminated string containing the error message.
+/// The string is stored in the .rodata section of the binary.
+///
+/// # Safety
+///
+/// The returned pointer must not be modified or freed and is valid as long as the program runs.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_service_remove_error_string(
+    error: iox2_service_remove_error_e,
+) -> *const c_char {
+    error.as_const_cstr().as_ptr() as *const c_char
+}
+
+/// Removes the static service config of a service. On success `has_been_removed`
+/// contains `true` if a config was removed and `false` if no matching service
+/// existed. On error it returns `iox2_service_remove_error_e`, otherwise `IOX2_OK`.
+///
+/// # Safety
+///
+/// * The `service_name` must be valid and non-null
+/// * The `config` must be valid and non-null
+/// * The `has_been_removed` must be valid and non-null
+/// * No other process must be creating, opening or otherwise using the same
+///   service while this call runs
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_service_remove(
+    service_type: iox2_service_type_e,
+    service_name: iox2_service_name_ptr,
+    config: iox2_config_ptr,
+    messaging_pattern: iox2_messaging_pattern_e,
+    has_been_removed: *mut bool,
+) -> c_int {
+    debug_assert!(!service_name.is_null());
+    debug_assert!(!config.is_null());
+    debug_assert!(!has_been_removed.is_null());
+    unsafe {
+        let config = &*config;
+        let service_name = &*service_name;
+        let messaging_pattern = messaging_pattern.into();
+
+        let result = match service_type {
+            iox2_service_type_e::IPC => {
+                IpcService::remove(service_name, config, messaging_pattern)
+            }
+            iox2_service_type_e::LOCAL => {
+                LocalService::remove(service_name, config, messaging_pattern)
+            }
+        };
+
+        match result {
+            Ok(value) => {
+                *has_been_removed = value;
+                IOX2_OK
+            }
+            Err(e) => e.into_c_int(),
+        }
     }
 }
 

--- a/iceoryx2-ffi/python/src/error.rs
+++ b/iceoryx2-ffi/python/src/error.rs
@@ -232,6 +232,13 @@ create_exception!(
 
 create_exception!(
     iceoryx2_ffi_python,
+    ServiceRemoveError,
+    PyException,
+    "Errors caused when removing the static config of a service."
+);
+
+create_exception!(
+    iceoryx2_ffi_python,
     ServerCreateError,
     PyException,
     "Errors caused when creating a server port."

--- a/iceoryx2-ffi/python/src/service.rs
+++ b/iceoryx2-ffi/python/src/service.rs
@@ -14,7 +14,7 @@ use pyo3::prelude::*;
 
 use crate::{
     config::Config,
-    error::{ServiceDetailsError, ServiceListError},
+    error::{ServiceDetailsError, ServiceListError, ServiceRemoveError},
     messaging_pattern::MessagingPattern,
     service_details::{ServiceDetails, ServiceDetailsType},
     service_name::ServiceName,
@@ -76,6 +76,39 @@ impl Service {
             )
             .map_err(|e| ServiceDetailsError::new_err(format!("{e:?}")))?
             .map(|details| ServiceDetails(ServiceDetailsType::Local(details)))),
+        }
+    }
+
+    #[staticmethod]
+    /// Removes the static config of a `Service`. Returns `True` when a config was
+    /// removed, `False` if no matching service existed.
+    ///
+    /// Safety: the caller must ensure that no other process is creating, opening
+    /// or otherwise using the same service while this call runs.
+    pub fn remove(
+        service_name: &ServiceName,
+        config: &Config,
+        messaging_pattern: MessagingPattern,
+        service_type: ServiceType,
+    ) -> PyResult<bool> {
+        use iceoryx2::service::Service;
+        match service_type {
+            ServiceType::Ipc => Ok(unsafe {
+                crate::IpcService::remove(
+                    &service_name.0,
+                    &config.0.lock(),
+                    messaging_pattern.into(),
+                )
+            }
+            .map_err(|e| ServiceRemoveError::new_err(format!("{e:?}")))?),
+            ServiceType::Local => Ok(unsafe {
+                crate::LocalService::remove(
+                    &service_name.0,
+                    &config.0.lock(),
+                    messaging_pattern.into(),
+                )
+            }
+            .map_err(|e| ServiceRemoveError::new_err(format!("{e:?}")))?),
         }
     }
 

--- a/iceoryx2/conformance-tests/src/service.rs
+++ b/iceoryx2/conformance-tests/src/service.rs
@@ -959,6 +959,20 @@ pub mod service {
     }
 
     #[conformance_test]
+    pub fn remove_returns_false_when_service_does_not_exist<
+        Sut: Service,
+        Factory: SutFactory<Sut>,
+    >() {
+        let _ = Factory::new();
+        let config = generate_isolated_config();
+        let service_name = generate_service_name();
+
+        let result = unsafe { Sut::remove(&service_name, &config, Factory::messaging_pattern()) };
+
+        assert_that!(result, eq Ok(false));
+    }
+
+    #[conformance_test]
     pub fn concurrent_service_creation_and_listing_works<Sut: Service, Factory: SutFactory<Sut>>() {
         let _watch_dog = Watchdog::new_with_timeout(Duration::from_secs(120));
         let test = Factory::new();

--- a/iceoryx2/src/service/mod.rs
+++ b/iceoryx2/src/service/mod.rs
@@ -963,6 +963,32 @@ pub trait Service: Debug + Sized + internal::ServiceInternal<Self> + Clone {
 
         Ok(())
     }
+
+    /// Removes the static service config of a [`Service`]. Returns `true` when a
+    /// config was removed, `false` if it did not exist.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// * no other process is creating, opening or otherwise using the same
+    ///   [`Service`] while this call runs, and
+    /// * any blackboard payload/management segments associated with the service
+    ///   are cleaned up separately when removing a blackboard service.
+    ///
+    /// For routine cleanup of dead participants prefer
+    /// [`Node::cleanup_dead_nodes()`](crate::node::Node::cleanup_dead_nodes). Use
+    /// [`Service::remove()`] to recover from the situation where a service's static
+    /// config persists in shared memory without any live owner registered to it.
+    unsafe fn remove(
+        service_name: &ServiceName,
+        config: &config::Config,
+        messaging_pattern: MessagingPattern,
+    ) -> Result<bool, NamedConceptRemoveError> {
+        let service_hash =
+            ServiceHash::new::<Self::ServiceNameHasher>(service_name, messaging_pattern);
+        unsafe { remove_static_service_config::<Self>(config, &service_hash.0.into()) }
+    }
 }
 
 pub(crate) unsafe fn remove_static_service_config<S: Service>(


### PR DESCRIPTION
Add a `Service::remove` trait method (with a crate-private `remove_static_service_config` helper) so users can clean up orphaned static service configs left behind after an abrupt process termination (e.g. SIGKILL). Mirror the new API in the C and Python FFIs as `iox2_service_remove` and `Service.remove`.

See https://github.com/eclipse-iceoryx/iceoryx2/issues/1584