### PR TITLE
[#1573] Rename degradation callback to degradation handler

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -330,3 +330,67 @@
         .unable_to_deliver_strategy(UnableToDeliverStrategy::RetryUntilDelivered)
         .create()?;
     ```
+
+1. The `DegradationCallback` was renamed to `DegradationHandler`, as well as its
+   setters and the parameter changed from port IDs to `DegradationCause` and
+   `DegradationInfo`
+
+    ```rust
+    /// old
+    pub_sub_service
+        .publisher_builder()
+        .set_degradation_callback(|sender_port_id, receiver_port_id| /* ... */)
+        .create()?
+    pub_sub_service
+        .subscriber_builder()
+        .set_degradation_callback(|sender_port_id, receiver_port_id| /* ... */)
+        .create()?
+
+    request_response_service
+        .client_builder()
+        .set_request_degradation_callback(|sender_port_id, receiver_port_id| /* ... */)
+        .set_response_degradation_callback(|sender_port_id, receiver_port_id| /* ... */)
+        .create()?
+    request_response_service
+        .server_builder()
+        .set_request_degradation_callback(|sender_port_id, receiver_port_id| /* ... */)
+        .set_response_degradation_callback(|sender_port_id, receiver_port_id| /* ... */)
+        .create()?
+
+    /// new
+    pub_sub_service
+        .publisher_builder()
+        .set_degradation_handler(|cause, info| /* ... */)
+        .create()?
+    pub_sub_service
+        .subscriber_builder()
+        .set_degradation_handler(|cause, info| /* ... */)
+        .create()?
+
+    request_response_service
+        .client_builder()
+        .set_request_degradation_handler(|cause, info| /* ... */)
+        .set_response_degradation_handler(/* ... */)
+        .create()?
+    request_response_service
+        .server_builder()
+        .set_request_degradation_handler(|cause, info|/* ... */)
+        .set_response_degradation_handler(|cause, info|/* ... */)
+        .create()?
+    ```
+
+1. The `DegradationAction::Fail` was renamed to `DegradationAction::DegradeAndFail`.
+
+    ```rust
+    // old
+    service
+        .publisher_builder()
+        .set_degradation_callback(|_, _| DegradationAction::Fail)
+        .create()?;
+
+    // new
+    service
+        .publisher_builder()
+        .set_degradation_handler(|_, _| DegradationAction::DegradeAndFail)
+        .create()?;
+    ```

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -425,7 +425,7 @@ impl<
             receiver_max_buffer_size: static_config.max_active_requests_per_client,
             receiver_max_borrowed_samples: static_config.max_active_requests_per_client,
             enable_safe_overflow: static_config.enable_safe_overflow_for_requests,
-            degradation_callback: client_factory.request_degradation_callback,
+            degradation_handler: client_factory.request_degradation_handler,
             unable_to_deliver_handler: client_factory.unable_to_deliver_handler,
             number_of_samples: number_of_requests,
             max_number_of_segments,
@@ -469,7 +469,7 @@ impl<
                 PolymorphicVec::new(HeapAllocator::global(), number_of_to_be_removed_connections)
                     .expect("Heap allocator provides memory."),
             )),
-            degradation_callback: client_factory.response_degradation_callback,
+            degradation_handler: client_factory.response_degradation_handler,
             message_type_details: static_config.response_message_type_details,
             receiver_max_borrowed_samples: static_config
                 .max_borrowed_responses_per_pending_response,

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -27,7 +27,7 @@ use iceoryx2_log::{error, fail, warn};
 use crate::port::DegradationCause;
 use crate::port::DegradationInfo;
 use crate::port::update_connections::ConnectionFailure;
-use crate::port::{DegradationAction, DegradationCallback, ReceiveError};
+use crate::port::{DegradationAction, DegradationHandler, ReceiveError};
 use crate::service::NoResource;
 use crate::service::ServiceState;
 use crate::service::naming_scheme::data_segment_name;
@@ -123,7 +123,7 @@ pub(crate) struct Receiver<Service: service::Service> {
     pub(crate) tagger: CyclicTagger,
     pub(crate) to_be_removed_connections:
         Option<UnsafeCell<PolymorphicVec<'static, SlotMapKey, HeapAllocator>>>,
-    pub(crate) degradation_callback: DegradationCallback<'static>,
+    pub(crate) degradation_handler: DegradationHandler<'static>,
     pub(crate) message_type_details: MessageTypeDetails,
     pub(crate) receiver_max_borrowed_samples: usize,
     pub(crate) enable_safe_overflow: bool,
@@ -461,7 +461,7 @@ impl<Service: service::Service> Receiver<Service> {
 
             match self.create(index, &sender_details) {
                 Ok(()) => Ok(()),
-                Err(e) => match self.degradation_callback.call(
+                Err(e) => match self.degradation_handler.call(
                     DegradationCause::FailedToEstablishConnection,
                     &DegradationInfo {
                         service_id: self.service_state.static_config.unique_service_id().value(),

--- a/iceoryx2/src/port/details/sender.rs
+++ b/iceoryx2/src/port/details/sender.rs
@@ -30,8 +30,8 @@ use iceoryx2_log::{error, fail, fatal_panic, warn};
 
 use crate::node::SharedNode;
 use crate::port::{
-    DegradationAction, DegradationCallback, DegradationCause, DegradationInfo, LoanError,
-    SendError, UnableToDeliverHandler, UnableToDeliverInfo,
+    DegradationAction, DegradationCause, DegradationHandler, DegradationInfo, LoanError, SendError,
+    UnableToDeliverHandler, UnableToDeliverInfo,
 };
 use crate::prelude::UnableToDeliverStrategy;
 use crate::service::config_scheme::connection_config;
@@ -116,7 +116,7 @@ pub(crate) struct Sender<Service: service::Service> {
     pub(crate) enable_safe_overflow: bool,
     pub(crate) number_of_samples: usize,
     pub(crate) max_number_of_segments: u8,
-    pub(crate) degradation_callback: DegradationCallback<'static>,
+    pub(crate) degradation_handler: DegradationHandler<'static>,
     pub(crate) unable_to_deliver_handler: Option<UnableToDeliverHandler<'static>>,
     pub(crate) service_state: Arc<ServiceState<Service, NoResource>>,
     pub(crate) tagger: CyclicTagger,
@@ -217,7 +217,7 @@ impl<Service: service::Service> Sender<Service> {
 
             match delivery_call_result {
                 Err(ZeroCopySendError::UnableToDeliver) => {
-                    // can only happen with blocking send and the degradation callback triggered a failure
+                    // can only happen with blocking send and the degradation handler triggered a failure
                     fail!(from self, with SendError::UnableToDeliver,
                           "{msg} {:?} could not be delivered to receiver {:?}.",
                           offset, connection.receiver_port_id);
@@ -241,7 +241,7 @@ impl<Service: service::Service> Sender<Service> {
                         "{msg} {:?} to receiver {:?} an internal mechanism failed and the offset was delivered only to a subset of receivers.", offset, connection.receiver_port_id);
                 }
                 Err(ZeroCopySendError::ConnectionCorrupted) => {
-                    match self.degradation_callback.call(
+                    match self.degradation_handler.call(
                         DegradationCause::ConnectionCorrupted,
                         &DegradationInfo {
                             service_id: self
@@ -525,7 +525,7 @@ impl<Service: service::Service> Sender<Service> {
                         fatal_panic!(from self, "This should never happen! Unable to acquire previously created receiver connection.")
                     }
                 },
-                Err(e) => match self.degradation_callback.call(
+                Err(e) => match self.degradation_handler.call(
                     DegradationCause::FailedToEstablishConnection,
                     &DegradationInfo {
                         service_id: self.service_state.static_config.unique_service_id().value(),

--- a/iceoryx2/src/port/mod.rs
+++ b/iceoryx2/src/port/mod.rs
@@ -98,7 +98,7 @@ impl UnableToDeliverHandler<'_> {
 
 /// Defines the action that shall be take when an degradation is detected. This can happen when a
 /// sample cannot be delivered, or when the system is corrupted and files are modified by
-/// non-iceoryx2 instances. Is used as return value of the [`DegradationCallback`] to define a
+/// non-iceoryx2 instances. Is used as return value of the [`DegradationHandler`] to define a
 /// custom behavior.
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum DegradationAction {
@@ -110,7 +110,7 @@ pub enum DegradationAction {
     DegradeAndFail,
 }
 
-/// Defines the cause of a degradation and is a parameter of the [`DegradationCallback`].
+/// Defines the cause of a degradation and is a parameter of the [`DegradationHandler`].
 pub enum DegradationCause {
     /// Connection could not be established
     FailedToEstablishConnection,
@@ -118,7 +118,7 @@ pub enum DegradationCause {
     ConnectionCorrupted,
 }
 
-/// The degradation context passed to the [`DegradationCallback`]
+/// The degradation context passed to the [`DegradationHandler`]
 pub struct DegradationInfo {
     /// The service id, which is involved in the degradation
     pub service_id: u128,
@@ -128,11 +128,11 @@ pub struct DegradationInfo {
     pub receiver_port_id: u128,
 }
 
-/// The degradation callback invoked when a degradation is detected
+/// The degradation handler which is invoked when a degradation is detected
 ///
 /// # Arguments
 ///
-/// * DegradationCause: is the cause that triggered the callback
+/// * DegradationCause: is the cause that triggered the handler
 /// * DegradationInfo: is a reference to [`DegradationInfo`] with additional information
 ///   for the user to handle the incident
 ///
@@ -148,19 +148,19 @@ impl<F: Fn(DegradationCause, &DegradationInfo) -> DegradationAction + Send> Degr
 
 tiny_fn! {
     /// Defines a custom behavior whenever a port detects a degradation.
-    pub struct DegradationCallback = Fn(cause: DegradationCause, context: &DegradationInfo) -> DegradationAction;
+    pub struct DegradationHandler = Fn(cause: DegradationCause, context: &DegradationInfo) -> DegradationAction;
 }
 
-unsafe impl Send for DegradationCallback<'_> {}
+unsafe impl Send for DegradationHandler<'_> {}
 
-impl Debug for DegradationCallback<'_> {
+impl Debug for DegradationHandler<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "")
     }
 }
 
-impl DegradationCallback<'_> {
-    /// A convenience function that takes a [`DegradationAction`] and returns a [`DegradationCallback`].
+impl DegradationHandler<'_> {
+    /// A convenience function that takes a [`DegradationAction`] and returns a [`DegradationHandler`].
     pub fn new_with(action: DegradationAction) -> Self {
         Self::new(move |_, _| action)
     }

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -452,7 +452,7 @@ impl<
                     enable_safe_overflow: static_config.enable_safe_overflow,
                     number_of_samples,
                     max_number_of_segments,
-                    degradation_callback: publisher_factory.degradation_callback,
+                    degradation_handler: publisher_factory.degradation_handler,
                     unable_to_deliver_handler: publisher_factory.unable_to_deliver_handler,
                     service_state: service.clone(),
                     tagger: CyclicTagger::new(),

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -342,7 +342,7 @@ impl<
             } else {
                 None
             },
-            degradation_callback: server_factory.request_degradation_callback,
+            degradation_handler: server_factory.request_degradation_handler,
             number_of_channels: 1,
             connection_storage: UnsafeCell::new(SlotMap::new(number_of_connections)),
             initial_channel_state: CHANNEL_STATE_OPEN,
@@ -403,7 +403,7 @@ impl<
             enable_safe_overflow: static_config.enable_safe_overflow_for_responses,
             number_of_samples: number_of_responses,
             max_number_of_segments,
-            degradation_callback: server_factory.response_degradation_callback,
+            degradation_handler: server_factory.response_degradation_handler,
             unable_to_deliver_handler: server_factory.unable_to_deliver_handler,
             service_state: service.clone(),
             tagger: CyclicTagger::new(),

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -215,7 +215,7 @@ impl<
                     )
                     .expect("Heap allocator provides memory."),
                 )),
-                degradation_callback: config.degradation_callback,
+                degradation_handler: config.degradation_handler,
                 number_of_channels: 1,
                 connection_storage: UnsafeCell::new(SlotMap::new(number_of_connections)),
                 initial_channel_state: CHANNEL_STATE_OPEN,

--- a/iceoryx2/src/service/port_factory/client.rs
+++ b/iceoryx2/src/service/port_factory/client.rs
@@ -32,7 +32,7 @@
 use super::request_response::PortFactory;
 use crate::{
     port::{
-        DegradationAction, DegradationCallback, DegradationFn, UnableToDeliverFn,
+        DegradationAction, DegradationFn, DegradationHandler, UnableToDeliverFn,
         UnableToDeliverHandler, client::Client,
     },
     prelude::UnableToDeliverStrategy,
@@ -113,8 +113,8 @@ pub struct PortFactoryClient<
 > {
     pub(crate) config: LocalClientConfig,
     pub(crate) preallocate_number_of_requests_override: PreallocatedRequestsOverride<'static>,
-    pub(crate) request_degradation_callback: DegradationCallback<'static>,
-    pub(crate) response_degradation_callback: DegradationCallback<'static>,
+    pub(crate) request_degradation_handler: DegradationHandler<'static>,
+    pub(crate) response_degradation_handler: DegradationHandler<'static>,
     pub(crate) unable_to_deliver_handler: Option<UnableToDeliverHandler<'static>>,
     pub(crate) factory: &'factory PortFactory<
         Service,
@@ -168,8 +168,8 @@ impl<
         Self {
             config: self.config,
             factory: self.factory,
-            request_degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
-            response_degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
+            request_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
+            response_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             unable_to_deliver_handler: None,
             preallocate_number_of_requests_override: PreallocatedRequestsOverride::new(|v| v),
         }
@@ -198,8 +198,8 @@ impl<
                 allocation_strategy: AllocationStrategy::Static,
             },
             preallocate_number_of_requests_override: PreallocatedRequestsOverride::new(|v| v),
-            request_degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
-            response_degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
+            request_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
+            response_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             unable_to_deliver_handler: None,
             factory,
         }
@@ -235,28 +235,28 @@ impl<
         self
     }
 
-    /// Sets the [`DegradationCallback`] for sending [`RequestMut`](crate::request_mut::RequestMut)
+    /// Sets the [`DegradationHandler`] for sending [`RequestMut`](crate::request_mut::RequestMut)
     /// from the [`Client`]. Whenever a request connection to a
-    /// [`Server`](crate::port::server::Server) is corrupted or it seems to be dead, this callback
+    /// [`Server`](crate::port::server::Server) is corrupted or it seems to be dead, this handler
     /// is called and depending on the returned [`DegradationAction`] measures will be taken.
-    pub fn set_request_degradation_callback<F: DegradationFn + 'static>(
+    pub fn set_request_degradation_handler<F: DegradationFn + 'static>(
         mut self,
-        callback: F,
+        handler: F,
     ) -> Self {
-        self.request_degradation_callback = DegradationCallback::new(callback);
+        self.request_degradation_handler = DegradationHandler::new(handler);
 
         self
     }
 
-    /// Sets the [`DegradationCallback`] for receiving [`Response`](crate::response::Response)s
+    /// Sets the [`DegradationHandler`] for receiving [`Response`](crate::response::Response)s
     /// from a [`Server`](crate::port::server::Server). Whenever a response connection to a
-    /// [`Server`](crate::port::server::Server) is corrupted or it seems to be dead, this callback
+    /// [`Server`](crate::port::server::Server) is corrupted or it seems to be dead, this handler
     /// is called and depending on the returned [`DegradationAction`] measures will be taken.
-    pub fn set_response_degradation_callback<F: DegradationFn + 'static>(
+    pub fn set_response_degradation_handler<F: DegradationFn + 'static>(
         mut self,
-        callback: F,
+        handler: F,
     ) -> Self {
-        self.response_degradation_callback = DegradationCallback::new(callback);
+        self.response_degradation_handler = DegradationHandler::new(handler);
 
         self
     }

--- a/iceoryx2/src/service/port_factory/publisher.rs
+++ b/iceoryx2/src/service/port_factory/publisher.rs
@@ -56,7 +56,7 @@
 
 use crate::{
     port::{
-        DegradationAction, DegradationCallback, DegradationFn, UnableToDeliverFn,
+        DegradationAction, DegradationFn, DegradationHandler, UnableToDeliverFn,
         UnableToDeliverHandler,
         publisher::{Publisher, PublisherCreateError},
         unable_to_deliver_strategy::UnableToDeliverStrategy,
@@ -113,7 +113,7 @@ pub struct PortFactoryPublisher<
     UserHeader: Debug + ZeroCopySend,
 > {
     pub(crate) config: LocalPublisherConfig,
-    pub(crate) degradation_callback: DegradationCallback<'static>,
+    pub(crate) degradation_handler: DegradationHandler<'static>,
     pub(crate) unable_to_deliver_handler: Option<UnableToDeliverHandler<'static>>,
     pub(crate) preallocate_number_of_samples_override: PreallocatedSamplesOverride<'static>,
     pub(crate) factory: &'factory PortFactory<Service, Payload, UserHeader>,
@@ -141,7 +141,7 @@ impl<
         Self {
             config: self.config,
             factory: self.factory,
-            degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
+            degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             unable_to_deliver_handler: None,
             preallocate_number_of_samples_override: PreallocatedSamplesOverride::new(|v| v),
         }
@@ -175,7 +175,7 @@ impl<
                     .publish_subscribe
                     .unable_to_deliver_strategy,
             },
-            degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
+            degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             unable_to_deliver_handler: None,
             preallocate_number_of_samples_override: PreallocatedSamplesOverride::new(|v| v),
             factory,
@@ -217,11 +217,11 @@ impl<
         self
     }
 
-    /// Sets the [`DegradationCallback`] of the [`Publisher`]. Whenever a connection to a
-    /// [`crate::port::subscriber::Subscriber`] is corrupted or it seems to be dead, this callback
+    /// Sets the [`DegradationHandler`] of the [`Publisher`]. Whenever a connection to a
+    /// [`crate::port::subscriber::Subscriber`] is corrupted or it seems to be dead, this handler
     /// is called and depending on the returned [`DegradationAction`] measures will be taken.
-    pub fn set_degradation_callback<F: DegradationFn + 'static>(mut self, callback: F) -> Self {
-        self.degradation_callback = DegradationCallback::new(callback);
+    pub fn set_degradation_handler<F: DegradationFn + 'static>(mut self, handler: F) -> Self {
+        self.degradation_handler = DegradationHandler::new(handler);
 
         self
     }

--- a/iceoryx2/src/service/port_factory/server.rs
+++ b/iceoryx2/src/service/port_factory/server.rs
@@ -36,7 +36,7 @@
 use super::request_response::PortFactory;
 use crate::{
     port::{
-        DegradationAction, DegradationCallback, DegradationFn, UnableToDeliverFn,
+        DegradationAction, DegradationFn, DegradationHandler, UnableToDeliverFn,
         UnableToDeliverHandler, server::Server,
     },
     prelude::UnableToDeliverStrategy,
@@ -123,8 +123,8 @@ pub struct PortFactoryServer<
     >,
 
     pub(crate) config: LocalServerConfig,
-    pub(crate) request_degradation_callback: DegradationCallback<'static>,
-    pub(crate) response_degradation_callback: DegradationCallback<'static>,
+    pub(crate) request_degradation_handler: DegradationHandler<'static>,
+    pub(crate) response_degradation_handler: DegradationHandler<'static>,
     pub(crate) unable_to_deliver_handler: Option<UnableToDeliverHandler<'static>>,
     pub(crate) preallocated_number_of_responses_override: PreallocatedResponseOverride<'static>,
 }
@@ -172,8 +172,8 @@ impl<
         Self {
             factory: self.factory,
             config: self.config,
-            request_degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
-            response_degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
+            request_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
+            response_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             unable_to_deliver_handler: None,
             preallocated_number_of_responses_override: PreallocatedResponseOverride::new(|v| v),
         }
@@ -203,8 +203,8 @@ impl<
                 allocation_strategy: AllocationStrategy::Static,
                 max_loaned_responses_per_request: defs.server_max_loaned_responses_per_request,
             },
-            request_degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
-            response_degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
+            request_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
+            response_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             unable_to_deliver_handler: None,
             preallocated_number_of_responses_override: PreallocatedResponseOverride::new(|v| v),
         }
@@ -252,29 +252,29 @@ impl<
         self
     }
 
-    /// Sets the [`DegradationCallback`] for receiving [`ActiveRequest`](crate::active_request::ActiveRequest)s
+    /// Sets the [`DegradationHandler`] for receiving [`ActiveRequest`](crate::active_request::ActiveRequest)s
     /// from a [`Client`](crate::port::client::Client). Whenever a request connection to a
-    /// [`Client`](crate::port::client::Client) is corrupted or it seems to be dead, this callback
+    /// [`Client`](crate::port::client::Client) is corrupted or it seems to be dead, this handler
     /// is called and depending on the returned [`DegradationAction`] measures will be taken.
-    pub fn set_request_degradation_callback<F: DegradationFn + 'static>(
+    pub fn set_request_degradation_handler<F: DegradationFn + 'static>(
         mut self,
-        callback: F,
+        handler: F,
     ) -> Self {
-        self.request_degradation_callback = DegradationCallback::new(callback);
+        self.request_degradation_handler = DegradationHandler::new(handler);
 
         self
     }
 
-    /// Sets the [`DegradationCallback`] for sending
+    /// Sets the [`DegradationHandler`] for sending
     /// [`ResponseMut`](crate::response_mut::ResponseMut)s
     /// to a [`Client`](crate::port::client::Client). Whenever a response connection to a
-    /// [`Client`](crate::port::client::Client) is corrupted or it seems to be dead, this callback
+    /// [`Client`](crate::port::client::Client) is corrupted or it seems to be dead, this handler
     /// is called and depending on the returned [`DegradationAction`] measures will be taken.
-    pub fn set_response_degradation_callback<F: DegradationFn + 'static>(
+    pub fn set_response_degradation_handler<F: DegradationFn + 'static>(
         mut self,
-        callback: F,
+        handler: F,
     ) -> Self {
-        self.response_degradation_callback = DegradationCallback::new(callback);
+        self.response_degradation_handler = DegradationHandler::new(handler);
 
         self
     }

--- a/iceoryx2/src/service/port_factory/subscriber.rs
+++ b/iceoryx2/src/service/port_factory/subscriber.rs
@@ -37,7 +37,7 @@ use iceoryx2_log::fail;
 
 use crate::{
     port::{
-        DegradationAction, DegradationCallback, DegradationFn,
+        DegradationAction, DegradationFn, DegradationHandler,
         subscriber::{Subscriber, SubscriberCreateError},
     },
     service,
@@ -48,7 +48,7 @@ use super::publish_subscribe::PortFactory;
 #[derive(Debug)]
 pub(crate) struct SubscriberConfig {
     pub(crate) buffer_size: Option<usize>,
-    pub(crate) degradation_callback: DegradationCallback<'static>,
+    pub(crate) degradation_handler: DegradationHandler<'static>,
 }
 
 /// Factory to create a new [`Subscriber`] port/endpoint for
@@ -88,7 +88,7 @@ impl<
         Self {
             config: SubscriberConfig {
                 buffer_size: self.config.buffer_size,
-                degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
+                degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             },
             factory: self.factory,
         }
@@ -98,7 +98,7 @@ impl<
         Self {
             config: SubscriberConfig {
                 buffer_size: None,
-                degradation_callback: DegradationCallback::new_with(DegradationAction::Warn),
+                degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             },
             factory,
         }
@@ -110,11 +110,11 @@ impl<
         self
     }
 
-    /// Sets the [`DegradationCallback`] of the [`Subscriber`]. Whenever a connection to a
-    /// [`crate::port::subscriber::Subscriber`] is corrupted or it seems to be dead, this callback
+    /// Sets the [`DegradationHandler`] of the [`Subscriber`]. Whenever a connection to a
+    /// [`crate::port::subscriber::Subscriber`] is corrupted or it seems to be dead, this handler
     /// is called and depending on the returned [`DegradationAction`] measures will be taken.
-    pub fn set_degradation_callback<F: DegradationFn + 'static>(mut self, callback: F) -> Self {
-        self.config.degradation_callback = DegradationCallback::new(callback);
+    pub fn set_degradation_handler<F: DegradationFn + 'static>(mut self, handler: F) -> Self {
+        self.config.degradation_handler = DegradationHandler::new(handler);
 
         self
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Rename the degradation callback to degradation handler.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #1573

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
