### PR TITLE
[#1573] Small fixes

### DIFF
--- a/examples/cxx/publish_subscribe_unable_to_deliver/src/publisher.cpp
+++ b/examples/cxx/publish_subscribe_unable_to_deliver/src/publisher.cpp
@@ -40,7 +40,7 @@ auto main() -> int {
     auto counter = 0;
     auto delivery_incident_counter = 0;
 
-    UnableToDeliverHandler unable_to_deliver_handler = [&](UnableToDeliverInfo& info) -> auto {
+    UnableToDeliverHandler unable_to_deliver_handler = [&](const UnableToDeliverInfo& info) -> auto {
         // only print the port IDs in the first iteration of the retry loop of each delivery incident
         if (info.retries() == 0) {
             delivery_incident_counter += 1;

--- a/iceoryx2-cxx/include/iox2/unable_to_deliver_handler.hpp
+++ b/iceoryx2-cxx/include/iox2/unable_to_deliver_handler.hpp
@@ -80,7 +80,7 @@ class UnableToDeliverInfo {
 /// handle the incident
 ///
 /// @eturn The [`UnableToDeliverAction`] to be taken to mitigate the incident
-using UnableToDeliverHandler = iox2::bb::StaticFunction<UnableToDeliverAction(UnableToDeliverInfo&)>;
+using UnableToDeliverHandler = iox2::bb::StaticFunction<UnableToDeliverAction(const UnableToDeliverInfo&)>;
 
 namespace detail {
 inline auto unable_to_deliver_handler_delegate(iox2_unable_to_deliver_info_h_ref info_handle,

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -1006,12 +1006,12 @@ TYPED_TEST(ServicePublishSubscribeTest, publisher_reallocates_memory_when_alloca
     }
 
     {
-        auto sample = publisher.loan_slice(INITIAL_SIZE * INITIAL_SIZE);
+        auto sample = publisher.loan_slice(INITIAL_SIZE * 4);
         ASSERT_THAT(sample.has_value(), Eq(true));
     }
 
     {
-        auto sample = publisher.loan_slice(INITIAL_SIZE * INITIAL_SIZE * INITIAL_SIZE);
+        auto sample = publisher.loan_slice(INITIAL_SIZE * 4 * 4);
         ASSERT_THAT(sample.has_value(), Eq(true));
     }
 }

--- a/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
@@ -1294,12 +1294,12 @@ TYPED_TEST(ServiceRequestResponseTest, client_reallocates_memory_when_allocation
     }
 
     {
-        auto request = client.loan_slice(INITIAL_SIZE * INITIAL_SIZE);
+        auto request = client.loan_slice(INITIAL_SIZE * 4);
         ASSERT_TRUE(request.has_value());
     }
 
     {
-        auto request = client.loan_slice(INITIAL_SIZE * INITIAL_SIZE * INITIAL_SIZE);
+        auto request = client.loan_slice(INITIAL_SIZE * 4 * 4);
         ASSERT_TRUE(request.has_value());
     }
 }
@@ -1361,12 +1361,12 @@ TYPED_TEST(ServiceRequestResponseTest, server_reallocates_memory_when_allocation
     }
 
     {
-        auto response = active_request->loan_slice(INITIAL_SIZE * INITIAL_SIZE);
+        auto response = active_request->loan_slice(INITIAL_SIZE * 4);
         ASSERT_TRUE(response.has_value());
     }
 
     {
-        auto response = active_request->loan_slice(INITIAL_SIZE * INITIAL_SIZE * INITIAL_SIZE);
+        auto response = active_request->loan_slice(INITIAL_SIZE * 4 * 4);
         ASSERT_TRUE(response.has_value());
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR fixes a small API issue and also reduces the memory consumption in some tests.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #1573

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
