### PR TITLE
[#1578] robust lock-free unique index set

### DIFF
--- a/iceoryx2-bb/lock-free/src/mpmc/container.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/container.rs
@@ -55,7 +55,9 @@
 //! }
 //! ```
 
-pub use crate::mpmc::unique_index_set::ReleaseMode;
+use crate::mpmc::unique_index_set_enums::{
+    ReleaseMode, ReleaseState, UniqueIndexSetAcquireFailure,
+};
 pub use iceoryx2_bb_elementary::CallbackProgression;
 
 use iceoryx2_bb_concurrency::atomic::Ordering;
@@ -513,6 +515,7 @@ impl<T: Copy + Debug, const CAPACITY: usize> FixedSizeContainer<T, CAPACITY> {
     /// # extern crate iceoryx2_bb_loggers;
     ///
     /// use iceoryx2_bb_lock_free::mpmc::container::*;
+    /// use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::*;
     ///
     /// const CAPACITY: usize = 139;
     /// let container = FixedSizeContainer::<u128, CAPACITY>::new();

--- a/iceoryx2-bb/lock-free/src/mpmc/mod.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/mod.rs
@@ -14,4 +14,6 @@
 
 pub mod bit_set;
 pub mod container;
+pub mod robust_unique_index_set;
 pub mod unique_index_set;
+pub mod unique_index_set_enums;

--- a/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
@@ -527,10 +527,29 @@ impl RobustUniqueIndexSet {
 }
 
 #[derive(Debug)]
+pub struct StaticRobustUniqueIndexSetData<const CAPACITY: usize> {
+    cells: [AtomicU64; CAPACITY],
+}
+
+impl<const CAPACITY: usize> Default for StaticRobustUniqueIndexSetData<CAPACITY> {
+    fn default() -> Self {
+        Self {
+            cells: [const { AtomicU64::new(0) }; CAPACITY],
+        }
+    }
+}
+
+impl<const CAPACITY: usize> StaticRobustUniqueIndexSetData<CAPACITY> {
+    pub fn allocator(&mut self) -> BumpAllocator {
+        BumpAllocator::new(self.cells.as_mut_ptr().cast())
+    }
+}
+
+#[derive(Debug)]
 #[repr(C)]
 pub struct StaticRobustUniqueIndexSet<const CAPACITY: usize> {
     state: RobustUniqueIndexSet,
-    cells: [AtomicU64; CAPACITY],
+    cells: StaticRobustUniqueIndexSetData<CAPACITY>,
 }
 
 impl<const CAPACITY: usize> Default for StaticRobustUniqueIndexSet<CAPACITY> {
@@ -566,14 +585,13 @@ impl<const CAPACITY: usize> StaticRobustUniqueIndexSet<CAPACITY> {
 
         let mut new_self = Self {
             state: unsafe { RobustUniqueIndexSet::new_uninit(capacity) },
-            cells: core::array::from_fn(|_| AtomicU64::new(0)),
+            cells: StaticRobustUniqueIndexSetData::default(),
         };
 
-        let allocator = BumpAllocator::new(new_self.cells.as_mut_ptr().cast());
         unsafe {
             new_self
                 .state
-                .init(&allocator)
+                .init(&new_self.cells.allocator())
                 .expect("All required memory is preallocated")
         };
 

--- a/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
@@ -96,7 +96,7 @@ use iceoryx2_bb_elementary::enum_gen;
 use iceoryx2_bb_elementary::relocatable_ptr::{PointerTrait, RelocatablePointer};
 use iceoryx2_bb_elementary_traits::allocator::AllocationError;
 use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
-use iceoryx2_log::{fail, fatal_panic};
+use iceoryx2_log::{error, fail, fatal_panic};
 
 use crate::mpmc::unique_index_set_enums::{
     ReleaseMode, ReleaseState, UniqueIndexCreationError, UniqueIndexSetAcquireFailure,
@@ -122,6 +122,11 @@ impl OwnerId {
 
         Ok(Self(value))
     }
+}
+
+struct RepairState {
+    generation_counter: u64,
+    borrowed_indices: u64,
 }
 
 #[repr(C)]
@@ -199,29 +204,39 @@ impl RobustUniqueIndexSet {
     /// Returns if the [`RobustUniqueIndexSet`] is locked or not. If the set is locked no more indices
     /// can be borrowed.
     pub fn is_locked(&self) -> bool {
-        self.borrowed_indices.load(Ordering::Relaxed) == u64::MAX
+        self.generation_counter.load(Ordering::Relaxed) == u64::MAX
     }
 
     fn lock(&self) -> ReleaseState {
-        match self.borrowed_indices.compare_exchange(
-            0,
-            u64::MAX,
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-        ) {
-            Ok(_) => ReleaseState::Locked,
-            Err(_) => ReleaseState::Unlocked,
+        if self.is_locked() {
+            return ReleaseState::Locked;
+        }
+
+        loop {
+            let state = self.repair_borrowed_indices();
+
+            if state.borrowed_indices == 0 {
+                match self.generation_counter.compare_exchange(
+                    state.generation_counter,
+                    u64::MAX,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => return ReleaseState::Locked,
+                    Err(_) => continue,
+                }
+            } else {
+                return ReleaseState::Unlocked;
+            }
         }
     }
 
     /// Returns the current len.
     pub fn borrowed_indices(&self) -> usize {
-        let borrowed_indices = self.borrowed_indices.load(Ordering::Relaxed);
-
-        if borrowed_indices == u64::MAX {
+        if self.is_locked() {
             0
         } else {
-            borrowed_indices as _
+            self.borrowed_indices.load(Ordering::Relaxed) as _
         }
     }
 
@@ -278,13 +293,13 @@ impl RobustUniqueIndexSet {
             //////////////////////////////////////
             let current_generation_count = self.generation_counter.load(Ordering::Acquire);
 
+            if current_generation_count == u64::MAX {
+                fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
+                    "{msg} since the RobustUniqueIndexSet is locked.");
+            }
+
             for n in 0..self.capacity {
                 let cell = unsafe { &*self.data_ptr.as_ptr().add(n) };
-
-                if self.is_locked() {
-                    fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
-                        "{msg} since the RobustUniqueIndexSet is locked.");
-                }
 
                 match cell.compare_exchange(
                     OwnerId::EMPTY.0,
@@ -293,11 +308,6 @@ impl RobustUniqueIndexSet {
                     Ordering::Relaxed,
                 ) {
                     Ok(_) => {
-                        if self.is_locked() {
-                            fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
-                                "{msg} since the RobustUniqueIndexSet is locked.");
-                        }
-
                         self.borrowed_indices.fetch_add(1, Ordering::Relaxed);
 
                         //////////////////////////////////////
@@ -305,7 +315,15 @@ impl RobustUniqueIndexSet {
                         //   1. cell & borrowed_indices
                         //   2. generation counter
                         //////////////////////////////////////
-                        self.generation_counter.fetch_add(1, Ordering::Release);
+                        if self.increment_generation_counter(Ordering::Release)
+                            == ReleaseState::Locked
+                        {
+                            // revert the increment, not important, just for consistency
+                            self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
+                            cell.store(OwnerId::EMPTY.0, Ordering::Relaxed);
+                            fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
+                                "{msg} since the RobustUniqueIndexSet is locked.");
+                        }
                         return Ok(n);
                     }
                     Err(_) => continue,
@@ -333,16 +351,40 @@ impl RobustUniqueIndexSet {
         self.verify_init("release()");
 
         let cell = unsafe { &*self.data_ptr.as_ptr().add(index) };
-        cell.store(OwnerId::EMPTY.0, Ordering::Relaxed);
 
-        self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
+        let cell_content = cell.load(Ordering::Relaxed);
 
-        //////////////////////////////////////
-        // SYNC POINT enforce order of:
-        //   1. cell & borrowed_indices
-        //   2. generation counter
-        //////////////////////////////////////
-        self.generation_counter.fetch_add(1, Ordering::Release);
+        if cell_content == OwnerId::EMPTY.0 {
+            error!(from self, "Release of the not acquired index {index} prevented." );
+        } else {
+            match cell.compare_exchange(
+                cell_content,
+                OwnerId::EMPTY.0,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    cell.store(OwnerId::EMPTY.0, Ordering::Relaxed);
+                    self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
+
+                    //////////////////////////////////////
+                    // SYNC POINT enforce order of:
+                    //   1. cell & borrowed_indices
+                    //   2. generation counter
+                    //////////////////////////////////////
+                    self.increment_generation_counter(Ordering::Release);
+                }
+                Err(v) => {
+                    if v == OwnerId::EMPTY.0 {
+                        error!(from self,
+                            "Prevented race in releasing the index {index} which would have resulted in a double free.");
+                    } else {
+                        error!(from self,
+                            "It seems like the index {index} was modified while releasing it. This could indicate a corrupted system.");
+                    }
+                }
+            }
+        }
 
         if mode == ReleaseMode::LockIfLastIndex {
             self.lock()
@@ -382,17 +424,21 @@ impl RobustUniqueIndexSet {
                     )
                     .is_ok()
             {
-                self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
-
                 //////////////////////////////////////
                 // SYNC POINT enforce order of:
-                //   1. cell & borrowed_indices
+                //   1. cell
                 //   2. generation counter
                 //////////////////////////////////////
-                self.generation_counter.fetch_add(1, Ordering::Release);
+                if self.increment_generation_counter(Ordering::Release) == ReleaseState::Locked {
+                    return ReleaseState::Locked;
+                }
 
                 if mode == ReleaseMode::LockIfLastIndex {
                     self.lock();
+                } else {
+                    // must be called here explicitly since self.lock() calls this
+                    // already
+                    self.repair_borrowed_indices();
                 }
             }
         }
@@ -400,6 +446,73 @@ impl RobustUniqueIndexSet {
         match self.is_locked() {
             true => ReleaseState::Locked,
             false => ReleaseState::Unlocked,
+        }
+    }
+
+    fn increment_generation_counter(&self, ordering: Ordering) -> ReleaseState {
+        let mut current_generation_count = self.generation_counter.load(Ordering::Relaxed);
+        loop {
+            if current_generation_count == u64::MAX {
+                return ReleaseState::Locked;
+            }
+
+            match self.generation_counter.compare_exchange(
+                current_generation_count,
+                current_generation_count + 1,
+                ordering,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return ReleaseState::Unlocked,
+                Err(v) => current_generation_count = v,
+            }
+        }
+    }
+
+    fn repair_borrowed_indices(&self) -> RepairState {
+        loop {
+            //////////////////////////////////////
+            // SYNC POINT enforce order of:
+            //   1. cell
+            //   2. generation counter
+            //////////////////////////////////////
+            let current_generation_count = self.generation_counter.load(Ordering::Acquire);
+
+            if current_generation_count == u64::MAX {
+                return RepairState {
+                    generation_counter: current_generation_count,
+                    borrowed_indices: 0,
+                };
+            }
+
+            let mut count = 0;
+            for n in 0..self.capacity {
+                let cell = unsafe { &*self.data_ptr.as_ptr().add(n) };
+                if cell.load(Ordering::Relaxed) != OwnerId::EMPTY.0 {
+                    count += 1;
+                }
+            }
+
+            self.borrowed_indices.store(count, Ordering::Relaxed);
+
+            //////////////////////////////////////
+            // SYNC POINT enforce order of:
+            //   1. borrowed_indices
+            //   2. generation counter
+            //////////////////////////////////////
+            match self.generation_counter.compare_exchange(
+                current_generation_count,
+                current_generation_count + 1,
+                Ordering::Release,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return RepairState {
+                        generation_counter: current_generation_count + 1,
+                        borrowed_indices: count,
+                    };
+                }
+                Err(_) => continue,
+            }
         }
     }
 }

--- a/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
@@ -16,6 +16,13 @@
 //! processes. Can be used as a building block for
 //! allocators or lock-free containers.
 //!
+//! The key properties of the robust unique index set:
+//!
+//!  * contains unique indices from 0 to CAPACITY
+//!  * indices can be acquired or released
+//!  * when releasing the last index the user has the option to lock the index set which means that
+//!    new indices can be never acquired again
+//!
 //! # Example
 //!
 //! ## Runtime fixed size RobustUniqueIndexSet
@@ -44,7 +51,7 @@
 //! println!("Acquired index {}", new_index);
 //!
 //! // return the index to the index set
-//! unsafe { index_set.release(new_index, ReleaseMode::default()) };
+//! unsafe { index_set.release(new_index, owner_id, ReleaseMode::default()) };
 //! ```
 //!
 //! ## Compile time FixedSizeUniqueIndexSet
@@ -68,7 +75,7 @@
 //! println!("Acquired index {}", new_index);
 //!
 //! // return the index to the index set
-//! index_set.release(new_index, ReleaseMode::default());
+//! index_set.release(new_index, owner_id, ReleaseMode::default());
 //! ```
 //!
 //! ## Recover indices from a dead process
@@ -96,7 +103,7 @@ use iceoryx2_bb_elementary::enum_gen;
 use iceoryx2_bb_elementary::relocatable_ptr::{PointerTrait, RelocatablePointer};
 use iceoryx2_bb_elementary_traits::allocator::AllocationError;
 use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
-use iceoryx2_log::{error, fail, fatal_panic};
+use iceoryx2_log::{fail, fatal_panic};
 
 use crate::mpmc::unique_index_set_enums::{
     ReleaseMode, ReleaseState, UniqueIndexCreationError, UniqueIndexSetAcquireFailure,
@@ -105,6 +112,11 @@ use crate::mpmc::unique_index_set_enums::{
 enum_gen! { OwnerIdNewError
   entry:
     InvalidOwnerValue
+}
+
+enum_gen! { RobustUniqueIndexSetReleaseError
+  entry:
+    IndexIsNotOwnedByProvidedOwner
 }
 
 #[repr(C)]
@@ -245,7 +257,7 @@ impl RobustUniqueIndexSet {
         self.capacity
     }
 
-    /// The compile time version of [`UniqueIndexSet::memory_size()`]
+    /// The compile time version of [`RobustUniqueIndexSet::memory_size()`]
     pub const fn const_memory_size(capacity: usize) -> usize {
         core::mem::size_of::<AtomicU64>() * capacity + core::mem::align_of::<AtomicU64>() - 1
     }
@@ -274,7 +286,7 @@ impl RobustUniqueIndexSet {
     /// println!("Acquired index {}", new_index);
     ///
     /// // return the index to the index set
-    /// unsafe { index_set.release(new_index, ReleaseMode::Default) };
+    /// unsafe { index_set.release(new_index, owner_id, ReleaseMode::Default) };
     /// ```
     ///
     /// # Safety
@@ -318,9 +330,10 @@ impl RobustUniqueIndexSet {
                         if self.increment_generation_counter(Ordering::Release)
                             == ReleaseState::Locked
                         {
-                            // revert the increment, not important, just for consistency
+                            // revert the increment, and the reservation not important, just for consistency
                             self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
                             cell.store(OwnerId::EMPTY.0, Ordering::Relaxed);
+
                             fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
                                 "{msg} since the RobustUniqueIndexSet is locked.");
                         }
@@ -341,55 +354,49 @@ impl RobustUniqueIndexSet {
     ///
     /// # Example
     ///
-    /// See [`RobustUniqueIndexSet::acquire_raw_index()`].
+    /// See [`RobustUniqueIndexSet::acquire()`].
     ///
     /// # Safety
     ///
-    ///  * Ensure that [`UniqueIndexSet::init()`] was called once.
+    ///  * Ensure that [`RobustUniqueIndexSet::init()`] was called once.
     ///
-    pub unsafe fn release(&self, index: usize, mode: ReleaseMode) -> ReleaseState {
+    pub unsafe fn release(
+        &self,
+        index: usize,
+        owner_id: OwnerId,
+        mode: ReleaseMode,
+    ) -> Result<ReleaseState, RobustUniqueIndexSetReleaseError> {
         self.verify_init("release()");
 
         let cell = unsafe { &*self.data_ptr.as_ptr().add(index) };
 
-        let cell_content = cell.load(Ordering::Relaxed);
+        match cell.compare_exchange(
+            owner_id.0,
+            OwnerId::EMPTY.0,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => {
+                self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
 
-        if cell_content == OwnerId::EMPTY.0 {
-            error!(from self, "Release of the not acquired index {index} prevented." );
-        } else {
-            match cell.compare_exchange(
-                cell_content,
-                OwnerId::EMPTY.0,
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => {
-                    cell.store(OwnerId::EMPTY.0, Ordering::Relaxed);
-                    self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
-
-                    //////////////////////////////////////
-                    // SYNC POINT enforce order of:
-                    //   1. cell & borrowed_indices
-                    //   2. generation counter
-                    //////////////////////////////////////
-                    self.increment_generation_counter(Ordering::Release);
-                }
-                Err(v) => {
-                    if v == OwnerId::EMPTY.0 {
-                        error!(from self,
-                            "Prevented race in releasing the index {index} which would have resulted in a double free.");
-                    } else {
-                        error!(from self,
-                            "It seems like the index {index} was modified while releasing it. This could indicate a corrupted system.");
-                    }
-                }
+                //////////////////////////////////////
+                // SYNC POINT enforce order of:
+                //   1. cell & borrowed_indices
+                //   2. generation counter
+                //////////////////////////////////////
+                self.increment_generation_counter(Ordering::Release);
+            }
+            Err(v) => {
+                fail!(from self,
+                    with RobustUniqueIndexSetReleaseError::IndexIsNotOwnedByProvidedOwner,
+                    "The index {index} that shall be released is not owned by {} but by {}.", owner_id.0, v);
             }
         }
 
         if mode == ReleaseMode::LockIfLastIndex {
-            self.lock()
+            Ok(self.lock())
         } else {
-            ReleaseState::Unlocked
+            Ok(ReleaseState::Unlocked)
         }
     }
 
@@ -405,6 +412,10 @@ impl RobustUniqueIndexSet {
         mut predicate: F,
     ) -> ReleaseState {
         self.verify_init("acquire()");
+
+        if self.is_locked() {
+            return ReleaseState::Locked;
+        }
 
         for n in 0..self.capacity {
             let cell = unsafe { &*self.data_ptr.as_ptr().add(n) };
@@ -449,6 +460,10 @@ impl RobustUniqueIndexSet {
         }
     }
 
+    /// This function ensures that a generation counter with the value `u64::MAX` is
+    /// never changed since it indicates a locked index set. If this would happen
+    /// the index set would be opened for modification again and the lock would be
+    /// reverted.
     fn increment_generation_counter(&self, ordering: Ordering) -> ReleaseState {
         let mut current_generation_count = self.generation_counter.load(Ordering::Relaxed);
         loop {
@@ -499,19 +514,13 @@ impl RobustUniqueIndexSet {
             //   1. borrowed_indices
             //   2. generation counter
             //////////////////////////////////////
-            match self.generation_counter.compare_exchange(
-                current_generation_count,
-                current_generation_count + 1,
-                Ordering::Release,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => {
-                    return RepairState {
-                        generation_counter: current_generation_count + 1,
-                        borrowed_indices: count,
-                    };
-                }
-                Err(_) => continue,
+            self.increment_generation_counter(Ordering::Release);
+
+            if current_generation_count + 1 == self.generation_counter.load(Ordering::Relaxed) {
+                return RepairState {
+                    generation_counter: current_generation_count + 1,
+                    borrowed_indices: count,
+                };
             }
         }
     }
@@ -593,15 +602,20 @@ impl<const CAPACITY: usize> StaticRobustUniqueIndexSet<CAPACITY> {
     /// println!("Acquired index {}", new_index);
     ///
     /// // return the index to the index set
-    /// unsafe { index_set.release(new_index, ReleaseMode::Default) };
+    /// unsafe { index_set.release(new_index, owner_id, ReleaseMode::Default) };
     /// ```
     pub fn acquire(&self, owner_id: OwnerId) -> Result<usize, UniqueIndexSetAcquireFailure> {
         unsafe { self.state.acquire(owner_id) }
     }
 
     /// Releases a raw index.
-    pub fn release(&self, index: usize, mode: ReleaseMode) -> ReleaseState {
-        unsafe { self.state.release(index, mode) }
+    pub fn release(
+        &self,
+        index: usize,
+        owner_id: OwnerId,
+        mode: ReleaseMode,
+    ) -> Result<ReleaseState, RobustUniqueIndexSetReleaseError> {
+        unsafe { self.state.release(index, owner_id, mode) }
     }
 
     /// See [`StaticRobustUniqueIndexSet::capacity()`]

--- a/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
@@ -119,6 +119,10 @@ enum_gen! { RobustUniqueIndexSetReleaseError
     IndexIsNotOwnedByProvidedOwner
 }
 
+const GENERATION_COUNTER_LOCK_INDICATOR: u64 = u64::MAX;
+
+/// Represents the who owns the index acquired by the [`RobustUniqueIndexSet`].
+/// This is used to recover leaked indices from dead owners.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct OwnerId(u64);
@@ -126,6 +130,7 @@ pub struct OwnerId(u64);
 impl OwnerId {
     const EMPTY: OwnerId = OwnerId(0);
 
+    /// Constructs a new [`OwnerId`]. The value is not allowed to be zero.
     pub fn new(value: u64) -> Result<Self, OwnerIdNewError> {
         if value == Self::EMPTY.0 {
             fail!(from "OwnerId::new()", with OwnerIdNewError::InvalidOwnerValue,
@@ -136,7 +141,7 @@ impl OwnerId {
     }
 }
 
-struct RepairState {
+struct SetState {
     generation_counter: u64,
     borrowed_indices: u64,
 }
@@ -144,20 +149,18 @@ struct RepairState {
 #[repr(C)]
 #[derive(Debug)]
 pub struct RobustUniqueIndexSet {
-    data_ptr: RelocatablePointer<AtomicU64>,
+    cell_ptr: RelocatablePointer<AtomicU64>,
     capacity: usize,
     is_memory_initialized: AtomicBool,
-    borrowed_indices: AtomicU64,
     generation_counter: AtomicU64,
 }
 
 impl RelocatableContainer for RobustUniqueIndexSet {
     unsafe fn new_uninit(capacity: usize) -> Self {
         Self {
-            data_ptr: unsafe { RelocatablePointer::new_uninit() },
+            cell_ptr: unsafe { RelocatablePointer::new_uninit() },
             capacity,
             is_memory_initialized: AtomicBool::new(false),
-            borrowed_indices: AtomicU64::new(0),
             generation_counter: AtomicU64::new(0),
         }
     }
@@ -181,14 +184,14 @@ impl RelocatableContainer for RobustUniqueIndexSet {
         };
 
         unsafe {
-            self.data_ptr.init(fail!(from self,
+            self.cell_ptr.init(fail!(from self,
                 when allocator.allocate(layout),
                 "Failed to initialize since the allocation of the data memory failed."))
         };
 
-        for i in 0..self.capacity + 1 {
+        for i in 0..self.capacity {
             unsafe {
-                (self.data_ptr.as_ptr() as *mut AtomicU64)
+                (self.cell_ptr.as_ptr() as *mut AtomicU64)
                     .add(i)
                     .write(AtomicU64::new(0))
             };
@@ -216,7 +219,7 @@ impl RobustUniqueIndexSet {
     /// Returns if the [`RobustUniqueIndexSet`] is locked or not. If the set is locked no more indices
     /// can be borrowed.
     pub fn is_locked(&self) -> bool {
-        self.generation_counter.load(Ordering::Relaxed) == u64::MAX
+        self.generation_counter.load(Ordering::Relaxed) == GENERATION_COUNTER_LOCK_INDICATOR
     }
 
     fn lock(&self) -> ReleaseState {
@@ -225,12 +228,19 @@ impl RobustUniqueIndexSet {
         }
 
         loop {
-            let state = self.repair_borrowed_indices();
+            let state = self.borrowed_indices_and_generation_counter();
 
+            // When the number of borrowed indices is 0 and the generation counter is unchanged
+            // this means that either the set is empty or that another thread is currently calling
+            // `acquire()` may have already populated a cell but before incrementing the generation counter
+            //
+            // In the latter case, the `acquire()` operation needs to finish by calling
+            // `increment_generation_counter` which would return `ReleaseState::Locked` and therefore
+            // the index would not be provided to the user.
             if state.borrowed_indices == 0 {
                 match self.generation_counter.compare_exchange(
                     state.generation_counter,
-                    u64::MAX,
+                    GENERATION_COUNTER_LOCK_INDICATOR,
                     Ordering::Relaxed,
                     Ordering::Relaxed,
                 ) {
@@ -240,15 +250,6 @@ impl RobustUniqueIndexSet {
             } else {
                 return ReleaseState::Unlocked;
             }
-        }
-    }
-
-    /// Returns the current len.
-    pub fn borrowed_indices(&self) -> usize {
-        if self.is_locked() {
-            0
-        } else {
-            self.borrowed_indices.load(Ordering::Relaxed) as _
         }
     }
 
@@ -296,22 +297,23 @@ impl RobustUniqueIndexSet {
     pub unsafe fn acquire(&self, owner_id: OwnerId) -> Result<usize, UniqueIndexSetAcquireFailure> {
         let msg = "Unable to acquire another index";
         self.verify_init("acquire()");
+        let cell_ptr = unsafe { self.cell_ptr.as_ptr() };
 
         loop {
             //////////////////////////////////////
             // SYNC POINT enforce order of:
-            //   1. cell & borrowed_indices
+            //   1. cell
             //   2. generation counter
             //////////////////////////////////////
             let current_generation_count = self.generation_counter.load(Ordering::Acquire);
 
-            if current_generation_count == u64::MAX {
+            if current_generation_count == GENERATION_COUNTER_LOCK_INDICATOR {
                 fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
                     "{msg} since the RobustUniqueIndexSet is locked.");
             }
 
             for n in 0..self.capacity {
-                let cell = unsafe { &*self.data_ptr.as_ptr().add(n) };
+                let cell = unsafe { &*cell_ptr.add(n) };
 
                 match cell.compare_exchange(
                     OwnerId::EMPTY.0,
@@ -320,20 +322,14 @@ impl RobustUniqueIndexSet {
                     Ordering::Relaxed,
                 ) {
                     Ok(_) => {
-                        self.borrowed_indices.fetch_add(1, Ordering::Relaxed);
-
                         //////////////////////////////////////
                         // SYNC POINT enforce order of:
-                        //   1. cell & borrowed_indices
+                        //   1. cell
                         //   2. generation counter
                         //////////////////////////////////////
                         if self.increment_generation_counter(Ordering::Release)
-                            == ReleaseState::Locked
+                            == GENERATION_COUNTER_LOCK_INDICATOR
                         {
-                            // revert the increment, and the reservation not important, just for consistency
-                            self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
-                            cell.store(OwnerId::EMPTY.0, Ordering::Relaxed);
-
                             fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
                                 "{msg} since the RobustUniqueIndexSet is locked.");
                         }
@@ -368,7 +364,7 @@ impl RobustUniqueIndexSet {
     ) -> Result<ReleaseState, RobustUniqueIndexSetReleaseError> {
         self.verify_init("release()");
 
-        let cell = unsafe { &*self.data_ptr.as_ptr().add(index) };
+        let cell = unsafe { &*self.cell_ptr.as_ptr().add(index) };
 
         match cell.compare_exchange(
             owner_id.0,
@@ -377,11 +373,9 @@ impl RobustUniqueIndexSet {
             Ordering::Relaxed,
         ) {
             Ok(_) => {
-                self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
-
                 //////////////////////////////////////
                 // SYNC POINT enforce order of:
-                //   1. cell & borrowed_indices
+                //   1. cell
                 //   2. generation counter
                 //////////////////////////////////////
                 self.increment_generation_counter(Ordering::Release);
@@ -417,8 +411,10 @@ impl RobustUniqueIndexSet {
             return ReleaseState::Locked;
         }
 
+        let cell_ptr = unsafe { self.cell_ptr.as_ptr() };
+
         for n in 0..self.capacity {
-            let cell = unsafe { &*self.data_ptr.as_ptr().add(n) };
+            let cell = unsafe { &*cell_ptr.add(n) };
             let value = cell.load(Ordering::Relaxed);
 
             if value == OwnerId::EMPTY.0 {
@@ -440,16 +436,14 @@ impl RobustUniqueIndexSet {
                 //   1. cell
                 //   2. generation counter
                 //////////////////////////////////////
-                if self.increment_generation_counter(Ordering::Release) == ReleaseState::Locked {
+                if self.increment_generation_counter(Ordering::Release)
+                    == GENERATION_COUNTER_LOCK_INDICATOR
+                {
                     return ReleaseState::Locked;
                 }
 
                 if mode == ReleaseMode::LockIfLastIndex {
                     self.lock();
-                } else {
-                    // must be called here explicitly since self.lock() calls this
-                    // already
-                    self.repair_borrowed_indices();
                 }
             }
         }
@@ -460,15 +454,15 @@ impl RobustUniqueIndexSet {
         }
     }
 
-    /// This function ensures that a generation counter with the value `u64::MAX` is
+    /// This function ensures that a generation counter with the value `GENERATION_COUNTER_LOCK_INDICIATOR` is
     /// never changed since it indicates a locked index set. If this would happen
     /// the index set would be opened for modification again and the lock would be
     /// reverted.
-    fn increment_generation_counter(&self, ordering: Ordering) -> ReleaseState {
+    fn increment_generation_counter(&self, ordering: Ordering) -> u64 {
         let mut current_generation_count = self.generation_counter.load(Ordering::Relaxed);
         loop {
-            if current_generation_count == u64::MAX {
-                return ReleaseState::Locked;
+            if current_generation_count == GENERATION_COUNTER_LOCK_INDICATOR {
+                return GENERATION_COUNTER_LOCK_INDICATOR;
             }
 
             match self.generation_counter.compare_exchange(
@@ -477,13 +471,23 @@ impl RobustUniqueIndexSet {
                 ordering,
                 Ordering::Relaxed,
             ) {
-                Ok(_) => return ReleaseState::Unlocked,
+                Ok(_) => return current_generation_count + 1,
                 Err(v) => current_generation_count = v,
             }
         }
     }
 
-    fn repair_borrowed_indices(&self) -> RepairState {
+    /// Returns how many indices were already borrowed.
+    pub fn borrowed_indices(&self) -> usize {
+        self.borrowed_indices_and_generation_counter()
+            .borrowed_indices as usize
+    }
+
+    /// This funtion returns the number of borrowed indices, meaning how many
+    /// `cell`s != `OwnerId::EMPTY` combined with the generation counter at that
+    /// time.
+    fn borrowed_indices_and_generation_counter(&self) -> SetState {
+        let cell_ptr = unsafe { self.cell_ptr.as_ptr() };
         loop {
             //////////////////////////////////////
             // SYNC POINT enforce order of:
@@ -492,8 +496,8 @@ impl RobustUniqueIndexSet {
             //////////////////////////////////////
             let current_generation_count = self.generation_counter.load(Ordering::Acquire);
 
-            if current_generation_count == u64::MAX {
-                return RepairState {
+            if current_generation_count == GENERATION_COUNTER_LOCK_INDICATOR {
+                return SetState {
                     generation_counter: current_generation_count,
                     borrowed_indices: 0,
                 };
@@ -501,23 +505,21 @@ impl RobustUniqueIndexSet {
 
             let mut count = 0;
             for n in 0..self.capacity {
-                let cell = unsafe { &*self.data_ptr.as_ptr().add(n) };
+                let cell = unsafe { &*cell_ptr.add(n) };
                 if cell.load(Ordering::Relaxed) != OwnerId::EMPTY.0 {
                     count += 1;
                 }
             }
 
-            self.borrowed_indices.store(count, Ordering::Relaxed);
-
             //////////////////////////////////////
             // SYNC POINT enforce order of:
-            //   1. borrowed_indices
+            //   1. cell
             //   2. generation counter
             //////////////////////////////////////
-            self.increment_generation_counter(Ordering::Release);
+            let new_generation_count = self.increment_generation_counter(Ordering::Release);
 
-            if current_generation_count + 1 == self.generation_counter.load(Ordering::Relaxed) {
-                return RepairState {
+            if current_generation_count + 1 == new_generation_count {
+                return SetState {
                     generation_counter: current_generation_count + 1,
                     borrowed_indices: count,
                 };

--- a/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
@@ -1,0 +1,517 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! A **threadsafe**, **lock-free** and **robust** set of indices. In a multi-process context it keeps
+//! a valid state, without index leaks, even when one process crashes. It provides to assign every
+//! borrowed index an [`OwnerId`] which allows to recover other processes leaked indices from crashed
+//! processes. Can be used as a building block for
+//! allocators or lock-free containers.
+//!
+//! # Example
+//!
+//! ## Runtime fixed size RobustUniqueIndexSet
+//!
+//! ```
+//! # extern crate iceoryx2_bb_loggers;
+//!
+//! use iceoryx2_bb_elementary::bump_allocator::*;
+//! use iceoryx2_bb_lock_free::mpmc::robust_unique_index_set::*;
+//! use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::*;
+//! use iceoryx2_bb_elementary_traits::relocatable_container::*;
+//!
+//! const CAPACITY: usize = 128;
+//! let mut memory = [0u8; RobustUniqueIndexSet::const_memory_size(CAPACITY)];
+//! let allocator = BumpAllocator::new(memory.as_mut_ptr());
+//!
+//! let mut index_set = unsafe { RobustUniqueIndexSet::new_uninit(CAPACITY) };
+//! unsafe { index_set.init(&allocator) }.expect("failed to allocate enough memory");
+//!
+//! let owner_id = OwnerId::new(313).unwrap(); // can be the PID + epoch for instance
+//! let new_index = match unsafe { index_set.acquire(owner_id) } {
+//!     Err(_) => panic!("Out of indices"),
+//!     Ok(i) => i,
+//! };
+//!
+//! println!("Acquired index {}", new_index);
+//!
+//! // return the index to the index set
+//! unsafe { index_set.release(new_index, ReleaseMode::default()) };
+//! ```
+//!
+//! ## Compile time FixedSizeUniqueIndexSet
+//!
+//! ```
+//! # extern crate iceoryx2_bb_loggers;
+//!
+//! use iceoryx2_bb_lock_free::mpmc::robust_unique_index_set::*;
+//! use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::*;
+//!
+//! const CAPACITY: usize = 128;
+//!
+//! let index_set = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+//!
+//! let owner_id = OwnerId::new(313).unwrap(); // can be the PID + epoch for instance
+//! let new_index = match index_set.acquire(owner_id) {
+//!     Err(_) => panic!("Out of indices"),
+//!     Ok(i) => i,
+//! };
+//!
+//! println!("Acquired index {}", new_index);
+//!
+//! // return the index to the index set
+//! index_set.release(new_index, ReleaseMode::default());
+//! ```
+//!
+//! ## Recover indices from a dead process
+//!
+//! ```
+//! # extern crate iceoryx2_bb_loggers;
+//!
+//! use iceoryx2_bb_lock_free::mpmc::robust_unique_index_set::*;
+//! use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::*;
+//!
+//! const CAPACITY: usize = 128;
+//!
+//! let index_set = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+//! let owner_id_of_dead_process = OwnerId::new(313).unwrap();
+//! index_set.recover(ReleaseMode::default(), |owner_id| {
+//!     owner_id == owner_id_of_dead_process
+//! });
+//! ```
+
+use core::alloc::Layout;
+use iceoryx2_bb_concurrency::atomic::Ordering;
+use iceoryx2_bb_concurrency::atomic::{AtomicBool, AtomicU64};
+use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
+use iceoryx2_bb_elementary::enum_gen;
+use iceoryx2_bb_elementary::relocatable_ptr::{PointerTrait, RelocatablePointer};
+use iceoryx2_bb_elementary_traits::allocator::AllocationError;
+use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
+use iceoryx2_log::{fail, fatal_panic};
+
+use crate::mpmc::unique_index_set_enums::{
+    ReleaseMode, ReleaseState, UniqueIndexCreationError, UniqueIndexSetAcquireFailure,
+};
+
+enum_gen! { OwnerIdNewError
+  entry:
+    InvalidOwnerValue
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OwnerId(u64);
+
+impl OwnerId {
+    const EMPTY: OwnerId = OwnerId(0);
+
+    pub fn new(value: u64) -> Result<Self, OwnerIdNewError> {
+        if value == Self::EMPTY.0 {
+            fail!(from "OwnerId::new()", with OwnerIdNewError::InvalidOwnerValue,
+                "Invalid value for OwnerId. The OwnerId cannot be 0.");
+        }
+
+        Ok(Self(value))
+    }
+}
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct RobustUniqueIndexSet {
+    data_ptr: RelocatablePointer<AtomicU64>,
+    capacity: usize,
+    is_memory_initialized: AtomicBool,
+    borrowed_indices: AtomicU64,
+    generation_counter: AtomicU64,
+}
+
+impl RelocatableContainer for RobustUniqueIndexSet {
+    unsafe fn new_uninit(capacity: usize) -> Self {
+        Self {
+            data_ptr: unsafe { RelocatablePointer::new_uninit() },
+            capacity,
+            is_memory_initialized: AtomicBool::new(false),
+            borrowed_indices: AtomicU64::new(0),
+            generation_counter: AtomicU64::new(0),
+        }
+    }
+
+    unsafe fn init<T: iceoryx2_bb_elementary_traits::allocator::BaseAllocator>(
+        &mut self,
+        allocator: &T,
+    ) -> Result<(), AllocationError> {
+        let msg = "Failed to initialize";
+        if self.is_memory_initialized.load(Ordering::Relaxed) {
+            fatal_panic!(from self,
+                "Memory already initialized. Initializing it twice may lead to undefined behavior.")
+        }
+
+        let layout = match Layout::array::<AtomicU64>(self.capacity) {
+            Ok(v) => v,
+            Err(e) => {
+                fail!(from self, with AllocationError::SizeTooLarge,
+                    "{msg} since the provided capacity would exceed the maximum supported size. [{e:?}]");
+            }
+        };
+
+        unsafe {
+            self.data_ptr.init(fail!(from self,
+                when allocator.allocate(layout),
+                "Failed to initialize since the allocation of the data memory failed."))
+        };
+
+        for i in 0..self.capacity + 1 {
+            unsafe {
+                (self.data_ptr.as_ptr() as *mut AtomicU64)
+                    .add(i)
+                    .write(AtomicU64::new(0))
+            };
+        }
+
+        self.is_memory_initialized.store(true, Ordering::Relaxed);
+
+        Ok(())
+    }
+
+    fn memory_size(capacity: usize) -> usize {
+        Self::const_memory_size(capacity)
+    }
+}
+
+impl RobustUniqueIndexSet {
+    #[inline(always)]
+    fn verify_init(&self, source: &str) {
+        debug_assert!(
+            self.is_memory_initialized.load(Ordering::Relaxed),
+            "Undefined behavior when calling RobustUniqueIndexSet::{source} and the object is not initialized."
+        );
+    }
+
+    /// Returns if the [`RobustUniqueIndexSet`] is locked or not. If the set is locked no more indices
+    /// can be borrowed.
+    pub fn is_locked(&self) -> bool {
+        self.borrowed_indices.load(Ordering::Relaxed) == u64::MAX
+    }
+
+    fn lock(&self) -> ReleaseState {
+        match self.borrowed_indices.compare_exchange(
+            0,
+            u64::MAX,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => ReleaseState::Locked,
+            Err(_) => ReleaseState::Unlocked,
+        }
+    }
+
+    /// Returns the current len.
+    pub fn borrowed_indices(&self) -> usize {
+        let borrowed_indices = self.borrowed_indices.load(Ordering::Relaxed);
+
+        if borrowed_indices == u64::MAX {
+            0
+        } else {
+            borrowed_indices as _
+        }
+    }
+
+    /// Returns the capacity of the [`RobustUniqueIndexSet`].
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// The compile time version of [`UniqueIndexSet::memory_size()`]
+    pub const fn const_memory_size(capacity: usize) -> usize {
+        core::mem::size_of::<AtomicU64>() * capacity + core::mem::align_of::<AtomicU64>() - 1
+    }
+
+    /// Acquires a new index. If the set does not contain any more indices it returns
+    /// [`None`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # extern crate iceoryx2_bb_loggers;
+    ///
+    /// use iceoryx2_bb_lock_free::mpmc::robust_unique_index_set::*;
+    /// use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::*;
+    ///
+    /// const CAPACITY: usize = 128;
+    ///
+    /// let index_set = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+    ///
+    /// let owner_id = OwnerId::new(313).unwrap(); // can be the PID + epoch for instance
+    /// let new_index = match unsafe { index_set.acquire(owner_id) } {
+    ///     Err(_) => panic!("Out of indices"),
+    ///     Ok(i) => i,
+    /// };
+    ///
+    /// println!("Acquired index {}", new_index);
+    ///
+    /// // return the index to the index set
+    /// unsafe { index_set.release(new_index, ReleaseMode::Default) };
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// * Ensure that [`RobustUniqueIndexSet::init()`] was called once.
+    ///
+    pub unsafe fn acquire(&self, owner_id: OwnerId) -> Result<usize, UniqueIndexSetAcquireFailure> {
+        let msg = "Unable to acquire another index";
+        self.verify_init("acquire()");
+
+        loop {
+            //////////////////////////////////////
+            // SYNC POINT enforce order of:
+            //   1. cell & borrowed_indices
+            //   2. generation counter
+            //////////////////////////////////////
+            let current_generation_count = self.generation_counter.load(Ordering::Acquire);
+
+            for n in 0..self.capacity {
+                let cell = unsafe { &*self.data_ptr.as_ptr().add(n) };
+
+                if self.is_locked() {
+                    fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
+                        "{msg} since the RobustUniqueIndexSet is locked.");
+                }
+
+                match cell.compare_exchange(
+                    OwnerId::EMPTY.0,
+                    owner_id.0,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        if self.is_locked() {
+                            fail!(from self, with UniqueIndexSetAcquireFailure::IsLocked,
+                                "{msg} since the RobustUniqueIndexSet is locked.");
+                        }
+
+                        self.borrowed_indices.fetch_add(1, Ordering::Relaxed);
+
+                        //////////////////////////////////////
+                        // SYNC POINT enforce order of:
+                        //   1. cell & borrowed_indices
+                        //   2. generation counter
+                        //////////////////////////////////////
+                        self.generation_counter.fetch_add(1, Ordering::Release);
+                        return Ok(n);
+                    }
+                    Err(_) => continue,
+                }
+            }
+
+            if current_generation_count == self.generation_counter.load(Ordering::Relaxed) {
+                fail!(from self, with UniqueIndexSetAcquireFailure::OutOfIndices,
+                    "{msg} since the RobustUniqueIndexSet is out of indices.");
+            }
+        }
+    }
+
+    /// Releases a raw index.
+    ///
+    /// # Example
+    ///
+    /// See [`RobustUniqueIndexSet::acquire_raw_index()`].
+    ///
+    /// # Safety
+    ///
+    ///  * Ensure that [`UniqueIndexSet::init()`] was called once.
+    ///
+    pub unsafe fn release(&self, index: usize, mode: ReleaseMode) -> ReleaseState {
+        self.verify_init("release()");
+
+        let cell = unsafe { &*self.data_ptr.as_ptr().add(index) };
+        cell.store(OwnerId::EMPTY.0, Ordering::Relaxed);
+
+        self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
+
+        //////////////////////////////////////
+        // SYNC POINT enforce order of:
+        //   1. cell & borrowed_indices
+        //   2. generation counter
+        //////////////////////////////////////
+        self.generation_counter.fetch_add(1, Ordering::Release);
+
+        if mode == ReleaseMode::LockIfLastIndex {
+            self.lock()
+        } else {
+            ReleaseState::Unlocked
+        }
+    }
+
+    /// Recovers leaked indices for which the predicate with the [`OwnerId`] returns true.
+    ///
+    /// # Safety
+    ///
+    /// * Ensure that [`RobustUniqueIndexSet::init()`] was called once.
+    ///
+    pub unsafe fn recover<F: FnMut(OwnerId) -> bool>(
+        &self,
+        mode: ReleaseMode,
+        mut predicate: F,
+    ) -> ReleaseState {
+        self.verify_init("acquire()");
+
+        for n in 0..self.capacity {
+            let cell = unsafe { &*self.data_ptr.as_ptr().add(n) };
+            let value = cell.load(Ordering::Relaxed);
+
+            if value == OwnerId::EMPTY.0 {
+                continue;
+            }
+
+            if predicate(OwnerId(value))
+                && cell
+                    .compare_exchange(
+                        value,
+                        OwnerId::EMPTY.0,
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                    )
+                    .is_ok()
+            {
+                self.borrowed_indices.fetch_sub(1, Ordering::Relaxed);
+
+                //////////////////////////////////////
+                // SYNC POINT enforce order of:
+                //   1. cell & borrowed_indices
+                //   2. generation counter
+                //////////////////////////////////////
+                self.generation_counter.fetch_add(1, Ordering::Release);
+
+                if mode == ReleaseMode::LockIfLastIndex {
+                    self.lock();
+                }
+            }
+        }
+
+        match self.is_locked() {
+            true => ReleaseState::Locked,
+            false => ReleaseState::Unlocked,
+        }
+    }
+}
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct StaticRobustUniqueIndexSet<const CAPACITY: usize> {
+    state: RobustUniqueIndexSet,
+    cells: [AtomicU64; CAPACITY],
+}
+
+impl<const CAPACITY: usize> Default for StaticRobustUniqueIndexSet<CAPACITY> {
+    fn default() -> Self {
+        Self::new_with_reduced_capacity(CAPACITY).expect("Does not exceed supported capacity.")
+    }
+}
+
+unsafe impl<const CAPACITY: usize> Sync for StaticRobustUniqueIndexSet<CAPACITY> {}
+unsafe impl<const CAPACITY: usize> Send for StaticRobustUniqueIndexSet<CAPACITY> {}
+
+impl<const CAPACITY: usize> StaticRobustUniqueIndexSet<CAPACITY> {
+    /// Creates a new [`StaticRobustUniqueIndexSet`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Creates a new [`StaticRobustUniqueIndexSet`] where the capacity is reduced. If the capacity
+    /// is greater than CAPACITY or zero it fails.
+    pub fn new_with_reduced_capacity(capacity: usize) -> Result<Self, UniqueIndexCreationError> {
+        let origin = "StaticRobustUniqueIndexSet::new_with_reduced_capacity()";
+        let msg = "Unable to create new StaticRobustUniqueIndexSet";
+        if capacity > CAPACITY {
+            fail!(from origin,
+                with UniqueIndexCreationError::ProvidedCapacityGreaterThanMaxCapacity,
+                "{msg} since the provided capacity value {capacity} exceeds maximum supported capacity of {CAPACITY}");
+        }
+
+        if capacity == 0 {
+            fail!(from origin, with UniqueIndexCreationError::ProvidedCapacityIsZero,
+                "{msg} since the provided capacity value is zero.");
+        }
+
+        let mut new_self = Self {
+            state: unsafe { RobustUniqueIndexSet::new_uninit(capacity) },
+            cells: core::array::from_fn(|_| AtomicU64::new(0)),
+        };
+
+        let allocator = BumpAllocator::new(new_self.cells.as_mut_ptr().cast());
+        unsafe {
+            new_self
+                .state
+                .init(&allocator)
+                .expect("All required memory is preallocated")
+        };
+
+        Ok(new_self)
+    }
+
+    /// Acquires a new index. If the set does not contain any more indices it returns
+    /// [`None`].
+    ///
+    /// ```
+    /// # extern crate iceoryx2_bb_loggers;
+    ///
+    /// use iceoryx2_bb_lock_free::mpmc::robust_unique_index_set::*;
+    /// use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::*;
+    ///
+    /// const CAPACITY: usize = 128;
+    ///
+    /// let index_set = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+    ///
+    /// let owner_id = OwnerId::new(313).unwrap(); // can be PID + epoch
+    /// let new_index = match unsafe { index_set.acquire(owner_id) } {
+    ///     Err(_) => panic!("Out of indices"),
+    ///     Ok(i) => i,
+    /// };
+    ///
+    /// println!("Acquired index {}", new_index);
+    ///
+    /// // return the index to the index set
+    /// unsafe { index_set.release(new_index, ReleaseMode::Default) };
+    /// ```
+    pub fn acquire(&self, owner_id: OwnerId) -> Result<usize, UniqueIndexSetAcquireFailure> {
+        unsafe { self.state.acquire(owner_id) }
+    }
+
+    /// Releases a raw index.
+    pub fn release(&self, index: usize, mode: ReleaseMode) -> ReleaseState {
+        unsafe { self.state.release(index, mode) }
+    }
+
+    /// See [`StaticRobustUniqueIndexSet::capacity()`]
+    pub fn capacity(&self) -> usize {
+        self.state.capacity()
+    }
+
+    /// See [`StaticRobustUniqueIndexSet::is_locked()`]
+    pub fn is_locked(&self) -> bool {
+        self.state.is_locked()
+    }
+
+    /// Returns the current len.
+    pub fn borrowed_indices(&self) -> usize {
+        self.state.borrowed_indices()
+    }
+
+    /// Recovers leaked indices for which the predicate with the [`OwnerId`] returns true.
+    pub fn recover<F: FnMut(OwnerId) -> bool>(
+        &self,
+        mode: ReleaseMode,
+        predicate: F,
+    ) -> ReleaseState {
+        unsafe { self.state.recover(mode, predicate) }
+    }
+}

--- a/iceoryx2-bb/lock-free/src/mpmc/unique_index_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/unique_index_set.rs
@@ -71,6 +71,7 @@
 //! # extern crate iceoryx2_bb_loggers;
 //!
 //! use iceoryx2_bb_lock_free::mpmc::unique_index_set::*;
+//! use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::*;
 //!
 //! const CAPACITY: usize = 128;
 //!
@@ -95,49 +96,16 @@ use iceoryx2_bb_concurrency::atomic::fence;
 use iceoryx2_bb_concurrency::atomic::{AtomicBool, AtomicU64};
 use iceoryx2_bb_concurrency::cell::UnsafeCell;
 use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
-use iceoryx2_bb_elementary::enum_gen;
 use iceoryx2_bb_elementary::relocatable_ptr::RelocatablePointer;
 use iceoryx2_bb_elementary_traits::allocator::{AllocationError, BaseAllocator};
 use iceoryx2_bb_elementary_traits::pointer_trait::PointerTrait;
 use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
 use iceoryx2_log::{fail, fatal_panic};
 
-enum_gen! { UniqueIndexCreationError
-  entry:
-    ProvidedCapacityGreaterThanMaxCapacity,
-    ProvidedCapacityIsZero
-}
-
-/// Describes if indices can still be acquired after the call to
-/// [`UniqueIndexSet::release_raw_index()`].
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum ReleaseMode {
-    /// No more indices can be acquired with [`UniqueIndexSet::acquire_raw_index()`] if the
-    /// released index was the last one.
-    LockIfLastIndex,
-    /// Indices can still be acquired with [`UniqueIndexSet::acquire_raw_index()`] after the
-    /// operation
-    Default,
-}
-
-/// Defines the state of the [`UniqueIndexSet`] after the release operation
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum ReleaseState {
-    /// The [`UniqueIndexSet`] is in locked mode since the last index was released. New indices
-    /// can no longer acquired from the [`UniqueIndexSet`].
-    Locked,
-    /// New indices can still be acquired from the [`UniqueIndexSet`]
-    Unlocked,
-}
-
-/// It states the reason if an index could not be acquired.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum UniqueIndexSetAcquireFailure {
-    /// The [`UniqueIndexSet`] does not contain any more indices
-    OutOfIndices,
-    /// The [`UniqueIndexSet`] is in a locked state and indices can no longer be acquired.
-    IsLocked,
-}
+use crate::mpmc::unique_index_set_enums::ReleaseMode;
+use crate::mpmc::unique_index_set_enums::ReleaseState;
+use crate::mpmc::unique_index_set_enums::UniqueIndexCreationError;
+use crate::mpmc::unique_index_set_enums::UniqueIndexSetAcquireFailure;
 
 /// Represents a [`UniqueIndex`]. When it goes out of scope it releases the index in the
 /// corresponding [`UniqueIndexSet`] or [`FixedSizeUniqueIndexSet`].
@@ -287,14 +255,23 @@ impl RelocatableContainer for UniqueIndexSet {
     }
 
     unsafe fn init<T: BaseAllocator>(&mut self, allocator: &T) -> Result<(), AllocationError> {
+        let msg = "Failed to initialize";
+
         if self.is_memory_initialized.load(Ordering::Relaxed) {
             fatal_panic!(from self, "Memory already initialized. Initializing it twice may lead to undefined behavior.");
         }
+
+        let layout = match Layout::array::<u32>(self.capacity as usize + 1) {
+            Ok(v) => v,
+            Err(e) => {
+                fail!(from self, with AllocationError::SizeTooLarge,
+                    "{msg} since the provided capacity would exceed the maximum supported size. [{e:?}]");
+            }
+        };
+
         unsafe {
             self.data_ptr.init(fail!(from self, when allocator
-                .allocate(Layout::from_size_align_unchecked(
-                    core::mem::size_of::<u32>() * (self.capacity + 1) as usize,
-                    core::mem::align_of::<u32>())),
+                .allocate(layout),
                 "Failed to initialize since the allocation of the data memory failed."
             ));
 
@@ -370,6 +347,7 @@ impl UniqueIndexSet {
     /// # extern crate iceoryx2_bb_loggers;
     ///
     /// use iceoryx2_bb_lock_free::mpmc::unique_index_set::*;
+    /// use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::*;
     ///
     /// const CAPACITY: usize = 128;
     ///
@@ -543,15 +521,16 @@ impl<const CAPACITY: usize> FixedSizeUniqueIndexSet<CAPACITY> {
     /// Creates a new [`FixedSizeUniqueIndexSet`] where the capacity is reduced. If the capacity
     /// is greater than CAPACITY or zero it fails.
     pub fn new_with_reduced_capacity(capacity: usize) -> Result<Self, UniqueIndexCreationError> {
+        let origin = "FixedSizeUniqueIndexSet::new_with_reduced_capacity";
         if capacity > CAPACITY {
-            fail!(from "FixedSizeUniqueIndexSet::new_with_reduced_capacity", with UniqueIndexCreationError::ProvidedCapacityGreaterThanMaxCapacity,
-                "Provided value of capacity {} exceeds maximum supported capacity of {}.",
+            fail!(from origin, with UniqueIndexCreationError::ProvidedCapacityGreaterThanMaxCapacity,
+                "Provided capacity value {} exceeds maximum supported capacity of {}.",
                 capacity, CAPACITY);
         }
 
         if capacity == 0 {
-            fail!(from "FixedSizeUniqueIndexSet::new_with_reduced_capacity", with UniqueIndexCreationError::ProvidedCapacityIsZero,
-                "Provided value of capacity is zero.");
+            fail!(from origin, with UniqueIndexCreationError::ProvidedCapacityIsZero,
+                "Provided capacity value is zero.");
         }
 
         let mut new_self = Self {

--- a/iceoryx2-bb/lock-free/src/mpmc/unique_index_set_enums.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/unique_index_set_enums.rs
@@ -14,13 +14,14 @@ use iceoryx2_bb_elementary::enum_gen;
 
 /// Describes if indices can still be acquired after the call to
 /// [`UniqueIndexSet::release_raw_index()`].
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum ReleaseMode {
     /// No more indices can be acquired with [`UniqueIndexSet::acquire_raw_index()`] if the
     /// released index was the last one.
     LockIfLastIndex,
     /// Indices can still be acquired with [`UniqueIndexSet::acquire_raw_index()`] after the
     /// operation
+    #[default]
     Default,
 }
 

--- a/iceoryx2-bb/lock-free/src/mpmc/unique_index_set_enums.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/unique_index_set_enums.rs
@@ -13,34 +13,40 @@
 use iceoryx2_bb_elementary::enum_gen;
 
 /// Describes if indices can still be acquired after the call to
-/// [`UniqueIndexSet::release_raw_index()`].
+/// [`UniqueIndexSet::release_raw_index()`](crate::mpmc::unique_index_set::UniqueIndexSet::release_raw_index()).
+/// or
+/// [`RobustUniqueIndexSet::release()`](crate::mpmc::robust_unique_index_set::RobustUniqueIndexSet::release()).
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Default)]
 pub enum ReleaseMode {
-    /// No more indices can be acquired with [`UniqueIndexSet::acquire_raw_index()`] if the
+    /// No more indices can be acquired with [`UniqueIndexSet::acquire_raw_index()`](crate::mpmc::unique_index_set::UniqueIndexSet::acquire_raw_index()) or
+    /// [`RobustUniqueIndexSet::acquire()`](crate::mpmc::robust_unique_index_set::RobustUniqueIndexSet::acquire()) if the
     /// released index was the last one.
     LockIfLastIndex,
-    /// Indices can still be acquired with [`UniqueIndexSet::acquire_raw_index()`] after the
+    /// Indices can still be acquired with [`UniqueIndexSet::acquire_raw_index()`](crate::mpmc::unique_index_set::UniqueIndexSet::acquire_raw_index()) or
+    /// [`RobustUniqueIndexSet::acquire()`](crate::mpmc::robust_unique_index_set::RobustUniqueIndexSet::acquire())
+    /// after the
     /// operation
     #[default]
     Default,
 }
 
-/// Defines the state of the [`UniqueIndexSet`] after the release operation
+/// Defines the state of the [`UniqueIndexSet`](crate::mpmc::unique_index_set::UniqueIndexSet) or
+/// [`RobustUniqueIndexSet`](crate::mpmc::robust_unique_index_set::RobustUniqueIndexSet) after the release operation
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ReleaseState {
-    /// The [`UniqueIndexSet`] is in locked mode since the last index was released. New indices
-    /// can no longer acquired from the [`UniqueIndexSet`].
+    /// The unique index set is in locked mode since the last index was released. New indices
+    /// can no longer acquired from the unique index set.
     Locked,
-    /// New indices can still be acquired from the [`UniqueIndexSet`]
+    /// New indices can still be acquired from the unique index set
     Unlocked,
 }
 
 /// It states the reason if an index could not be acquired.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum UniqueIndexSetAcquireFailure {
-    /// The [`UniqueIndexSet`] does not contain any more indices
+    /// The unique index set does not contain any more indices
     OutOfIndices,
-    /// The [`UniqueIndexSet`] is in a locked state and indices can no longer be acquired.
+    /// The unique index set is in a locked state and indices can no longer be acquired.
     IsLocked,
 }
 

--- a/iceoryx2-bb/lock-free/src/mpmc/unique_index_set_enums.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/unique_index_set_enums.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2_bb_elementary::enum_gen;
+
+/// Describes if indices can still be acquired after the call to
+/// [`UniqueIndexSet::release_raw_index()`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ReleaseMode {
+    /// No more indices can be acquired with [`UniqueIndexSet::acquire_raw_index()`] if the
+    /// released index was the last one.
+    LockIfLastIndex,
+    /// Indices can still be acquired with [`UniqueIndexSet::acquire_raw_index()`] after the
+    /// operation
+    Default,
+}
+
+/// Defines the state of the [`UniqueIndexSet`] after the release operation
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ReleaseState {
+    /// The [`UniqueIndexSet`] is in locked mode since the last index was released. New indices
+    /// can no longer acquired from the [`UniqueIndexSet`].
+    Locked,
+    /// New indices can still be acquired from the [`UniqueIndexSet`]
+    Unlocked,
+}
+
+/// It states the reason if an index could not be acquired.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum UniqueIndexSetAcquireFailure {
+    /// The [`UniqueIndexSet`] does not contain any more indices
+    OutOfIndices,
+    /// The [`UniqueIndexSet`] is in a locked state and indices can no longer be acquired.
+    IsLocked,
+}
+
+enum_gen! { UniqueIndexCreationError
+  entry:
+    ProvidedCapacityGreaterThanMaxCapacity,
+    ProvidedCapacityIsZero
+}

--- a/iceoryx2-bb/lock-free/tests-common/src/lib.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/lib.rs
@@ -17,6 +17,7 @@ extern crate iceoryx2_bb_loggers;
 
 pub mod bitset_tests;
 pub mod mpmc_container_tests;
+pub mod mpmc_robust_unique_index_set_tests;
 pub mod mpmc_unique_index_set_tests;
 pub mod spmc_unrestricted_atomic_tests;
 pub mod spsc_index_queue_tests;

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_container_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_container_tests.rs
@@ -19,6 +19,7 @@ pub mod generic {
     use alloc::vec;
     use alloc::vec::Vec;
     use core::fmt::Debug;
+    use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::{ReleaseMode, ReleaseState};
 
     use iceoryx2_bb_concurrency::atomic::{AtomicU32, Ordering};
     use iceoryx2_bb_elementary::CallbackProgression;
@@ -26,8 +27,6 @@ pub mod generic {
     use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
     use iceoryx2_bb_lock_free::mpmc::container::ContainerAddFailure;
     use iceoryx2_bb_lock_free::mpmc::container::*;
-    use iceoryx2_bb_lock_free::mpmc::unique_index_set::ReleaseMode;
-    use iceoryx2_bb_lock_free::mpmc::unique_index_set::ReleaseState;
     use iceoryx2_bb_posix::barrier::{BarrierBuilder, BarrierHandle, Handle};
     use iceoryx2_bb_posix::mutex::{MutexBuilder, MutexHandle};
     use iceoryx2_bb_posix::system_configuration::SystemInfo;

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
@@ -253,3 +253,70 @@ pub fn acquire_and_release_works_with_uninitialized_memory() {
         assert_that!(sut.borrowed_indices(), eq n - 1);
     }
 }
+
+#[test]
+pub fn concurrent_acquire_release() {
+    const REPETITIONS: i64 = 1000;
+    let number_of_threads = (SystemInfo::NumberOfCpuCores.value()).clamp(2, 4);
+
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+    let barrier_handle = BarrierHandle::new();
+    let barrier = BarrierBuilder::new(number_of_threads as u32)
+        .create(&barrier_handle)
+        .unwrap();
+    let owner_id = OwnerId::new(9191).unwrap();
+
+    thread_scope(|s| {
+        for _ in 0..number_of_threads {
+            s.thread_builder()
+                .spawn(|| {
+                    let mut indices = vec![];
+                    let mut repetition = 0;
+
+                    barrier.wait();
+                    loop {
+                        match sut.acquire(owner_id) {
+                            Ok(e) => {
+                                indices.push(e);
+                            }
+                            Err(UniqueIndexSetAcquireFailure::OutOfIndices) => {
+                                repetition += 1;
+                                while let Some(index) = indices.pop() {
+                                    sut.release(index, ReleaseMode::Default);
+                                }
+                                if repetition == REPETITIONS {
+                                    break;
+                                }
+                            }
+                            Err(UniqueIndexSetAcquireFailure::IsLocked) => {
+                                assert_that!(true, eq false);
+                            }
+                        }
+                    }
+                })
+                .expect("failed to spawn thread");
+        }
+
+        Ok(())
+    })
+    .expect("failed to run thread scope");
+
+    // check if the sut is still in an consistent state
+    let mut ids = vec![];
+    let mut id_counter = [0u64; CAPACITY];
+
+    for id in id_counter.iter_mut().take(CAPACITY) {
+        let e = sut.acquire(owner_id);
+        assert_that!(e, is_ok);
+        *id += 1;
+        ids.push(e.unwrap());
+    }
+
+    for id in id_counter.iter_mut().take(CAPACITY) {
+        assert_that!(*id, eq 1);
+    }
+
+    let e = sut.acquire(owner_id);
+    assert_that!(e, is_err);
+    assert_that!(e.err().unwrap(), eq UniqueIndexSetAcquireFailure::OutOfIndices);
+}

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
@@ -40,3 +40,216 @@ pub fn capacity_is_set_correctly() {
     let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new_with_reduced_capacity(0);
     assert_that!(sut, is_err);
 }
+
+#[test]
+pub fn acquire_and_release_works() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let mut indices = vec![];
+    for n in 0..CAPACITY {
+        assert_that!(sut.borrowed_indices(), eq n);
+        indices.push(sut.acquire(owner_id).unwrap());
+        assert_that!(sut.borrowed_indices(), eq n + 1);
+    }
+
+    for n in (1..CAPACITY + 1).rev() {
+        assert_that!(sut.borrowed_indices(), eq n);
+        sut.release(indices.pop().unwrap(), ReleaseMode::Default);
+        assert_that!(sut.borrowed_indices(), eq n - 1);
+    }
+}
+
+#[test]
+pub fn indices_are_unique() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let mut indices = vec![];
+    for _ in 0..CAPACITY {
+        let index = sut.acquire(owner_id).unwrap();
+
+        assert_that!(indices, not_contains index);
+        indices.push(index);
+    }
+}
+
+#[test]
+pub fn indices_are_between_zero_and_capacity() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    for _ in 0..CAPACITY {
+        let index = sut.acquire(owner_id).unwrap();
+
+        assert_that!(index, lt CAPACITY);
+    }
+}
+
+#[test]
+pub fn when_full_acquire_returns_out_of_indices() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    for _ in 0..CAPACITY {
+        sut.acquire(owner_id).unwrap();
+    }
+
+    assert_that!(sut.acquire(owner_id).err(), eq Some(UniqueIndexSetAcquireFailure::OutOfIndices));
+}
+
+#[test]
+pub fn release_makes_space_for_more_indices() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    for _ in 0..CAPACITY {
+        sut.acquire(owner_id).unwrap();
+    }
+
+    sut.release(CAPACITY / 2, ReleaseMode::Default);
+
+    assert_that!(sut.acquire(owner_id), is_ok);
+    assert_that!(sut.acquire(owner_id).err(), eq Some(UniqueIndexSetAcquireFailure::OutOfIndices));
+}
+
+#[test]
+pub fn new_set_is_not_locked_and_empty() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    assert_that!(sut.is_locked(), eq false);
+    assert_that!(sut.borrowed_indices(), eq 0);
+}
+
+#[test]
+pub fn release_last_index_and_set_release_mode_to_locked_locks_set() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let index = sut.acquire(owner_id).unwrap();
+
+    assert_that!(sut.release(index, ReleaseMode::LockIfLastIndex), eq ReleaseState::Locked);
+    assert_that!(sut.is_locked(), eq true);
+}
+
+#[test]
+pub fn release_not_last_index_and_set_release_mode_to_locked_does_not_lock_the_set() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let index_1 = sut.acquire(owner_id).unwrap();
+    let _index_2 = sut.acquire(owner_id).unwrap();
+
+    assert_that!(sut.release(index_1, ReleaseMode::LockIfLastIndex), eq ReleaseState::Unlocked);
+    assert_that!(sut.is_locked(), eq false);
+}
+
+#[test]
+pub fn acquire_all_indices_and_release_with_release_mode_lock_locks_set_after_last_release() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let mut indices = vec![];
+
+    for _ in 0..CAPACITY {
+        indices.push(sut.acquire(owner_id).unwrap());
+    }
+
+    for _ in 0..CAPACITY - 1 {
+        assert_that!(sut.release(indices.pop().unwrap(), ReleaseMode::LockIfLastIndex), eq ReleaseState::Unlocked);
+    }
+
+    assert_that!(sut.release(indices.pop().unwrap(), ReleaseMode::LockIfLastIndex), eq ReleaseState::Locked);
+    assert_that!(sut.is_locked(), eq true);
+}
+
+#[test]
+pub fn new_indices_cannot_be_acquired_from_locked_set() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let index = sut.acquire(owner_id).unwrap();
+    sut.release(index, ReleaseMode::LockIfLastIndex);
+
+    assert_that!(sut.acquire(owner_id).err(), eq Some(UniqueIndexSetAcquireFailure::IsLocked));
+}
+
+#[test]
+pub fn zero_borrowed_indices_in_locked_set() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let index = sut.acquire(owner_id).unwrap();
+    sut.release(index, ReleaseMode::LockIfLastIndex);
+
+    assert_that!(sut.borrowed_indices(), eq 0);
+}
+
+#[test]
+pub fn recover_releases_indices_of_owner() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let mut indices = vec![];
+    for n in 0..CAPACITY {
+        let owner_id = OwnerId::new(n as u64 + 1).unwrap();
+        let index = sut.acquire(owner_id).unwrap();
+        indices.push(index);
+    }
+
+    for n in 0..CAPACITY {
+        let id_to_remove = OwnerId::new(n as u64 + 1).unwrap();
+        sut.recover(ReleaseMode::Default, |owner_id| owner_id == id_to_remove);
+
+        assert_that!(sut.borrowed_indices(), eq CAPACITY - n - 1);
+    }
+}
+
+#[test]
+pub fn recover_locks_the_set_if_release_mode_is_lock() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(558).unwrap();
+    for _ in 0..CAPACITY {
+        sut.acquire(owner_id).unwrap();
+    }
+
+    assert_that!(sut.recover(ReleaseMode::LockIfLastIndex, |id| id == owner_id), eq ReleaseState::Locked);
+    assert_that!(sut.is_locked(), eq true);
+}
+
+#[test]
+pub fn recover_does_not_lock_the_set_if_release_mode_is_lock_and_the_set_is_not_empty_after_recover()
+ {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(558).unwrap();
+    for _ in 0..CAPACITY / 2 {
+        sut.acquire(owner_id).unwrap();
+    }
+    sut.acquire(OwnerId::new(912).unwrap()).unwrap();
+
+    assert_that!(sut.recover(ReleaseMode::LockIfLastIndex, |id| id == owner_id), eq ReleaseState::Unlocked);
+    assert_that!(sut.is_locked(), eq false);
+}
+
+#[test]
+pub fn acquire_and_release_works_with_uninitialized_memory() {
+    let mut memory = [0u8; RobustUniqueIndexSet::const_memory_size(CAPACITY)];
+    let allocator = BumpAllocator::new(memory.as_mut_ptr());
+    let mut sut = unsafe { RobustUniqueIndexSet::new_uninit(CAPACITY) };
+    unsafe { assert_that!(sut.init(&allocator), is_ok) };
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let mut indices = vec![];
+    for n in 0..CAPACITY {
+        assert_that!(sut.borrowed_indices(), eq n);
+        indices.push(unsafe { sut.acquire(owner_id).unwrap() });
+        assert_that!(sut.borrowed_indices(), eq n + 1);
+    }
+
+    for n in (1..CAPACITY + 1).rev() {
+        assert_that!(sut.borrowed_indices(), eq n);
+        unsafe { sut.release(indices.pop().unwrap(), ReleaseMode::Default) };
+        assert_that!(sut.borrowed_indices(), eq n - 1);
+    }
+}

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2023 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::vec;
+use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
+use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
+use iceoryx2_bb_lock_free::mpmc::robust_unique_index_set::*;
+use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::{
+    ReleaseMode, ReleaseState, UniqueIndexSetAcquireFailure,
+};
+use iceoryx2_bb_posix::barrier::{BarrierBuilder, BarrierHandle, Handle};
+use iceoryx2_bb_posix::system_configuration::SystemInfo;
+use iceoryx2_bb_posix::thread::thread_scope;
+use iceoryx2_bb_testing::assert_that;
+use iceoryx2_bb_testing_macros::test;
+
+const CAPACITY: usize = 128;
+
+#[test]
+pub fn capacity_is_set_correctly() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+    assert_that!(sut.capacity(), eq CAPACITY);
+
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new_with_reduced_capacity(CAPACITY * 2);
+    assert_that!(sut, is_err);
+
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new_with_reduced_capacity(CAPACITY / 2);
+    assert_that!(sut, is_ok);
+    assert_that!(sut.unwrap().capacity(), eq CAPACITY / 2);
+
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new_with_reduced_capacity(0);
+    assert_that!(sut, is_err);
+}

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
@@ -53,13 +53,13 @@ pub fn acquire_and_release_works() {
         assert_that!(sut.borrowed_indices(), eq n + 1);
     }
 
-    for n in (1..CAPACITY + 1).rev() {
-        assert_that!(sut.borrowed_indices(), eq n);
+    for n in (0..CAPACITY).rev() {
+        assert_that!(sut.borrowed_indices(), eq n + 1);
         assert_that!(
             sut.release(indices.pop().unwrap(), owner_id, ReleaseMode::Default),
             is_ok
         );
-        assert_that!(sut.borrowed_indices(), eq n - 1);
+        assert_that!(sut.borrowed_indices(), eq n);
     }
 }
 
@@ -72,7 +72,7 @@ pub fn indices_are_unique() {
     for _ in 0..CAPACITY {
         let index = sut.acquire(owner_id).unwrap();
 
-        assert_that!(indices, not_contains index);
+        assert_that!(indices, excludes index);
         indices.push(index);
     }
 }
@@ -177,6 +177,7 @@ pub fn acquire_all_indices_and_release_with_release_mode_lock_locks_set_after_la
         assert_that!(sut.release(indices.pop().unwrap(), owner_id, ReleaseMode::LockIfLastIndex), eq Ok(ReleaseState::Unlocked));
     }
 
+    assert_that!(sut.is_locked(), eq false);
     assert_that!(sut.release(indices.pop().unwrap(), owner_id, ReleaseMode::LockIfLastIndex), eq Ok(ReleaseState::Locked));
     assert_that!(sut.is_locked(), eq true);
 }
@@ -238,6 +239,7 @@ pub fn recover_locks_the_set_if_release_mode_is_lock() {
     }
 
     assert_that!(sut.recover(ReleaseMode::LockIfLastIndex, |id| id == owner_id), eq ReleaseState::Locked);
+    assert_that!(sut.borrowed_indices(), eq 0);
     assert_that!(sut.is_locked(), eq true);
 }
 
@@ -271,7 +273,7 @@ pub fn recover_of_locked_set_always_returns_locked() {
 }
 
 #[test]
-pub fn acquire_and_release_works_with_uninitialized_memory() {
+pub fn acquire_and_release_works_with_relocatable_variant() {
     let mut memory = [0u8; RobustUniqueIndexSet::const_memory_size(CAPACITY)];
     let allocator = BumpAllocator::new(memory.as_mut_ptr());
     let mut sut = unsafe { RobustUniqueIndexSet::new_uninit(CAPACITY) };
@@ -285,13 +287,13 @@ pub fn acquire_and_release_works_with_uninitialized_memory() {
         assert_that!(sut.borrowed_indices(), eq n + 1);
     }
 
-    for n in (1..CAPACITY + 1).rev() {
-        assert_that!(sut.borrowed_indices(), eq n);
+    for n in (0..CAPACITY).rev() {
+        assert_that!(sut.borrowed_indices(), eq n + 1);
         assert_that!(
             unsafe { sut.release(indices.pop().unwrap(), owner_id, ReleaseMode::Default) },
             is_ok
         );
-        assert_that!(sut.borrowed_indices(), eq n - 1);
+        assert_that!(sut.borrowed_indices(), eq n);
     }
 }
 
@@ -353,6 +355,8 @@ pub fn concurrent_acquire_release() {
         let e = sut.acquire(owner_id);
         assert_that!(e, is_ok);
         *id += 1;
+        assert_that!(ids, excludes e.unwrap());
+        assert_that!(e.unwrap(), lt CAPACITY);
         ids.push(e.unwrap());
     }
 

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_robust_unique_index_set_tests.rs
@@ -55,7 +55,10 @@ pub fn acquire_and_release_works() {
 
     for n in (1..CAPACITY + 1).rev() {
         assert_that!(sut.borrowed_indices(), eq n);
-        sut.release(indices.pop().unwrap(), ReleaseMode::Default);
+        assert_that!(
+            sut.release(indices.pop().unwrap(), owner_id, ReleaseMode::Default),
+            is_ok
+        );
         assert_that!(sut.borrowed_indices(), eq n - 1);
     }
 }
@@ -107,7 +110,10 @@ pub fn release_makes_space_for_more_indices() {
         sut.acquire(owner_id).unwrap();
     }
 
-    sut.release(CAPACITY / 2, ReleaseMode::Default);
+    assert_that!(
+        sut.release(CAPACITY / 2, owner_id, ReleaseMode::Default),
+        is_ok
+    );
 
     assert_that!(sut.acquire(owner_id), is_ok);
     assert_that!(sut.acquire(owner_id).err(), eq Some(UniqueIndexSetAcquireFailure::OutOfIndices));
@@ -128,7 +134,7 @@ pub fn release_last_index_and_set_release_mode_to_locked_locks_set() {
     let owner_id = OwnerId::new(123).unwrap();
     let index = sut.acquire(owner_id).unwrap();
 
-    assert_that!(sut.release(index, ReleaseMode::LockIfLastIndex), eq ReleaseState::Locked);
+    assert_that!(sut.release(index, owner_id, ReleaseMode::LockIfLastIndex), eq Ok(ReleaseState::Locked));
     assert_that!(sut.is_locked(), eq true);
 }
 
@@ -140,7 +146,19 @@ pub fn release_not_last_index_and_set_release_mode_to_locked_does_not_lock_the_s
     let index_1 = sut.acquire(owner_id).unwrap();
     let _index_2 = sut.acquire(owner_id).unwrap();
 
-    assert_that!(sut.release(index_1, ReleaseMode::LockIfLastIndex), eq ReleaseState::Unlocked);
+    assert_that!(sut.release(index_1, owner_id, ReleaseMode::LockIfLastIndex), eq Ok(ReleaseState::Unlocked));
+    assert_that!(sut.is_locked(), eq false);
+}
+
+#[test]
+pub fn releasing_non_owned_index_fails() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let bad_owner_id = OwnerId::new(7127).unwrap();
+    let index = sut.acquire(owner_id).unwrap();
+
+    assert_that!(sut.release(index, bad_owner_id, ReleaseMode::LockIfLastIndex), eq Err(RobustUniqueIndexSetReleaseError::IndexIsNotOwnedByProvidedOwner));
     assert_that!(sut.is_locked(), eq false);
 }
 
@@ -156,10 +174,10 @@ pub fn acquire_all_indices_and_release_with_release_mode_lock_locks_set_after_la
     }
 
     for _ in 0..CAPACITY - 1 {
-        assert_that!(sut.release(indices.pop().unwrap(), ReleaseMode::LockIfLastIndex), eq ReleaseState::Unlocked);
+        assert_that!(sut.release(indices.pop().unwrap(), owner_id, ReleaseMode::LockIfLastIndex), eq Ok(ReleaseState::Unlocked));
     }
 
-    assert_that!(sut.release(indices.pop().unwrap(), ReleaseMode::LockIfLastIndex), eq ReleaseState::Locked);
+    assert_that!(sut.release(indices.pop().unwrap(), owner_id, ReleaseMode::LockIfLastIndex), eq Ok(ReleaseState::Locked));
     assert_that!(sut.is_locked(), eq true);
 }
 
@@ -169,7 +187,10 @@ pub fn new_indices_cannot_be_acquired_from_locked_set() {
 
     let owner_id = OwnerId::new(123).unwrap();
     let index = sut.acquire(owner_id).unwrap();
-    sut.release(index, ReleaseMode::LockIfLastIndex);
+    assert_that!(
+        sut.release(index, owner_id, ReleaseMode::LockIfLastIndex),
+        is_ok
+    );
 
     assert_that!(sut.acquire(owner_id).err(), eq Some(UniqueIndexSetAcquireFailure::IsLocked));
 }
@@ -180,7 +201,10 @@ pub fn zero_borrowed_indices_in_locked_set() {
 
     let owner_id = OwnerId::new(123).unwrap();
     let index = sut.acquire(owner_id).unwrap();
-    sut.release(index, ReleaseMode::LockIfLastIndex);
+    assert_that!(
+        sut.release(index, owner_id, ReleaseMode::LockIfLastIndex),
+        is_ok
+    );
 
     assert_that!(sut.borrowed_indices(), eq 0);
 }
@@ -233,6 +257,20 @@ pub fn recover_does_not_lock_the_set_if_release_mode_is_lock_and_the_set_is_not_
 }
 
 #[test]
+pub fn recover_of_locked_set_always_returns_locked() {
+    let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
+
+    let owner_id = OwnerId::new(123).unwrap();
+    let index = sut.acquire(owner_id).unwrap();
+    assert_that!(
+        sut.release(index, owner_id, ReleaseMode::LockIfLastIndex),
+        is_ok
+    );
+
+    assert_that!(sut.recover(ReleaseMode::Default, |id| id == owner_id), eq ReleaseState::Locked);
+}
+
+#[test]
 pub fn acquire_and_release_works_with_uninitialized_memory() {
     let mut memory = [0u8; RobustUniqueIndexSet::const_memory_size(CAPACITY)];
     let allocator = BumpAllocator::new(memory.as_mut_ptr());
@@ -249,7 +287,10 @@ pub fn acquire_and_release_works_with_uninitialized_memory() {
 
     for n in (1..CAPACITY + 1).rev() {
         assert_that!(sut.borrowed_indices(), eq n);
-        unsafe { sut.release(indices.pop().unwrap(), ReleaseMode::Default) };
+        assert_that!(
+            unsafe { sut.release(indices.pop().unwrap(), owner_id, ReleaseMode::Default) },
+            is_ok
+        );
         assert_that!(sut.borrowed_indices(), eq n - 1);
     }
 }
@@ -257,7 +298,7 @@ pub fn acquire_and_release_works_with_uninitialized_memory() {
 #[test]
 pub fn concurrent_acquire_release() {
     const REPETITIONS: i64 = 1000;
-    let number_of_threads = (SystemInfo::NumberOfCpuCores.value()).clamp(2, 4);
+    let number_of_threads = (SystemInfo::NumberOfCpuCores.value()).clamp(2, usize::MAX);
 
     let sut = StaticRobustUniqueIndexSet::<CAPACITY>::new();
     let barrier_handle = BarrierHandle::new();
@@ -282,7 +323,10 @@ pub fn concurrent_acquire_release() {
                             Err(UniqueIndexSetAcquireFailure::OutOfIndices) => {
                                 repetition += 1;
                                 while let Some(index) = indices.pop() {
-                                    sut.release(index, ReleaseMode::Default);
+                                    assert_that!(
+                                        sut.release(index, owner_id, ReleaseMode::Default),
+                                        is_ok
+                                    );
                                 }
                                 if repetition == REPETITIONS {
                                     break;

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_unique_index_set_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_unique_index_set_tests.rs
@@ -14,6 +14,9 @@ use alloc::vec;
 use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
 use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
 use iceoryx2_bb_lock_free::mpmc::unique_index_set::*;
+use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::{
+    ReleaseMode, ReleaseState, UniqueIndexSetAcquireFailure,
+};
 use iceoryx2_bb_posix::barrier::{BarrierBuilder, BarrierHandle, Handle};
 use iceoryx2_bb_posix::system_configuration::SystemInfo;
 use iceoryx2_bb_posix::thread::thread_scope;

--- a/iceoryx2-bb/memory/src/pool_allocator.rs
+++ b/iceoryx2-bb/memory/src/pool_allocator.rs
@@ -60,6 +60,7 @@ use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
 use iceoryx2_bb_elementary::math::align;
 use iceoryx2_bb_elementary_traits::relocatable_container::*;
 use iceoryx2_bb_lock_free::mpmc::unique_index_set::*;
+use iceoryx2_bb_lock_free::mpmc::unique_index_set_enums::ReleaseMode;
 use iceoryx2_log::fail;
 use iceoryx2_log::fatal_panic;
 

--- a/iceoryx2-pal/testing/src/assert.rs
+++ b/iceoryx2-pal/testing/src/assert.rs
@@ -202,6 +202,20 @@ macro_rules! assert_that {
             }
         }
     };
+    ($lhs:expr, not_contains $rhs:expr) => {
+        {
+            let mut does_contain = false;
+            for value in &$lhs {
+                if *value == $rhs {
+                    does_contain = true;
+                    break;
+                }
+            }
+            if does_contain {
+                assert_that!(message_contains $lhs, $rhs);
+            }
+        }
+    };
     ($lhs:expr, contains_match |$element:ident| $predicate:expr) => {
         {
             let mut does_contain = false;
@@ -273,6 +287,17 @@ macro_rules! assert_that {
     [message_contains $lhs:expr, $rhs:expr] => {
         core::panic!(
             "assertion failed: {}expr: {} contains {} ({:?});  contents: {:?}{}",
+            assert_that![color_start],
+            core::stringify!($lhs),
+            core::stringify!($rhs),
+            $rhs,
+            $lhs,
+            assert_that![color_end]
+        );
+    };
+    [message_contains $lhs:expr, $rhs:expr] => {
+        core::panic!(
+            "assertion failed: {}expr: {} shall not contain {} ({:?});  contents: {:?}{}",
             assert_that![color_start],
             core::stringify!($lhs),
             core::stringify!($rhs),

--- a/iceoryx2-pal/testing/src/assert.rs
+++ b/iceoryx2-pal/testing/src/assert.rs
@@ -202,7 +202,7 @@ macro_rules! assert_that {
             }
         }
     };
-    ($lhs:expr, not_contains $rhs:expr) => {
+    ($lhs:expr, excludes $rhs:expr) => {
         {
             let mut does_contain = false;
             for value in &$lhs {
@@ -212,7 +212,7 @@ macro_rules! assert_that {
                 }
             }
             if does_contain {
-                assert_that!(message_contains $lhs, $rhs);
+                assert_that!(message_excludes $lhs, $rhs);
             }
         }
     };
@@ -295,7 +295,7 @@ macro_rules! assert_that {
             assert_that![color_end]
         );
     };
-    [message_contains $lhs:expr, $rhs:expr] => {
+    [message_excludes $lhs:expr, $rhs:expr] => {
         core::panic!(
             "assertion failed: {}expr: {} shall not contain {} ({:?});  contents: {:?}{}",
             assert_that![color_start],

--- a/iceoryx2/src/service/dynamic_config/blackboard.rs
+++ b/iceoryx2/src/service/dynamic_config/blackboard.rs
@@ -30,7 +30,7 @@
 
 use crate::identifiers::{UniqueNodeId, UniquePortId, UniqueReaderId, UniqueWriterId};
 use iceoryx2_bb_container::queue::RelocatableContainer;
-use iceoryx2_bb_lock_free::mpmc::{container::*, unique_index_set::ReleaseMode};
+use iceoryx2_bb_lock_free::mpmc::{container::*, unique_index_set_enums::ReleaseMode};
 use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
 use iceoryx2_log::fatal_panic;
 

--- a/iceoryx2/src/service/dynamic_config/event.rs
+++ b/iceoryx2/src/service/dynamic_config/event.rs
@@ -29,7 +29,7 @@
 
 use iceoryx2_bb_concurrency::atomic::AtomicU64;
 use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
-use iceoryx2_bb_lock_free::mpmc::{container::*, unique_index_set::ReleaseMode};
+use iceoryx2_bb_lock_free::mpmc::{container::*, unique_index_set_enums::ReleaseMode};
 use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
 use iceoryx2_log::fatal_panic;
 

--- a/iceoryx2/src/service/dynamic_config/mod.rs
+++ b/iceoryx2/src/service/dynamic_config/mod.rs
@@ -35,7 +35,7 @@ use iceoryx2_bb_container::queue::RelocatableContainer;
 use iceoryx2_bb_elementary::CallbackProgression;
 use iceoryx2_bb_lock_free::mpmc::{
     container::{Container, ContainerAddFailure, ContainerHandle},
-    unique_index_set::{ReleaseMode, ReleaseState},
+    unique_index_set_enums::{ReleaseMode, ReleaseState},
 };
 use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
 use iceoryx2_log::{fail, fatal_panic};

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -27,7 +27,7 @@
 //! # }
 //! ```
 use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
-use iceoryx2_bb_lock_free::mpmc::{container::*, unique_index_set::ReleaseMode};
+use iceoryx2_bb_lock_free::mpmc::{container::*, unique_index_set_enums::ReleaseMode};
 use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
 use iceoryx2_log::fatal_panic;
 

--- a/iceoryx2/src/service/dynamic_config/request_response.rs
+++ b/iceoryx2/src/service/dynamic_config/request_response.rs
@@ -12,7 +12,10 @@
 
 use iceoryx2_bb_container::queue::RelocatableContainer;
 use iceoryx2_bb_elementary::CallbackProgression;
-use iceoryx2_bb_lock_free::mpmc::container::{Container, ContainerHandle, ReleaseMode};
+use iceoryx2_bb_lock_free::mpmc::{
+    container::{Container, ContainerHandle},
+    unique_index_set_enums::ReleaseMode,
+};
 use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
 use iceoryx2_log::fatal_panic;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Introduces a unique index set where the user can specify an owner id whenever they take out an index. The owner can be a PID + epoch. This allows other processes to recover leaked indices of dead processes - therefore it is robust. It never leaks or enters an invalid state if a process dies.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #1578

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
