### PR TITLE
[eclipse-iceoryx#1215] Drop python requirement to 3.8

### DIFF
--- a/iceoryx2-ffi/python/pyproject.toml
+++ b/iceoryx2-ffi/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "iceoryx2"
 version = "0.8.999"
 description = "Lock-Free Zero-Copy Inter-process Communication"
 readme = "README.md"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.8,<4.0"
 license = "Apache-2.0 OR MIT"
 keywords = ["ipc", "inter-process communication", "zero-copy", "shared memory", "publish-subscribe", "request-response", "event"]
 authors = [
@@ -55,7 +55,7 @@ target-dir = "../../target/ff/python"
 packages = [{include = "iceoryx2", from = "python-src"}]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<4.0"
+python = ">=3.8,<4.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.3"

--- a/iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py
+++ b/iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py
@@ -44,7 +44,8 @@ def publish_subscribe(
     self: ServiceBuilder, t: Type[T]
 ) -> ServiceBuilderPublishSubscribe:
     """Returns the `ServiceBuilderPublishSusbcribe` to create a new publish-subscribe service. The payload ctype must be provided as argument."""
-    type_name = t.__name__
+    type_name = getattr(t, "__name__", None)
+    type_name = type_name or get_origin(t).__name__
     type_size = 0
     type_align = 0
     type_variant = TypeVariant.FixedSize

--- a/iceoryx2-ffi/python/python-src/iceoryx2/request_response_extensions.py
+++ b/iceoryx2-ffi/python/python-src/iceoryx2/request_response_extensions.py
@@ -13,7 +13,13 @@
 """Strong type safe extensions for the request-response messaging pattern."""
 
 import ctypes
-from typing import Any, Type, TypeVar, get_args, get_origin
+from typing import Any, Type, TypeVar
+
+import sys
+if sys.version_info >= (3, 8):
+    from typing import get_args, get_origin
+else:
+    from typing_extensions import get_args, get_origin
 
 from ._iceoryx2 import *
 from .slice import Slice
@@ -31,11 +37,13 @@ def request_response(
 
     The request/response payload ctype must be provided as argument.
     """
-    request_type_name = request.__name__
+    request_type_name = getattr(request, "__name__", None)
+    request_type_name = request_type_name or get_origin(request).__name__
     request_type_size = 0
     request_type_align = 0
     request_type_variant = TypeVariant.FixedSize
-    response_type_name = response.__name__
+    response_type_name = getattr(response, "__name__", None)
+    response_type_name = response_type_name or get_origin(response).__name__
     response_type_size = 0
     response_type_align = 0
     response_type_variant = TypeVariant.FixedSize

--- a/iceoryx2-ffi/python/tests/node_tests.py
+++ b/iceoryx2-ffi/python/tests/node_tests.py
@@ -73,17 +73,16 @@ def test_created_nodes_can_be_listed(service_type: iox2.ServiceType) -> None:
     node_list = iox2.Node.list(service_type, config)
     assert len(node_list) == 2
     for node in node_list:
-        match node:
-            case node.Alive():
-                assert isinstance(node, iox2.NodeState.Alive)
-                assert node[0].id in (sut_1.id, sut_2.id)
-                assert node[0].details.name in (sut_1.name, sut_2.name)
-            case node.Dead():
-                assert False
-            case node.Inaccessible():
-                assert False
-            case node.Undefined():
-                assert False
+        if isinstance(node, node.Alive):
+            assert isinstance(node, iox2.NodeState.Alive)
+            assert node[0].id in (sut_1.id, sut_2.id)
+            assert node[0].details.name in (sut_1.name, sut_2.name)
+        elif isinstance(node, node.Dead):
+            assert False
+        elif isinstance(node, node.Inaccessible):
+            assert False
+        elif isinstance(node, node.Undefined):
+            assert False
 
 
 @pytest.mark.parametrize("service_type", service_types)

--- a/iceoryx2-ffi/python/tests/service_builder_blackboard_tests.py
+++ b/iceoryx2-ffi/python/tests/service_builder_blackboard_tests.py
@@ -470,15 +470,14 @@ def test_node_listing_works(service_type: iox2.ServiceType) -> None:
 
     assert len(nodes) == 1
     for n in nodes:
-        match n:
-            case n.Alive():
-                assert n[0].id == node.id
-            case node.Dead():
-                assert False
-            case node.Inaccessible():
-                assert False
-            case node.Undefined():
-                assert False
+        if isinstance(n, n.Alive):
+            assert n[0].id == node.id
+        elif isinstance(n, node.Dead):
+            assert False
+        elif isinstance(n, node.Inaccessible):
+            assert False
+        elif isinstance(n, node.Undefined):
+            assert False
 
 
 @pytest.mark.parametrize("service_type", service_types)

--- a/iceoryx2-ffi/python/tests/service_builder_event_tests.py
+++ b/iceoryx2-ffi/python/tests/service_builder_event_tests.py
@@ -195,15 +195,14 @@ def test_node_listing_works(service_type: iox2.ServiceType) -> None:
 
     assert len(nodes) == 1
     for n in nodes:
-        match n:
-            case n.Alive():
-                assert n[0].id == node.id
-            case node.Dead():
-                assert False
-            case node.Inaccessible():
-                assert False
-            case node.Undefined():
-                assert False
+        if isinstance(n, n.Alive):
+            assert n[0].id == node.id
+        elif isinstance(n, node.Dead):
+            assert False
+        elif isinstance(n, node.Inaccessible):
+            assert False
+        elif isinstance(n, node.Undefined):
+            assert False
 
 
 @pytest.mark.parametrize("service_type", service_types)

--- a/iceoryx2-ffi/python/tests/service_builder_publish_subscribe_tests.py
+++ b/iceoryx2-ffi/python/tests/service_builder_publish_subscribe_tests.py
@@ -219,15 +219,14 @@ def test_node_listing_works(service_type: iox2.ServiceType) -> None:
 
     assert len(nodes) == 1
     for n in nodes:
-        match n:
-            case n.Alive():
-                assert n[0].id == node.id
-            case node.Dead():
-                assert False
-            case node.Inaccessible():
-                assert False
-            case node.Undefined():
-                assert False
+        if isinstance(n, n.Alive):
+            assert n[0].id == node.id
+        elif isinstance(n, node.Dead):
+            assert False
+        elif isinstance(n, node.Inaccessible):
+            assert False
+        elif isinstance(n, node.Undefined):
+            assert False
 
 
 @pytest.mark.parametrize("service_type", service_types)

--- a/iceoryx2-ffi/python/tests/service_builder_request_response_tests.py
+++ b/iceoryx2-ffi/python/tests/service_builder_request_response_tests.py
@@ -246,15 +246,14 @@ def test_node_listing_works(service_type: iox2.ServiceType) -> None:
 
     assert len(nodes) == 1
     for n in nodes:
-        match n:
-            case n.Alive():
-                assert n[0].id == node.id
-            case node.Dead():
-                assert False
-            case node.Inaccessible():
-                assert False
-            case node.Undefined():
-                assert False
+        if isinstance(n, n.Alive):
+            assert n[0].id == node.id
+        elif isinstance(n, node.Dead):
+            assert False
+        elif isinstance(n, node.Inaccessible):
+            assert False
+        elif isinstance(n, node.Undefined):
+            assert False
 
 
 @pytest.mark.parametrize("service_type", service_types)


### PR DESCRIPTION
1. Remove all match ... case ... blocks to remove requirement of 3.10.
2. Change the behaviour such as type_name = t.name. In python 3.8, type _GenericAlias don't have an attr named name, it should be get by get_origin(t).name.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [ ] Add sensible notes for the reviewer
* [ ] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [ ] Relevant issues are linked in the [References](#references) section
* [ ] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [ ] Commits messages are according to this [guideline][commit-guidelines]
    * [ ] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
