### PR TITLE
[#1629] Fix segfault when connection is removed

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -44,6 +44,8 @@
 * Implement C++20 'source_location' based on compiler source location builtins
   and use it for better `Expected` and `Optional` messages on contract violations
   [#1496](https://github.com/eclipse-iceoryx/iceoryx2/issues/1496)
+* Print error value in 'Expected' if it is convertible into an integer type
+  [#1528](https://github.com/eclipse-iceoryx/iceoryx2/issues/1528)
 * Enable override of preallocated data chunks for sender ports
   [#1551](https://github.com/eclipse-iceoryx/iceoryx2/issues/1551)
 * Add `Zeroable` and `PlainOldDataWithoutPadding` derive macros that generate

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -147,6 +147,8 @@
   [#1578](https://github.com/eclipse-iceoryx/iceoryx2/issues/1578)
 * Fix various CLI quirks
   [#1595](https://github.com/eclipse-iceoryx/iceoryx2/issues/1595)
+* Fix segfault when connection is removed
+  [#1629](https://github.com/eclipse-iceoryx/iceoryx2/issues/1629)
 
 ### Refactoring
 

--- a/iceoryx2-bb/cxx/include/iox2/legacy/detail/expected.inl
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/detail/expected.inl
@@ -166,11 +166,38 @@ inline const ErrorType& expected<ValueType, ErrorType>::error(bb::detail::Source
 }
 
 template <typename ValueType, typename ErrorType>
+template <typename E>
+inline std::enable_if_t<!(std::is_integral<E>::value || std::is_enum<E>::value), void>
+expected<ValueType, ErrorType>::log_error_unchecked() const noexcept {
+}
+
+template <typename ValueType, typename ErrorType>
+template <typename E>
+inline std::enable_if_t<std::is_integral<E>::value, void>
+expected<ValueType, ErrorType>::log_error_unchecked() const noexcept {
+    IOX2_LOG(Error,
+             "About to access the value of the 'Expected' but it contains the error: " << m_store.error_unchecked());
+}
+
+template <typename ValueType, typename ErrorType>
+template <typename E>
+inline std::enable_if_t<std::is_enum<E>::value, void>
+expected<ValueType, ErrorType>::log_error_unchecked() const noexcept {
+    IOX2_LOG(Error,
+             "About to access the value of the 'Expected' but it contains the error: "
+                 << static_cast<std::underlying_type_t<E>>(m_store.error_unchecked()) << " [" << typeid(E).name()
+                 << " (mangled)]");
+}
+
+template <typename ValueType, typename ErrorType>
 template <typename U>
 inline const enable_if_non_void_t<U>&
 expected<ValueType, ErrorType>::value_checked(bb::detail::SourceLocation location) const& noexcept {
-    IOX2_ENFORCE_INTERNAL(
-        location, has_value(), "Expected::has_value()", "Trying to access the value but an error is stored!");
+    if (has_error()) {
+        log_error_unchecked();
+        IOX2_ENFORCE_INTERNAL(
+            location, has_value(), "Expected::has_value()", "Trying to access the value but an error is stored!");
+    }
     return m_store.value_unchecked();
 }
 

--- a/iceoryx2-bb/cxx/include/iox2/legacy/expected.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/expected.hpp
@@ -18,6 +18,10 @@
 #include "iox2/bb/detail/attributes.hpp"
 #include "iox2/bb/detail/source_location.hpp"
 #include "iox2/legacy/detail/expected_helper.hpp"
+#include "iox2/legacy/logging.hpp"
+
+#include <type_traits>
+#include <typeinfo>
 
 namespace iox2 {
 namespace legacy {
@@ -371,6 +375,16 @@ class IOX2_NO_DISCARD expected final {
 
     ErrorType& error_checked(bb::detail::SourceLocation location) & noexcept;
     const ErrorType& error_checked(bb::detail::SourceLocation location) const& noexcept;
+
+    template <typename E = ErrorType>
+    std::enable_if_t<!(std::is_integral<E>::value || std::is_enum<E>::value), void>
+    log_error_unchecked() const noexcept;
+
+    template <typename E = ErrorType>
+    std::enable_if_t<std::is_integral<E>::value, void> log_error_unchecked() const noexcept;
+
+    template <typename E = ErrorType>
+    std::enable_if_t<std::is_enum<E>::value, void> log_error_unchecked() const noexcept;
 
   private:
     detail::expected_storage<ValueType, ErrorType> m_store;

--- a/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
+++ b/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
@@ -3249,6 +3249,42 @@ pub mod service_publish_subscribe {
     }
 
     #[conformance_test]
+    pub fn sample_is_still_acessible_when_publisher_was_disconnected<Sut: Service>() {
+        const NUMBER_OF_SAMPLES: usize = 4;
+        let service_name = generate_service_name();
+        let config = testing::generate_isolated_config();
+        let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
+
+        let sut = node
+            .service_builder(&service_name)
+            .publish_subscribe::<usize>()
+            .subscriber_max_buffer_size(NUMBER_OF_SAMPLES)
+            .subscriber_max_borrowed_samples(NUMBER_OF_SAMPLES)
+            .max_publishers(1)
+            .create()
+            .unwrap();
+
+        let publisher = sut.publisher_builder().create().unwrap();
+        let subscriber = sut.subscriber_builder().create().unwrap();
+
+        let mut samples = Vec::new();
+        for i in 0..NUMBER_OF_SAMPLES {
+            assert_that!(publisher.send_copy(i), is_ok);
+
+            let result = subscriber.receive().unwrap();
+            assert_that!(result, is_some);
+            samples.push(result.unwrap());
+        }
+
+        drop(publisher);
+        let _ = subscriber.receive(); // 'receive' will internally call 'update_connections'
+
+        for (i, sample) in samples.iter().enumerate() {
+            assert_that!(**sample, eq i);
+        }
+    }
+
+    #[conformance_test]
     pub fn subscriber_disconnected_publisher_does_not_block_new_publishers<Sut: Service>() {
         set_log_level(LogLevel::Error);
         const NUMBER_OF_SAMPLES: usize = 4;

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -264,28 +264,130 @@ impl<Service: service::Service> Receiver<Service> {
             let connection_storage = unsafe { &mut *self.connection_storage.get() };
 
             if let Some(connection) = connection_storage.get_mut(key) {
-                let mut keep_connection = false;
-                for id in 0..self.number_of_channels {
-                    if connection.receiver.has_data(ChannelId::new(id)) {
-                        keep_connection = true;
-                        break;
-                    }
-                }
+                let receiver = &connection.receiver;
+                let (connection_has_data, connection_has_borrows) =
+                    Self::all_receiver_channel_has_data_and_has_borrows(receiver);
 
+                let keep_connection = connection_has_data | connection_has_borrows;
                 if keep_connection {
-                    if unsafe { &mut *to_be_removed_connections.get() }
-                        .push(key)
-                        .is_err()
-                    {
-                        warn!(from self,
-                            "Expired connection buffer exceeded. A sender disconnected with undelivered data that will be discarded. Increase the expired connection buffer to mitigate the problem.");
-                        connection_storage.remove(key);
+                    let to_be_removed_connections =
+                        unsafe { &mut *to_be_removed_connections.get() };
+                    if to_be_removed_connections.push(key).is_err() {
+                        let msg_begin = "Expired connection buffer exceeded.";
+                        let msg_disconnet_with_data =
+                            "A sender disconnected with undelivered data that will be discarded.";
+                        let msg_disconnet_with_borrows = "A sender disconnected with data that is still borrowed. This will lead to segmentation faults when the data is accessed later on.";
+                        let msg_end =
+                            "Increase the expired connection buffer to mitigate the problem.";
+
+                        // push failed! let's see if there is something that can be removed
+                        let index_and_key_to_remove =
+                            Self::find_connection_without_data_and_borrows(
+                                connection_storage,
+                                to_be_removed_connections,
+                            );
+
+                        if let Some((index, key)) = index_and_key_to_remove {
+                            // we found a connection without data and borrows which can be removed from the container
+                            to_be_removed_connections.remove(index);
+                            connection_storage.remove(key);
+                        } else if connection_has_borrows {
+                            // we did not find a connection that can safely be removed to create some space for the connection with borrows;
+                            // removing a connection with borrows might lead to segfaults -> try to remove a connection without borrows
+                            let index_and_key_to_remove = Self::find_connection_without_data(
+                                connection_storage,
+                                to_be_removed_connections,
+                            );
+
+                            if let Some((index, key)) = index_and_key_to_remove {
+                                // we found a connection without borrows which can be removed from the container
+                                warn!(from self, "{} {} {}", msg_begin, msg_disconnet_with_data, msg_end);
+                                to_be_removed_connections.remove(index);
+                                connection_storage.remove(key);
+                            }
+                        }
+
+                        if to_be_removed_connections.push(key).is_err() {
+                            if connection_has_borrows {
+                                fatal_panic!(from self, "{} {} {}", msg_begin, msg_disconnet_with_borrows, msg_end);
+                            } else {
+                                warn!(from self, "{} {} {}", msg_begin, msg_disconnet_with_data, msg_end);
+                            }
+                            connection_storage.remove(key);
+                        }
                     }
                 } else {
                     connection_storage.remove(key);
                 }
             }
         }
+    }
+
+    fn find_connection_without_data_and_borrows(
+        connection_storage: &SlotMap<Connection<Service>>,
+        connections: &PolymorphicVec<'static, SlotMapKey, HeapAllocator>,
+    ) -> Option<(usize, SlotMapKey)> {
+        Self::find_connection_with_condition(
+            connection_storage,
+            connections,
+            |has_data, has_borrows| !(has_data | has_borrows),
+        )
+    }
+
+    fn find_connection_without_data(
+        connection_storage: &SlotMap<Connection<Service>>,
+        connections: &PolymorphicVec<'static, SlotMapKey, HeapAllocator>,
+    ) -> Option<(usize, SlotMapKey)> {
+        Self::find_connection_with_condition(
+            connection_storage,
+            connections,
+            |has_data, _has_borrows| !has_data,
+        )
+    }
+
+    fn find_connection_with_condition<C: Fn(bool, bool) -> bool>(
+        connection_storage: &SlotMap<Connection<Service>>,
+        connections: &PolymorphicVec<'static, SlotMapKey, HeapAllocator>,
+        condition: C,
+    ) -> Option<(usize, SlotMapKey)> {
+        let mut index_and_key = None;
+        for (n, &connection_key) in connections.iter().enumerate() {
+            let connection = match connection_storage.get(connection_key) {
+                Some(connection) => connection,
+                None => {
+                    index_and_key = Some((n, connection_key));
+                    break;
+                }
+            };
+
+            let receiver = &connection.receiver;
+            let (has_data, has_borrows) =
+                Self::all_receiver_channel_has_data_and_has_borrows(receiver);
+
+            if condition(has_data, has_borrows) {
+                index_and_key = Some((n, connection_key));
+                break;
+            }
+        }
+
+        index_and_key
+    }
+
+    fn all_receiver_channel_has_data_and_has_borrows(
+        receiver: &<Service::Connection as ZeroCopyConnection>::Receiver,
+    ) -> (bool, bool) {
+        let mut has_data = false;
+        let mut has_borrows = false;
+        for id in 0..receiver.number_of_channels() {
+            let channel_id = ChannelId::new(id);
+            has_data |= receiver.has_data(channel_id);
+            has_borrows |= receiver.borrow_count(channel_id) > 0;
+            if has_data & has_borrows {
+                break;
+            }
+        }
+
+        (has_data, has_borrows)
     }
 
     pub(crate) fn remove_connection(&self, index: usize) {
@@ -407,9 +509,21 @@ impl<Service: service::Service> Receiver<Service> {
                     }
                 }
 
-                for idx in clean_connections.iter().rev() {
-                    to_be_removed_connections.remove(idx.0);
-                    connection_storage.remove(idx.1);
+                for &(index, key) in clean_connections.iter().rev() {
+                    let has_borrows = if let Some(connection) = connection_storage.get(key) {
+                        let receiver = &connection.receiver;
+                        // this point is only reached if there are no data in the connection
+                        let (_has_data, has_borrows) =
+                            Self::all_receiver_channel_has_data_and_has_borrows(receiver);
+                        has_borrows
+                    } else {
+                        false
+                    };
+
+                    if !has_borrows {
+                        to_be_removed_connections.remove(index);
+                        connection_storage.remove(key);
+                    }
                 }
             }
         }
@@ -469,7 +583,7 @@ impl<Service: service::Service> Receiver<Service> {
     ) -> Result<(), ConnectionFailure> {
         let connection_storage = unsafe { &*self.connection_storage.get() };
 
-        let is_connected = match unsafe { &*self.connections[index].get() } {
+        let remove_connection = match unsafe { &*self.connections[index].get() } {
             None => true,
             Some(connection_key) => match connection_storage.get(*connection_key) {
                 Some(connection) => {
@@ -483,7 +597,7 @@ impl<Service: service::Service> Receiver<Service> {
             },
         };
 
-        if is_connected {
+        if remove_connection {
             self.prepare_connection_removal(index);
 
             match self.create(index, &sender_details) {

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -266,7 +266,7 @@ impl<Service: service::Service> Receiver<Service> {
             if let Some(connection) = connection_storage.get_mut(key) {
                 let receiver = &connection.receiver;
                 let (connection_has_data, connection_has_borrows) =
-                    Self::all_receiver_channel_has_data_and_has_borrows(receiver);
+                    Self::receiver_channels_have_data_or_borrows(receiver);
 
                 let keep_connection = connection_has_data | connection_has_borrows;
                 if keep_connection {
@@ -274,7 +274,7 @@ impl<Service: service::Service> Receiver<Service> {
                         unsafe { &mut *to_be_removed_connections.get() };
                     if to_be_removed_connections.push(key).is_err() {
                         let msg_begin = "Expired connection buffer exceeded.";
-                        let msg_disconnet_with_data =
+                        let msg_disconnect_with_data =
                             "A sender disconnected with undelivered data that will be discarded.";
                         let msg_disconnet_with_borrows = "A sender disconnected with data that is still borrowed. This will lead to segmentation faults when the data is accessed later on.";
                         let msg_end =
@@ -294,14 +294,14 @@ impl<Service: service::Service> Receiver<Service> {
                         } else if connection_has_borrows {
                             // we did not find a connection that can safely be removed to create some space for the connection with borrows;
                             // removing a connection with borrows might lead to segfaults -> try to remove a connection without borrows
-                            let index_and_key_to_remove = Self::find_connection_without_data(
+                            let index_and_key_to_remove = Self::find_connection_without_borrows(
                                 connection_storage,
                                 to_be_removed_connections,
                             );
 
                             if let Some((index, key)) = index_and_key_to_remove {
                                 // we found a connection without borrows which can be removed from the container
-                                warn!(from self, "{} {} {}", msg_begin, msg_disconnet_with_data, msg_end);
+                                warn!(from self, "{} {} {}", msg_begin, msg_disconnect_with_data, msg_end);
                                 to_be_removed_connections.remove(index);
                                 connection_storage.remove(key);
                             }
@@ -311,7 +311,7 @@ impl<Service: service::Service> Receiver<Service> {
                             if connection_has_borrows {
                                 fatal_panic!(from self, "{} {} {}", msg_begin, msg_disconnet_with_borrows, msg_end);
                             } else {
-                                warn!(from self, "{} {} {}", msg_begin, msg_disconnet_with_data, msg_end);
+                                warn!(from self, "{} {} {}", msg_begin, msg_disconnect_with_data, msg_end);
                             }
                             connection_storage.remove(key);
                         }
@@ -334,14 +334,14 @@ impl<Service: service::Service> Receiver<Service> {
         )
     }
 
-    fn find_connection_without_data(
+    fn find_connection_without_borrows(
         connection_storage: &SlotMap<Connection<Service>>,
         connections: &PolymorphicVec<'static, SlotMapKey, HeapAllocator>,
     ) -> Option<(usize, SlotMapKey)> {
         Self::find_connection_with_condition(
             connection_storage,
             connections,
-            |has_data, _has_borrows| !has_data,
+            |_has_data, has_borrows| !has_borrows,
         )
     }
 
@@ -361,8 +361,7 @@ impl<Service: service::Service> Receiver<Service> {
             };
 
             let receiver = &connection.receiver;
-            let (has_data, has_borrows) =
-                Self::all_receiver_channel_has_data_and_has_borrows(receiver);
+            let (has_data, has_borrows) = Self::receiver_channels_have_data_or_borrows(receiver);
 
             if condition(has_data, has_borrows) {
                 index_and_key = Some((n, connection_key));
@@ -373,7 +372,7 @@ impl<Service: service::Service> Receiver<Service> {
         index_and_key
     }
 
-    fn all_receiver_channel_has_data_and_has_borrows(
+    fn receiver_channels_have_data_or_borrows(
         receiver: &<Service::Connection as ZeroCopyConnection>::Receiver,
     ) -> (bool, bool) {
         let mut has_data = false;
@@ -514,7 +513,7 @@ impl<Service: service::Service> Receiver<Service> {
                         let receiver = &connection.receiver;
                         // this point is only reached if there are no data in the connection
                         let (_has_data, has_borrows) =
-                            Self::all_receiver_channel_has_data_and_has_borrows(receiver);
+                            Self::receiver_channels_have_data_or_borrows(receiver);
                         has_borrows
                     } else {
                         false

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -476,53 +476,57 @@ impl<Service: service::Service> Receiver<Service> {
             let to_be_removed_connections = unsafe { &mut *to_be_removed_connections.get() };
 
             if !to_be_removed_connections.is_empty() {
-                let mut clean_connections = PolymorphicVec::new(
-                    HeapAllocator::global(),
-                    to_be_removed_connections.capacity(),
-                )
-                .expect("Heap allocator provides memory.");
                 let connection_storage = unsafe { &mut *self.connection_storage.get() };
 
-                for (n, connection_key) in to_be_removed_connections.iter().enumerate() {
-                    let connection = match connection_storage.get(*connection_key) {
-                        Some(connection) => connection,
-                        None => {
-                            unsafe { clean_connections.push_unchecked((n, *connection_key)) };
+                let mut indices_to_skip = 0;
+                // loop through all 'to_be_removed_connections' break the for-loop if a connection needs to be removed;
+                // then continue the for-loop but skip the previously looped indices
+                loop {
+                    let mut index_and_key = None;
+                    for (n, connection_key) in to_be_removed_connections
+                        .iter()
+                        .skip(indices_to_skip)
+                        .enumerate()
+                    {
+                        let connection = match connection_storage.get(*connection_key) {
+                            Some(connection) => connection,
+                            None => {
+                                index_and_key = Some((n, *connection_key));
+                                break;
+                            }
+                        };
+                        let receiver = &connection.receiver;
+
+                        if receiver.borrow_count(channel_id) == receiver.max_borrowed_samples() {
                             continue;
                         }
-                    };
 
-                    if connection.receiver.borrow_count(channel_id)
-                        == connection.receiver.max_borrowed_samples()
-                    {
+                        if let Some((details, absolute_address)) =
+                            self.receive_from_connection(connection, *connection_key, channel_id)?
+                        {
+                            ret_val = Some((details, absolute_address));
+                            break;
+                        } else {
+                            let (_has_data, has_borrows) =
+                                Self::receiver_channels_have_data_or_borrows(receiver);
+
+                            if !has_borrows {
+                                index_and_key = Some((n, *connection_key));
+                                break;
+                            }
+                        }
+                    }
+                    // there is a connection which has neither data nor borrows nor is it present in the 'connection_storage'
+                    if let Some((index, key)) = index_and_key {
+                        to_be_removed_connections.remove(index);
+                        connection_storage.remove(key);
+                        indices_to_skip = index;
+
                         continue;
                     }
 
-                    if let Some((details, absolute_address)) =
-                        self.receive_from_connection(connection, *connection_key, channel_id)?
-                    {
-                        ret_val = Some((details, absolute_address));
-                        break;
-                    } else {
-                        unsafe { clean_connections.push_unchecked((n, *connection_key)) };
-                    }
-                }
-
-                for &(index, key) in clean_connections.iter().rev() {
-                    let has_borrows = if let Some(connection) = connection_storage.get(key) {
-                        let receiver = &connection.receiver;
-                        // this point is only reached if there are no data in the connection
-                        let (_has_data, has_borrows) =
-                            Self::receiver_channels_have_data_or_borrows(receiver);
-                        has_borrows
-                    } else {
-                        false
-                    };
-
-                    if !has_borrows {
-                        to_be_removed_connections.remove(index);
-                        connection_storage.remove(key);
-                    }
+                    // at this point we either were able to receive a sample or iterated through all connections
+                    break;
                 }
             }
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR fixes a segfault when a sample is accesses which corresponding connection was already closed.

The issue occurs only with pub-sub and not with request-response.

In order to have better debug information from CI failures, the `Expected` now also prints the error value on an access violation.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1629
Closes #1528

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
