### PR TITLE
[#1634] address follow up left overs

### DIFF
--- a/examples/rust/publish_subscribe/publisher.rs
+++ b/examples/rust/publish_subscribe/publisher.rs
@@ -29,7 +29,6 @@ fn main() -> Result<(), Box<dyn core::error::Error>> {
         .service_builder(&"My/Funk/ServiceName".try_into()?)
         .publish_subscribe::<TransmissionData>()
         .open_or_create()?;
-    service.service_hash();
 
     let publisher = service.publisher_builder().create()?;
 

--- a/iceoryx2-bb/posix/src/file.rs
+++ b/iceoryx2-bb/posix/src/file.rs
@@ -601,7 +601,7 @@ impl File {
             };
 
             if config.sync_on_open {
-                if let Err(e) = new_self.flush() {
+                if let Err(e) = new_self.sync_all() {
                     debug!(from new_self,
                         "Unable to sync file before opening it. The file properties and content might be out-of-date. [{e:?}]");
                 }
@@ -924,7 +924,7 @@ impl File {
     }
 
     /// Syncs all file modification with the file system.
-    pub fn flush(&mut self) -> Result<(), FileSyncError> {
+    pub fn sync_all(&mut self) -> Result<(), FileSyncError> {
         if unsafe { posix::fsync(self.file_descriptor.native_handle()) } == 0 {
             return Ok(());
         }

--- a/iceoryx2-bb/posix/src/process_state.rs
+++ b/iceoryx2-bb/posix/src/process_state.rs
@@ -242,6 +242,7 @@ enum_gen! {
     Interrupt,
     FailedToAcquireUniqueProcessIdFromContextFile,
     FailedToAcquireUniqueProcessId,
+    InternalError,
     UnknownError(i32)
 
   mapping:
@@ -909,11 +910,18 @@ impl ProcessMonitor {
         // first we need to open the context_file with AccessMode::Write only since it could
         // be in init mode. After the initialization we can open it with AccessMode::Read
         match Self::open_file(self, &self.context_path, AccessMode::Write) {
-            Ok(Some(context_file)) => {
-                if context_file.permission().unwrap() == INIT_PERMISSION {
-                    return Ok(ProcessState::Starting);
+            Ok(Some(context_file)) => match context_file.permission() {
+                Ok(permission) => {
+                    if permission == INIT_PERMISSION {
+                        return Ok(ProcessState::Starting);
+                    }
                 }
-            }
+                Err(e) => {
+                    fail!(from self, with ProcessMonitorStateError::InternalError,
+                            "{msg} since the permissions of the context file \"{}\" could not be acquired. [{e:?}]",
+                            self.context_path);
+                }
+            },
             Ok(None) => {
                 return Ok(ProcessState::DoesNotExist);
             }
@@ -954,9 +962,19 @@ impl ProcessMonitor {
                 return Ok(ProcessState::CleaningUp);
             }
         } else {
-            if File::does_exist(&self.state_path).unwrap() {
-                return Err(ProcessMonitorStateError::CorruptedState);
+            match File::does_exist(&self.state_path) {
+                Ok(true) => {
+                    fail!(from self, with ProcessMonitorStateError::CorruptedState,
+                        "{msg} since the process state is corruped.");
+                }
+                Ok(false) => (),
+                Err(e) => {
+                    fail!(from self, with ProcessMonitorStateError::InternalError,
+                        "{msg} since it is not possible to check if the state file \"{}\" does exist. [{e:?}]",
+                        self.state_path);
+                }
             }
+
             return Ok(ProcessState::CleaningUp);
         }
 

--- a/iceoryx2-bb/posix/tests-common/src/file_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/file_tests.rs
@@ -177,7 +177,7 @@ pub fn simple_read_write_works() {
 
     let mut content = "oh look what is in the file \n in in that line \t fuuu".to_string();
     let result = file.write(unsafe { content.as_mut_vec() }.as_slice());
-    assert_that!(file.flush(), is_ok);
+    assert_that!(file.sync_all(), is_ok);
 
     assert_that!(result, is_ok);
     assert_that!(content, len result.ok().unwrap() as usize);
@@ -201,7 +201,7 @@ pub fn write_appends_content_to_file() {
         file.write(b"a horse with a blanket does not require shoes"),
         is_ok
     );
-    assert_that!(file.flush(), is_ok);
+    assert_that!(file.sync_all(), is_ok);
     assert_that!(file.seek(0), is_ok);
 
     let mut read_content = String::new();
@@ -216,7 +216,7 @@ pub fn multiple_read_calls_move_file_cursor() {
     let mut file = test.create_file(&test.file);
 
     assert_that!(file.write(b"hakuna matata"), is_ok);
-    assert_that!(file.flush(), is_ok);
+    assert_that!(file.sync_all(), is_ok);
     assert_that!(file.seek(0), is_ok);
 
     let mut buffer = [0u8; 1];
@@ -239,7 +239,7 @@ pub fn read_line_works() {
         file.write(b"whatever you do\nwherever you go\ndo not forget your towel!"),
         is_ok
     );
-    assert_that!(file.flush(), is_ok);
+    assert_that!(file.sync_all(), is_ok);
     assert_that!(file.seek(0), is_ok);
 
     let mut buffer = String::new();
@@ -479,7 +479,7 @@ pub fn simple_read_write_of_a_value_works() {
     let mut file = test.create_file(&test.file);
 
     file.write_val(&value_written).unwrap();
-    assert_that!(file.flush(), is_ok);
+    assert_that!(file.sync_all(), is_ok);
     assert_that!(file.seek(0), is_ok);
 
     let value_read = file.read_val::<TestValue>().unwrap();
@@ -501,7 +501,7 @@ pub fn simple_read_at_write_at_of_a_value_works() {
     file.write(&[255u8; OFFSET * 2]).unwrap();
 
     file.write_val_at(OFFSET as u64, &value_written).unwrap();
-    assert_that!(file.flush(), is_ok);
+    assert_that!(file.sync_all(), is_ok);
 
     let value_read = file.read_val_at::<TestValue>(OFFSET as u64).unwrap();
 
@@ -518,7 +518,7 @@ pub fn when_file_does_not_contain_the_required_bytes_read_val_fails() {
     let mut file = test.create_file(&test.file);
 
     file.write_val(&value_written).unwrap();
-    assert_that!(file.flush(), is_ok);
+    assert_that!(file.sync_all(), is_ok);
     assert_that!(file.seek(0), is_ok);
 
     assert_that!(file.read_val::<TestValue>().err(), eq Some(FileReadValError::FileSizeTooSmallToContainValue));
@@ -535,7 +535,7 @@ pub fn when_file_does_not_contain_the_required_bytes_read_val_at_fails() {
     let mut file = test.create_file(&test.file);
 
     file.write_val(&value_written).unwrap();
-    assert_that!(file.flush(), is_ok);
+    assert_that!(file.sync_all(), is_ok);
     assert_that!(file.seek(0), is_ok);
 
     assert_that!(file.read_val_at::<TestValue>(1).err(), eq Some(FileReadValError::FileSizeTooSmallToContainValue));


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes # <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
