### PR TITLE
[#1631] Ensure the expired connection buffer is at least as large as subscriber max borrowed samples

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -200,6 +200,9 @@
   [#1540](https://github.com/eclipse-iceoryx/iceoryx2/issues/1540)
 * Move tunnel crates into services architecture layer
   [#1552](https://github.com/eclipse-iceoryx/iceoryx2/issues/1552)
+* Ensure the expired connection buffer is at least as large as subscriber max
+  borrowed samples
+  [#1631](https://github.com/eclipse-iceoryx/iceoryx2/issues/1631)
 
 ### Workflow
 

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -309,7 +309,7 @@ impl<Service: service::Service> Receiver<Service> {
 
                         if to_be_removed_connections.push(key).is_err() {
                             if connection_has_borrows {
-                                fatal_panic!(from self, "{} {} {}", msg_begin, msg_disconnet_with_borrows, msg_end);
+                                fatal_panic!(from self, "This should never happen! {} {} {}", msg_begin, msg_disconnet_with_borrows, msg_end);
                             } else {
                                 warn!(from self, "{} {} {}", msg_begin, msg_disconnect_with_data, msg_end);
                             }

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -210,12 +210,25 @@ impl<
             None => static_config.subscriber_max_buffer_size,
         };
 
-        let number_of_to_be_removed_connections = service
+        let subscriber_max_borrowed_samples = static_config.subscriber_max_borrowed_samples;
+        let subscriber_expired_connection_buffer = service
             .shared_node()
             .config()
             .defaults
             .publish_subscribe
             .subscriber_expired_connection_buffer;
+
+        let number_of_to_be_removed_connections = if subscriber_expired_connection_buffer
+            >= subscriber_max_borrowed_samples
+        {
+            subscriber_expired_connection_buffer
+        } else {
+            warn!(
+                "Subscriber max borrowed samples is larger than expired connection buffer! Set buffer capacity to value of max borrowed samples."
+            );
+            subscriber_max_borrowed_samples
+        };
+
         let number_of_active_connections = publisher_list.capacity();
         let number_of_connections =
             number_of_to_be_removed_connections + number_of_active_connections;
@@ -232,7 +245,7 @@ impl<
                 receiver_port_id: subscriber_id.value(),
                 service_state: service.clone(),
                 message_type_details: static_config.message_type_details,
-                receiver_max_borrowed_samples: static_config.subscriber_max_borrowed_samples,
+                receiver_max_borrowed_samples: subscriber_max_borrowed_samples,
                 enable_safe_overflow: static_config.enable_safe_overflow,
                 buffer_size,
                 tagger: CyclicTagger::new(),


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

See title

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1631 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
