### PR TITLE
[#1650] Fix 'NodeCreationFailure::InternalError' on node creation

### DIFF
--- a/doc/development-setup/nostd-testing.md
+++ b/doc/development-setup/nostd-testing.md
@@ -143,7 +143,7 @@ annotated test functions are registered for execution.
 my-crate/
 ├── src/
 └── tests/
-    └── main.rs
+    └── tests.rs
 ```
 
 ```rust
@@ -161,7 +161,8 @@ my-crate-tests-common = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "my-crate-tests"
+path = "tests/tests.rs"
 harness = false
 ```
 
@@ -191,7 +192,7 @@ cargo nextest run --package my-crate
 For every crate that defines tests for `no_std` targets, an additional binary
 crate is created with the naming convention: `${crate-name}-tests-nostd`.
 
-Again, a single `main.rs` file is required to set up the test harness and
+Again, a single `tests.rs` file is required to set up the test harness and
 link to the common test library so that all annotated test functions
 are registered for execution.
 
@@ -201,7 +202,7 @@ here:
 ```console
 my-crate-tests-nostd/
 └── src/
-    └── main.rs
+    └── tests.rs
 ```
 
 ```rust

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -23,7 +23,7 @@
     conflicts when merging.
 -->
 
-* [#1](https://github.com/eclipse-iceoryx/iceoryx2/issues/1) Example text
+* [#1650](https://github.com/eclipse-iceoryx/iceoryx2/issues/1650) Fix 'NodeCreationFailure::InternalError' on concurrent node creation
 
 ### Refactoring
 
@@ -32,6 +32,7 @@
     conflicts when merging.
 -->
 
+* [#1651](https://github.com/eclipse-iceoryx/iceoryx2/issues/1651) Make the names of the test binaries relatable to the crates
 * [#996](https://github.com/eclipse-iceoryx/iceoryx2/issues/996) Move BumpAllocator from iceoryx2-bb-memory into iceoryx2-bb-elementary
 
 ### Workflow

--- a/iceoryx2-bb/concurrency/Cargo.toml
+++ b/iceoryx2-bb/concurrency/Cargo.toml
@@ -27,5 +27,6 @@ iceoryx2-bb-elementary-traits = { workspace = true }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-concurrency-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-bb/container/Cargo.toml
+++ b/iceoryx2-bb/container/Cargo.toml
@@ -38,5 +38,6 @@ iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 serde_test = { workspace = true }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-container-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-bb/derive-macros/Cargo.toml
+++ b/iceoryx2-bb/derive-macros/Cargo.toml
@@ -34,5 +34,6 @@ iceoryx2-bb-derive-macros-tests-common = { workspace = true, features = ["std"] 
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-derive-macros-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-bb/elementary/Cargo.toml
+++ b/iceoryx2-bb/elementary/Cargo.toml
@@ -35,5 +35,6 @@ iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing-macros = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-elementary-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-bb/linux/Cargo.toml
+++ b/iceoryx2-bb/linux/Cargo.toml
@@ -24,7 +24,8 @@ std = [
 ]
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-linux-tests"
+path = "tests/tests.rs"
 harness = false
 
 [dependencies]

--- a/iceoryx2-bb/lock-free/Cargo.toml
+++ b/iceoryx2-bb/lock-free/Cargo.toml
@@ -34,7 +34,8 @@ iceoryx2-bb-loggers = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-lock-free-tests"
+path = "tests/tests.rs"
 harness = false
 
 [target.'cfg(loom)'.dev-dependencies]

--- a/iceoryx2-bb/memory/Cargo.toml
+++ b/iceoryx2-bb/memory/Cargo.toml
@@ -35,5 +35,6 @@ iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 iceoryx2-bb-memory-tests-common = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-memory-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-bb/posix/Cargo.toml
+++ b/iceoryx2-bb/posix/Cargo.toml
@@ -49,5 +49,6 @@ iceoryx2-bb-loggers = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-posix-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-bb/posix/src/shared_memory.rs
+++ b/iceoryx2-bb/posix/src/shared_memory.rs
@@ -80,7 +80,7 @@ use iceoryx2_bb_elementary_traits::testing::abandonable::Abandonable;
 use iceoryx2_bb_system_types::file_name::*;
 use iceoryx2_bb_system_types::file_path::*;
 use iceoryx2_bb_system_types::path::*;
-use iceoryx2_log::{error, fail, fatal_panic, trace, warn};
+use iceoryx2_log::{debug, error, fail, fatal_panic, trace, warn};
 use iceoryx2_pal_configuration::PATH_SEPARATOR;
 use iceoryx2_pal_posix::posix::POSIX_SUPPORT_ADVANCED_SIGNAL_HANDLING;
 use iceoryx2_pal_posix::posix::POSIX_SUPPORT_PERSISTENT_SHARED_MEMORY;
@@ -217,6 +217,11 @@ impl SharedMemoryBuilder {
         let actual_shm_size = fail!(from self, when fd.metadata(),
                 "{} since a failure occurred while acquiring the file attributes.", msg)
         .size();
+
+        if actual_shm_size == 0 {
+            debug!("Attemption to open a shared memory with size of 0!");
+        }
+
         self.size = actual_shm_size as usize;
 
         let memory_mapping = Self::create_memory_mapping(fd, &self)?;

--- a/iceoryx2-bb/posix/src/shared_memory.rs
+++ b/iceoryx2-bb/posix/src/shared_memory.rs
@@ -219,7 +219,7 @@ impl SharedMemoryBuilder {
         .size();
 
         if actual_shm_size == 0 {
-            debug!("Attemption to open a shared memory with size of 0!");
+            debug!("Trying to open a shared memory with size zero.");
         }
 
         self.size = actual_shm_size as usize;

--- a/iceoryx2-bb/system-types/Cargo.toml
+++ b/iceoryx2-bb/system-types/Cargo.toml
@@ -38,5 +38,6 @@ iceoryx2-bb-system-types-tests-common = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-system-types-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-bb/threadsafe/Cargo.toml
+++ b/iceoryx2-bb/threadsafe/Cargo.toml
@@ -33,5 +33,6 @@ iceoryx2-bb-loggers = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-threadsafe-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-bb/trait-tests/Cargo.toml
+++ b/iceoryx2-bb/trait-tests/Cargo.toml
@@ -18,5 +18,6 @@ iceoryx2-bb-loggers = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-bb-trait-tests-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-cal/Cargo.toml
+++ b/iceoryx2-cal/Cargo.toml
@@ -56,5 +56,6 @@ iceoryx2-bb-loggers = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-cal-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2-cal/conformance-tests/Cargo.toml
+++ b/iceoryx2-cal/conformance-tests/Cargo.toml
@@ -28,7 +28,8 @@ std = [
 ]
 
 [[test]]
-name = "tests"
+name = "iceoryx2-cal-conformance-tests-tests"
+path = "tests/tests.rs"
 harness = false
 
 [dependencies]

--- a/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
@@ -408,58 +408,70 @@ pub mod dynamic_storage_trait {
         }
     }
 
-    #[ignore] // TODO: iox2-671 enable this test when the concurrency issue is fixed.
+    #[cfg(not(any(target_os = "windows")))] // TODO: iox2-671 enable this test when the concurrency issue is fixed.
     #[conformance_test]
     pub fn initialization_blocks_other_openers<
         Sut: DynamicStorage<TestData>,
         WrongTypeSut: DynamicStorage<u64>,
     >() {
         const TIMEOUT: Duration = Duration::from_millis(100);
+        const ITERATIONS: usize = 100;
 
-        let storage_name = generate_file_path().file_name();
-        let config = generate_isolated_config::<Sut>();
-        let _watchdog = Watchdog::new();
-        let handle = BarrierHandle::new();
-        let barrier_1 = Arc::new(BarrierBuilder::new(2).create(&handle).unwrap());
-        let barrier_2 = barrier_1.clone();
+        for _ in 0..ITERATIONS {
+            let storage_name = generate_file_path().file_name();
+            let config = generate_isolated_config::<Sut>();
+            let _watchdog = Watchdog::new();
+            let handle = BarrierHandle::new();
+            let barrier_1 = Arc::new(BarrierBuilder::new(2).create(&handle).unwrap());
+            let barrier_2 = barrier_1.clone();
 
-        thread_scope(|s| {
-            let config_1 = config.clone();
-            s.thread_builder().spawn(move || {
-                barrier_1.wait();
-                let _sut = Sut::Builder::new(&storage_name)
-                    .config(&config_1)
-                    .supplementary_size(0)
-                    .has_ownership(false)
-                    .initializer(|value, _| {
-                        nanosleep(TIMEOUT).unwrap();
-                        value.value.store(789, Ordering::Relaxed);
-                        true
-                    })
-                    .create(TestData::new(123))
-                    .unwrap();
-            })?;
+            thread_scope(|s| {
+                let config_1 = config.clone();
+                s.thread_builder().spawn(move || {
+                    barrier_1.wait();
+                    let _sut = Sut::Builder::new(&storage_name)
+                        .config(&config_1)
+                        .supplementary_size(0)
+                        .has_ownership(false)
+                        .initializer(|value, _| {
+                            nanosleep(TIMEOUT).unwrap();
+                            value.value.store(789, Ordering::Relaxed);
+                            true
+                        })
+                        .create(TestData::new(123))
+                        .unwrap();
+                })?;
 
-            let config_2 = config.clone();
-            s.thread_builder().spawn(move || {
-                barrier_2.wait();
-                loop {
-                let sut2 = Sut::Builder::new(&storage_name).config(&config_2).open(AccessMode::ReadWrite);
-                if let Ok(res) = sut2 {
-                    assert_that!(res.get().value.load(Ordering::Relaxed), eq 789);
-                    break;
-                } else {
-                    let err = sut2.err().unwrap();
-                    assert_that!(err == DynamicStorageOpenError::DoesNotExist || err == DynamicStorageOpenError::InitializationNotYetFinalized, eq true);
-                }
-            }})?;
+                let config_2 = config.clone();
+                s.thread_builder().spawn(move || {
+                    barrier_2.wait();
+                    loop {
+                        let sut2 = Sut::Builder::new(&storage_name)
+                            .config(&config_2)
+                            .open(AccessMode::ReadWrite);
+                        if let Ok(res) = sut2 {
+                            assert_that!(res.get().value.load(Ordering::Relaxed), eq 789);
+                            break;
+                        } else {
+                            let err = sut2.err().unwrap();
+                            let has_expected_error = err == DynamicStorageOpenError::DoesNotExist
+                                || err == DynamicStorageOpenError::InitializationNotYetFinalized;
+                            if !has_expected_error {
+                                assert_that!(err, eq(DynamicStorageOpenError::DoesNotExist)); // just to get the error value
+                            }
+                            assert_that!(has_expected_error, eq true);
+                        }
+                    }
+                })?;
 
-            Ok(())
-        }).unwrap();
+                Ok(())
+            })
+            .unwrap();
 
-        if POSIX_SUPPORT_PERSISTENT_SHARED_MEMORY {
-            assert_that!(Sut::does_exist_cfg(&storage_name, &config), eq Ok(true));
-            assert_that!(unsafe { Sut::remove_cfg(&storage_name, &config) }, eq Ok(true));
+            if POSIX_SUPPORT_PERSISTENT_SHARED_MEMORY {
+                assert_that!(Sut::does_exist_cfg(&storage_name, &config), eq Ok(true));
+                assert_that!(unsafe { Sut::remove_cfg(&storage_name, &config) }, eq Ok(true));
+            }
         }
     }
 

--- a/iceoryx2-cal/conformance-tests/src/zero_copy_connection_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/zero_copy_connection_trait.rs
@@ -2006,7 +2006,7 @@ pub mod zero_copy_connection_trait {
         assert_that!(unsafe { Sut::remove_sender(&name, &config) }, eq Err(ZeroCopyPortRemoveError::DoesNotExist));
     }
 
-    #[ignore] // TODO: iox2-671 enable this test when the concurrency issue is fixed.
+    #[cfg(not(any(target_os = "windows")))] // TODO: iox2-671 enable this test when the concurrency issue is fixed.
     #[conformance_test]
     pub fn concurrent_creation_and_destruction_works<Sut: ZeroCopyConnection>() {
         const ITERATIONS: usize = 1000;

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -48,6 +48,7 @@ pub use core::ops::Deref;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use core::ptr::NonNull;
+use core::time::Duration;
 use iceoryx2_bb_concurrency::atomic::Ordering;
 
 use alloc::format;
@@ -59,7 +60,7 @@ use alloc::vec::Vec;
 use iceoryx2_bb_concurrency::atomic::AtomicU64;
 use iceoryx2_bb_elementary::package_version::PackageVersion;
 use iceoryx2_bb_elementary_traits::non_null::NonNullCompat;
-use iceoryx2_bb_posix::adaptive_wait::AdaptiveWaitBuilder;
+use iceoryx2_bb_posix::adaptive_wait::{AdaptiveWaitBuilder, AdaptiveWaitStrategy};
 use iceoryx2_bb_posix::directory::*;
 use iceoryx2_bb_posix::file_descriptor::FileDescriptorManagement;
 use iceoryx2_bb_posix::memory_mapping::MemoryMappingCreationError;
@@ -202,7 +203,9 @@ impl<T: Send + Sync + Debug> Builder<'_, T> {
         let msg = "Failed to open posix_shared_memory::DynamicStorage";
 
         let full_name = self.config.path_for(&self.storage_name).file_name();
-        let mut wait_for_read_write_access = fail!(from self, when AdaptiveWaitBuilder::new().create(),
+        let mut wait_for_read_write_access = fail!(from self,
+                                    when AdaptiveWaitBuilder::new()
+                                        .strategy(AdaptiveWaitStrategy::FixedTicks(Duration::from_millis(1))).create(),
                                     with DynamicStorageOpenError::InternalError,
                                     "{} since the AdaptiveWait could not be initialized.", msg);
 

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -62,6 +62,7 @@ use iceoryx2_bb_elementary_traits::non_null::NonNullCompat;
 use iceoryx2_bb_posix::adaptive_wait::AdaptiveWaitBuilder;
 use iceoryx2_bb_posix::directory::*;
 use iceoryx2_bb_posix::file_descriptor::FileDescriptorManagement;
+use iceoryx2_bb_posix::memory_mapping::MemoryMappingCreationError;
 use iceoryx2_bb_posix::shared_memory::*;
 use iceoryx2_bb_system_types::path::Path;
 use iceoryx2_log::fail;
@@ -220,8 +221,11 @@ impl<T: Send + Sync + Debug> Builder<'_, T> {
                         msg, self.timeout);
                     }
                 }
-                Err(_) => {
-                    fail!(from self, with DynamicStorageOpenError::InternalError, "{} since the underlying shared memory could not be opened.", msg);
+                Err(SharedMemoryCreationError::MemoryMappingCreationError(
+                    MemoryMappingCreationError::MappingSizeIsZero,
+                )) => (),
+                Err(e) => {
+                    fail!(from self, with DynamicStorageOpenError::InternalError, "{} since the underlying shared memory could not be opened. Error: {:?}", msg, e);
                 }
             };
 

--- a/iceoryx2/Cargo.toml
+++ b/iceoryx2/Cargo.toml
@@ -63,5 +63,6 @@ iceoryx2-bb-loggers = { workspace = true, features = ["std"] }
 iceoryx2-bb-testing = { workspace = true, features = ["std"] }
 
 [[test]]
-name = "tests"
+name = "iceoryx2-tests"
+path = "tests/tests.rs"
 harness = false

--- a/iceoryx2/conformance-tests/Cargo.toml
+++ b/iceoryx2/conformance-tests/Cargo.toml
@@ -27,7 +27,8 @@ std = [
 ]
 
 [[test]]
-name = "tests"
+name = "iceoryx2-conformance-tests-tests"
+path = "tests/tests.rs"
 harness = false
 
 [dependencies]

--- a/iceoryx2/conformance-tests/src/publisher.rs
+++ b/iceoryx2/conformance-tests/src/publisher.rs
@@ -768,7 +768,6 @@ pub mod publisher {
     #[should_panic]
     #[cfg(debug_assertions)]
     pub fn custom_fixed_size_payload_panics_when_loaning_more_than_one_element<Sut: Service>() {
-        set_log_level(LogLevel::Error);
         let service_name = generate_service_name();
         let config = testing::generate_isolated_config();
         let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();

--- a/iceoryx2/conformance-tests/src/service.rs
+++ b/iceoryx2/conformance-tests/src/service.rs
@@ -408,8 +408,12 @@ pub mod service {
         const NUMBER_OF_ITERATIONS: usize = 25;
         let test = Factory::new();
 
+        let handle_start = BarrierHandle::new();
         let handle_enter = BarrierHandle::new();
         let handle_exit = BarrierHandle::new();
+        let barrier_start = BarrierBuilder::new(number_of_threads as _)
+            .create(&handle_start)
+            .unwrap();
         let barrier_enter = BarrierBuilder::new(number_of_threads as _)
             .create(&handle_enter)
             .unwrap();
@@ -421,6 +425,7 @@ pub mod service {
         thread_scope(|s| {
             for _ in 0..number_of_threads {
                 s.thread_builder().spawn(|| {
+                    barrier_start.wait();
                     let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
                     for _ in 0..NUMBER_OF_ITERATIONS {
                         let service_name = generate_service_name();

--- a/iceoryx2/conformance-tests/src/service.rs
+++ b/iceoryx2/conformance-tests/src/service.rs
@@ -43,7 +43,6 @@ pub mod service {
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_bb_testing::watchdog::Watchdog;
     use iceoryx2_bb_testing_macros::conformance_test;
-    use iceoryx2_log::{LogLevel, set_log_level};
 
     pub trait SutFactory<Sut: Service>: Send + Sync {
         type Factory: PortFactory;
@@ -500,7 +499,6 @@ pub mod service {
         Sut: Service,
         Factory: SutFactory<Sut>,
     >() {
-        set_log_level(LogLevel::Debug);
         let _watch_dog = Watchdog::new_with_timeout(Duration::from_secs(120));
         const NUMBER_OF_CLOSE_THREADS: usize = 1;
         let number_of_open_threads = (SystemInfo::NumberOfCpuCores.value()).clamp(2, 4);

--- a/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
+++ b/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
@@ -45,7 +45,6 @@ pub mod service_publish_subscribe {
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_bb_testing::watchdog::Watchdog;
     use iceoryx2_bb_testing_macros::conformance_test;
-    use iceoryx2_log::{LogLevel, set_log_level};
 
     #[derive(Debug, ZeroCopySend)]
     #[repr(C)]
@@ -3284,7 +3283,6 @@ pub mod service_publish_subscribe {
 
     #[conformance_test]
     pub fn subscriber_disconnected_publisher_does_not_block_new_publishers<Sut: Service>() {
-        set_log_level(LogLevel::Error);
         const NUMBER_OF_SAMPLES: usize = 4;
         let service_name = generate_service_name();
         let config = testing::generate_isolated_config();
@@ -3319,7 +3317,6 @@ pub mod service_publish_subscribe {
 
     #[conformance_test]
     pub fn subscriber_acquires_samples_of_disconnected_publisher_first<Sut: Service>() {
-        set_log_level(LogLevel::Error);
         let service_name = generate_service_name();
         let config = testing::generate_isolated_config();
         let node = NodeBuilder::new().config(&config).create::<Sut>().unwrap();
@@ -3350,7 +3347,6 @@ pub mod service_publish_subscribe {
 
     #[conformance_test]
     pub fn communication_with_custom_payload_works<Sut: Service>() {
-        set_log_level(LogLevel::Error);
         const NUMBER_OF_ELEMENTS: usize = 1;
         let service_name = generate_service_name();
         let config = testing::generate_isolated_config();
@@ -3386,7 +3382,6 @@ pub mod service_publish_subscribe {
 
     #[conformance_test]
     pub fn communication_with_custom_slice_payload_works<Sut: Service>() {
-        set_log_level(LogLevel::Error);
         const NUMBER_OF_ELEMENTS: usize = 7;
         let service_name = generate_service_name();
         let config = testing::generate_isolated_config();

--- a/iceoryx2/conformance-tests/src/waitset.rs
+++ b/iceoryx2/conformance-tests/src/waitset.rs
@@ -161,7 +161,6 @@ pub mod waitset {
     where
         <S::Event as Event>::Listener: SynchronousMultiplexing,
     {
-        set_log_level(LogLevel::Debug);
         let config = generate_isolated_config();
         let node = NodeBuilder::new().config(&config).create::<S>().unwrap();
         let sut = WaitSetBuilder::new().create::<S>().unwrap();


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR fixes a race on accessing the global shared memory counter.

In addition, for better debuggability, the test binary names have a distinct name which reflect the crate they are testing.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1650 
Closes #1651 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
