### PR TITLE
[#1660] Rework process alive detection

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -24,6 +24,7 @@
 -->
 
 * [#1650](https://github.com/eclipse-iceoryx/iceoryx2/issues/1650) Fix 'NodeCreationFailure::InternalError' on concurrent node creation
+* [#1660](https://github.com/eclipse-iceoryx/iceoryx2/issues/1660) Rework process alive detection to avoid false negatives to enable communication across docker containers
 
 ### Refactoring
 

--- a/iceoryx2-bb/posix/src/process_state.rs
+++ b/iceoryx2-bb/posix/src/process_state.rs
@@ -261,7 +261,6 @@ enum_gen! {
     Interrupt,
     FailedToAcquireLockState,
     FailedToAcquireUniqueProcessId,
-    FailedToAcquireUniqueProcessIdFromContextFile,
     UnableToOpenContextFile,
     UnableToOpenStateFile,
     UnableToOpenOwnerLockFile,
@@ -932,9 +931,7 @@ impl ProcessMonitor {
             Err(e) => return Err(e.into()),
         }
 
-        let other_process_id = if let Some(context_file) =
-            Self::open_file(self, &self.context_path, AccessMode::Read)?
-        {
+        if let Some(context_file) = Self::open_file(self, &self.context_path, AccessMode::Read)? {
             let other_process_id: UniqueProcessId = match context_file.read_val() {
                 Ok(v) => v,
                 Err(e) => {
@@ -988,16 +985,7 @@ impl ProcessMonitor {
                 let lock_state = fail!(from self, when Self::get_lock_state(&state_file),
                                     "{} since the lock state of the state file could not be acquired.", msg);
                 match lock_state as _ {
-                    posix::F_WRLCK => {
-                        // It is possible that the file system is not yet completely synced and the
-                        // file lock cannot be acquired despite the process is already dead.
-                        // Therefore, we check again manually.
-                        if Process::from_pid(other_process_id.pid()).is_alive() {
-                            Ok(ProcessState::Alive)
-                        } else {
-                            Ok(ProcessState::Dead)
-                        }
-                    }
+                    posix::F_WRLCK => Ok(ProcessState::Alive),
                     _ => Ok(ProcessState::Dead),
                 }
             }
@@ -1154,14 +1142,6 @@ impl ProcessCleaner {
             }
         };
 
-        let other_process_id: UniqueProcessId = match context_file.read_val() {
-            Ok(v) => v,
-            Err(e) => {
-                fail!(from origin, with ProcessCleanerCreateError::FailedToAcquireUniqueProcessIdFromContextFile,
-                          "{msg} since the unique process id contained in the owner lock file could not be read. [{e:?}]");
-            }
-        };
-
         let owner_lock_file = match ProcessMonitor::open_file(
             origin,
             &owner_lock_path,
@@ -1199,8 +1179,7 @@ impl ProcessCleaner {
             with ProcessCleanerCreateError::FailedToAcquireLockState,
             "{} since the lock state could not be acquired.", msg);
 
-        if lock_state == posix::F_WRLCK as _ && Process::from_pid(other_process_id.pid()).is_alive()
-        {
+        if lock_state == posix::F_WRLCK as _ {
             fail!(from origin, with ProcessCleanerCreateError::ProcessIsStillAlive,
                 "{} since the corresponding process is still alive.", msg);
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

Remove from_pid check in ProcessState to avoid false negatives on dead node detection.

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1660  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
