### PR TITLE
[#1670] Fix SIGBUS on cleanup with write-only shm segment with root

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -25,6 +25,7 @@
 
 * [#1650](https://github.com/eclipse-iceoryx/iceoryx2/issues/1650) Fix 'NodeCreationFailure::InternalError' on concurrent node creation
 * [#1660](https://github.com/eclipse-iceoryx/iceoryx2/issues/1660) Rework process alive detection to avoid false negatives to enable communication across docker containers
+* [#1670](https://github.com/eclipse-iceoryx/iceoryx2/issues/1670) Fix SIGBUS on cleanup with write-only shared memory with root
 
 ### Refactoring
 

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -237,6 +237,19 @@ impl<T: Send + Sync + Debug> Builder<'_, T> {
                                     "{} since the adaptive wait call failed.", msg);
         };
 
+        let permissions = match shm.permission() {
+            Ok(p) => p,
+            Err(e) => {
+                fail!(from self, with DynamicStorageOpenError::InternalError, "{} since a failure occurred while acquiring the file permissions. Error: {:?}", msg, e);
+            }
+        };
+        // NOTE: although the shm is opened for reading, root can still open a write-only shm;
+        // when this happens, the subsequent read will cause a SIGBUS
+        if !permissions.has(Permission::OWNER_READ) {
+            fail!(from self, with DynamicStorageOpenError::InitializationNotYetFinalized,
+                  "{} since it is not readable.",msg);
+        }
+
         let init_state = shm.base_address().as_ptr() as *const Data<T>;
 
         loop {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1670 
<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
