### PR TITLE
[#1684] Lazy initialization for DynamicStorage

### DIFF
--- a/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
@@ -82,7 +82,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(123))
+            .initializer(|value, _| {
+                value.write(TestData::new(123));
+                true
+            })
+            .create()
             .unwrap();
 
         assert_that!(*sut.name(), eq storage_name);
@@ -129,7 +133,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(123));
+            .initializer(|value, _| {
+                value.write(TestData::new(123));
+                true
+            })
+            .create();
         drop(sut);
 
         let sut = Sut::Builder::new(&storage_name)
@@ -150,10 +158,18 @@ pub mod dynamic_storage_trait {
 
         let _sut1 = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(123));
+            .initializer(|value, _| {
+                value.write(TestData::new(123));
+                true
+            })
+            .create();
         let sut2 = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(123));
+            .initializer(|value, _| {
+                value.write(TestData::new(123));
+                true
+            })
+            .create();
 
         assert_that!(sut2, is_err);
         assert_that!(
@@ -174,7 +190,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(123))
+            .initializer(|value, _| {
+                value.write(TestData::new(123));
+                true
+            })
+            .create()
             .unwrap();
 
         let sut2 = Sut::Builder::new(&storage_name)
@@ -196,7 +216,12 @@ pub mod dynamic_storage_trait {
         assert_that!(sut3.err().unwrap(), eq DynamicStorageOpenError::DoesNotExist);
         drop(sut2);
 
-        let sut = Sut::Builder::new(&storage_name).create(TestData::new(123));
+        let sut = Sut::Builder::new(&storage_name)
+            .initializer(|value, _| {
+                value.write(TestData::new(123));
+                true
+            })
+            .create();
         assert_that!(sut, is_ok);
     }
 
@@ -211,7 +236,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(789))
+            .initializer(|value, _| {
+                value.write(TestData::new(789));
+                true
+            })
+            .create()
             .unwrap();
 
         let mut sut_vec = vec![];
@@ -250,7 +279,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(9887))
+            .initializer(|value, _| {
+                value.write(TestData::new(9887));
+                true
+            })
+            .create()
             .unwrap();
 
         assert_that!(sut.has_ownership(), eq true);
@@ -284,7 +317,11 @@ pub mod dynamic_storage_trait {
         let sut = Sut::Builder::new(&storage_name)
             .has_ownership(false)
             .config(&config)
-            .create(TestData::new(9887))
+            .initializer(|value, _| {
+                value.write(TestData::new(9887));
+                true
+            })
+            .create()
             .unwrap();
 
         assert_that!(sut.has_ownership(), eq false);
@@ -319,7 +356,11 @@ pub mod dynamic_storage_trait {
         let sut = Sut::Builder::new(&storage_name)
             .has_ownership(false)
             .config(&config)
-            .create(TestData::new(9887))
+            .initializer(|value, _| {
+                value.write(TestData::new(9887));
+                true
+            })
+            .create()
             .unwrap();
 
         sut.acquire_ownership();
@@ -338,7 +379,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(123))
+            .initializer(|value, _| {
+                value.write(TestData::new(123));
+                true
+            })
+            .create()
             .unwrap();
 
         let sut2 = Sut::Builder::new(&storage_name)
@@ -368,6 +413,9 @@ pub mod dynamic_storage_trait {
             .config(&config)
             .supplementary_size(134)
             .initializer(|value, allocator| {
+                value.write(TestData::new(123));
+                let value = unsafe { value.assume_init_mut() };
+
                 let layout = Layout::from_size_align(134, 1).unwrap();
                 let mem = allocator.allocate(layout).unwrap();
 
@@ -385,7 +433,7 @@ pub mod dynamic_storage_trait {
                 }
                 true
             })
-            .create(TestData::new(123))
+            .create()
             .unwrap();
 
         assert_that!(sut.get().value.load(Ordering::Relaxed), eq 8912);
@@ -439,11 +487,13 @@ pub mod dynamic_storage_trait {
                         .supplementary_size(0)
                         .has_ownership(false)
                         .initializer(|value, _| {
+                            value.write(TestData::new(123));
+                            let value = unsafe { value.assume_init_mut() };
                             nanosleep(TIMEOUT).unwrap();
                             value.value.store(789, Ordering::Relaxed);
                             true
                         })
-                        .create(TestData::new(123))
+                        .create()
                         .unwrap();
                 })?;
 
@@ -506,7 +556,7 @@ pub mod dynamic_storage_trait {
                         nanosleep(TIMEOUT * 2).unwrap();
                         true
                     })
-                    .create(TestData::new(123))
+                    .create()
                     .unwrap();
             })?;
 
@@ -528,6 +578,7 @@ pub mod dynamic_storage_trait {
         .unwrap();
     }
 
+    // TODO: test when initializer is not set
     #[conformance_test]
     pub fn create_fails_when_initialization_fails<
         Sut: DynamicStorage<TestData>,
@@ -540,7 +591,7 @@ pub mod dynamic_storage_trait {
             .supplementary_size(134)
             .initializer(|_, _| false)
             .config(&config)
-            .create(TestData::new(123));
+            .create();
 
         assert_that!(sut, is_err);
         assert_that!(
@@ -572,13 +623,13 @@ pub mod dynamic_storage_trait {
         assert_that!(Sut::does_exist_cfg(&sut_name, &config), eq Ok(false));
         let sut_1 = Sut::Builder::new(&sut_name)
             .config(&config)
-            .open_or_create(TestData::new(123));
+            .open_or_create();
         assert_that!(sut_1, is_ok);
         assert_that!(Sut::does_exist_cfg(&sut_name, &config), eq Ok(true));
 
         let sut_2 = Sut::Builder::new(&sut_name)
             .config(&config)
-            .open_or_create(TestData::new(123));
+            .open_or_create();
         assert_that!(sut_2, is_ok);
 
         drop(sut_2);
@@ -600,7 +651,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new_with_lifetime_tracking(123))
+            .initializer(|value, _| {
+                value.write(TestData::new_with_lifetime_tracking(123));
+                true
+            })
+            .create()
             .unwrap();
         sut.release_ownership();
         drop(sut);
@@ -621,7 +676,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new_with_lifetime_tracking(123))
+            .initializer(|value, _| {
+                value.write(TestData::new_with_lifetime_tracking(123));
+                true
+            })
+            .create()
             .unwrap();
         sut.release_ownership();
         // it leaks a memory mapping here but this we want explicitly to test remove also
@@ -645,7 +704,7 @@ pub mod dynamic_storage_trait {
             .path_hint(config.get_path_hint());
         let sut = WrongTypeSut::Builder::new(&storage_name)
             .config(&wrong_type_config)
-            .create(123);
+            .create();
         assert_that!(sut, is_ok);
         assert_that!(Sut::does_exist_cfg(&storage_name, &config), eq Ok(false));
     }
@@ -673,7 +732,7 @@ pub mod dynamic_storage_trait {
             testdata_storages.push(
                 Sut::Builder::new(&storage_name)
                     .config(&config)
-                    .create(TestData::new(123))
+                    .create()
                     .unwrap(),
             );
             testdata_storages_names.push(storage_name);
@@ -681,7 +740,7 @@ pub mod dynamic_storage_trait {
             u64_storages.push(
                 WrongTypeSut::Builder::new(&storage_name)
                     .config(&wrong_type_config)
-                    .create(34)
+                    .create()
                     .unwrap(),
             );
 
@@ -693,7 +752,7 @@ pub mod dynamic_storage_trait {
             u64_storages.push(
                 WrongTypeSut::Builder::new(&storage_name)
                     .config(&wrong_type_config)
-                    .create(21)
+                    .create()
                     .unwrap(),
             );
             u64_storages_names.push(storage_name);
@@ -728,7 +787,7 @@ pub mod dynamic_storage_trait {
 
         let _sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(1234))
+            .create()
             .unwrap();
         let sut = WrongTypeSut::Builder::new(&storage_name)
             .config(&wrong_type_config)
@@ -749,7 +808,7 @@ pub mod dynamic_storage_trait {
             .path_hint(config.get_path_hint());
         let _sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(1234))
+            .create()
             .unwrap();
         assert_that!(unsafe { WrongTypeSut::remove_cfg(&storage_name, &wrong_type_config) }, eq Ok(false));
     }
@@ -766,7 +825,11 @@ pub mod dynamic_storage_trait {
 
         let sut = Sut::Builder::new(&storage_name)
             .config(&config)
-            .create(TestData::new(919))
+            .initializer(|value, _| {
+                value.write(TestData::new(919));
+                true
+            })
+            .create()
             .unwrap();
 
         Sut::abandon(sut);

--- a/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
@@ -578,7 +578,6 @@ pub mod dynamic_storage_trait {
         .unwrap();
     }
 
-    // TODO: test when initializer is not set
     #[conformance_test]
     pub fn create_fails_when_initialization_fails<
         Sut: DynamicStorage<TestData>,
@@ -623,6 +622,7 @@ pub mod dynamic_storage_trait {
         assert_that!(Sut::does_exist_cfg(&sut_name, &config), eq Ok(false));
         let sut_1 = Sut::Builder::new(&sut_name)
             .config(&config)
+            .initializer(|_, _| true)
             .open_or_create();
         assert_that!(sut_1, is_ok);
         assert_that!(Sut::does_exist_cfg(&sut_name, &config), eq Ok(true));
@@ -704,6 +704,7 @@ pub mod dynamic_storage_trait {
             .path_hint(config.get_path_hint());
         let sut = WrongTypeSut::Builder::new(&storage_name)
             .config(&wrong_type_config)
+            .initializer(|_, _| true)
             .create();
         assert_that!(sut, is_ok);
         assert_that!(Sut::does_exist_cfg(&storage_name, &config), eq Ok(false));
@@ -732,6 +733,7 @@ pub mod dynamic_storage_trait {
             testdata_storages.push(
                 Sut::Builder::new(&storage_name)
                     .config(&config)
+                    .initializer(|_, _| true)
                     .create()
                     .unwrap(),
             );
@@ -740,6 +742,7 @@ pub mod dynamic_storage_trait {
             u64_storages.push(
                 WrongTypeSut::Builder::new(&storage_name)
                     .config(&wrong_type_config)
+                    .initializer(|_, _| true)
                     .create()
                     .unwrap(),
             );
@@ -752,6 +755,7 @@ pub mod dynamic_storage_trait {
             u64_storages.push(
                 WrongTypeSut::Builder::new(&storage_name)
                     .config(&wrong_type_config)
+                    .initializer(|_, _| true)
                     .create()
                     .unwrap(),
             );
@@ -787,6 +791,7 @@ pub mod dynamic_storage_trait {
 
         let _sut = Sut::Builder::new(&storage_name)
             .config(&config)
+            .initializer(|_, _| true)
             .create()
             .unwrap();
         let sut = WrongTypeSut::Builder::new(&storage_name)
@@ -808,6 +813,7 @@ pub mod dynamic_storage_trait {
             .path_hint(config.get_path_hint());
         let _sut = Sut::Builder::new(&storage_name)
             .config(&config)
+            .initializer(|_, _| true)
             .create()
             .unwrap();
         assert_that!(unsafe { WrongTypeSut::remove_cfg(&storage_name, &wrong_type_config) }, eq Ok(false));
@@ -843,5 +849,25 @@ pub mod dynamic_storage_trait {
             .unwrap();
 
         assert_that!(sut.get().value.load(Ordering::Relaxed), eq 919);
+    }
+
+    #[conformance_test]
+    pub fn create_fails_when_initializer_is_not_set<
+        Sut: DynamicStorage<TestData>,
+        WrongTypeSut: DynamicStorage<u64>,
+    >() {
+        let storage_name = generate_file_path().file_name();
+        let config = generate_isolated_config::<Sut>();
+
+        let sut = Sut::Builder::new(&storage_name).config(&config).create();
+
+        assert_that!(sut, is_err);
+        assert_that!(
+            sut.err().unwrap(), eq
+            DynamicStorageCreateError::InitializationFailed
+        );
+
+        assert_that!(<Sut as NamedConceptMgmt>::does_exist_cfg(&storage_name, &config), eq Ok(false));
+        assert_that!(unsafe { <Sut as NamedConceptMgmt>::remove_cfg(&storage_name, &config) }, eq Ok(false));
     }
 }

--- a/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/dynamic_storage_trait.rs
@@ -413,13 +413,12 @@ pub mod dynamic_storage_trait {
             .config(&config)
             .supplementary_size(134)
             .initializer(|value, allocator| {
-                value.write(TestData::new(123));
+                value.write(TestData::new(8912));
                 let value = unsafe { value.assume_init_mut() };
 
                 let layout = Layout::from_size_align(134, 1).unwrap();
                 let mem = allocator.allocate(layout).unwrap();
 
-                value.value.store(8912, Ordering::Relaxed);
                 value.supplementary_ptr = mem.as_ptr() as *mut u8;
                 value.supplementary_len = mem.len();
 
@@ -487,10 +486,8 @@ pub mod dynamic_storage_trait {
                         .supplementary_size(0)
                         .has_ownership(false)
                         .initializer(|value, _| {
-                            value.write(TestData::new(123));
-                            let value = unsafe { value.assume_init_mut() };
                             nanosleep(TIMEOUT).unwrap();
-                            value.value.store(789, Ordering::Relaxed);
+                            value.write(TestData::new(789));
                             true
                         })
                         .create()

--- a/iceoryx2-cal/conformance-tests/src/named_concept_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/named_concept_trait.rs
@@ -71,7 +71,11 @@ impl<T: DynamicStorage<u64>> NamedConceptTest for DynamicStorageTest<T> {
         let sut = <Self::Sut as DynamicStorage<u64>>::Builder::new(name)
             .config(config)
             .has_ownership(true)
-            .create(123)?;
+            .initializer(|value, _| {
+                value.write(123);
+                true
+            })
+            .create()?;
 
         Ok(Box::new(sut))
     }

--- a/iceoryx2-cal/conformance-tests/src/named_concept_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/named_concept_trait.rs
@@ -71,10 +71,7 @@ impl<T: DynamicStorage<u64>> NamedConceptTest for DynamicStorageTest<T> {
         let sut = <Self::Sut as DynamicStorage<u64>>::Builder::new(name)
             .config(config)
             .has_ownership(true)
-            .initializer(|value, _| {
-                value.write(123);
-                true
-            })
+            .initializer(|_, _| true)
             .create()?;
 
         Ok(Box::new(sut))

--- a/iceoryx2-cal/conformance-tests/tests-common/src/dynamic_storage_trait_tests.rs
+++ b/iceoryx2-cal/conformance-tests/tests-common/src/dynamic_storage_trait_tests.rs
@@ -23,12 +23,12 @@ instantiate_conformance_tests_with_module!(
     super::PosixStorage<u64>
 );
 
-// instantiate_conformance_tests_with_module!(
-//     process_local,
-//     iceoryx2_cal_conformance_tests::dynamic_storage_trait,
-//     super::LocalStorage<super::TestData>,
-//     super::LocalStorage<u64>
-// );
+instantiate_conformance_tests_with_module!(
+    process_local,
+    iceoryx2_cal_conformance_tests::dynamic_storage_trait,
+    super::LocalStorage<super::TestData>,
+    super::LocalStorage<u64>
+);
 
 #[cfg(not(target_os = "windows"))]
 use iceoryx2_cal::dynamic_storage::file::Storage as FileStorage;

--- a/iceoryx2-cal/conformance-tests/tests-common/src/dynamic_storage_trait_tests.rs
+++ b/iceoryx2-cal/conformance-tests/tests-common/src/dynamic_storage_trait_tests.rs
@@ -23,12 +23,12 @@ instantiate_conformance_tests_with_module!(
     super::PosixStorage<u64>
 );
 
-instantiate_conformance_tests_with_module!(
-    process_local,
-    iceoryx2_cal_conformance_tests::dynamic_storage_trait,
-    super::LocalStorage<super::TestData>,
-    super::LocalStorage<u64>
-);
+// instantiate_conformance_tests_with_module!(
+//     process_local,
+//     iceoryx2_cal_conformance_tests::dynamic_storage_trait,
+//     super::LocalStorage<super::TestData>,
+//     super::LocalStorage<u64>
+// );
 
 #[cfg(not(target_os = "windows"))]
 use iceoryx2_cal::dynamic_storage::file::Storage as FileStorage;

--- a/iceoryx2-cal/src/communication_channel/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/communication_channel/posix_shared_memory.rs
@@ -180,13 +180,18 @@ impl CommunicationChannelCreator<u64, Channel> for Creator {
             .supplementary_size(SafelyOverflowingIndexQueue::const_memory_size(
                 self.buffer_size,
             ))
-            .initializer(|mgmt, allocator| unsafe { mgmt.index_queue.init(allocator).is_ok() })
-            .create(Management {
-                enable_safe_overflow: self.enable_safe_overflow,
-                index_queue: unsafe {
-                    RelocatableSafelyOverflowingIndexQueue::new_uninit(self.buffer_size)
-                },
-            }) {
+            .initializer(|mgmt, allocator| unsafe {
+                mgmt.write(Management {
+                    index_queue: RelocatableSafelyOverflowingIndexQueue::new_uninit(
+                        self.buffer_size,
+                    ),
+                    enable_safe_overflow: self.enable_safe_overflow,
+                });
+
+                mgmt.assume_init_mut().index_queue.init(allocator).is_ok()
+            })
+            .create()
+        {
             Ok(s) => s,
             Err(DynamicStorageCreateError::AlreadyExists) => {
                 fail!(from self, with CommunicationChannelCreateError::AlreadyExists,

--- a/iceoryx2-cal/src/dynamic_storage/file.rs
+++ b/iceoryx2-cal/src/dynamic_storage/file.rs
@@ -98,7 +98,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Clone for Configuration<T> {
 #[repr(C)]
 struct Data<T: Send + Sync + Debug + ZeroCopySend> {
     version: AtomicU64,
-    data: T,
+    data: MaybeUninit<T>,
 }
 
 impl<T: Send + Sync + Debug + ZeroCopySend> Default for Configuration<T> {
@@ -359,6 +359,8 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
         let version_ptr = unsafe { core::ptr::addr_of_mut!((*value).version) };
         unsafe { version_ptr.write(AtomicU64::new(0)) };
 
+        unsafe { core::ptr::addr_of_mut!((*value).data).write(MaybeUninit::uninit()) };
+
         let supplementary_start = (storage.memory_mapping.base_address() as usize
             + core::mem::size_of::<Data<T>>()) as *mut u8;
         let supplementary_len = storage.memory_mapping.size() - core::mem::size_of::<Data<T>>();
@@ -371,7 +373,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
         let origin = format!("{self:?}");
         if !self
             .initializer
-            .call(&mut MaybeUninit::uninit(), &mut allocator)
+            .call(unsafe { &mut (*value).data }, &mut allocator)
         {
             storage.file.acquire_ownership();
             fail!(from origin, with DynamicStorageCreateError::InitializationFailed,
@@ -589,7 +591,11 @@ impl<T: Send + Sync + Debug + ZeroCopySend> DynamicStorage<T> for Storage<T> {
     }
 
     fn get(&self) -> &T {
-        unsafe { &(*(self.memory_mapping.base_address() as *const Data<T>)).data }
+        unsafe {
+            (*(self.memory_mapping.base_address() as *const Data<T>))
+                .data
+                .assume_init_ref()
+        }
     }
 
     fn has_ownership(&self) -> bool {

--- a/iceoryx2-cal/src/dynamic_storage/file.rs
+++ b/iceoryx2-cal/src/dynamic_storage/file.rs
@@ -17,6 +17,7 @@ pub use core::ops::Deref;
 
 use core::fmt::Debug;
 use core::marker::PhantomData;
+use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use iceoryx2_bb_concurrency::atomic::Ordering;
 
@@ -352,14 +353,11 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
     fn init_impl(
         &mut self,
         mut storage: Storage<T>,
-        initial_value: T,
     ) -> Result<Storage<T>, DynamicStorageCreateError> {
         let msg = "Failed to init dynamic_storage::file::DynamicStorage";
         let value = storage.memory_mapping.base_address_mut() as *mut Data<T>;
         let version_ptr = unsafe { core::ptr::addr_of_mut!((*value).version) };
         unsafe { version_ptr.write(AtomicU64::new(0)) };
-
-        unsafe { core::ptr::addr_of_mut!((*value).data).write(initial_value) };
 
         let supplementary_start = (storage.memory_mapping.base_address() as usize
             + core::mem::size_of::<Data<T>>()) as *mut u8;
@@ -373,7 +371,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
         let origin = format!("{self:?}");
         if !self
             .initializer
-            .call(unsafe { &mut (*value).data }, &mut allocator)
+            .call(&mut MaybeUninit::uninit(), &mut allocator)
         {
             storage.file.acquire_ownership();
             fail!(from origin, with DynamicStorageCreateError::InitializationFailed,
@@ -408,7 +406,7 @@ impl<'builder, T: Send + Sync + Debug + ZeroCopySend> DynamicStorageBuilder<'bui
         self
     }
 
-    fn initializer<F: FnMut(&mut T, &mut BumpAllocator) -> bool + 'builder>(
+    fn initializer<F: FnMut(&mut MaybeUninit<T>, &mut BumpAllocator) -> bool + 'builder>(
         mut self,
         value: F,
     ) -> Self {
@@ -426,25 +424,22 @@ impl<'builder, T: Send + Sync + Debug + ZeroCopySend> DynamicStorageBuilder<'bui
         self
     }
 
-    fn create(mut self, initial_value: T) -> Result<Storage<T>, DynamicStorageCreateError> {
+    fn create(mut self) -> Result<Storage<T>, DynamicStorageCreateError> {
         let shm = self.create_impl()?;
-        self.init_impl(shm, initial_value)
+        self.init_impl(shm)
     }
 
     fn open(self, access_mode: AccessMode) -> Result<Storage<T>, DynamicStorageOpenError> {
         self.open_impl(access_mode)
     }
 
-    fn open_or_create(
-        mut self,
-        initial_value: T,
-    ) -> Result<Storage<T>, DynamicStorageOpenOrCreateError> {
+    fn open_or_create(mut self) -> Result<Storage<T>, DynamicStorageOpenOrCreateError> {
         loop {
             match self.open_impl(AccessMode::ReadWrite) {
                 Ok(storage) => return Ok(storage),
                 Err(DynamicStorageOpenError::DoesNotExist) => match self.create_impl() {
                     Ok(shm) => {
-                        return Ok(self.init_impl(shm, initial_value)?);
+                        return Ok(self.init_impl(shm)?);
                     }
                     Err(DynamicStorageCreateError::AlreadyExists) => continue,
                     Err(e) => return Err(e.into()),

--- a/iceoryx2-cal/src/dynamic_storage/file.rs
+++ b/iceoryx2-cal/src/dynamic_storage/file.rs
@@ -164,7 +164,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> NamedConceptBuilder<Storage<T>> for 
             supplementary_size: 0,
             config: Configuration::default(),
             timeout: Duration::ZERO,
-            initializer: Initializer::new(|_, _| true),
+            initializer: Initializer::new(|_, _| false),
             _phantom_data: PhantomData,
         }
     }

--- a/iceoryx2-cal/src/dynamic_storage/file.rs
+++ b/iceoryx2-cal/src/dynamic_storage/file.rs
@@ -97,7 +97,6 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Clone for Configuration<T> {
 #[repr(C)]
 struct Data<T: Send + Sync + Debug + ZeroCopySend> {
     version: AtomicU64,
-    call_drop_on_destruction: bool,
     data: T,
 }
 
@@ -482,11 +481,9 @@ impl<T: Debug + Send + Sync + ZeroCopySend> Abandonable for Storage<T> {
 impl<T: Debug + Send + Sync + ZeroCopySend> Drop for Storage<T> {
     fn drop(&mut self) {
         if self.file.has_ownership() {
-            let data = unsafe { &mut (*(self.memory_mapping.base_address_mut() as *mut Data<T>)) };
-            if data.call_drop_on_destruction {
-                let user_type = &mut data.data;
-                unsafe { core::ptr::drop_in_place(user_type) };
-            }
+            let user_type =
+                unsafe { &mut (*(self.memory_mapping.base_address_mut() as *mut Data<T>)).data };
+            unsafe { core::ptr::drop_in_place(user_type) };
         }
     }
 }

--- a/iceoryx2-cal/src/dynamic_storage/mod.rs
+++ b/iceoryx2-cal/src/dynamic_storage/mod.rs
@@ -39,7 +39,12 @@
 //! fn process_one<Storage: DynamicStorage<AtomicU64>>() {
 //!     let storage_name = FileName::new(b"myStorageName").unwrap();
 //!     let mut storage = Storage::Builder::new(&storage_name)
-//!                         .create(AtomicU64::new(873)).unwrap();
+//!                         .initializer(|value, _| {
+//!                             value.write(AtomicU64::new(873));
+//!                             true
+//!                         })
+//!                         .create()
+//!                         .unwrap();
 //!
 //!     println!("Created storage {}", storage.name());
 //!     storage.get().store(991, Ordering::Relaxed);
@@ -55,7 +60,6 @@
 //! }
 //! ```
 
-// TODO: adapt documentation, add missing tests
 use core::{fmt::Debug, mem::MaybeUninit, time::Duration};
 
 use iceoryx2_bb_elementary::enum_gen;

--- a/iceoryx2-cal/src/dynamic_storage/mod.rs
+++ b/iceoryx2-cal/src/dynamic_storage/mod.rs
@@ -55,6 +55,7 @@
 //! }
 //! ```
 
+// TODO: adapt documentation, add missing tests
 use core::{fmt::Debug, mem::MaybeUninit, time::Duration};
 
 use iceoryx2_bb_elementary::enum_gen;

--- a/iceoryx2-cal/src/dynamic_storage/mod.rs
+++ b/iceoryx2-cal/src/dynamic_storage/mod.rs
@@ -55,7 +55,7 @@
 //! }
 //! ```
 
-use core::{fmt::Debug, time::Duration};
+use core::{fmt::Debug, mem::MaybeUninit, time::Duration};
 
 use iceoryx2_bb_elementary::enum_gen;
 use iceoryx2_bb_elementary_traits::{
@@ -70,7 +70,7 @@ use crate::static_storage::file::{NamedConcept, NamedConceptBuilder, NamedConcep
 
 tiny_fn! {
     /// The callback called to initialize the data inside the [`DynamicStorage`]
-    pub struct Initializer<T> = FnMut(value: &mut T, allocator: &mut BumpAllocator) -> bool;
+    pub struct Initializer<T> = FnMut(value: &mut MaybeUninit<T>, allocator: &mut BumpAllocator) -> bool;
 }
 
 impl<T> Debug for Initializer<'_, T> {
@@ -150,13 +150,15 @@ pub trait DynamicStorageBuilder<'builder, T: Send + Sync + ZeroCopySend, D: Dyna
     /// with a mutable reference to the new value and a mutable reference to a bump allocator
     /// which provides access to the supplementary memory. If the initialization failed it
     /// shall return false, otherwise true.
-    fn initializer<F: FnMut(&mut T, &mut BumpAllocator) -> bool + 'builder>(self, value: F)
-    -> Self;
+    fn initializer<F: FnMut(&mut MaybeUninit<T>, &mut BumpAllocator) -> bool + 'builder>(
+        self,
+        value: F,
+    ) -> Self;
 
     /// Creates a new [`DynamicStorage`]. The returned object has the ownership of the
     /// [`DynamicStorage`] and when it goes out of scope the underlying resources shall be
     /// removed without corrupting already opened [`DynamicStorage`]s.
-    fn create(self, initial_value: T) -> Result<D, DynamicStorageCreateError>;
+    fn create(self) -> Result<D, DynamicStorageCreateError>;
 
     /// Opens a [`DynamicStorage`]. The implementation must ensure that a [`DynamicStorage`]
     /// which is in the midst of creation cannot be opened. If the [`DynamicStorage`] does not
@@ -164,7 +166,7 @@ pub trait DynamicStorageBuilder<'builder, T: Send + Sync + ZeroCopySend, D: Dyna
     fn open(self, access_mode: AccessMode) -> Result<D, DynamicStorageOpenError>;
 
     /// Opens the [`DynamicStorage`] if it exists, otherwise it creates it.
-    fn open_or_create(self, initial_value: T) -> Result<D, DynamicStorageOpenOrCreateError>;
+    fn open_or_create(self) -> Result<D, DynamicStorageOpenOrCreateError>;
 }
 
 /// Is being built by the [`DynamicStorageBuilder`]. The [`DynamicStorage`] trait shall provide

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -117,7 +117,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Clone for Configuration<T> {
 #[repr(C)]
 struct Data<T: Send + Sync + Debug + ZeroCopySend> {
     version: AtomicU64,
-    data: T,
+    data: MaybeUninit<T>,
 }
 
 impl<T: Send + Sync + Debug + ZeroCopySend> Default for Configuration<T> {
@@ -328,6 +328,8 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
         let version_ptr = unsafe { core::ptr::addr_of_mut!((*value).version) };
         unsafe { version_ptr.write(AtomicU64::new(0)) };
 
+        unsafe { core::ptr::addr_of_mut!((*value).data).write(MaybeUninit::uninit()) };
+
         let supplementary_start =
             (shm.base_address().as_ptr() as usize + core::mem::size_of::<Data<T>>()) as *mut u8;
         let supplementary_len = shm.size() - core::mem::size_of::<Data<T>>();
@@ -340,7 +342,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
         let origin = format!("{self:?}");
         if !self
             .initializer
-            .call(&mut MaybeUninit::uninit(), &mut allocator)
+            .call(unsafe { &mut (*value).data }, &mut allocator)
         {
             unsafe { core::ptr::drop_in_place(value) };
             shm.acquire_ownership();
@@ -531,7 +533,11 @@ impl<T: Send + Sync + Debug + ZeroCopySend> DynamicStorage<T> for Storage<T> {
     }
 
     fn get(&self) -> &T {
-        unsafe { &(*(self.shm.base_address().as_ptr() as *const Data<T>)).data }
+        unsafe {
+            (*(self.shm.base_address().as_ptr() as *const Data<T>))
+                .data
+                .assume_init_ref()
+        }
     }
 
     fn has_ownership(&self) -> bool {

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -322,14 +322,11 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
     fn init_impl(
         &mut self,
         mut shm: SharedMemory,
-        initial_value: T,
     ) -> Result<Storage<T>, DynamicStorageCreateError> {
         let msg = "Failed to init dynamic_storage::PosixSharedMemory";
         let value = shm.base_address().as_ptr() as *mut Data<T>;
         let version_ptr = unsafe { core::ptr::addr_of_mut!((*value).version) };
         unsafe { version_ptr.write(AtomicU64::new(0)) };
-
-        unsafe { core::ptr::addr_of_mut!((*value).data).write(initial_value) };
 
         let supplementary_start =
             (shm.base_address().as_ptr() as usize + core::mem::size_of::<Data<T>>()) as *mut u8;
@@ -343,7 +340,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
         let origin = format!("{self:?}");
         if !self
             .initializer
-            .call(unsafe { &mut (*value).data }, &mut allocator)
+            .call(&mut MaybeUninit::uninit(), &mut allocator)
         {
             unsafe { core::ptr::drop_in_place(value) };
             shm.acquire_ownership();
@@ -384,7 +381,7 @@ impl<'builder, T: Send + Sync + Debug + ZeroCopySend> DynamicStorageBuilder<'bui
         self
     }
 
-    fn initializer<F: FnMut(&mut T, &mut BumpAllocator) -> bool + 'builder>(
+    fn initializer<F: FnMut(&mut MaybeUninit<T>, &mut BumpAllocator) -> bool + 'builder>(
         mut self,
         value: F,
     ) -> Self {
@@ -402,25 +399,22 @@ impl<'builder, T: Send + Sync + Debug + ZeroCopySend> DynamicStorageBuilder<'bui
         self
     }
 
-    fn create(mut self, initial_value: T) -> Result<Storage<T>, DynamicStorageCreateError> {
+    fn create(mut self) -> Result<Storage<T>, DynamicStorageCreateError> {
         let shm = self.create_impl()?;
-        self.init_impl(shm, initial_value)
+        self.init_impl(shm)
     }
 
     fn open(self, access_mode: AccessMode) -> Result<Storage<T>, DynamicStorageOpenError> {
         self.open_impl(access_mode)
     }
 
-    fn open_or_create(
-        mut self,
-        initial_value: T,
-    ) -> Result<Storage<T>, DynamicStorageOpenOrCreateError> {
+    fn open_or_create(mut self) -> Result<Storage<T>, DynamicStorageOpenOrCreateError> {
         loop {
             match self.open_impl(AccessMode::ReadWrite) {
                 Ok(storage) => return Ok(storage),
                 Err(DynamicStorageOpenError::DoesNotExist) => match self.create_impl() {
                     Ok(shm) => {
-                        return Ok(self.init_impl(shm, initial_value)?);
+                        return Ok(self.init_impl(shm)?);
                     }
                     Err(DynamicStorageCreateError::AlreadyExists) => continue,
                     Err(e) => return Err(e.into()),

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -30,7 +30,12 @@
 //!                 .supplementary_size(additional_size)
 //!                 // we always have to use a thread-safe object since multiple processes can
 //!                 // access this concurrently
-//!                 .create(AtomicI64::new(0)).unwrap();
+//!                 .initializer(|value, _| {
+//!                     value.write(AtomicI64::new(0));
+//!                     true
+//!                 })
+//!                 .create()
+//!                 .unwrap();
 //! owner.get().store(123, Ordering::Relaxed);
 //!
 //! // usually a different process

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -117,7 +117,6 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Clone for Configuration<T> {
 #[repr(C)]
 struct Data<T: Send + Sync + Debug + ZeroCopySend> {
     version: AtomicU64,
-    call_drop_on_destruction: bool,
     data: T,
 }
 
@@ -454,11 +453,9 @@ impl<T: Debug + Send + Sync + ZeroCopySend> Abandonable for Storage<T> {
 impl<T: Debug + Send + Sync + ZeroCopySend> Drop for Storage<T> {
     fn drop(&mut self) {
         if self.shm.has_ownership() {
-            let data = unsafe { &mut (*(self.shm.base_address().as_ptr() as *mut Data<T>)) };
-            if data.call_drop_on_destruction {
-                let user_type = &mut data.data;
-                unsafe { core::ptr::drop_in_place(user_type) };
-            }
+            let user_type =
+                unsafe { &mut (*(self.shm.base_address().as_ptr() as *mut Data<T>)).data };
+            unsafe { core::ptr::drop_in_place(user_type) };
         }
     }
 }

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -183,7 +183,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> NamedConceptBuilder<Storage<T>> for 
             supplementary_size: 0,
             config: Configuration::default(),
             timeout: Duration::ZERO,
-            initializer: Initializer::new(|_, _| true),
+            initializer: Initializer::new(|_, _| false),
             _phantom_data: PhantomData,
         }
     }

--- a/iceoryx2-cal/src/dynamic_storage/process_local.rs
+++ b/iceoryx2-cal/src/dynamic_storage/process_local.rs
@@ -28,7 +28,12 @@
 //! let storage_name = FileName::new(b"myDynStorage").unwrap();
 //! let storage = Builder::new(&storage_name)
 //!                 .supplementary_size(additional_size)
-//!                 .create(AtomicI64::new(444)).unwrap();
+//!                 .initializer(|value, _| {
+//!                     value.write(AtomicI64::new(444));
+//!                     true
+//!                 })
+//!                 .create()
+//!                 .unwrap();
 //!
 //! // at some other place in the local process, can be another thread
 //! let reader = Builder::<AtomicI64>::new(&storage_name)

--- a/iceoryx2-cal/src/dynamic_storage/process_local.rs
+++ b/iceoryx2-cal/src/dynamic_storage/process_local.rs
@@ -357,7 +357,7 @@ impl<T: Send + Sync + Debug + 'static + ZeroCopySend> NamedConceptBuilder<Storag
             has_ownership: true,
             supplementary_size: 0,
             config: Configuration::default(),
-            initializer: Initializer::new(|_, _| true),
+            initializer: Initializer::new(|_, _| false),
             _phantom_data: PhantomData,
         }
     }

--- a/iceoryx2-cal/src/dynamic_storage/process_local.rs
+++ b/iceoryx2-cal/src/dynamic_storage/process_local.rs
@@ -422,7 +422,7 @@ impl<T: Send + Sync + Debug + 'static + ZeroCopySend> Builder<'_, T> {
         let origin = format!("{self:?}");
         if !self
             .initializer
-            .call(&mut MaybeUninit::uninit(), &mut allocator)
+            .call(unsafe { &mut *value }, &mut allocator)
         {
             fail!(from origin, with DynamicStorageCreateError::InitializationFailed,
                 "{} since the initialization of the underlying construct failed.", msg);

--- a/iceoryx2-cal/src/dynamic_storage/process_local.rs
+++ b/iceoryx2-cal/src/dynamic_storage/process_local.rs
@@ -80,7 +80,7 @@ struct StorageEntry {
 
 #[derive(Debug)]
 struct StorageDetails<T> {
-    data_ptr: *mut T,
+    data_ptr: *mut MaybeUninit<T>,
     layout: Layout,
 }
 
@@ -161,17 +161,17 @@ impl<T: Send + Sync + Debug + ZeroCopySend> NamedConceptConfiguration for Config
 }
 
 impl<T> StorageDetails<T> {
-    fn new(value: T, additional_size: u64) -> Self {
+    fn new(additional_size: u64) -> Self {
         let size = core::mem::size_of::<T>() + additional_size as usize;
         let align = core::mem::align_of::<T>();
         let layout = unsafe { Layout::from_size_align_unchecked(size, align) };
         let new_self = Self {
             data_ptr: fatal_panic!(from "StorageDetails::new", when HeapAllocator::new()
                 .allocate(layout), "Failed to allocate {} bytes for dynamic global storage.", size)
-            .as_ptr() as *mut T,
+            .as_ptr() as *mut MaybeUninit<T>,
             layout,
         };
-        unsafe { new_self.data_ptr.write(value) };
+        unsafe { new_self.data_ptr.write(MaybeUninit::uninit()) };
         new_self
     }
 }
@@ -294,7 +294,7 @@ impl<T: Send + Sync + Debug + 'static + ZeroCopySend> DynamicStorage<T> for Stor
     }
 
     fn get(&self) -> &T {
-        unsafe { &*self.data.data_ptr }
+        unsafe { (*self.data.data_ptr).assume_init_ref() }
     }
 
     fn has_ownership(&self) -> bool {
@@ -399,7 +399,6 @@ impl<T: Send + Sync + Debug + 'static + ZeroCopySend> Builder<'_, T> {
     fn create_impl(
         &mut self,
         guard: &mut MutexGuard<'static, BTreeMap<FilePath, StorageEntry>>,
-        initial_value: T,
     ) -> Result<Storage<T>, DynamicStorageCreateError> {
         let msg = "Failed to create dynamic storage";
 
@@ -410,12 +409,9 @@ impl<T: Send + Sync + Debug + 'static + ZeroCopySend> Builder<'_, T> {
                 "{} since the storage does already exist.", msg);
         }
 
-        let storage_details = Arc::new(StorageDetails::new(
-            initial_value,
-            self.supplementary_size as u64,
-        ));
+        let storage_details = Arc::new(StorageDetails::new(self.supplementary_size as u64));
 
-        let value = storage_details.data_ptr;
+        let value: *mut MaybeUninit<T> = storage_details.data_ptr;
         let supplementary_start = (value as usize + core::mem::size_of::<T>()) as *mut u8;
 
         let mut allocator = BumpAllocator::new(
@@ -426,7 +422,7 @@ impl<T: Send + Sync + Debug + 'static + ZeroCopySend> Builder<'_, T> {
         let origin = format!("{self:?}");
         if !self
             .initializer
-            .call(unsafe { &mut *value }, &mut allocator)
+            .call(&mut MaybeUninit::uninit(), &mut allocator)
         {
             fail!(from origin, with DynamicStorageCreateError::InitializationFailed,
                 "{} since the initialization of the underlying construct failed.", msg);
@@ -463,7 +459,7 @@ impl<'builder, T: Send + Sync + Debug + 'static + ZeroCopySend>
         self
     }
 
-    fn initializer<F: FnMut(&mut T, &mut BumpAllocator) -> bool + 'builder>(
+    fn initializer<F: FnMut(&mut MaybeUninit<T>, &mut BumpAllocator) -> bool + 'builder>(
         mut self,
         value: F,
     ) -> Self {
@@ -490,20 +486,17 @@ impl<'builder, T: Send + Sync + Debug + 'static + ZeroCopySend>
         self.open_impl(&mut guard)
     }
 
-    fn create(mut self, initial_value: T) -> Result<Storage<T>, DynamicStorageCreateError> {
+    fn create(mut self) -> Result<Storage<T>, DynamicStorageCreateError> {
         let msg = "Failed to create dynamic storage";
         let mut guard = fail!(from self, when PROCESS_LOCAL_STORAGE.lock(),
             with DynamicStorageCreateError::InternalError,
             "{} due to a failure while acquiring the lock.", msg
         );
 
-        self.create_impl(&mut guard, initial_value)
+        self.create_impl(&mut guard)
     }
 
-    fn open_or_create(
-        mut self,
-        initial_value: T,
-    ) -> Result<Storage<T>, DynamicStorageOpenOrCreateError> {
+    fn open_or_create(mut self) -> Result<Storage<T>, DynamicStorageOpenOrCreateError> {
         let msg = "Failed to open or create dynamic storage";
         let mut guard = fail!(from self, when PROCESS_LOCAL_STORAGE.lock(),
             with DynamicStorageOpenOrCreateError::DynamicStorageOpenError(DynamicStorageOpenError::InternalError),
@@ -512,12 +505,10 @@ impl<'builder, T: Send + Sync + Debug + 'static + ZeroCopySend>
 
         match self.open_impl(&mut guard) {
             Ok(storage) => Ok(storage),
-            Err(DynamicStorageOpenError::DoesNotExist) => {
-                match self.create_impl(&mut guard, initial_value) {
-                    Ok(storage) => Ok(storage),
-                    Err(e) => Err(e.into()),
-                }
-            }
+            Err(DynamicStorageOpenError::DoesNotExist) => match self.create_impl(&mut guard) {
+                Ok(storage) => Ok(storage),
+                Err(e) => Err(e.into()),
+            },
             Err(e) => Err(e.into()),
         }
     }

--- a/iceoryx2-cal/src/event/common.rs
+++ b/iceoryx2-cal/src/event/common.rs
@@ -13,7 +13,7 @@
 #[doc(hidden)]
 pub mod details {
     use core::ptr::NonNull;
-    use core::{fmt::Debug, marker::PhantomData, time::Duration};
+    use core::{fmt::Debug, marker::PhantomData, mem::MaybeUninit, time::Duration};
 
     use alloc::vec::Vec;
 
@@ -611,10 +611,18 @@ pub mod details {
     > ListenerBuilder<Tracker, WaitMechanism, Storage>
     {
         fn init(
-            mgmt: &mut Management<Tracker, WaitMechanism>,
+            &self,
+            mgmt: &mut MaybeUninit<Management<Tracker, WaitMechanism>>,
             allocator: &mut BumpAllocator,
         ) -> bool {
+            mgmt.write(Management {
+                id_tracker: unsafe { Tracker::new_uninit(self.trigger_id_max.as_value() + 1) },
+                signal_mechanism: WaitMechanism::new(),
+                reference_counter: AtomicUsize::new(1),
+                has_listener: AtomicBool::new(true),
+            });
             let origin = "init()";
+            let mgmt = unsafe { mgmt.assume_init_mut() };
             if unsafe { mgmt.id_tracker.init(allocator).is_err() } {
                 debug!(from origin, "Unable to initialize IdTracker.");
                 return false;
@@ -652,14 +660,10 @@ pub mod details {
             match Storage::Builder::new(&self.name)
                 .config(&self.config.convert())
                 .supplementary_size(Tracker::memory_size(id_tracker_capacity))
-                .initializer(Self::init)
+                .initializer(|mgmt, allocator| -> bool { self.init(mgmt, allocator) })
                 .has_ownership(false)
-                .create(Management {
-                    id_tracker: unsafe { Tracker::new_uninit(id_tracker_capacity) },
-                    signal_mechanism: WaitMechanism::new(),
-                    reference_counter: AtomicUsize::new(1),
-                    has_listener: AtomicBool::new(true),
-                }) {
+                .create()
+            {
                 Ok(storage) => Ok(Listener {
                     storage,
                     _tracker: PhantomData,

--- a/iceoryx2-cal/src/event/common.rs
+++ b/iceoryx2-cal/src/event/common.rs
@@ -611,18 +611,20 @@ pub mod details {
     > ListenerBuilder<Tracker, WaitMechanism, Storage>
     {
         fn init(
-            &self,
             mgmt: &mut MaybeUninit<Management<Tracker, WaitMechanism>>,
             allocator: &mut BumpAllocator,
+            id_tarcker_capacity: usize,
         ) -> bool {
+            let origin = "init()";
+
             mgmt.write(Management {
-                id_tracker: unsafe { Tracker::new_uninit(self.trigger_id_max.as_value() + 1) },
+                id_tracker: unsafe { Tracker::new_uninit(id_tarcker_capacity) },
                 signal_mechanism: WaitMechanism::new(),
                 reference_counter: AtomicUsize::new(1),
                 has_listener: AtomicBool::new(true),
             });
-            let origin = "init()";
             let mgmt = unsafe { mgmt.assume_init_mut() };
+
             if unsafe { mgmt.id_tracker.init(allocator).is_err() } {
                 debug!(from origin, "Unable to initialize IdTracker.");
                 return false;
@@ -660,7 +662,9 @@ pub mod details {
             match Storage::Builder::new(&self.name)
                 .config(&self.config.convert())
                 .supplementary_size(Tracker::memory_size(id_tracker_capacity))
-                .initializer(|mgmt, allocator| -> bool { self.init(mgmt, allocator) })
+                .initializer(|mgmt, allocator| -> bool {
+                    Self::init(mgmt, allocator, id_tracker_capacity)
+                })
                 .has_ownership(false)
                 .create()
             {

--- a/iceoryx2-cal/src/shared_memory/common.rs
+++ b/iceoryx2-cal/src/shared_memory/common.rs
@@ -174,7 +174,7 @@ pub mod details {
         fn initialize(
             &self,
             allocator_config: &Allocator::Configuration,
-            details: &mut AllocatorDetails<Allocator>,
+            details: &mut MaybeUninit<AllocatorDetails<Allocator>>,
             init_allocator: &mut BumpAllocator,
         ) -> bool {
             let msg = "Unable to initialize shared memory";
@@ -187,6 +187,16 @@ pub mod details {
                     return false;
                 }
             };
+
+            let allocator_mgmt_size = Allocator::management_size(self.size, allocator_config);
+            details.write(AllocatorDetails {
+                allocator_id: Allocator::unique_id(),
+                allocator: MaybeUninit::uninit(),
+                mgmt_size: allocator_mgmt_size,
+                payload_size: self.size,
+                payload_start_offset: 0,
+            });
+            let details = unsafe { details.assume_init_mut() };
 
             details.payload_start_offset = (memory.as_ptr() as *const u8) as usize
                 - (details as *const AllocatorDetails<Allocator>) as usize;
@@ -243,13 +253,8 @@ pub mod details {
                 .initializer(|details, init_allocator| -> bool {
                     self.initialize(allocator_config, details, init_allocator)
                 })
-                .create(AllocatorDetails {
-                    allocator_id: Allocator::unique_id(),
-                    allocator: MaybeUninit::uninit(),
-                    mgmt_size: allocator_mgmt_size,
-                    payload_size: self.size,
-                    payload_start_offset: 0,
-                }) {
+                .create()
+            {
                 Ok(s) => s,
                 Err(DynamicStorageCreateError::AlreadyExists) => {
                     fail!(from self, with SharedMemoryCreateError::AlreadyExists,

--- a/iceoryx2-cal/src/shared_memory/common.rs
+++ b/iceoryx2-cal/src/shared_memory/common.rs
@@ -174,6 +174,7 @@ pub mod details {
         fn initialize(
             &self,
             allocator_config: &Allocator::Configuration,
+            allocator_mgmt_size: usize,
             details: &mut MaybeUninit<AllocatorDetails<Allocator>>,
             init_allocator: &mut BumpAllocator,
         ) -> bool {
@@ -188,7 +189,6 @@ pub mod details {
                 }
             };
 
-            let allocator_mgmt_size = Allocator::management_size(self.size, allocator_config);
             details.write(AllocatorDetails {
                 allocator_id: Allocator::unique_id(),
                 allocator: MaybeUninit::uninit(),
@@ -251,7 +251,12 @@ pub mod details {
                 .supplementary_size(self.size + allocator_mgmt_size)
                 .has_ownership(self.has_ownership)
                 .initializer(|details, init_allocator| -> bool {
-                    self.initialize(allocator_config, details, init_allocator)
+                    self.initialize(
+                        allocator_config,
+                        allocator_mgmt_size,
+                        details,
+                        init_allocator,
+                    )
                 })
                 .create()
             {

--- a/iceoryx2-cal/src/zero_copy_connection/common.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/common.rs
@@ -409,6 +409,16 @@ pub mod details {
         .timeout(self.timeout)
         .supplementary_size(supplementary_size)
         .initializer(|data, allocator| {
+            data.write(
+                SharedManagementData::new(
+                                        self.enable_safe_overflow,
+                                        self.max_borrowed_samples_per_channel,
+                                        self.number_of_samples_per_segment,
+                                        self.number_of_segments,
+                                        self.number_of_channels
+                                    )
+            );
+            let data = unsafe{ data.assume_init_mut() };
             unsafe { data.init(allocator, self.submission_queue_size(), self.completion_queue_size())};
             for channel in data.channels.iter() {
                 channel.state.store(self.initial_channel_state.0, Ordering::Relaxed);
@@ -416,15 +426,7 @@ pub mod details {
 
             true
         })
-        .open_or_create(
-            SharedManagementData::new(
-                                    self.enable_safe_overflow,
-                                    self.max_borrowed_samples_per_channel,
-                                    self.number_of_samples_per_segment,
-                                    self.number_of_segments,
-                                    self.number_of_channels
-                                )
-            );
+        .open_or_create();
 
             let storage = match storage {
                 Ok(storage) => storage,

--- a/iceoryx2/src/node/global_management_segment.rs
+++ b/iceoryx2/src/node/global_management_segment.rs
@@ -45,7 +45,8 @@ impl<S: Service> GlobalManagementSegment<S> {
         .has_ownership(false)
         .config(&config)
         .timeout(global_config.global.creation_timeout)
-        .open_or_create(State::default())
+        .initializer(|_, _| true)
+        .open_or_create()
         {
             Ok(storage) => storage,
             Err(e) => {

--- a/iceoryx2/src/service/builder/blackboard.rs
+++ b/iceoryx2/src/service/builder/blackboard.rs
@@ -17,6 +17,7 @@
 use core::alloc::Layout;
 use core::hash::Hash;
 use core::marker::PhantomData;
+use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 
 use alloc::boxed::Box;
@@ -708,7 +709,13 @@ impl<
                 .config(&mgmt_config)
                 .has_ownership(false)
                 .supplementary_size(RelocatableFlatMap::<KeyMemory<MAX_BLACKBOARD_KEY_SIZE>, usize>::const_memory_size(capacity)+RelocatableVec::<Entry>::const_memory_size(capacity))
-                .initializer(|mgmt: &mut Mgmt, allocator: &mut BumpAllocator| {
+                .initializer(|mgmt: &mut MaybeUninit<Mgmt>, allocator: &mut BumpAllocator| {
+                    mgmt.write(Mgmt {
+                        map: unsafe { RelocatableFlatMap::<KeyMemory<MAX_BLACKBOARD_KEY_SIZE>, usize>::new_uninit(capacity) },
+                        entries: unsafe { RelocatableVec::<Entry>::new_uninit(capacity) },
+                    });
+                    let mgmt = unsafe { mgmt.assume_init_mut() };
+
                     if unsafe {mgmt.map.init(allocator)}.is_err() || unsafe {mgmt.entries.init(allocator).is_err()} {
                         return false
                     }
@@ -737,7 +744,7 @@ impl<
                         }
                     }
                     true})
-                .create(Mgmt{ map: unsafe { RelocatableFlatMap::<KeyMemory<MAX_BLACKBOARD_KEY_SIZE>, usize>::new_uninit(capacity) }, entries: unsafe {RelocatableVec::<Entry>::new_uninit(capacity)}}),
+                .create(),
                     with ServiceCreateError::ServiceInCorruptedState, "{} since the blackboard management segment could not be created. This could indicate a corrupted system.",
                     msg);
 

--- a/iceoryx2/src/service/builder/mod.rs
+++ b/iceoryx2/src/service/builder/mod.rs
@@ -29,6 +29,7 @@ pub mod blackboard;
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::marker::PhantomData;
+use core::mem::MaybeUninit;
 
 use alloc::format;
 use alloc::string::String;
@@ -823,8 +824,17 @@ impl<ServiceType: service::Service> BuilderWithServiceType<ServiceType> {
         }
     }
 
-    fn config_init_call(config: &mut DynamicConfig, allocator: &mut BumpAllocator) -> bool {
-        unsafe { config.init(allocator) };
+    fn config_init_call(
+        &self,
+        config: &mut MaybeUninit<DynamicConfig>,
+        allocator: &mut BumpAllocator,
+        args: &DynamicConfigCreationArgs,
+    ) -> bool {
+        config.write(DynamicConfig::new_uninit(
+            super::dynamic_config::MessagingPattern::new(&args.messaging_pattern_settings),
+            args.max_number_of_nodes,
+        ));
+        unsafe { config.assume_init_mut().init(allocator) };
         true
     }
 
@@ -842,8 +852,8 @@ impl<ServiceType: service::Service> BuilderWithServiceType<ServiceType> {
             .config(&dynamic_config_storage_config::<ServiceType>(self.shared_node.config()))
             .supplementary_size(args.additional_size + required_memory_size)
             .has_ownership(false)
-            .initializer(Self::config_init_call)
-            .create(DynamicConfig::new_uninit(super::dynamic_config::MessagingPattern::new(&args.messaging_pattern_settings), args.max_number_of_nodes) ) {
+            .initializer(|config, allocator| -> bool {self.config_init_call(config, allocator, &args)})
+            .create() {
                 Ok(dynamic_storage) => {
                    Ok(dynamic_storage)
                 },

--- a/iceoryx2/src/service/builder/mod.rs
+++ b/iceoryx2/src/service/builder/mod.rs
@@ -825,7 +825,6 @@ impl<ServiceType: service::Service> BuilderWithServiceType<ServiceType> {
     }
 
     fn config_init_call(
-        &self,
         config: &mut MaybeUninit<DynamicConfig>,
         allocator: &mut BumpAllocator,
         args: &DynamicConfigCreationArgs,
@@ -852,7 +851,7 @@ impl<ServiceType: service::Service> BuilderWithServiceType<ServiceType> {
             .config(&dynamic_config_storage_config::<ServiceType>(self.shared_node.config()))
             .supplementary_size(args.additional_size + required_memory_size)
             .has_ownership(false)
-            .initializer(|config, allocator| -> bool {self.config_init_call(config, allocator, &args)})
+            .initializer(|config, allocator| -> bool {Self::config_init_call(config, allocator, &args)})
             .create() {
                 Ok(dynamic_storage) => {
                    Ok(dynamic_storage)


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
See title + the unused `call_drop_on_destruction` member of the `Data` struct was removed.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1684

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
