### PR TITLE
[#156] Implements `fd translator` + `trempoline states file` for macOS

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -29,6 +29,7 @@
     conflicts when merging.
 -->
 
+* [#156](https://github.com/eclipse-iceoryx/iceoryx2/issues/156) Remove `fchmod`/`shm_open` macOS workarounds; route permissions through a trampoline state file.
 * [#1548](https://github.com/eclipse-iceoryx/iceoryx2/issues/1548) Fix Payload data lifetime tracking in python ffi by anchoring views to their owning Sample.
 * [#1641](https://github.com/eclipse-iceoryx/iceoryx2/issues/1641) Deliver with Backpressure::Retry when receiver is disconnected until the buffer is full.
 * [#1673](https://github.com/eclipse-iceoryx/iceoryx2/issues/1673) Thread-stack-size is the same as process-stack-size on all platforms.

--- a/iceoryx2-pal/posix/src/macos/fcntl.rs
+++ b/iceoryx2-pal/posix/src/macos/fcntl.rs
@@ -16,7 +16,7 @@
 use crate::posix::MemZeroedStruct;
 use crate::posix::types::*;
 
-use super::Errno;
+use super::macos_fd_translator::ShmFdTranslator;
 
 pub unsafe fn open_with_mode(pathname: *const c_char, flags: int, mode: mode_t) -> int {
     unsafe { crate::internal::open(pathname, flags, mode as core::ffi::c_uint) }
@@ -24,13 +24,25 @@ pub unsafe fn open_with_mode(pathname: *const c_char, flags: int, mode: mode_t) 
 
 pub unsafe fn fstat(fd: int, buf: *mut stat_t) -> int {
     let mut os_specific_buffer = native_stat_t::new_zeroed();
-    match unsafe { crate::internal::fstat(fd, &mut os_specific_buffer) } {
-        0 => {
-            unsafe { *buf = os_specific_buffer.into() };
-            0
-        }
-        v => v,
+    let ret = unsafe { crate::internal::fstat(fd, &mut os_specific_buffer) };
+    if ret != 0 {
+        return ret;
     }
+
+    // iox2-156: mode/uid/gid come from trampoline; size/timestamps from shm.
+    if let Some(state_fd) = ShmFdTranslator::get_instance().lookup_state_fd(fd) {
+        let user_mode = unsafe { super::mman::read_state_mode(state_fd) };
+        os_specific_buffer.st_mode = (os_specific_buffer.st_mode & !0o7777) | (user_mode & 0o7777);
+
+        let mut state_buffer = native_stat_t::new_zeroed();
+        if unsafe { crate::internal::fstat(state_fd, &mut state_buffer) } == 0 {
+            os_specific_buffer.st_uid = state_buffer.st_uid;
+            os_specific_buffer.st_gid = state_buffer.st_gid;
+        }
+    }
+
+    unsafe { *buf = os_specific_buffer.into() };
+    0
 }
 
 pub unsafe fn fcntl_int(fd: int, cmd: int, arg: int) -> int {
@@ -46,21 +58,68 @@ pub unsafe fn fcntl2(fd: int, cmd: int) -> int {
 }
 
 pub unsafe fn fchmod(fd: int, mode: mode_t) -> int {
-    // TODO iox2-156, shared memory permission cannot be adjusted with fchmod, therefore setting
-    //                  it so that the owner can access everything
-    // when fixed use:
-    // crate::internal::fchmod(fd, mode)
-
-    let ret_val = unsafe { crate::internal::fchmod(fd, mode) };
-    if ret_val == -1 && Errno::get() == Errno::EINVAL {
-        Errno::set(Errno::ESUCCES);
-        return 0;
+    // iox2-156: route shm-fd mode change to trampoline content.
+    if let Some(state_fd) = ShmFdTranslator::get_instance().lookup_state_fd(fd) {
+        if unsafe { super::mman::write_state_mode(state_fd, mode) } {
+            0
+        } else {
+            -1
+        }
+    } else {
+        unsafe { crate::internal::fchmod(fd, mode) }
     }
-
-    ret_val
-    // TODO iox2-156, end
 }
 
 pub unsafe fn open(pathname: *const c_char, flags: int) -> int {
     unsafe { crate::internal::open(pathname, flags) }
+}
+
+// iox2-156 regression: fchmod through the wrapper must be visible to fstat.
+#[cfg(test)]
+mod iox2_156_repro_tests {
+    use crate::internal;
+    use crate::posix::types::{int, mode_t, stat_t};
+    use crate::posix::{Errno, MemZeroedStruct};
+
+    fn unique_shm_name(tag: &str) -> Vec<u8> {
+        let pid = unsafe { internal::getpid() };
+        format!("/iox2_156_{tag}_{pid}\0").into_bytes()
+    }
+
+    #[test]
+    fn fchmod_on_shm_fd_should_change_observed_mode() {
+        let name = unique_shm_name("verify");
+        unsafe { super::super::mman::shm_unlink(name.as_ptr().cast()) };
+
+        let create_mode: mode_t = (internal::S_IRUSR | internal::S_IWUSR) as mode_t;
+        let oflag = internal::O_CREAT as int | internal::O_RDWR as int;
+        let fd = unsafe { super::super::mman::shm_open(name.as_ptr().cast(), oflag, create_mode) };
+        assert!(
+            fd >= 0,
+            "shm_open failed unexpectedly (errno = {:?})",
+            Errno::get()
+        );
+
+        let new_mode: mode_t =
+            (internal::S_IRUSR | internal::S_IRGRP | internal::S_IROTH) as mode_t;
+        let fchmod_ret = unsafe { super::fchmod(fd, new_mode) };
+
+        let mut st = stat_t::new_zeroed();
+        let fstat_ret = unsafe { super::fstat(fd, &mut st) };
+
+        unsafe {
+            super::super::unistd::close(fd);
+            super::super::mman::shm_unlink(name.as_ptr().cast());
+        }
+
+        assert_eq!(fchmod_ret, 0, "wrapper fchmod should report success");
+        assert_eq!(fstat_ret, 0, "fstat on shm fd should succeed");
+
+        let observed = (st.st_mode as u32) & 0o777;
+        let expected = (new_mode as u32) & 0o777;
+        assert_eq!(
+            observed, expected,
+            "fchmod did not propagate to the shm permissions: observed=0o{observed:o}, expected=0o{expected:o}"
+        );
+    }
 }

--- a/iceoryx2-pal/posix/src/macos/macos_fd_translator.rs
+++ b/iceoryx2-pal/posix/src/macos/macos_fd_translator.rs
@@ -12,29 +12,21 @@
 
 // iox2-156: shm_fd → state_fd mapping for permission trampoline routing.
 
+use alloc::collections::BTreeMap;
 use std::sync::Mutex;
 
 use crate::posix::types::int;
 
-const MAX_SHM_ENTRIES: usize = 1024;
-
-#[doc(hidden)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ShmEntry {
-    pub shm_fd: int,
-    pub state_fd: int,
-}
-
 #[doc(hidden)]
 pub struct ShmFdTranslator {
-    entries: Mutex<[Option<ShmEntry>; MAX_SHM_ENTRIES]>,
+    // shm_fd -> state_fd
+    entries: Mutex<BTreeMap<int, int>>,
 }
 
 impl ShmFdTranslator {
     const fn new() -> Self {
-        const INIT: Option<ShmEntry> = None;
         Self {
-            entries: Mutex::new([INIT; MAX_SHM_ENTRIES]),
+            entries: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -45,42 +37,21 @@ impl ShmFdTranslator {
 
     pub fn register(&self, shm_fd: int, state_fd: int) -> bool {
         let mut entries = self.entries.lock().expect("ShmFdTranslator mutex poisoned");
-        let mut free_slot: Option<usize> = None;
-        for (idx, slot) in entries.iter().enumerate() {
-            match slot {
-                Some(e) if e.shm_fd == shm_fd => return false,
-                None if free_slot.is_none() => free_slot = Some(idx),
-                _ => {}
-            }
+        if entries.contains_key(&shm_fd) {
+            return false;
         }
-        match free_slot {
-            Some(idx) => {
-                entries[idx] = Some(ShmEntry { shm_fd, state_fd });
-                true
-            }
-            None => false,
-        }
+        entries.insert(shm_fd, state_fd);
+        true
     }
 
     pub fn lookup_state_fd(&self, shm_fd: int) -> Option<int> {
         let entries = self.entries.lock().expect("ShmFdTranslator mutex poisoned");
-        entries.iter().find_map(|slot| match slot {
-            Some(e) if e.shm_fd == shm_fd => Some(e.state_fd),
-            _ => None,
-        })
+        entries.get(&shm_fd).copied()
     }
 
     pub fn unregister(&self, shm_fd: int) -> Option<int> {
         let mut entries = self.entries.lock().expect("ShmFdTranslator mutex poisoned");
-        for slot in entries.iter_mut() {
-            if let Some(e) = *slot {
-                if e.shm_fd == shm_fd {
-                    *slot = None;
-                    return Some(e.state_fd);
-                }
-            }
-        }
-        None
+        entries.remove(&shm_fd)
     }
 }
 
@@ -108,15 +79,26 @@ mod tests {
 
     #[test]
     fn many_entries_independent() {
+        // BTreeMap has no fixed capacity, so go well past the old 1024 array limit.
         let t = ShmFdTranslator::new();
-        for i in 0..256 {
+        for i in 0..5000 {
             assert!(t.register(i, i + 10_000));
         }
-        for i in 0..256 {
+        for i in 0..5000 {
             assert_eq!(t.lookup_state_fd(i), Some(i + 10_000));
         }
-        for i in (0..256).rev() {
+        for i in (0..5000).rev() {
             assert_eq!(t.unregister(i), Some(i + 10_000));
         }
+    }
+
+    #[test]
+    fn reregister_after_unregister_succeeds() {
+        // A closed shm fd may be reused by the OS for a new shm later.
+        let t = ShmFdTranslator::new();
+        assert!(t.register(42, 100));
+        assert_eq!(t.unregister(42), Some(100));
+        assert!(t.register(42, 200));
+        assert_eq!(t.lookup_state_fd(42), Some(200));
     }
 }

--- a/iceoryx2-pal/posix/src/macos/macos_fd_translator.rs
+++ b/iceoryx2-pal/posix/src/macos/macos_fd_translator.rs
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+// iox2-156: shm_fd → state_fd mapping for permission trampoline routing.
+
+use std::sync::Mutex;
+
+use crate::posix::types::int;
+
+const MAX_SHM_ENTRIES: usize = 1024;
+
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ShmEntry {
+    pub shm_fd: int,
+    pub state_fd: int,
+}
+
+#[doc(hidden)]
+pub struct ShmFdTranslator {
+    entries: Mutex<[Option<ShmEntry>; MAX_SHM_ENTRIES]>,
+}
+
+impl ShmFdTranslator {
+    const fn new() -> Self {
+        const INIT: Option<ShmEntry> = None;
+        Self {
+            entries: Mutex::new([INIT; MAX_SHM_ENTRIES]),
+        }
+    }
+
+    pub fn get_instance() -> &'static Self {
+        static INSTANCE: ShmFdTranslator = ShmFdTranslator::new();
+        &INSTANCE
+    }
+
+    pub fn register(&self, shm_fd: int, state_fd: int) -> bool {
+        let mut entries = self.entries.lock().expect("ShmFdTranslator mutex poisoned");
+        let mut free_slot: Option<usize> = None;
+        for (idx, slot) in entries.iter().enumerate() {
+            match slot {
+                Some(e) if e.shm_fd == shm_fd => return false,
+                None if free_slot.is_none() => free_slot = Some(idx),
+                _ => {}
+            }
+        }
+        match free_slot {
+            Some(idx) => {
+                entries[idx] = Some(ShmEntry { shm_fd, state_fd });
+                true
+            }
+            None => false,
+        }
+    }
+
+    pub fn lookup_state_fd(&self, shm_fd: int) -> Option<int> {
+        let entries = self.entries.lock().expect("ShmFdTranslator mutex poisoned");
+        entries.iter().find_map(|slot| match slot {
+            Some(e) if e.shm_fd == shm_fd => Some(e.state_fd),
+            _ => None,
+        })
+    }
+
+    pub fn unregister(&self, shm_fd: int) -> Option<int> {
+        let mut entries = self.entries.lock().expect("ShmFdTranslator mutex poisoned");
+        for slot in entries.iter_mut() {
+            if let Some(e) = *slot
+                && e.shm_fd == shm_fd
+            {
+                *slot = None;
+                return Some(e.state_fd);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_lookup_unregister_roundtrip() {
+        let t = ShmFdTranslator::new();
+        assert!(t.register(100, 200));
+        assert_eq!(t.lookup_state_fd(100), Some(200));
+        assert_eq!(t.unregister(100), Some(200));
+        assert_eq!(t.lookup_state_fd(100), None);
+        assert_eq!(t.unregister(100), None);
+    }
+
+    #[test]
+    fn duplicate_register_is_rejected() {
+        let t = ShmFdTranslator::new();
+        assert!(t.register(7, 8));
+        assert!(!t.register(7, 9));
+        assert_eq!(t.lookup_state_fd(7), Some(8));
+    }
+
+    #[test]
+    fn many_entries_independent() {
+        let t = ShmFdTranslator::new();
+        for i in 0..256 {
+            assert!(t.register(i, i + 10_000));
+        }
+        for i in 0..256 {
+            assert_eq!(t.lookup_state_fd(i), Some(i + 10_000));
+        }
+        for i in (0..256).rev() {
+            assert_eq!(t.unregister(i), Some(i + 10_000));
+        }
+    }
+}

--- a/iceoryx2-pal/posix/src/macos/macos_fd_translator.rs
+++ b/iceoryx2-pal/posix/src/macos/macos_fd_translator.rs
@@ -73,11 +73,11 @@ impl ShmFdTranslator {
     pub fn unregister(&self, shm_fd: int) -> Option<int> {
         let mut entries = self.entries.lock().expect("ShmFdTranslator mutex poisoned");
         for slot in entries.iter_mut() {
-            if let Some(e) = *slot
-                && e.shm_fd == shm_fd
-            {
-                *slot = None;
-                return Some(e.state_fd);
+            if let Some(e) = *slot {
+                if e.shm_fd == shm_fd {
+                    *slot = None;
+                    return Some(e.state_fd);
+                }
             }
         }
         None

--- a/iceoryx2-pal/posix/src/macos/mman.rs
+++ b/iceoryx2-pal/posix/src/macos/mman.rs
@@ -21,9 +21,14 @@ use std::io::Write;
 
 use crate::posix::*;
 
+use super::macos_fd_translator::ShmFdTranslator;
 use super::settings::{MAX_PATH_LENGTH, SHM_STATE_DIRECTORY, SHM_STATE_SUFFIX};
 
 const SHM_MAX_NAME_LEN: usize = 33;
+
+// iox2-156: user mode bytes live at this offset in the .shm_state file.
+pub(crate) const SHM_STATE_MODE_OFFSET: i64 = SHM_MAX_NAME_LEN as i64;
+pub(crate) const SHM_STATE_MODE_LEN: usize = 4;
 
 pub unsafe fn mlock(addr: *const void, len: size_t) -> int {
     unsafe { crate::internal::mlock(addr, len) }
@@ -81,53 +86,80 @@ unsafe fn shm_file_path(name: *const c_char, suffix: &[u8]) -> [u8; MAX_PATH_LEN
     state_file_path
 }
 
-unsafe fn get_real_shm_name(name: *const c_char) -> Option<[u8; SHM_MAX_NAME_LEN]> {
+unsafe fn open_state_file(name: *const c_char) -> Option<([u8; SHM_MAX_NAME_LEN], int)> {
     unsafe {
         let shm_file_path = shm_file_path(name, SHM_STATE_SUFFIX);
-        let shm_state_fd = open_with_mode(shm_file_path.as_ptr().cast(), O_RDONLY, 0);
-        if shm_state_fd == -1 {
+        // O_RDWR so iox2-156 routing can pwrite mode bytes later.
+        let state_fd = open_with_mode(shm_file_path.as_ptr().cast(), O_RDWR, 0);
+        if state_fd == -1 {
             return None;
         }
 
         let mut buffer = [0u8; SHM_MAX_NAME_LEN];
-
-        if read(
-            shm_state_fd,
-            buffer.as_mut_ptr().cast(),
-            SHM_MAX_NAME_LEN - 1,
-        ) <= 0
-        {
-            close(shm_state_fd);
+        if read(state_fd, buffer.as_mut_ptr().cast(), SHM_MAX_NAME_LEN - 1) <= 0 {
+            close(state_fd);
             return None;
         }
 
-        close(shm_state_fd);
-        Some(buffer)
+        Some((buffer, state_fd))
     }
 }
 
-unsafe fn write_real_shm_name(name: *const c_char, buffer: &[u8]) -> bool {
+unsafe fn create_state_file(name: *const c_char, real_name: &[u8], mode: mode_t) -> Option<int> {
     unsafe {
         let shm_file_path = shm_file_path(name, SHM_STATE_SUFFIX);
-        let shm_state_fd = open_with_mode(
+        let state_fd = open_with_mode(
             shm_file_path.as_ptr().cast(),
             O_EXCL | O_CREAT | O_RDWR,
-            S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH,
+            S_IWUSR | S_IRUSR,
         );
-
-        if shm_state_fd == -1 {
-            return false;
+        if state_fd == -1 {
+            return None;
         }
 
-        if write(shm_state_fd, buffer.as_ptr().cast(), buffer.len()) != buffer.len() as _ {
+        if write(state_fd, real_name.as_ptr().cast(), real_name.len()) != real_name.len() as _ {
+            close(state_fd);
             remove(shm_file_path.as_ptr().cast());
-            close(shm_state_fd);
-            return false;
+            return None;
         }
 
-        close(shm_state_fd);
-        true
+        if !write_state_mode(state_fd, mode) {
+            close(state_fd);
+            remove(shm_file_path.as_ptr().cast());
+            return None;
+        }
+
+        Some(state_fd)
     }
+}
+
+pub(crate) unsafe fn write_state_mode(state_fd: int, mode: mode_t) -> bool {
+    let bytes = (mode as u32).to_le_bytes();
+    let written = unsafe {
+        crate::internal::pwrite(
+            state_fd,
+            bytes.as_ptr().cast(),
+            SHM_STATE_MODE_LEN,
+            SHM_STATE_MODE_OFFSET,
+        )
+    };
+    written == SHM_STATE_MODE_LEN as _
+}
+
+pub(crate) unsafe fn read_state_mode(state_fd: int) -> mode_t {
+    let mut bytes = [0u8; SHM_STATE_MODE_LEN];
+    let n = unsafe {
+        crate::internal::pread(
+            state_fd,
+            bytes.as_mut_ptr().cast(),
+            SHM_STATE_MODE_LEN,
+            SHM_STATE_MODE_OFFSET,
+        )
+    };
+    if n != SHM_STATE_MODE_LEN as _ {
+        return 0 as mode_t;
+    }
+    u32::from_le_bytes(bytes) as mode_t
 }
 
 unsafe fn generate_real_shm_name() -> [u8; SHM_MAX_NAME_LEN] {
@@ -153,48 +185,77 @@ unsafe fn generate_real_shm_name() -> [u8; SHM_MAX_NAME_LEN] {
     buffer
 }
 
-pub unsafe fn shm_open(name: *const c_char, oflag: int, _mode: mode_t) -> int {
-    let real_name = unsafe { get_real_shm_name(name) };
-    if oflag & O_EXCL != 0 && real_name.is_some() {
+pub unsafe fn shm_open(name: *const c_char, oflag: int, mode: mode_t) -> int {
+    let existing = unsafe { open_state_file(name) };
+    if oflag & O_EXCL != 0 && existing.is_some() {
+        if let Some((_, state_fd)) = existing {
+            unsafe { close(state_fd) };
+        }
         Errno::set(Errno::EEXIST);
         return -1;
     }
 
-    let real_name = match real_name {
-        Some(name) => name,
+    let (real_name, state_fd, created) = match existing {
+        Some((real_name, state_fd)) => (real_name, state_fd, false),
         None => {
             if oflag & O_CREAT == 0 {
                 Errno::set(Errno::ENOENT);
                 return -1;
             }
             let real_name = unsafe { generate_real_shm_name() };
-            if unsafe { !write_real_shm_name(name, &real_name) } {
-                return -1;
-            }
-            real_name
+            let state_fd = match unsafe { create_state_file(name, &real_name, mode) } {
+                Some(fd) => fd,
+                None => return -1,
+            };
+            (real_name, state_fd, true)
         }
     };
 
-    // TODO iox2-156, shared memory permission cannot be adjusted with fchmod, therefore setting
-    //                  it so that the owner can access everything
-    let mode = S_IRWXU;
-    // TODO iox2-156, end
-    unsafe { crate::internal::shm_open(real_name.as_ptr().cast(), oflag, mode as uint) }
+    // macOS ignores shm_open mode; iox2-156 user mode lives on the trampoline.
+    let shm_fd =
+        unsafe { crate::internal::shm_open(real_name.as_ptr().cast(), oflag, S_IRWXU as uint) };
+    if shm_fd == -1 {
+        let err = Errno::get();
+        unsafe { close(state_fd) };
+        if created {
+            unsafe { remove(shm_file_path(name, SHM_STATE_SUFFIX).as_ptr().cast()) };
+        }
+        Errno::set(err);
+        return -1;
+    }
+
+    if !ShmFdTranslator::get_instance().register(shm_fd, state_fd) {
+        unsafe {
+            crate::internal::close(shm_fd);
+            close(state_fd);
+        }
+        if created {
+            unsafe { remove(shm_file_path(name, SHM_STATE_SUFFIX).as_ptr().cast()) };
+        }
+        Errno::set(Errno::ENFILE);
+        return -1;
+    }
+
+    shm_fd
 }
 
 pub unsafe fn shm_unlink(name: *const c_char) -> int {
-    let real_name = unsafe { get_real_shm_name(name) };
-
-    if let Some(real_name) = real_name {
-        let ret_val = unsafe { crate::internal::shm_unlink(real_name.as_ptr().cast()) };
-        if ret_val == 0 || (ret_val == -1 && Errno::get() == Errno::ENOENT) {
-            unsafe { remove(shm_file_path(name, SHM_STATE_SUFFIX).as_ptr().cast()) };
+    let real_name = match unsafe { open_state_file(name) } {
+        Some((real_name, state_fd)) => {
+            unsafe { close(state_fd) };
+            real_name
         }
-        return ret_val;
-    }
+        None => {
+            Errno::set(Errno::ENOENT);
+            return -1;
+        }
+    };
 
-    Errno::set(Errno::ENOENT);
-    -1
+    let ret_val = unsafe { crate::internal::shm_unlink(real_name.as_ptr().cast()) };
+    if ret_val == 0 || (ret_val == -1 && Errno::get() == Errno::ENOENT) {
+        unsafe { remove(shm_file_path(name, SHM_STATE_SUFFIX).as_ptr().cast()) };
+    }
+    ret_val
 }
 
 pub unsafe fn mmap(

--- a/iceoryx2-pal/posix/src/macos/mod.rs
+++ b/iceoryx2-pal/posix/src/macos/mod.rs
@@ -14,6 +14,7 @@ pub mod constants;
 pub mod dirent;
 pub mod errno;
 pub mod fcntl;
+pub mod macos_fd_translator;
 pub mod mman;
 pub mod pthread;
 pub mod pwd;

--- a/iceoryx2-pal/posix/src/macos/unistd.rs
+++ b/iceoryx2-pal/posix/src/macos/unistd.rs
@@ -66,7 +66,13 @@ pub unsafe fn dup(fildes: int) -> int {
 }
 
 pub unsafe fn close(fd: int) -> int {
-    unsafe { crate::internal::close(fd) }
+    // iox2-156: unregister before close to avoid fd-reuse races.
+    let state_fd = super::macos_fd_translator::ShmFdTranslator::get_instance().unregister(fd);
+    let ret = unsafe { crate::internal::close(fd) };
+    if let Some(state_fd) = state_fd {
+        unsafe { crate::internal::close(state_fd) };
+    }
+    ret
 }
 
 pub unsafe fn read(fd: int, buf: *mut void, count: size_t) -> ssize_t {
@@ -106,7 +112,11 @@ pub unsafe fn ftruncate(fd: int, length: off_t) -> int {
 }
 
 pub unsafe fn fchown(fd: int, owner: uid_t, group: gid_t) -> int {
-    unsafe { crate::internal::fchown(fd, owner, group) }
+    // iox2-156: ownership lives on the trampoline state file for shm fds.
+    let target_fd = super::macos_fd_translator::ShmFdTranslator::get_instance()
+        .lookup_state_fd(fd)
+        .unwrap_or(fd);
+    unsafe { crate::internal::fchown(target_fd, owner, group) }
 }
 
 pub unsafe fn fsync(fd: int) -> int {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->


  Two TODO-marked workarounds in `iceoryx2-pal/posix/src/macos/` short-circuited permission handling:
  - `fchmod` swallowed `EINVAL` and returned success without applying any change.
  - `shm_open` hardcoded `S_IRWXU`, ignoring the user-requested mode.

Removes both workarounds and routes permission syscalls through a  trampoline file, mirroring the existing Windows `HandleTranslator` pattern.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #156

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
