### PR TITLE
[#1707] Expose `CustomHeaderMarker`/`CustomPayloadMarker` in C++ bindings

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -18,6 +18,7 @@
 * [#1584](https://github.com/eclipse-iceoryx/iceoryx2/issues/1584) Introduce `Node::force_remove_service` to remove corrupted services manually.
 * [#1544](https://github.com/eclipse-iceoryx/iceoryx2/issues/1544) Announce service removal over the tunnel to remote hosts
 * [#1616](https://github.com/eclipse-iceoryx/iceoryx2/issues/1616) Add reactive execution mode to tunnel
+* [#1707](https://github.com/eclipse-iceoryx/iceoryx2/issues/1707) Expose `CustomHeaderMarker` and `CustomPayloadMarker` in C++ bindings
 
 ### Bugfixes
 

--- a/iceoryx2-cxx/include/iox2/active_request.hpp
+++ b/iceoryx2-cxx/include/iox2/active_request.hpp
@@ -15,10 +15,13 @@
 
 #include "internal/helper.hpp"
 #include "iox2/bb/expected.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/internal/helper.hpp"
 #include "iox2/payload_info.hpp"
 #include "iox2/response_mut_uninit.hpp"
 #include "iox2/service_type.hpp"
+
+#include <type_traits>
 
 namespace iox2 {
 /// Represents a one-to-one connection to a [`Client`] holding the corresponding
@@ -255,7 +258,14 @@ ActiveRequest<Service, RequestPayload, RequestUserHeader, ResponsePayload, Respo
 
     iox2_active_request_payload(&m_handle, &ptr, &number_of_elements);
 
-    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), number_of_elements);
+    // for the custom payload marker, the slice length is the
+    // runtime payload byte size
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_active_request_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), length);
 }
 
 template <ServiceType Service,

--- a/iceoryx2-cxx/include/iox2/custom_header_marker.hpp
+++ b/iceoryx2-cxx/include/iox2/custom_header_marker.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef IOX2_CUSTOM_HEADER_MARKER_HPP
+#define IOX2_CUSTOM_HEADER_MARKER_HPP
+
+namespace iox2 {
+
+/// User header type for a service whose user header type details are set at runtime.
+struct CustomHeaderMarker { };
+
+} // namespace iox2
+
+#endif

--- a/iceoryx2-cxx/include/iox2/custom_payload_marker.hpp
+++ b/iceoryx2-cxx/include/iox2/custom_payload_marker.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+#ifndef IOX2_CUSTOM_PAYLOAD_MARKER_HPP
+#define IOX2_CUSTOM_PAYLOAD_MARKER_HPP
+
+#include <cstdint>
+
+namespace iox2 {
+
+/// Payload element for a service whose payload type details are set at runtime.
+struct CustomPayloadMarker {
+    uint8_t value;
+};
+
+} // namespace iox2
+
+#endif

--- a/iceoryx2-cxx/include/iox2/message_type_details.hpp
+++ b/iceoryx2-cxx/include/iox2/message_type_details.hpp
@@ -22,6 +22,9 @@ namespace iox2 {
 /// [`crate::service::Service`]
 class TypeDetail {
   public:
+    /// Creates a [`TypeDetail`] from runtime values.
+    TypeDetail(TypeVariant variant, const char* type_name, size_t size, size_t alignment);
+
     /// The [`TypeVariant`] of the type
     auto variant() const -> TypeVariant;
 

--- a/iceoryx2-cxx/include/iox2/request_mut.hpp
+++ b/iceoryx2-cxx/include/iox2/request_mut.hpp
@@ -15,12 +15,15 @@
 
 #include "iox2/bb/expected.hpp"
 #include "iox2/bb/slice.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/header_request_response.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 #include "iox2/payload_info.hpp"
 #include "iox2/pending_response.hpp"
 #include "iox2/port_error.hpp"
 #include "iox2/service_type.hpp"
+
+#include <type_traits>
 
 namespace iox2 {
 
@@ -204,7 +207,15 @@ inline auto RequestMut<Service, RequestPayload, RequestUserHeader, ResponsePaylo
     const void* ptr = nullptr;
     size_t number_of_elements = 0;
     iox2_request_mut_payload(&m_handle, &ptr, &number_of_elements);
-    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), number_of_elements);
+
+    // for the custom payload marker, the slice length is the
+    // runtime payload byte size
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_request_mut_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), length);
 }
 
 template <ServiceType Service,
@@ -231,7 +242,15 @@ inline auto RequestMut<Service, RequestPayload, RequestUserHeader, ResponsePaylo
     void* ptr = nullptr;
     size_t number_of_elements = 0;
     iox2_request_mut_payload_mut(&m_handle, &ptr, &number_of_elements);
-    return bb::MutableSlice<ValueType>(static_cast<ValueType*>(ptr), number_of_elements);
+
+    // for the custom payload marker, the slice length is the
+    // runtime payload byte size
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_request_mut_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::MutableSlice<ValueType>(static_cast<ValueType*>(ptr), length);
 }
 
 template <ServiceType Service,

--- a/iceoryx2-cxx/include/iox2/request_mut_uninit.hpp
+++ b/iceoryx2-cxx/include/iox2/request_mut_uninit.hpp
@@ -124,7 +124,7 @@ template <typename T, typename>
 inline auto
 RequestMutUninit<Service, RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader>::user_header() const
     -> const T& {
-    return m_request.user_header();
+    return m_request.template user_header<T>();
 }
 
 template <ServiceType Service,
@@ -136,7 +136,7 @@ template <typename T, typename>
 inline auto
 RequestMutUninit<Service, RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader>::user_header_mut()
     -> T& {
-    return m_request.user_header_mut();
+    return m_request.template user_header_mut<T>();
 }
 
 template <ServiceType Service,

--- a/iceoryx2-cxx/include/iox2/response.hpp
+++ b/iceoryx2-cxx/include/iox2/response.hpp
@@ -15,8 +15,11 @@
 
 #include "header_request_response.hpp"
 #include "iox2/bb/slice.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/payload_info.hpp"
 #include "iox2/service_type.hpp"
+
+#include <type_traits>
 
 namespace iox2 {
 /// It stores the payload and can be received by the [`PendingResponse`] after a
@@ -114,7 +117,15 @@ inline auto Response<Service, ResponsePayload, ResponseUserHeader>::payload() co
     const void* ptr = nullptr;
     size_t number_of_elements = 0;
     iox2_response_payload(&m_handle, &ptr, &number_of_elements);
-    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), number_of_elements);
+
+    // for the custom payload marker, the slice length is the
+    // runtime payload byte size
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_response_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), length);
 }
 
 template <ServiceType Service, typename ResponsePayload, typename ResponseUserHeader>

--- a/iceoryx2-cxx/include/iox2/response_mut.hpp
+++ b/iceoryx2-cxx/include/iox2/response_mut.hpp
@@ -15,10 +15,13 @@
 
 #include "iox2/bb/expected.hpp"
 #include "iox2/bb/slice.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/header_request_response.hpp"
 #include "iox2/payload_info.hpp"
 #include "iox2/port_error.hpp"
 #include "iox2/service_type.hpp"
+
+#include <type_traits>
 
 namespace iox2 {
 
@@ -158,7 +161,15 @@ inline auto ResponseMut<Service, ResponsePayload, ResponseUserHeader>::payload()
     const void* ptr = nullptr;
     size_t number_of_elements = 0;
     iox2_response_mut_payload(&m_handle, &ptr, &number_of_elements);
-    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), number_of_elements);
+
+    // for the custom payload marker, the slice length is the
+    // runtime payload byte size
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_response_mut_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), length);
 }
 
 template <ServiceType Service, typename ResponsePayload, typename ResponseUserHeader>
@@ -176,7 +187,14 @@ inline auto ResponseMut<Service, ResponsePayload, ResponseUserHeader>::payload_m
     size_t number_of_elements = 0;
     iox2_response_mut_payload_mut(&m_handle, &ptr, &number_of_elements);
 
-    return bb::MutableSlice<ValueType>(static_cast<ValueType*>(ptr), number_of_elements);
+    // for the custom payload marker, the slice length is the
+    // runtime payload byte size
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_response_mut_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::MutableSlice<ValueType>(static_cast<ValueType*>(ptr), length);
 }
 
 

--- a/iceoryx2-cxx/include/iox2/response_mut_uninit.hpp
+++ b/iceoryx2-cxx/include/iox2/response_mut_uninit.hpp
@@ -107,13 +107,13 @@ inline auto ResponseMutUninit<Service, ResponsePayload, ResponseUserHeader>::hea
 template <ServiceType Service, typename ResponsePayload, typename ResponseUserHeader>
 template <typename T, typename>
 inline auto ResponseMutUninit<Service, ResponsePayload, ResponseUserHeader>::user_header() const -> const T& {
-    return m_response.user_header();
+    return m_response.template user_header<T>();
 }
 
 template <ServiceType Service, typename ResponsePayload, typename ResponseUserHeader>
 template <typename T, typename>
 inline auto ResponseMutUninit<Service, ResponsePayload, ResponseUserHeader>::user_header_mut() -> T& {
-    return m_response.user_header_mut();
+    return m_response.template user_header_mut<T>();
 }
 
 template <ServiceType Service, typename ResponsePayload, typename ResponseUserHeader>

--- a/iceoryx2-cxx/include/iox2/sample.hpp
+++ b/iceoryx2-cxx/include/iox2/sample.hpp
@@ -134,8 +134,8 @@ inline auto Sample<S, Payload, UserHeader>::payload() const -> bb::ImmutableSlic
 
     iox2_sample_payload(&m_handle, &ptr, &number_of_elements);
 
-    // for the custom payload marker the FFI reports the element count; the slice length is the
-    // runtime payload byte size which is provided directly by the FFI
+    // for the custom payload marker, the slice length is the
+    // runtime payload byte size
     auto length = number_of_elements;
     if (std::is_same<ValueType, CustomPayloadMarker>::value) {
         length = iox2_sample_payload_number_of_bytes(&m_handle);

--- a/iceoryx2-cxx/include/iox2/sample.hpp
+++ b/iceoryx2-cxx/include/iox2/sample.hpp
@@ -14,11 +14,14 @@
 #define IOX2_SAMPLE_HPP
 
 #include "iox2/bb/slice.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/header_publish_subscribe.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 #include "iox2/payload_info.hpp"
 #include "iox2/service_type.hpp"
 #include "iox2/unique_port_id.hpp"
+
+#include <type_traits>
 
 namespace iox2 {
 
@@ -131,7 +134,14 @@ inline auto Sample<S, Payload, UserHeader>::payload() const -> bb::ImmutableSlic
 
     iox2_sample_payload(&m_handle, &ptr, &number_of_elements);
 
-    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), number_of_elements);
+    // for the custom payload marker the FFI reports the element count; the slice length is the
+    // runtime payload byte size which is provided directly by the FFI
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_sample_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), length);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-cxx/include/iox2/sample_mut.hpp
@@ -195,8 +195,8 @@ inline auto SampleMut<S, Payload, UserHeader>::payload() const -> bb::ImmutableS
 
     iox2_sample_mut_payload(&m_handle, &ptr, &number_of_elements);
 
-    // for the custom payload marker the FFI reports the element count; the slice length is the
-    // runtime payload byte size which is provided directly by the FFI
+    // for the custom payload marker, the slice length is the
+    // runtime payload byte size
     auto length = number_of_elements;
     if (std::is_same<ValueType, CustomPayloadMarker>::value) {
         length = iox2_sample_mut_payload_number_of_bytes(&m_handle);

--- a/iceoryx2-cxx/include/iox2/sample_mut.hpp
+++ b/iceoryx2-cxx/include/iox2/sample_mut.hpp
@@ -15,12 +15,15 @@
 
 #include "iox2/bb/expected.hpp"
 #include "iox2/bb/slice.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/header_publish_subscribe.hpp"
 #include "iox2/iceoryx2.h"
 #include "iox2/internal/iceoryx2.hpp"
 #include "iox2/payload_info.hpp"
 #include "iox2/publisher_error.hpp"
 #include "iox2/service_type.hpp"
+
+#include <type_traits>
 
 namespace iox2 {
 
@@ -192,7 +195,14 @@ inline auto SampleMut<S, Payload, UserHeader>::payload() const -> bb::ImmutableS
 
     iox2_sample_mut_payload(&m_handle, &ptr, &number_of_elements);
 
-    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), number_of_elements);
+    // for the custom payload marker the FFI reports the element count; the slice length is the
+    // runtime payload byte size which is provided directly by the FFI
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_sample_mut_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::ImmutableSlice<ValueType>(static_cast<const ValueType*>(ptr), length);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
@@ -203,7 +213,12 @@ inline auto SampleMut<S, Payload, UserHeader>::payload_mut() -> bb::MutableSlice
 
     iox2_sample_mut_payload_mut(&m_handle, &ptr, &number_of_elements);
 
-    return bb::MutableSlice<ValueType>(static_cast<ValueType*>(ptr), number_of_elements);
+    auto length = number_of_elements;
+    if (std::is_same<ValueType, CustomPayloadMarker>::value) {
+        length = iox2_sample_mut_payload_number_of_bytes(&m_handle);
+    }
+
+    return bb::MutableSlice<ValueType>(static_cast<ValueType*>(ptr), length);
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-cxx/include/iox2/sample_mut_uninit.hpp
+++ b/iceoryx2-cxx/include/iox2/sample_mut_uninit.hpp
@@ -100,13 +100,13 @@ inline auto SampleMutUninit<S, Payload, UserHeader>::header() const -> HeaderPub
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto SampleMutUninit<S, Payload, UserHeader>::user_header() const -> const T& {
-    return m_sample.user_header();
+    return m_sample.template user_header<T>();
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>
 template <typename T, typename>
 inline auto SampleMutUninit<S, Payload, UserHeader>::user_header_mut() -> T& {
-    return m_sample.user_header_mut();
+    return m_sample.template user_header_mut<T>();
 }
 
 template <ServiceType S, typename Payload, typename UserHeader>

--- a/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -18,12 +18,20 @@
 #include "iox2/bb/detail/builder.hpp"
 #include "iox2/bb/expected.hpp"
 #include "iox2/bb/layout.hpp"
+#include "iox2/bb/slice.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 #include "iox2/internal/service_builder_internal.hpp"
+#include "iox2/message_type_details.hpp"
 #include "iox2/payload_info.hpp"
 #include "iox2/port_factory_publish_subscribe.hpp"
 #include "iox2/service_builder_publish_subscribe_error.hpp"
 #include "iox2/service_type.hpp"
+#include "iox2/type_name.hpp"
+#include "iox2/type_variant.hpp"
+
+#include <cstring>
+#include <type_traits>
 
 namespace iox2 {
 /// Builder to create new [`MessagingPattern::PublishSubscribe`] based [`Service`]s
@@ -106,6 +114,11 @@ class ServiceBuilderPublishSubscribe {
     template <typename NewHeader>
     auto user_header() && -> ServiceBuilderPublishSubscribe<Payload, NewHeader, S>&&;
 
+    /// Overrides the payload type details with values provided at runtime instead of derived
+    /// from the compile-time `Payload`. Only available for `bb::Slice<CustomPayloadMarker>`.
+    template <typename P = Payload, typename = std::enable_if_t<std::is_same<P, bb::Slice<CustomPayloadMarker>>::value>>
+    auto set_payload_type_details(const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&&;
+
     /// If the [`Service`] exists, it will be opened otherwise a new [`Service`] will be
     /// created.
     auto open_or_create() && -> bb::Expected<PortFactoryPublishSubscribe<S, Payload, UserHeader>,
@@ -143,6 +156,7 @@ class ServiceBuilderPublishSubscribe {
     void set_parameters();
 
     iox2_service_builder_pub_sub_h m_handle = nullptr;
+    bb::Optional<TypeDetail> m_payload_type_details_override;
 };
 
 template <typename Payload, typename UserHeader, ServiceType S>
@@ -180,20 +194,27 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
     }
 
     using ValueType = typename PayloadInfo<Payload>::ValueType;
+
+    // payload type details, derived from the compile-time Payload unless overridden at runtime
+    const auto derived_type_name = internal::get_type_name<Payload>();
     auto type_variant = bb::IsSlice<Payload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
+    const char* payload_type_name = derived_type_name.unchecked_access().c_str();
+    uint64_t payload_type_name_len = derived_type_name.size();
+    uint64_t payload_type_size = sizeof(ValueType);
+    uint64_t payload_type_align = alignof(ValueType);
 
-    // payload type details
-    const auto payload_type_name = internal::get_type_name<Payload>();
-    const auto payload_type_size = sizeof(ValueType);
-    const auto payload_type_align = alignof(ValueType);
+    if (m_payload_type_details_override.has_value()) {
+        const auto& details = m_payload_type_details_override.value();
+        type_variant =
+            details.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
+        payload_type_name = details.type_name();
+        payload_type_name_len = std::strlen(details.type_name());
+        payload_type_size = details.size();
+        payload_type_align = details.alignment();
+    }
 
-    const auto payload_result =
-        iox2_service_builder_pub_sub_set_payload_type_details(&m_handle,
-                                                              type_variant,
-                                                              payload_type_name.unchecked_access().c_str(),
-                                                              payload_type_name.size(),
-                                                              payload_type_size,
-                                                              payload_type_align);
+    const auto payload_result = iox2_service_builder_pub_sub_set_payload_type_details(
+        &m_handle, type_variant, payload_type_name, payload_type_name_len, payload_type_size, payload_type_align);
 
     if (payload_result != IOX2_OK) {
         IOX2_PANIC("This should never happen! Implementation failure while setting the Payload-Type.");
@@ -225,6 +246,14 @@ inline auto ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::
     // required here since we just change the template header type but the builder structure stays the same
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return std::move(*reinterpret_cast<ServiceBuilderPublishSubscribe<Payload, NewHeader, S>*>(this));
+}
+
+template <typename Payload, typename UserHeader, ServiceType S>
+template <typename, typename>
+inline auto ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_payload_type_details(
+    const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&& {
+    m_payload_type_details_override = bb::Optional<TypeDetail>(value);
+    return std::move(*this);
 }
 
 template <typename Payload, typename UserHeader, ServiceType S>

--- a/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -35,6 +35,36 @@
 #include <type_traits>
 
 namespace iox2 {
+template <typename Payload, typename UserHeader, ServiceType S>
+class ServiceBuilderPublishSubscribe;
+
+/// Overrides the payload type details with values provided at runtime instead of derived from the
+/// compile-time `Payload`. Only available for `bb::Slice<CustomPayloadMarker>`.
+///
+/// # Safety
+///
+///  * It is preferred to let the type details be derived from the provided type; overriding them is
+///    only meant for advanced usage.
+///  * The provided [`TypeDetail`] must accurately describe the payload type that is loaned, sent and
+///    received at runtime; a mismatching size or alignment leads to undefined behavior.
+template <typename Payload, typename UserHeader, ServiceType S>
+auto set_payload_type_details(ServiceBuilderPublishSubscribe<Payload, UserHeader, S>& builder, const TypeDetail& value)
+    -> std::enable_if_t<std::is_same<Payload, bb::Slice<CustomPayloadMarker>>::value>;
+
+/// Overrides the user header type details with values provided at runtime instead of derived from
+/// the compile-time `UserHeader`. Only available for `CustomHeaderMarker`.
+///
+/// # Safety
+///
+///  * It is preferred to let the type details be derived from the provided type; overriding them is
+///    only meant for advanced usage.
+///  * The provided [`TypeDetail`] must accurately describe the user header type that is accessed at
+///    runtime; a mismatching size or alignment leads to undefined behavior.
+template <typename Payload, typename UserHeader, ServiceType S>
+auto set_user_header_type_details(ServiceBuilderPublishSubscribe<Payload, UserHeader, S>& builder,
+                                  const TypeDetail& value)
+    -> std::enable_if_t<std::is_same<UserHeader, CustomHeaderMarker>::value>;
+
 /// Builder to create new [`MessagingPattern::PublishSubscribe`] based [`Service`]s
 template <typename Payload, typename UserHeader, ServiceType S>
 class ServiceBuilderPublishSubscribe {
@@ -115,17 +145,10 @@ class ServiceBuilderPublishSubscribe {
     template <typename NewHeader>
     auto user_header() && -> ServiceBuilderPublishSubscribe<Payload, NewHeader, S>&&;
 
-    /// Overrides the user header type details with values provided at runtime instead of derived
-    /// from the compile-time `UserHeader`. Only available for `CustomHeaderMarker`.
-    template <typename H = UserHeader, typename = std::enable_if_t<std::is_same<H, CustomHeaderMarker>::value>>
-    auto set_user_header_type_details(
-        const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&&;
-
-    /// Overrides the payload type details with values provided at runtime instead of derived
-    /// from the compile-time `Payload`. Only available for `bb::Slice<CustomPayloadMarker>`.
-    template <typename P = Payload, typename = std::enable_if_t<std::is_same<P, bb::Slice<CustomPayloadMarker>>::value>>
-    auto
-    set_payload_type_details(const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&&;
+    /// Returns the builder as an r-value so the fluent chain can be resumed after a free function,
+    /// such as [`set_payload_type_details()`] or [`set_user_header_type_details()`], has been
+    /// applied to the named builder.
+    auto resume_build() & -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&&;
 
     /// If the [`Service`] exists, it will be opened otherwise a new [`Service`] will be
     /// created.
@@ -159,11 +182,20 @@ class ServiceBuilderPublishSubscribe {
     template <ServiceType>
     friend class ServiceBuilder;
 
+    template <typename P, typename U, ServiceType St>
+    friend auto set_payload_type_details(ServiceBuilderPublishSubscribe<P, U, St>& builder, const TypeDetail& value)
+        -> std::enable_if_t<std::is_same<P, bb::Slice<CustomPayloadMarker>>::value>;
+    template <typename P, typename U, ServiceType St>
+    friend auto set_user_header_type_details(ServiceBuilderPublishSubscribe<P, U, St>& builder, const TypeDetail& value)
+        -> std::enable_if_t<std::is_same<U, CustomHeaderMarker>::value>;
+
     explicit ServiceBuilderPublishSubscribe(iox2_service_builder_h handle);
 
     void set_parameters();
-    void set_payload_type_details();
-    void set_user_header_type_details();
+    void derive_payload_type_details();
+    void override_payload_type_details(const TypeDetail& value);
+    void derive_user_header_type_details();
+    void override_user_header_type_details(const TypeDetail& value);
 
     iox2_service_builder_pub_sub_h m_handle = nullptr;
     bb::Optional<TypeDetail> m_user_header_type_details_override;
@@ -204,70 +236,86 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
         iox2_service_builder_pub_sub_set_max_nodes(&m_handle, m_max_nodes.value());
     }
 
-    set_user_header_type_details();
-    set_payload_type_details();
+    if (m_user_header_type_details_override.has_value()) {
+        override_user_header_type_details(m_user_header_type_details_override.value());
+    } else {
+        derive_user_header_type_details();
+    }
+
+    if (m_payload_type_details_override.has_value()) {
+        override_payload_type_details(m_payload_type_details_override.value());
+    } else {
+        derive_payload_type_details();
+    }
 }
 
 template <typename Payload, typename UserHeader, ServiceType S>
-inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_user_header_type_details() {
-    // user header type details, derived from the compile-time UserHeader unless overridden at runtime
+inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::derive_user_header_type_details() {
+    // user header type details derived from the compile-time UserHeader
     const auto header_layout = bb::Layout::from<UserHeader>();
-    const auto derived_user_header_type_name = internal::get_type_name<UserHeader>();
-    auto user_header_type_variant = iox2_type_variant_e_FIXED_SIZE;
-    const char* user_header_type_name = derived_user_header_type_name.unchecked_access().c_str();
-    uint64_t user_header_type_name_len = derived_user_header_type_name.size();
-    uint64_t user_header_type_size = header_layout.size();
-    uint64_t user_header_type_align = header_layout.alignment();
+    const auto user_header_type_name = internal::get_type_name<UserHeader>();
 
-    if (m_user_header_type_details_override.has_value()) {
-        const auto& header_details_override = m_user_header_type_details_override.value();
-        user_header_type_variant = header_details_override.variant() == TypeVariant::FixedSize
-                                       ? iox2_type_variant_e_FIXED_SIZE
-                                       : iox2_type_variant_e_DYNAMIC;
-        user_header_type_name = header_details_override.type_name();
-        user_header_type_name_len = std::strlen(header_details_override.type_name());
-        user_header_type_size = header_details_override.size();
-        user_header_type_align = header_details_override.alignment();
-    }
+    const auto result =
+        iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
+                                                                  iox2_type_variant_e_FIXED_SIZE,
+                                                                  user_header_type_name.unchecked_access().c_str(),
+                                                                  user_header_type_name.size(),
+                                                                  header_layout.size(),
+                                                                  header_layout.alignment());
 
-    const auto user_header_result = iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
-                                                                                              user_header_type_variant,
-                                                                                              user_header_type_name,
-                                                                                              user_header_type_name_len,
-                                                                                              user_header_type_size,
-                                                                                              user_header_type_align);
-
-    if (user_header_result != IOX2_OK) {
+    if (result != IOX2_OK) {
         IOX2_PANIC("This should never happen! Implementation failure while setting the User-Header-Type.");
     }
 }
 
 template <typename Payload, typename UserHeader, ServiceType S>
-inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_payload_type_details() {
+inline void
+ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::override_user_header_type_details(const TypeDetail& value) {
+    // user header type details provided at runtime
+    const auto type_variant =
+        value.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
+
+    const auto result = iox2_service_builder_pub_sub_set_user_header_type_details(
+        &m_handle, type_variant, value.type_name(), std::strlen(value.type_name()), value.size(), value.alignment());
+
+    if (result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the User-Header-Type.");
+    }
+}
+
+template <typename Payload, typename UserHeader, ServiceType S>
+inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::derive_payload_type_details() {
     using ValueType = typename PayloadInfo<Payload>::ValueType;
 
-    // payload type details, derived from the compile-time Payload unless overridden at runtime
-    const auto derived_type_name = internal::get_type_name<Payload>();
-    auto type_variant = bb::IsSlice<Payload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
-    const char* payload_type_name = derived_type_name.unchecked_access().c_str();
-    uint64_t payload_type_name_len = derived_type_name.size();
-    uint64_t payload_type_size = sizeof(ValueType);
-    uint64_t payload_type_align = alignof(ValueType);
+    // payload type details derived from the compile-time Payload
+    const auto payload_type_name = internal::get_type_name<Payload>();
+    const auto type_variant =
+        bb::IsSlice<Payload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
 
-    if (m_payload_type_details_override.has_value()) {
-        const auto& payload_details_override = m_payload_type_details_override.value();
-        type_variant = payload_details_override.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE
-                                                                                    : iox2_type_variant_e_DYNAMIC;
-        payload_type_name = payload_details_override.type_name();
-        payload_type_name_len = std::strlen(payload_details_override.type_name());
-        payload_type_size = payload_details_override.size();
-        payload_type_align = payload_details_override.alignment();
+    const auto result =
+        iox2_service_builder_pub_sub_set_payload_type_details(&m_handle,
+                                                              type_variant,
+                                                              payload_type_name.unchecked_access().c_str(),
+                                                              payload_type_name.size(),
+                                                              sizeof(ValueType),
+                                                              alignof(ValueType));
+
+    if (result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the Payload-Type.");
     }
+}
 
-    const auto payload_result = iox2_service_builder_pub_sub_set_payload_type_details(
-        &m_handle, type_variant, payload_type_name, payload_type_name_len, payload_type_size, payload_type_align);
+template <typename Payload, typename UserHeader, ServiceType S>
+inline void
+ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::override_payload_type_details(const TypeDetail& value) {
+    // payload type details provided at runtime
+    const auto type_variant =
+        value.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
 
-    if (payload_result != IOX2_OK) {
+    const auto result = iox2_service_builder_pub_sub_set_payload_type_details(
+        &m_handle, type_variant, value.type_name(), std::strlen(value.type_name()), value.size(), value.alignment());
+
+    if (result != IOX2_OK) {
         IOX2_PANIC("This should never happen! Implementation failure while setting the Payload-Type.");
     }
 }
@@ -283,19 +331,23 @@ inline auto ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::
 }
 
 template <typename Payload, typename UserHeader, ServiceType S>
-template <typename, typename>
-inline auto ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_user_header_type_details(
-    const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&& {
-    m_user_header_type_details_override = bb::Optional<TypeDetail>(value);
+inline auto ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::
+    resume_build() & -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&& {
     return std::move(*this);
 }
 
 template <typename Payload, typename UserHeader, ServiceType S>
-template <typename, typename>
-inline auto ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_payload_type_details(
-    const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&& {
-    m_payload_type_details_override = bb::Optional<TypeDetail>(value);
-    return std::move(*this);
+inline auto set_user_header_type_details(ServiceBuilderPublishSubscribe<Payload, UserHeader, S>& builder,
+                                         const TypeDetail& value)
+    -> std::enable_if_t<std::is_same<UserHeader, CustomHeaderMarker>::value> {
+    builder.m_user_header_type_details_override = bb::Optional<TypeDetail>(value);
+}
+
+template <typename Payload, typename UserHeader, ServiceType S>
+inline auto set_payload_type_details(ServiceBuilderPublishSubscribe<Payload, UserHeader, S>& builder,
+                                     const TypeDetail& value)
+    -> std::enable_if_t<std::is_same<Payload, bb::Slice<CustomPayloadMarker>>::value> {
+    builder.m_payload_type_details_override = bb::Optional<TypeDetail>(value);
 }
 
 template <typename Payload, typename UserHeader, ServiceType S>

--- a/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -162,6 +162,8 @@ class ServiceBuilderPublishSubscribe {
     explicit ServiceBuilderPublishSubscribe(iox2_service_builder_h handle);
 
     void set_parameters();
+    void set_payload_type_details();
+    void set_user_header_type_details();
 
     iox2_service_builder_pub_sub_h m_handle = nullptr;
     bb::Optional<TypeDetail> m_user_header_type_details_override;
@@ -202,8 +204,12 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
         iox2_service_builder_pub_sub_set_max_nodes(&m_handle, m_max_nodes.value());
     }
 
-    using ValueType = typename PayloadInfo<Payload>::ValueType;
+    set_user_header_type_details();
+    set_payload_type_details();
+}
 
+template <typename Payload, typename UserHeader, ServiceType S>
+inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_user_header_type_details() {
     // user header type details, derived from the compile-time UserHeader unless overridden at runtime
     const auto header_layout = bb::Layout::from<UserHeader>();
     const auto derived_user_header_type_name = internal::get_type_name<UserHeader>();
@@ -223,6 +229,22 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
         user_header_type_size = header_details_override.size();
         user_header_type_align = header_details_override.alignment();
     }
+
+    const auto user_header_result = iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
+                                                                                              user_header_type_variant,
+                                                                                              user_header_type_name,
+                                                                                              user_header_type_name_len,
+                                                                                              user_header_type_size,
+                                                                                              user_header_type_align);
+
+    if (user_header_result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the User-Header-Type.");
+    }
+}
+
+template <typename Payload, typename UserHeader, ServiceType S>
+inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_payload_type_details() {
+    using ValueType = typename PayloadInfo<Payload>::ValueType;
 
     // payload type details, derived from the compile-time Payload unless overridden at runtime
     const auto derived_type_name = internal::get_type_name<Payload>();
@@ -248,18 +270,8 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
     if (payload_result != IOX2_OK) {
         IOX2_PANIC("This should never happen! Implementation failure while setting the Payload-Type.");
     }
-
-    const auto user_header_result = iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
-                                                                                              user_header_type_variant,
-                                                                                              user_header_type_name,
-                                                                                              user_header_type_name_len,
-                                                                                              user_header_type_size,
-                                                                                              user_header_type_align);
-
-    if (user_header_result != IOX2_OK) {
-        IOX2_PANIC("This should never happen! Implementation failure while setting the User-Header-Type.");
-    }
 }
+
 
 template <typename Payload, typename UserHeader, ServiceType S>
 template <typename NewHeader>

--- a/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe.hpp
@@ -19,6 +19,7 @@
 #include "iox2/bb/expected.hpp"
 #include "iox2/bb/layout.hpp"
 #include "iox2/bb/slice.hpp"
+#include "iox2/custom_header_marker.hpp"
 #include "iox2/custom_payload_marker.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 #include "iox2/internal/service_builder_internal.hpp"
@@ -114,10 +115,17 @@ class ServiceBuilderPublishSubscribe {
     template <typename NewHeader>
     auto user_header() && -> ServiceBuilderPublishSubscribe<Payload, NewHeader, S>&&;
 
+    /// Overrides the user header type details with values provided at runtime instead of derived
+    /// from the compile-time `UserHeader`. Only available for `CustomHeaderMarker`.
+    template <typename H = UserHeader, typename = std::enable_if_t<std::is_same<H, CustomHeaderMarker>::value>>
+    auto set_user_header_type_details(
+        const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&&;
+
     /// Overrides the payload type details with values provided at runtime instead of derived
     /// from the compile-time `Payload`. Only available for `bb::Slice<CustomPayloadMarker>`.
     template <typename P = Payload, typename = std::enable_if_t<std::is_same<P, bb::Slice<CustomPayloadMarker>>::value>>
-    auto set_payload_type_details(const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&&;
+    auto
+    set_payload_type_details(const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&&;
 
     /// If the [`Service`] exists, it will be opened otherwise a new [`Service`] will be
     /// created.
@@ -156,6 +164,7 @@ class ServiceBuilderPublishSubscribe {
     void set_parameters();
 
     iox2_service_builder_pub_sub_h m_handle = nullptr;
+    bb::Optional<TypeDetail> m_user_header_type_details_override;
     bb::Optional<TypeDetail> m_payload_type_details_override;
 };
 
@@ -195,6 +204,26 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
 
     using ValueType = typename PayloadInfo<Payload>::ValueType;
 
+    // user header type details, derived from the compile-time UserHeader unless overridden at runtime
+    const auto header_layout = bb::Layout::from<UserHeader>();
+    const auto derived_user_header_type_name = internal::get_type_name<UserHeader>();
+    auto user_header_type_variant = iox2_type_variant_e_FIXED_SIZE;
+    const char* user_header_type_name = derived_user_header_type_name.unchecked_access().c_str();
+    uint64_t user_header_type_name_len = derived_user_header_type_name.size();
+    uint64_t user_header_type_size = header_layout.size();
+    uint64_t user_header_type_align = header_layout.alignment();
+
+    if (m_user_header_type_details_override.has_value()) {
+        const auto& header_details_override = m_user_header_type_details_override.value();
+        user_header_type_variant = header_details_override.variant() == TypeVariant::FixedSize
+                                       ? iox2_type_variant_e_FIXED_SIZE
+                                       : iox2_type_variant_e_DYNAMIC;
+        user_header_type_name = header_details_override.type_name();
+        user_header_type_name_len = std::strlen(header_details_override.type_name());
+        user_header_type_size = header_details_override.size();
+        user_header_type_align = header_details_override.alignment();
+    }
+
     // payload type details, derived from the compile-time Payload unless overridden at runtime
     const auto derived_type_name = internal::get_type_name<Payload>();
     auto type_variant = bb::IsSlice<Payload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
@@ -204,13 +233,13 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
     uint64_t payload_type_align = alignof(ValueType);
 
     if (m_payload_type_details_override.has_value()) {
-        const auto& details = m_payload_type_details_override.value();
-        type_variant =
-            details.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
-        payload_type_name = details.type_name();
-        payload_type_name_len = std::strlen(details.type_name());
-        payload_type_size = details.size();
-        payload_type_align = details.alignment();
+        const auto& payload_details_override = m_payload_type_details_override.value();
+        type_variant = payload_details_override.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE
+                                                                                    : iox2_type_variant_e_DYNAMIC;
+        payload_type_name = payload_details_override.type_name();
+        payload_type_name_len = std::strlen(payload_details_override.type_name());
+        payload_type_size = payload_details_override.size();
+        payload_type_align = payload_details_override.alignment();
     }
 
     const auto payload_result = iox2_service_builder_pub_sub_set_payload_type_details(
@@ -220,19 +249,12 @@ inline void ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_paramete
         IOX2_PANIC("This should never happen! Implementation failure while setting the Payload-Type.");
     }
 
-    // user header type details
-    const auto header_layout = bb::Layout::from<UserHeader>();
-    const auto user_header_type_name = internal::get_type_name<UserHeader>();
-    const auto user_header_type_size = header_layout.size();
-    const auto user_header_type_align = header_layout.alignment();
-
-    const auto user_header_result =
-        iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
-                                                                  iox2_type_variant_e_FIXED_SIZE,
-                                                                  user_header_type_name.unchecked_access().c_str(),
-                                                                  user_header_type_name.size(),
-                                                                  user_header_type_size,
-                                                                  user_header_type_align);
+    const auto user_header_result = iox2_service_builder_pub_sub_set_user_header_type_details(&m_handle,
+                                                                                              user_header_type_variant,
+                                                                                              user_header_type_name,
+                                                                                              user_header_type_name_len,
+                                                                                              user_header_type_size,
+                                                                                              user_header_type_align);
 
     if (user_header_result != IOX2_OK) {
         IOX2_PANIC("This should never happen! Implementation failure while setting the User-Header-Type.");
@@ -246,6 +268,14 @@ inline auto ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::
     // required here since we just change the template header type but the builder structure stays the same
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return std::move(*reinterpret_cast<ServiceBuilderPublishSubscribe<Payload, NewHeader, S>*>(this));
+}
+
+template <typename Payload, typename UserHeader, ServiceType S>
+template <typename, typename>
+inline auto ServiceBuilderPublishSubscribe<Payload, UserHeader, S>::set_user_header_type_details(
+    const TypeDetail& value) && -> ServiceBuilderPublishSubscribe<Payload, UserHeader, S>&& {
+    m_user_header_type_details_override = bb::Optional<TypeDetail>(value);
+    return std::move(*this);
 }
 
 template <typename Payload, typename UserHeader, ServiceType S>

--- a/iceoryx2-cxx/include/iox2/service_builder_request_response.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_request_response.hpp
@@ -18,14 +18,102 @@
 #include "iox2/bb/detail/builder.hpp"
 #include "iox2/bb/expected.hpp"
 #include "iox2/bb/layout.hpp"
+#include "iox2/bb/slice.hpp"
+#include "iox2/custom_header_marker.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/internal/iceoryx2.hpp"
 #include "iox2/internal/service_builder_internal.hpp"
+#include "iox2/message_type_details.hpp"
 #include "iox2/payload_info.hpp"
 #include "iox2/port_factory_request_response.hpp"
 #include "iox2/service_builder_request_response_error.hpp"
 #include "iox2/service_type.hpp"
+#include "iox2/type_name.hpp"
+#include "iox2/type_variant.hpp"
+
+#include <cstring>
+#include <type_traits>
 
 namespace iox2 {
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+class ServiceBuilderRequestResponse;
+
+/// Overrides the request user header type details with values provided at runtime instead of derived
+/// from the compile-time `RequestUserHeader`. Only available for `CustomHeaderMarker`.
+///
+/// # Safety
+///
+///  * It is preferred to let the type details be derived from the provided type; overriding them is
+///    only meant for advanced usage.
+///  * The provided [`TypeDetail`] must accurately describe the request user header type that is
+///    accessed at runtime; a mismatching size or alignment leads to undefined behavior.
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+auto set_request_header_type_details(
+    ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>& builder,
+    const TypeDetail& value) -> std::enable_if_t<std::is_same<RequestUserHeader, CustomHeaderMarker>::value>;
+
+/// Overrides the response user header type details with values provided at runtime instead of
+/// derived from the compile-time `ResponseUserHeader`. Only available for `CustomHeaderMarker`.
+///
+/// # Safety
+///
+///  * It is preferred to let the type details be derived from the provided type; overriding them is
+///    only meant for advanced usage.
+///  * The provided [`TypeDetail`] must accurately describe the response user header type that is
+///    accessed at runtime; a mismatching size or alignment leads to undefined behavior.
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+auto set_response_header_type_details(
+    ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>& builder,
+    const TypeDetail& value) -> std::enable_if_t<std::is_same<ResponseUserHeader, CustomHeaderMarker>::value>;
+
+/// Overrides the request payload type details with values provided at runtime instead of derived
+/// from the compile-time `RequestPayload`. Only available for `bb::Slice<CustomPayloadMarker>`.
+///
+/// # Safety
+///
+///  * It is preferred to let the type details be derived from the provided type; overriding them is
+///    only meant for advanced usage.
+///  * The provided [`TypeDetail`] must accurately describe the request payload type that is loaned,
+///    sent and received at runtime; a mismatching size or alignment leads to undefined behavior.
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+auto set_request_payload_type_details(
+    ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>& builder,
+    const TypeDetail& value) -> std::enable_if_t<std::is_same<RequestPayload, bb::Slice<CustomPayloadMarker>>::value>;
+
+/// Overrides the response payload type details with values provided at runtime instead of derived
+/// from the compile-time `ResponsePayload`. Only available for `bb::Slice<CustomPayloadMarker>`.
+///
+/// # Safety
+///
+///  * It is preferred to let the type details be derived from the provided type; overriding them is
+///    only meant for advanced usage.
+///  * The provided [`TypeDetail`] must accurately describe the response payload type that is loaned,
+///    sent and received at runtime; a mismatching size or alignment leads to undefined behavior.
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+auto set_response_payload_type_details(
+    ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>& builder,
+    const TypeDetail& value) -> std::enable_if_t<std::is_same<ResponsePayload, bb::Slice<CustomPayloadMarker>>::value>;
+
 template <typename RequestPayload,
           typename RequestUserHeader,
           typename ResponsePayload,
@@ -157,6 +245,15 @@ class ServiceBuilderRequestResponse {
                                                                     NewResponseUserHeader,
                                                                     S>&&;
 
+    /// Returns the builder as an r-value so the fluent chain can be resumed after a free function,
+    /// such as [`set_request_header_type_details()`] or [`set_request_payload_type_details()`], has
+    /// been applied to the named builder.
+    auto resume_build() & -> ServiceBuilderRequestResponse<RequestPayload,
+                                                           RequestUserHeader,
+                                                           ResponsePayload,
+                                                           ResponseUserHeader,
+                                                           S>&&;
+
     /// If the [`Service`] exists, it will be opened otherwise a new [`Service`] will be
     /// created.
     auto open_or_create() && -> bb::Expected<
@@ -198,11 +295,40 @@ class ServiceBuilderRequestResponse {
     template <ServiceType>
     friend class ServiceBuilder;
 
+    template <typename ReqP, typename ReqH, typename ResP, typename ResH, ServiceType St>
+    friend auto set_request_header_type_details(ServiceBuilderRequestResponse<ReqP, ReqH, ResP, ResH, St>& builder,
+                                                const TypeDetail& value)
+        -> std::enable_if_t<std::is_same<ReqH, CustomHeaderMarker>::value>;
+    template <typename ReqP, typename ReqH, typename ResP, typename ResH, ServiceType St>
+    friend auto set_response_header_type_details(ServiceBuilderRequestResponse<ReqP, ReqH, ResP, ResH, St>& builder,
+                                                 const TypeDetail& value)
+        -> std::enable_if_t<std::is_same<ResH, CustomHeaderMarker>::value>;
+    template <typename ReqP, typename ReqH, typename ResP, typename ResH, ServiceType St>
+    friend auto set_request_payload_type_details(ServiceBuilderRequestResponse<ReqP, ReqH, ResP, ResH, St>& builder,
+                                                 const TypeDetail& value)
+        -> std::enable_if_t<std::is_same<ReqP, bb::Slice<CustomPayloadMarker>>::value>;
+    template <typename ReqP, typename ReqH, typename ResP, typename ResH, ServiceType St>
+    friend auto set_response_payload_type_details(ServiceBuilderRequestResponse<ReqP, ReqH, ResP, ResH, St>& builder,
+                                                  const TypeDetail& value)
+        -> std::enable_if_t<std::is_same<ResP, bb::Slice<CustomPayloadMarker>>::value>;
+
     explicit ServiceBuilderRequestResponse(iox2_service_builder_h handle);
 
     void set_parameters();
+    void derive_request_header_type_details();
+    void override_request_header_type_details(const TypeDetail& value);
+    void derive_response_header_type_details();
+    void override_response_header_type_details(const TypeDetail& value);
+    void derive_request_payload_type_details();
+    void override_request_payload_type_details(const TypeDetail& value);
+    void derive_response_payload_type_details();
+    void override_response_payload_type_details(const TypeDetail& value);
 
     iox2_service_builder_request_response_h m_handle = nullptr;
+    bb::Optional<TypeDetail> m_request_header_type_details_override;
+    bb::Optional<TypeDetail> m_response_header_type_details_override;
+    bb::Optional<TypeDetail> m_request_payload_type_details_override;
+    bb::Optional<TypeDetail> m_response_payload_type_details_override;
 };
 
 template <typename RequestPayload,
@@ -247,6 +373,20 @@ inline auto ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, Res
                                                         ResponsePayload,
                                                         NewResponseUserHeader,
                                                         S>*>(this));
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline auto ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    resume_build() & -> ServiceBuilderRequestResponse<RequestPayload,
+                                                      RequestUserHeader,
+                                                      ResponsePayload,
+                                                      ResponseUserHeader,
+                                                      S>&& {
+    return std::move(*this);
 }
 
 template <typename RequestPayload,
@@ -445,83 +585,251 @@ inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, Res
             &m_handle, m_enable_fire_and_forget_requests.value());
     }
 
-    // request payload type details
-    using RequestValueType = typename PayloadInfo<RequestPayload>::ValueType;
-    auto type_variant_request_payload =
-        bb::IsSlice<RequestPayload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
-
-    const auto request_payload_type_name = internal::get_type_name<RequestPayload>();
-    const auto request_payload_type_size = sizeof(RequestValueType);
-    const auto request_payload_type_align = alignof(RequestValueType);
-
-    const auto request_payload_result = iox2_service_builder_request_response_set_request_payload_type_details(
-        &m_handle,
-        type_variant_request_payload,
-        request_payload_type_name.unchecked_access().c_str(),
-        request_payload_type_name.size(),
-        request_payload_type_size,
-        request_payload_type_align);
-
-    if (request_payload_result != IOX2_OK) {
-        IOX2_PANIC("This should never happen! Implementation failure while setting the RequestPayload-Type.");
+    if (m_request_header_type_details_override.has_value()) {
+        override_request_header_type_details(m_request_header_type_details_override.value());
+    } else {
+        derive_request_header_type_details();
     }
 
-    // response payload type details
-    using ResponseValueType = typename PayloadInfo<ResponsePayload>::ValueType;
-    auto type_variant_response_payload =
-        bb::IsSlice<ResponsePayload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
-
-    const auto response_payload_type_name = internal::get_type_name<ResponsePayload>();
-    const auto response_payload_type_size = sizeof(ResponseValueType);
-    const auto response_payload_type_align = alignof(ResponseValueType);
-
-    const auto response_payload_result = iox2_service_builder_request_response_set_response_payload_type_details(
-        &m_handle,
-        type_variant_response_payload,
-        response_payload_type_name.unchecked_access().c_str(),
-        response_payload_type_name.size(),
-        response_payload_type_size,
-        response_payload_type_align);
-
-    if (response_payload_result != IOX2_OK) {
-        IOX2_PANIC("This should never happen! Implementation failure while setting the ResponsePayload-Type.");
+    if (m_response_header_type_details_override.has_value()) {
+        override_response_header_type_details(m_response_header_type_details_override.value());
+    } else {
+        derive_response_header_type_details();
     }
 
-    // request header type details
-    const auto request_header_layout = bb::Layout::from<RequestUserHeader>();
-    const auto request_header_type_name = internal::get_type_name<RequestUserHeader>();
-    const auto request_header_type_size = request_header_layout.size();
-    const auto request_header_type_align = request_header_layout.alignment();
+    if (m_request_payload_type_details_override.has_value()) {
+        override_request_payload_type_details(m_request_payload_type_details_override.value());
+    } else {
+        derive_request_payload_type_details();
+    }
 
-    const auto request_header_result = iox2_service_builder_request_response_set_request_header_type_details(
+    if (m_response_payload_type_details_override.has_value()) {
+        override_response_payload_type_details(m_response_payload_type_details_override.value());
+    } else {
+        derive_response_payload_type_details();
+    }
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    derive_request_header_type_details() {
+    // request header type details derived from the compile-time RequestUserHeader
+    const auto header_layout = bb::Layout::from<RequestUserHeader>();
+    const auto header_type_name = internal::get_type_name<RequestUserHeader>();
+
+    const auto result = iox2_service_builder_request_response_set_request_header_type_details(
         &m_handle,
         iox2_type_variant_e_FIXED_SIZE,
-        request_header_type_name.unchecked_access().c_str(),
-        request_header_type_name.size(),
-        request_header_type_size,
-        request_header_type_align);
+        header_type_name.unchecked_access().c_str(),
+        header_type_name.size(),
+        header_layout.size(),
+        header_layout.alignment());
 
-    if (request_header_result != IOX2_OK) {
+    if (result != IOX2_OK) {
         IOX2_PANIC("This should never happen! Implementation failure while setting the Request-Header-Type.");
     }
+}
 
-    // response header type details
-    const auto response_header_layout = bb::Layout::from<ResponseUserHeader>();
-    const auto response_header_type_name = internal::get_type_name<ResponseUserHeader>();
-    const auto response_header_type_size = response_header_layout.size();
-    const auto response_header_type_align = response_header_layout.alignment();
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    override_request_header_type_details(const TypeDetail& value) {
+    // request header type details provided at runtime
+    const auto type_variant =
+        value.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
 
-    const auto response_header_result = iox2_service_builder_request_response_set_response_header_type_details(
+    const auto result = iox2_service_builder_request_response_set_request_header_type_details(
+        &m_handle, type_variant, value.type_name(), std::strlen(value.type_name()), value.size(), value.alignment());
+
+    if (result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the Request-Header-Type.");
+    }
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    derive_response_header_type_details() {
+    // response header type details derived from the compile-time ResponseUserHeader
+    const auto header_layout = bb::Layout::from<ResponseUserHeader>();
+    const auto header_type_name = internal::get_type_name<ResponseUserHeader>();
+
+    const auto result = iox2_service_builder_request_response_set_response_header_type_details(
         &m_handle,
         iox2_type_variant_e_FIXED_SIZE,
-        response_header_type_name.unchecked_access().c_str(),
-        response_header_type_name.size(),
-        response_header_type_size,
-        response_header_type_align);
+        header_type_name.unchecked_access().c_str(),
+        header_type_name.size(),
+        header_layout.size(),
+        header_layout.alignment());
 
-    if (response_header_result != IOX2_OK) {
+    if (result != IOX2_OK) {
         IOX2_PANIC("This should never happen! Implementation failure while setting the Response-Header-Type.");
     }
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    override_response_header_type_details(const TypeDetail& value) {
+    // response header type details provided at runtime
+    const auto type_variant =
+        value.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
+
+    const auto result = iox2_service_builder_request_response_set_response_header_type_details(
+        &m_handle, type_variant, value.type_name(), std::strlen(value.type_name()), value.size(), value.alignment());
+
+    if (result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the Response-Header-Type.");
+    }
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    derive_request_payload_type_details() {
+    using ValueType = typename PayloadInfo<RequestPayload>::ValueType;
+
+    // request payload type details derived from the compile-time RequestPayload
+    const auto payload_type_name = internal::get_type_name<RequestPayload>();
+    const auto type_variant =
+        bb::IsSlice<RequestPayload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
+
+    const auto result = iox2_service_builder_request_response_set_request_payload_type_details(
+        &m_handle,
+        type_variant,
+        payload_type_name.unchecked_access().c_str(),
+        payload_type_name.size(),
+        sizeof(ValueType),
+        alignof(ValueType));
+
+    if (result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the RequestPayload-Type.");
+    }
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    override_request_payload_type_details(const TypeDetail& value) {
+    // request payload type details provided at runtime
+    const auto type_variant =
+        value.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
+
+    const auto result = iox2_service_builder_request_response_set_request_payload_type_details(
+        &m_handle, type_variant, value.type_name(), std::strlen(value.type_name()), value.size(), value.alignment());
+
+    if (result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the RequestPayload-Type.");
+    }
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    derive_response_payload_type_details() {
+    using ValueType = typename PayloadInfo<ResponsePayload>::ValueType;
+
+    // response payload type details derived from the compile-time ResponsePayload
+    const auto payload_type_name = internal::get_type_name<ResponsePayload>();
+    const auto type_variant =
+        bb::IsSlice<ResponsePayload>::VALUE ? iox2_type_variant_e_DYNAMIC : iox2_type_variant_e_FIXED_SIZE;
+
+    const auto result = iox2_service_builder_request_response_set_response_payload_type_details(
+        &m_handle,
+        type_variant,
+        payload_type_name.unchecked_access().c_str(),
+        payload_type_name.size(),
+        sizeof(ValueType),
+        alignof(ValueType));
+
+    if (result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the ResponsePayload-Type.");
+    }
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline void ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>::
+    override_response_payload_type_details(const TypeDetail& value) {
+    // response payload type details provided at runtime
+    const auto type_variant =
+        value.variant() == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
+
+    const auto result = iox2_service_builder_request_response_set_response_payload_type_details(
+        &m_handle, type_variant, value.type_name(), std::strlen(value.type_name()), value.size(), value.alignment());
+
+    if (result != IOX2_OK) {
+        IOX2_PANIC("This should never happen! Implementation failure while setting the ResponsePayload-Type.");
+    }
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline auto set_request_header_type_details(
+    ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>& builder,
+    const TypeDetail& value) -> std::enable_if_t<std::is_same<RequestUserHeader, CustomHeaderMarker>::value> {
+    builder.m_request_header_type_details_override = bb::Optional<TypeDetail>(value);
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline auto set_response_header_type_details(
+    ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>& builder,
+    const TypeDetail& value) -> std::enable_if_t<std::is_same<ResponseUserHeader, CustomHeaderMarker>::value> {
+    builder.m_response_header_type_details_override = bb::Optional<TypeDetail>(value);
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline auto set_request_payload_type_details(
+    ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>& builder,
+    const TypeDetail& value) -> std::enable_if_t<std::is_same<RequestPayload, bb::Slice<CustomPayloadMarker>>::value> {
+    builder.m_request_payload_type_details_override = bb::Optional<TypeDetail>(value);
+}
+
+template <typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader,
+          ServiceType S>
+inline auto set_response_payload_type_details(
+    ServiceBuilderRequestResponse<RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader, S>& builder,
+    const TypeDetail& value) -> std::enable_if_t<std::is_same<ResponsePayload, bb::Slice<CustomPayloadMarker>>::value> {
+    builder.m_response_payload_type_details_override = bb::Optional<TypeDetail>(value);
 }
 } // namespace iox2
 #endif

--- a/iceoryx2-cxx/src/message_type_details.cpp
+++ b/iceoryx2-cxx/src/message_type_details.cpp
@@ -13,9 +13,21 @@
 #include "iox2/message_type_details.hpp"
 #include "iox2/bb/into.hpp"
 
+#include <cstring>
+
 namespace iox2 {
 TypeDetail::TypeDetail(iox2_type_detail_t value)
     : m_value { value } {
+}
+
+TypeDetail::TypeDetail(TypeVariant variant, const char* type_name, size_t size, size_t alignment)
+    : m_value {} {
+    m_value.variant = variant == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;
+    m_value.size = size;
+    m_value.alignment = alignment;
+
+    m_value.type_name[IOX2_TYPE_NAME_LENGTH - 1] = '\0';
+    std::strncpy(&m_value.type_name[0], type_name, IOX2_TYPE_NAME_LENGTH - 1);
 }
 
 auto TypeDetail::variant() const -> TypeVariant {

--- a/iceoryx2-cxx/src/message_type_details.cpp
+++ b/iceoryx2-cxx/src/message_type_details.cpp
@@ -20,6 +20,7 @@ TypeDetail::TypeDetail(iox2_type_detail_t value)
     : m_value { value } {
 }
 
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 TypeDetail::TypeDetail(TypeVariant variant, const char* type_name, size_t size, size_t alignment)
     : m_value {} {
     m_value.variant = variant == TypeVariant::FixedSize ? iox2_type_variant_e_FIXED_SIZE : iox2_type_variant_e_DYNAMIC;

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -1720,63 +1720,63 @@ TYPED_TEST(ServicePublishSubscribeTest, only_max_subscribers_can_be_created) {
 
 TYPED_TEST(ServicePublishSubscribeTest, custom_user_header_type_details_override_is_applied) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* HEADER_TYPE_NAME = "MyHeader";
     constexpr uint64_t HEADER_SIZE = 16;
     constexpr uint64_t HEADER_ALIGNMENT = 8;
     const auto service_name = iox2_testing::generate_service_name();
 
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
-    auto service =
-        node.service_builder(service_name)
-            .template publish_subscribe<uint64_t>()
-            .template user_header<CustomHeaderMarker>()
-            .set_user_header_type_details(TypeDetail(TypeVariant::FixedSize, "MyHeader", HEADER_SIZE, HEADER_ALIGNMENT))
-            .create()
-            .value();
+    auto service_builder = node.service_builder(service_name)
+                               .template publish_subscribe<uint64_t>()
+                               .template user_header<CustomHeaderMarker>();
+    set_user_header_type_details(service_builder,
+                                 TypeDetail(TypeVariant::FixedSize, HEADER_TYPE_NAME, HEADER_SIZE, HEADER_ALIGNMENT));
+    auto service = service_builder.resume_build().create().value();
 
     auto user_header = service.static_config().message_type_details().user_header();
     ASSERT_THAT(user_header.variant(), Eq(TypeVariant::FixedSize));
-    ASSERT_THAT(user_header.type_name(), StrEq("MyHeader"));
+    ASSERT_THAT(user_header.type_name(), StrEq(HEADER_TYPE_NAME));
     ASSERT_THAT(user_header.size(), Eq(HEADER_SIZE));
     ASSERT_THAT(user_header.alignment(), Eq(HEADER_ALIGNMENT));
 }
 
 TYPED_TEST(ServicePublishSubscribeTest, custom_payload_type_details_override_is_applied) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* PAYLOAD_TYPE_NAME = "MyType";
     constexpr uint64_t PAYLOAD_SIZE = 12;
     constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
 
     const auto service_name = iox2_testing::generate_service_name();
 
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
-    auto service =
-        node.service_builder(service_name)
-            .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
-            .set_payload_type_details(TypeDetail(TypeVariant::FixedSize, "MyType", PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
-            .create()
-            .value();
+    auto service_builder =
+        node.service_builder(service_name).template publish_subscribe<bb::Slice<CustomPayloadMarker>>();
+    set_payload_type_details(service_builder,
+                             TypeDetail(TypeVariant::FixedSize, PAYLOAD_TYPE_NAME, PAYLOAD_SIZE, PAYLOAD_ALIGNMENT));
+    auto service = service_builder.resume_build().create().value();
 
     auto payload = service.static_config().message_type_details().payload();
 
     ASSERT_THAT(payload.variant(), Eq(TypeVariant::FixedSize));
-    ASSERT_THAT(payload.type_name(), StrEq("MyType"));
+    ASSERT_THAT(payload.type_name(), StrEq(PAYLOAD_TYPE_NAME));
     ASSERT_THAT(payload.size(), Eq(PAYLOAD_SIZE));
     ASSERT_THAT(payload.alignment(), Eq(PAYLOAD_ALIGNMENT));
 }
 
 TYPED_TEST(ServicePublishSubscribeTest, custom_payload_marker_send_receive_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* PAYLOAD_TYPE_NAME = "MyType";
     constexpr uint64_t PAYLOAD_SIZE = 12;
     constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
 
     const auto service_name = iox2_testing::generate_service_name();
 
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
-    auto service =
-        node.service_builder(service_name)
-            .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
-            .set_payload_type_details(TypeDetail(TypeVariant::FixedSize, "MyType", PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
-            .create()
-            .value();
+    auto service_builder =
+        node.service_builder(service_name).template publish_subscribe<bb::Slice<CustomPayloadMarker>>();
+    set_payload_type_details(service_builder,
+                             TypeDetail(TypeVariant::FixedSize, PAYLOAD_TYPE_NAME, PAYLOAD_SIZE, PAYLOAD_ALIGNMENT));
+    auto service = service_builder.resume_build().create().value();
 
     auto sut_publisher = service.publisher_builder().initial_max_slice_len(1).create().value();
     auto sut_subscriber = service.subscriber_builder().create().value();

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -1763,32 +1763,50 @@ TYPED_TEST(ServicePublishSubscribeTest, custom_payload_type_details_override_is_
     ASSERT_THAT(payload.alignment(), Eq(PAYLOAD_ALIGNMENT));
 }
 
-TYPED_TEST(ServicePublishSubscribeTest, custom_payload_marker_send_receive_works) {
+// NOLINTBEGIN(readability-function-cognitive-complexity), false positive caused by ASSERT_THAT
+TYPED_TEST(ServicePublishSubscribeTest, custom_header_payload_marker_send_receive_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* HEADER_TYPE_NAME = "MyHeader";
+    constexpr uint64_t HEADER_SIZE = 16;
+    constexpr uint64_t HEADER_ALIGNMENT = 8;
+    constexpr uint8_t HEADER_BASE_VALUE = 100;
     constexpr const char* PAYLOAD_TYPE_NAME = "MyType";
-    constexpr uint64_t PAYLOAD_SIZE = 12;
+    constexpr uint64_t PAYLOAD_SIZE = 16;
     constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
+    constexpr uint8_t PAYLOAD_BASE_VALUE = 1;
 
     const auto service_name = iox2_testing::generate_service_name();
 
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
-    auto service_builder =
-        node.service_builder(service_name).template publish_subscribe<bb::Slice<CustomPayloadMarker>>();
+    auto service_builder = node.service_builder(service_name)
+                               .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
+                               .template user_header<CustomHeaderMarker>();
+
+    set_user_header_type_details(service_builder,
+                                 TypeDetail(TypeVariant::FixedSize, HEADER_TYPE_NAME, HEADER_SIZE, HEADER_ALIGNMENT));
     set_payload_type_details(service_builder,
                              TypeDetail(TypeVariant::FixedSize, PAYLOAD_TYPE_NAME, PAYLOAD_SIZE, PAYLOAD_ALIGNMENT));
+
     auto service = service_builder.resume_build().create().value();
 
     auto sut_publisher = service.publisher_builder().initial_max_slice_len(1).create().value();
     auto sut_subscriber = service.subscriber_builder().create().value();
 
+    // Publisher: populate the payload and header, then send.
     auto send_sample = sut_publisher.loan_slice_uninit(1).value();
     auto send_payload = send_sample.payload_mut();
     ASSERT_THAT(send_payload.number_of_bytes(), Eq(PAYLOAD_SIZE));
     for (uint64_t i = 0; i < PAYLOAD_SIZE; ++i) {
-        send_payload[i].value = static_cast<uint8_t>(i + 1);
+        send_payload[i].value = static_cast<uint8_t>(PAYLOAD_BASE_VALUE + i);
     }
+    auto& send_header = send_sample.template user_header_mut<std::array<uint8_t, HEADER_SIZE>>();
+    for (uint64_t i = 0; i < HEADER_SIZE; ++i) {
+        send_header.at(i) = static_cast<uint8_t>(HEADER_BASE_VALUE + i);
+    }
+
     send(assume_init(std::move(send_sample))).value();
 
+    // Subscriber: verify the received payload and header bytes.
     auto recv_result = sut_subscriber.receive().value();
     ASSERT_TRUE(recv_result.has_value());
 
@@ -1796,8 +1814,13 @@ TYPED_TEST(ServicePublishSubscribeTest, custom_payload_marker_send_receive_works
     auto recv_payload = recv_sample.payload();
     ASSERT_THAT(recv_payload.number_of_bytes(), Eq(PAYLOAD_SIZE));
     for (uint64_t i = 0; i < PAYLOAD_SIZE; ++i) {
-        ASSERT_THAT(recv_payload[i].value, Eq(static_cast<uint8_t>(i + 1)));
+        ASSERT_THAT(recv_payload[i].value, Eq(static_cast<uint8_t>(PAYLOAD_BASE_VALUE + i)));
+    }
+    const auto& recv_header = recv_sample.template user_header<std::array<uint8_t, HEADER_SIZE>>();
+    for (uint64_t i = 0; i < HEADER_SIZE; ++i) {
+        ASSERT_THAT(recv_header.at(i), Eq(static_cast<uint8_t>(HEADER_BASE_VALUE + i)));
     }
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 } // namespace

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #include "iox2/bb/optional.hpp"
+#include "iox2/custom_header_marker.hpp"
 #include "iox2/custom_payload_marker.hpp"
 #include "iox2/legacy/uninitialized_array.hpp"
 #include "iox2/message_type_details.hpp"
@@ -1717,6 +1718,28 @@ TYPED_TEST(ServicePublishSubscribeTest, only_max_subscribers_can_be_created) {
     ASSERT_TRUE(sut.has_value());
 }
 
+TYPED_TEST(ServicePublishSubscribeTest, custom_user_header_type_details_override_is_applied) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint64_t HEADER_SIZE = 16;
+    constexpr uint64_t HEADER_ALIGNMENT = 8;
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service =
+        node.service_builder(service_name)
+            .template publish_subscribe<uint64_t>()
+            .template user_header<CustomHeaderMarker>()
+            .set_user_header_type_details(TypeDetail(TypeVariant::FixedSize, "MyHeader", HEADER_SIZE, HEADER_ALIGNMENT))
+            .create()
+            .value();
+
+    auto user_header = service.static_config().message_type_details().user_header();
+    ASSERT_THAT(user_header.variant(), Eq(TypeVariant::FixedSize));
+    ASSERT_THAT(user_header.type_name(), StrEq("MyHeader"));
+    ASSERT_THAT(user_header.size(), Eq(HEADER_SIZE));
+    ASSERT_THAT(user_header.alignment(), Eq(HEADER_ALIGNMENT));
+}
+
 TYPED_TEST(ServicePublishSubscribeTest, custom_payload_type_details_override_is_applied) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
     constexpr uint64_t PAYLOAD_SIZE = 12;
@@ -1725,11 +1748,12 @@ TYPED_TEST(ServicePublishSubscribeTest, custom_payload_type_details_override_is_
     const auto service_name = iox2_testing::generate_service_name();
 
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
-    auto service = node.service_builder(service_name)
-                       .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
-                       .set_payload_type_details(TypeDetail(TypeVariant::FixedSize, "MyType", PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
-                       .create()
-                       .value();
+    auto service =
+        node.service_builder(service_name)
+            .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
+            .set_payload_type_details(TypeDetail(TypeVariant::FixedSize, "MyType", PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
+            .create()
+            .value();
 
     auto payload = service.static_config().message_type_details().payload();
 
@@ -1747,11 +1771,12 @@ TYPED_TEST(ServicePublishSubscribeTest, custom_payload_marker_send_receive_works
     const auto service_name = iox2_testing::generate_service_name();
 
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
-    auto service = node.service_builder(service_name)
-                       .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
-                       .set_payload_type_details(TypeDetail(TypeVariant::FixedSize, "MyType", PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
-                       .create()
-                       .value();
+    auto service =
+        node.service_builder(service_name)
+            .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
+            .set_payload_type_details(TypeDetail(TypeVariant::FixedSize, "MyType", PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
+            .create()
+            .value();
 
     auto sut_publisher = service.publisher_builder().initial_max_slice_len(1).create().value();
     auto sut_subscriber = service.subscriber_builder().create().value();
@@ -1774,4 +1799,5 @@ TYPED_TEST(ServicePublishSubscribeTest, custom_payload_marker_send_receive_works
         ASSERT_THAT(recv_payload[i].value, Eq(static_cast<uint8_t>(i + 1)));
     }
 }
+
 } // namespace

--- a/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_publish_subscribe_tests.cpp
@@ -11,9 +11,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #include "iox2/bb/optional.hpp"
+#include "iox2/custom_payload_marker.hpp"
 #include "iox2/legacy/uninitialized_array.hpp"
+#include "iox2/message_type_details.hpp"
 #include "iox2/node.hpp"
 #include "iox2/service.hpp"
+#include "iox2/type_variant.hpp"
 
 #include "test.hpp"
 #include <array>
@@ -1712,5 +1715,63 @@ TYPED_TEST(ServicePublishSubscribeTest, only_max_subscribers_can_be_created) {
 
     auto sut = service.subscriber_builder().create();
     ASSERT_TRUE(sut.has_value());
+}
+
+TYPED_TEST(ServicePublishSubscribeTest, custom_payload_type_details_override_is_applied) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint64_t PAYLOAD_SIZE = 12;
+    constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name)
+                       .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
+                       .set_payload_type_details(TypeDetail(TypeVariant::FixedSize, "MyType", PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
+                       .create()
+                       .value();
+
+    auto payload = service.static_config().message_type_details().payload();
+
+    ASSERT_THAT(payload.variant(), Eq(TypeVariant::FixedSize));
+    ASSERT_THAT(payload.type_name(), StrEq("MyType"));
+    ASSERT_THAT(payload.size(), Eq(PAYLOAD_SIZE));
+    ASSERT_THAT(payload.alignment(), Eq(PAYLOAD_ALIGNMENT));
+}
+
+TYPED_TEST(ServicePublishSubscribeTest, custom_payload_marker_send_receive_works) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint64_t PAYLOAD_SIZE = 12;
+    constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name)
+                       .template publish_subscribe<bb::Slice<CustomPayloadMarker>>()
+                       .set_payload_type_details(TypeDetail(TypeVariant::FixedSize, "MyType", PAYLOAD_SIZE, PAYLOAD_ALIGNMENT))
+                       .create()
+                       .value();
+
+    auto sut_publisher = service.publisher_builder().initial_max_slice_len(1).create().value();
+    auto sut_subscriber = service.subscriber_builder().create().value();
+
+    auto send_sample = sut_publisher.loan_slice_uninit(1).value();
+    auto send_payload = send_sample.payload_mut();
+    ASSERT_THAT(send_payload.number_of_bytes(), Eq(PAYLOAD_SIZE));
+    for (uint64_t i = 0; i < PAYLOAD_SIZE; ++i) {
+        send_payload[i].value = static_cast<uint8_t>(i + 1);
+    }
+    send(assume_init(std::move(send_sample))).value();
+
+    auto recv_result = sut_subscriber.receive().value();
+    ASSERT_TRUE(recv_result.has_value());
+
+    auto recv_sample = std::move(recv_result.value());
+    auto recv_payload = recv_sample.payload();
+    ASSERT_THAT(recv_payload.number_of_bytes(), Eq(PAYLOAD_SIZE));
+    for (uint64_t i = 0; i < PAYLOAD_SIZE; ++i) {
+        ASSERT_THAT(recv_payload[i].value, Eq(static_cast<uint8_t>(i + 1)));
+    }
 }
 } // namespace

--- a/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
@@ -2261,4 +2261,101 @@ TYPED_TEST(ServiceRequestResponseTest, custom_response_payload_type_details_over
     ASSERT_THAT(payload.alignment(), Eq(PAYLOAD_ALIGNMENT));
 }
 
+// NOLINTBEGIN(readability-function-cognitive-complexity), false positive caused by ASSERT_THAT
+TYPED_TEST(ServiceRequestResponseTest, custom_header_payload_marker_send_receive_works) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* HEADER_TYPE_NAME = "MyHeader";
+    constexpr uint64_t HEADER_SIZE = 16;
+    constexpr uint64_t HEADER_ALIGNMENT = 8;
+    constexpr const char* PAYLOAD_TYPE_NAME = "MyType";
+    constexpr uint64_t PAYLOAD_SIZE = 16;
+    constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
+
+    constexpr uint8_t REQUEST_PAYLOAD_BASE_VALUE = 1;
+    constexpr uint8_t RESPONSE_PAYLOAD_BASE_VALUE = 50;
+    constexpr uint8_t REQUEST_HEADER_BASE_VALUE = 100;
+    constexpr uint8_t RESPONSE_HEADER_BASE_VALUE = 150;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service_builder =
+        node.service_builder(service_name)
+            .template request_response<bb::Slice<CustomPayloadMarker>, bb::Slice<CustomPayloadMarker>>()
+            .template request_user_header<CustomHeaderMarker>()
+            .template response_user_header<CustomHeaderMarker>();
+
+    set_request_header_type_details(
+        service_builder, TypeDetail(TypeVariant::FixedSize, HEADER_TYPE_NAME, HEADER_SIZE, HEADER_ALIGNMENT));
+    set_response_header_type_details(
+        service_builder, TypeDetail(TypeVariant::FixedSize, HEADER_TYPE_NAME, HEADER_SIZE, HEADER_ALIGNMENT));
+    set_request_payload_type_details(
+        service_builder, TypeDetail(TypeVariant::FixedSize, PAYLOAD_TYPE_NAME, PAYLOAD_SIZE, PAYLOAD_ALIGNMENT));
+    set_response_payload_type_details(
+        service_builder, TypeDetail(TypeVariant::FixedSize, PAYLOAD_TYPE_NAME, PAYLOAD_SIZE, PAYLOAD_ALIGNMENT));
+
+    auto service = service_builder.resume_build().create().value();
+
+    auto sut_client = service.client_builder().initial_max_slice_len(1).create().value();
+    auto sut_server = service.server_builder().initial_max_slice_len(1).create().value();
+
+    // Client: populate request payload and request header, then send.
+    auto request = sut_client.loan_slice_uninit(1).value();
+    auto request_payload = request.payload_mut();
+    ASSERT_THAT(request_payload.number_of_bytes(), Eq(PAYLOAD_SIZE));
+    for (uint64_t i = 0; i < PAYLOAD_SIZE; ++i) {
+        request_payload[i].value = static_cast<uint8_t>(REQUEST_PAYLOAD_BASE_VALUE + i);
+    }
+    auto& request_header = request.template user_header_mut<std::array<uint8_t, HEADER_SIZE>>();
+    for (uint64_t i = 0; i < HEADER_SIZE; ++i) {
+        request_header.at(i) = static_cast<uint8_t>(REQUEST_HEADER_BASE_VALUE + i);
+    }
+
+    auto pending_response = send(assume_init(std::move(request))).value();
+
+    // Server: verify the received request bytes, then populate response payload and header.
+    auto active_request_result = sut_server.receive().value();
+    ASSERT_TRUE(active_request_result.has_value());
+    auto active_request = std::move(active_request_result.value());
+
+    auto recv_request_payload = active_request.payload();
+    ASSERT_THAT(recv_request_payload.number_of_bytes(), Eq(PAYLOAD_SIZE));
+    for (uint64_t i = 0; i < PAYLOAD_SIZE; ++i) {
+        ASSERT_THAT(recv_request_payload[i].value, Eq(static_cast<uint8_t>(REQUEST_PAYLOAD_BASE_VALUE + i)));
+    }
+    const auto& recv_request_header = active_request.template user_header<std::array<uint8_t, HEADER_SIZE>>();
+    for (uint64_t i = 0; i < HEADER_SIZE; ++i) {
+        ASSERT_THAT(recv_request_header.at(i), Eq(static_cast<uint8_t>(REQUEST_HEADER_BASE_VALUE + i)));
+    }
+
+    auto response = active_request.loan_slice_uninit(1).value();
+    auto response_payload = response.payload_mut();
+    ASSERT_THAT(response_payload.number_of_bytes(), Eq(PAYLOAD_SIZE));
+    for (uint64_t i = 0; i < PAYLOAD_SIZE; ++i) {
+        response_payload[i].value = static_cast<uint8_t>(RESPONSE_PAYLOAD_BASE_VALUE + i);
+    }
+    auto& response_header = response.template user_header_mut<std::array<uint8_t, HEADER_SIZE>>();
+    for (uint64_t i = 0; i < HEADER_SIZE; ++i) {
+        response_header.at(i) = static_cast<uint8_t>(RESPONSE_HEADER_BASE_VALUE + i);
+    }
+
+    send(assume_init(std::move(response))).value();
+
+    // Client: verify the received response bytes.
+    auto recv_response_result = pending_response.receive().value();
+    ASSERT_TRUE(recv_response_result.has_value());
+    auto recv_response = std::move(recv_response_result.value());
+
+    auto recv_response_payload = recv_response.payload();
+    ASSERT_THAT(recv_response_payload.number_of_bytes(), Eq(PAYLOAD_SIZE));
+    for (uint64_t i = 0; i < PAYLOAD_SIZE; ++i) {
+        ASSERT_THAT(recv_response_payload[i].value, Eq(static_cast<uint8_t>(RESPONSE_PAYLOAD_BASE_VALUE + i)));
+    }
+    const auto& recv_response_header = recv_response.template user_header<std::array<uint8_t, HEADER_SIZE>>();
+    for (uint64_t i = 0; i < HEADER_SIZE; ++i) {
+        ASSERT_THAT(recv_response_header.at(i), Eq(static_cast<uint8_t>(RESPONSE_HEADER_BASE_VALUE + i)));
+    }
+}
+// NOLINTEND(readability-function-cognitive-complexity)
+
 } // namespace

--- a/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
@@ -11,8 +11,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #include "iox2/bb/optional.hpp"
+#include "iox2/custom_header_marker.hpp"
+#include "iox2/custom_payload_marker.hpp"
+#include "iox2/message_type_details.hpp"
 #include "iox2/node.hpp"
 #include "iox2/service.hpp"
+#include "iox2/type_variant.hpp"
 
 #include "test.hpp"
 #include <array>
@@ -2169,6 +2173,92 @@ TYPED_TEST(ServiceRequestResponseTest, client_can_request_graceful_disconnect) {
 
     ASSERT_FALSE(active_request.is_connected());
     ASSERT_FALSE(active_request.has_disconnect_hint());
+}
+
+TYPED_TEST(ServiceRequestResponseTest, custom_request_header_type_details_override_is_applied) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* HEADER_TYPE_NAME = "MyHeader";
+    constexpr uint64_t HEADER_SIZE = 16;
+    constexpr uint64_t HEADER_ALIGNMENT = 8;
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service_builder = node.service_builder(service_name)
+                               .template request_response<uint64_t, uint64_t>()
+                               .template request_user_header<CustomHeaderMarker>();
+    set_request_header_type_details(
+        service_builder, TypeDetail(TypeVariant::FixedSize, HEADER_TYPE_NAME, HEADER_SIZE, HEADER_ALIGNMENT));
+    auto service = service_builder.resume_build().create().value();
+
+    auto user_header = service.static_config().request_message_type_details().user_header();
+    ASSERT_THAT(user_header.variant(), Eq(TypeVariant::FixedSize));
+    ASSERT_THAT(user_header.type_name(), StrEq(HEADER_TYPE_NAME));
+    ASSERT_THAT(user_header.size(), Eq(HEADER_SIZE));
+    ASSERT_THAT(user_header.alignment(), Eq(HEADER_ALIGNMENT));
+}
+
+TYPED_TEST(ServiceRequestResponseTest, custom_response_header_type_details_override_is_applied) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* HEADER_TYPE_NAME = "MyHeader";
+    constexpr uint64_t HEADER_SIZE = 16;
+    constexpr uint64_t HEADER_ALIGNMENT = 8;
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service_builder = node.service_builder(service_name)
+                               .template request_response<uint64_t, uint64_t>()
+                               .template response_user_header<CustomHeaderMarker>();
+    set_response_header_type_details(
+        service_builder, TypeDetail(TypeVariant::FixedSize, HEADER_TYPE_NAME, HEADER_SIZE, HEADER_ALIGNMENT));
+    auto service = service_builder.resume_build().create().value();
+
+    auto user_header = service.static_config().response_message_type_details().user_header();
+    ASSERT_THAT(user_header.variant(), Eq(TypeVariant::FixedSize));
+    ASSERT_THAT(user_header.type_name(), StrEq(HEADER_TYPE_NAME));
+    ASSERT_THAT(user_header.size(), Eq(HEADER_SIZE));
+    ASSERT_THAT(user_header.alignment(), Eq(HEADER_ALIGNMENT));
+}
+
+TYPED_TEST(ServiceRequestResponseTest, custom_request_payload_type_details_override_is_applied) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* PAYLOAD_TYPE_NAME = "MyType";
+    constexpr uint64_t PAYLOAD_SIZE = 12;
+    constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service_builder =
+        node.service_builder(service_name).template request_response<bb::Slice<CustomPayloadMarker>, uint64_t>();
+    set_request_payload_type_details(
+        service_builder, TypeDetail(TypeVariant::FixedSize, PAYLOAD_TYPE_NAME, PAYLOAD_SIZE, PAYLOAD_ALIGNMENT));
+    auto service = service_builder.resume_build().create().value();
+
+    auto payload = service.static_config().request_message_type_details().payload();
+    ASSERT_THAT(payload.variant(), Eq(TypeVariant::FixedSize));
+    ASSERT_THAT(payload.type_name(), StrEq(PAYLOAD_TYPE_NAME));
+    ASSERT_THAT(payload.size(), Eq(PAYLOAD_SIZE));
+    ASSERT_THAT(payload.alignment(), Eq(PAYLOAD_ALIGNMENT));
+}
+
+TYPED_TEST(ServiceRequestResponseTest, custom_response_payload_type_details_override_is_applied) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr const char* PAYLOAD_TYPE_NAME = "MyType";
+    constexpr uint64_t PAYLOAD_SIZE = 12;
+    constexpr uint64_t PAYLOAD_ALIGNMENT = 8;
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service_builder =
+        node.service_builder(service_name).template request_response<uint64_t, bb::Slice<CustomPayloadMarker>>();
+    set_response_payload_type_details(
+        service_builder, TypeDetail(TypeVariant::FixedSize, PAYLOAD_TYPE_NAME, PAYLOAD_SIZE, PAYLOAD_ALIGNMENT));
+    auto service = service_builder.resume_build().create().value();
+
+    auto payload = service.static_config().response_message_type_details().payload();
+    ASSERT_THAT(payload.variant(), Eq(TypeVariant::FixedSize));
+    ASSERT_THAT(payload.type_name(), StrEq(PAYLOAD_TYPE_NAME));
+    ASSERT_THAT(payload.size(), Eq(PAYLOAD_SIZE));
+    ASSERT_THAT(payload.alignment(), Eq(PAYLOAD_ALIGNMENT));
 }
 
 } // namespace

--- a/iceoryx2-ffi/c/src/api/active_request.rs
+++ b/iceoryx2-ffi/c/src/api/active_request.rs
@@ -303,6 +303,26 @@ pub unsafe extern "C" fn iox2_active_request_payload(
     }
 }
 
+/// Returns the number of bytes of the received request payload.
+///
+/// # Safety
+///
+/// * `handle` obtained by [`iox2_server_receive()`](crate::iox2_server_receive())
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_active_request_payload_number_of_bytes(
+    handle: iox2_active_request_h_ref,
+) -> c_size_t {
+    handle.assert_non_null();
+    unsafe {
+        let active_request = &mut *handle.as_type();
+        let number_of_bytes = match active_request.service_type {
+            iox2_service_type_e::IPC => active_request.value.as_mut().ipc.payload().len(),
+            iox2_service_type_e::LOCAL => active_request.value.as_mut().local.payload().len(),
+        };
+        number_of_bytes as c_size_t
+    }
+}
+
 /// Loans memory from the servers data segment.
 ///
 /// # Arguments

--- a/iceoryx2-ffi/c/src/api/request_mut.rs
+++ b/iceoryx2-ffi/c/src/api/request_mut.rs
@@ -418,6 +418,26 @@ pub unsafe extern "C" fn iox2_request_mut_payload(
     }
 }
 
+/// Returns the number of bytes of the request payload.
+///
+/// # Safety
+///
+/// * `handle` obtained by [`iox2_client_loan_slice_uninit()`](crate::iox2_client_loan_slice_uninit())
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_request_mut_payload_number_of_bytes(
+    handle: iox2_request_mut_h_ref,
+) -> c_size_t {
+    handle.assert_non_null();
+    unsafe {
+        let request = &mut *handle.as_type();
+        let number_of_bytes = match request.service_type {
+            iox2_service_type_e::IPC => request.value.as_mut().ipc.payload_mut().len(),
+            iox2_service_type_e::LOCAL => request.value.as_mut().local.payload_mut().len(),
+        };
+        number_of_bytes as c_size_t
+    }
+}
+
 /// Takes the ownership of the request and sends it
 ///
 /// # Safety

--- a/iceoryx2-ffi/c/src/api/response.rs
+++ b/iceoryx2-ffi/c/src/api/response.rs
@@ -244,6 +244,26 @@ pub unsafe extern "C" fn iox2_response_payload(
     }
 }
 
+/// Returns the number of bytes of the response payload.
+///
+/// # Safety
+///
+/// * `handle` obtained by [`iox2_pending_response_receive()`](crate::iox2_pending_response_receive())
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_response_payload_number_of_bytes(
+    handle: iox2_response_h_ref,
+) -> c_size_t {
+    handle.assert_non_null();
+    unsafe {
+        let response = &mut *handle.as_type();
+        let number_of_bytes = match response.service_type {
+            iox2_service_type_e::IPC => response.value.as_mut().ipc.payload().len(),
+            iox2_service_type_e::LOCAL => response.value.as_mut().local.payload().len(),
+        };
+        number_of_bytes as c_size_t
+    }
+}
+
 /// Destroys the response.
 ///
 /// # Safety

--- a/iceoryx2-ffi/c/src/api/response_mut.rs
+++ b/iceoryx2-ffi/c/src/api/response_mut.rs
@@ -312,6 +312,27 @@ pub unsafe extern "C" fn iox2_response_mut_payload_mut(
     }
 }
 
+/// Returns the number of bytes of the response payload.
+///
+/// # Safety
+///
+/// * `handle` obtained by
+///   [`iox2_active_request_loan_slice_uninit()`](crate::iox2_active_request_loan_slice_uninit())
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_response_mut_payload_number_of_bytes(
+    handle: iox2_response_mut_h_ref,
+) -> c_size_t {
+    handle.assert_non_null();
+    unsafe {
+        let response = &mut *handle.as_type();
+        let number_of_bytes = match response.service_type {
+            iox2_service_type_e::IPC => response.value.as_mut().ipc.payload_mut().len(),
+            iox2_service_type_e::LOCAL => response.value.as_mut().local.payload_mut().len(),
+        };
+        number_of_bytes as c_size_t
+    }
+}
+
 /// Sends the response.
 /// Returns `IOX2_OK` on success otherwise [`iox2_send_error_e`](crate::api::iox2_send_error_e).
 ///

--- a/iceoryx2-ffi/c/src/api/sample.rs
+++ b/iceoryx2-ffi/c/src/api/sample.rs
@@ -248,6 +248,26 @@ pub unsafe extern "C" fn iox2_sample_payload(
     }
 }
 
+/// Returns the number of bytes of the sample's payload.
+///
+/// # Safety
+///
+/// * `handle` obtained by [`iox2_subscriber_receive()`](crate::iox2_subscriber_receive())
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_sample_payload_number_of_bytes(
+    handle: iox2_sample_h_ref,
+) -> c_size_t {
+    handle.assert_non_null();
+    unsafe {
+        let sample = &mut *handle.as_type();
+        let number_of_bytes = match sample.service_type {
+            iox2_service_type_e::IPC => sample.value.as_mut().ipc.payload().len(),
+            iox2_service_type_e::LOCAL => sample.value.as_mut().local.payload().len(),
+        };
+        number_of_bytes as c_size_t
+    }
+}
+
 /// This function needs to be called to destroy the sample!
 ///
 /// # Arguments

--- a/iceoryx2-ffi/c/src/api/sample_mut.rs
+++ b/iceoryx2-ffi/c/src/api/sample_mut.rs
@@ -311,6 +311,26 @@ pub unsafe extern "C" fn iox2_sample_mut_payload(
     }
 }
 
+/// Returns the number of bytes of the sample's payload.
+///
+/// # Safety
+///
+/// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_sample_mut_payload_number_of_bytes(
+    handle: iox2_sample_mut_h_ref,
+) -> c_size_t {
+    handle.assert_non_null();
+    unsafe {
+        let sample = &mut *handle.as_type();
+        let number_of_bytes = match sample.service_type {
+            iox2_service_type_e::IPC => sample.value.as_mut().ipc.payload_mut().len(),
+            iox2_service_type_e::LOCAL => sample.value.as_mut().local.payload_mut().len(),
+        };
+        number_of_bytes as c_size_t
+    }
+}
+
 /// Takes the ownership of the sample and sends it
 ///
 /// # Safety


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Expose the ability to set type details for user header and payload at runtime to C++.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1707 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
