### PR TITLE
Fix: Payload data lifetime tracking in python ffi by anchoring views to their owning Sample

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -29,6 +29,7 @@
     conflicts when merging.
 -->
 
+* [#1548](https://github.com/eclipse-iceoryx/iceoryx2/issues/1548) Fix Payload data lifetime tracking in python ffi by anchoring views to their owning Sample.
 * [#1641](https://github.com/eclipse-iceoryx/iceoryx2/issues/1641) Deliver with Backpressure::Retry when receiver is disconnected until the buffer is full.
 * [#1673](https://github.com/eclipse-iceoryx/iceoryx2/issues/1673) Thread-stack-size is the same as process-stack-size on all platforms.
 * [#1690](https://github.com/eclipse-iceoryx/iceoryx2/issues/1690) Fix dependencies in iceoryx2-bb-loggers to re-enable `bazel query`.

--- a/examples/python/service_types/ipc_publisher.py
+++ b/examples/python/service_types/ipc_publisher.py
@@ -31,6 +31,9 @@ node = iox2.NodeBuilder.new().create(iox2.ServiceType.Ipc)
 service = (
     node.service_builder(iox2.ServiceName.new("Service-Variants-Example"))
     .publish_subscribe(ctypes.c_uint64)
+    # Must match the threadsafe subscriber that shares this service, since the
+    # borrowed-samples setting is a service-wide attribute verified on open.
+    .subscriber_max_borrowed_samples(4)
     .open_or_create()
 )
 

--- a/examples/python/service_types/ipc_threadsafe_subscriber.py
+++ b/examples/python/service_types/ipc_threadsafe_subscriber.py
@@ -31,6 +31,11 @@ node = iox2.NodeBuilder.new().create(iox2.ServiceType.Ipc)
 service = (
     node.service_builder(iox2.ServiceName.new("Service-Variants-Example"))
     .publish_subscribe(ctypes.c_uint64)
+    # A received sample now keeps its payload alive until the sample (and any
+    # pointer obtained from `payload()`) is dropped. Since this subscriber is
+    # shared between two threads and each thread may hold its previous sample
+    # while receiving the next one, more borrowed samples can be alive at once.
+    .subscriber_max_borrowed_samples(4)
     .open_or_create()
 )
 

--- a/iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py
+++ b/iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py
@@ -27,17 +27,21 @@ def payload(self: Any) -> Any:
     assert self.__payload_type_details is not None
     if get_origin(self.__payload_type_details) is Slice:
         (contained_type,) = get_args(self.__payload_type_details)
-        return Slice(self.payload_ptr, self.__slice_len, contained_type)
+        return Slice(self.payload_ptr, self.__slice_len, contained_type, owner=self)
 
-    return ctypes.cast(self.payload_ptr, ctypes.POINTER(self.__payload_type_details))
+    ptr = ctypes.cast(self.payload_ptr, ctypes.POINTER(self.__payload_type_details))
+    ptr._iox2_owner = self  # type: ignore[attr-defined]
+    return ptr
 
 
 def user_header(self: Any) -> Any:
     """Returns a `ctypes.POINTER` to the user header."""
     assert self.__user_header_type_details is not None
-    return ctypes.cast(
+    ptr = ctypes.cast(
         self.user_header_ptr, ctypes.POINTER(self.__user_header_type_details)
     )
+    ptr._iox2_owner = self  # type: ignore[attr-defined]
+    return ptr
 
 
 def publish_subscribe(

--- a/iceoryx2-ffi/python/python-src/iceoryx2/request_response_extensions.py
+++ b/iceoryx2-ffi/python/python-src/iceoryx2/request_response_extensions.py
@@ -147,11 +147,13 @@ def request_payload(self: Any) -> Any:
     assert self.__request_payload_type_details is not None
     if get_origin(self.__request_payload_type_details) is Slice:
         (contained_type,) = get_args(self.__request_payload_type_details)
-        return Slice(self.payload_ptr, self.__slice_len, contained_type)
+        return Slice(self.payload_ptr, self.__slice_len, contained_type, owner=self)
 
-    return ctypes.cast(
+    ptr = ctypes.cast(
         self.payload_ptr, ctypes.POINTER(self.__request_payload_type_details)
     )
+    ptr._iox2_owner = self
+    return ptr
 
 
 def response_payload(self: Any) -> Any:
@@ -159,28 +161,34 @@ def response_payload(self: Any) -> Any:
     assert self.__response_payload_type_details is not None
     if get_origin(self.__response_payload_type_details) is Slice:
         (contained_type,) = get_args(self.__response_payload_type_details)
-        return Slice(self.payload_ptr, self.__slice_len, contained_type)
+        return Slice(self.payload_ptr, self.__slice_len, contained_type, owner=self)
 
-    return ctypes.cast(
+    ptr = ctypes.cast(
         self.payload_ptr, ctypes.POINTER(self.__response_payload_type_details)
     )
+    ptr._iox2_owner = self
+    return ptr
 
 
 def request_header(self: Any) -> Any:
     """Returns a `ctypes.POINTER` to the request header."""
     assert self.__request_header_type_details is not None
-    return ctypes.cast(
+    ptr = ctypes.cast(
         self.user_header_ptr, ctypes.POINTER(self.__request_header_type_details)
     )
+    ptr._iox2_owner = self
+    return ptr
 
 
 def response_header(self: Any) -> Any:
     """Returns a `ctypes.POINTER` to the response header."""
     assert self.__response_header_type_details is not None
-    return ctypes.cast(
+    ptr = ctypes.cast(
         self.user_header_ptr,
         ctypes.POINTER(self.__response_header_type_details),
     )
+    ptr._iox2_owner = self
+    return ptr
 
 
 def write_request_payload(self: RequestMutUninit, t: Type[ReqT]) -> RequestMut:

--- a/iceoryx2-ffi/python/python-src/iceoryx2/slice.py
+++ b/iceoryx2-ffi/python/python-src/iceoryx2/slice.py
@@ -28,11 +28,18 @@ class Slice(Generic[T]):
     T -  The type of elements in the slice. Can be const-qualified for read-only slices.
     """
 
-    def __init__(self, data_ptr: int, number_of_elements: int, t: Type[T]) -> None:
+    def __init__(
+        self,
+        data_ptr: int,
+        number_of_elements: int,
+        t: Type[T],
+        owner: Any = None,
+    ) -> None:
         """Initializes a slice with a data_ptr, number_of_elements it contains and the type."""
         self.data_ptr = data_ptr
         self.number_of_elements = number_of_elements
         self.contained_type = t
+        self._owner = owner
 
     def __str__(self) -> str:
         """Returns human-readable string of the contents."""

--- a/iceoryx2-ffi/python/tests/payload_lifetime_tests.py
+++ b/iceoryx2-ffi/python/tests/payload_lifetime_tests.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import ctypes
+import gc
+
+import iceoryx2 as iox2
+import pytest
+
+service_types = [iox2.ServiceType.Ipc, iox2.ServiceType.Local]
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_saved_payload_value_persists_after_sample_drop(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+    service_name = iox2.testing.generate_service_name()
+    service = (
+        node.service_builder(service_name)
+        .publish_subscribe(iox2.Slice[ctypes.c_uint64])
+        .open_or_create()
+    )
+    publisher = service.publisher_builder().initial_max_slice_len(8).create()
+    subscriber = service.subscriber_builder().create()
+
+    marker = 0xCAFEBABEDEADBEEF
+    loan = publisher.loan_slice_uninit(4)
+    for i in range(4):
+        loan.payload()[i] = marker
+    loan.assume_init().send()
+
+    sample = subscriber.receive()
+    assert sample is not None
+    payload_ref = sample.payload()
+
+    del sample
+    gc.collect()
+
+    overwrite = 0xDEADC0FFEE
+    loan2 = publisher.loan_slice_uninit(4)
+    for i in range(4):
+        loan2.payload()[i] = overwrite
+    loan2.assume_init().send()
+    sample2 = subscriber.receive()
+    assert sample2 is not None
+    del sample2
+    gc.collect()
+
+    assert payload_ref[0] == marker, (
+        f"iox2-1548: saved payload was overwritten "
+        f"(got 0x{payload_ref[0]:x}, expected 0x{marker:x})"
+    )
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_accumulated_payload_references_each_keep_own_data(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+    service_name = iox2.testing.generate_service_name()
+    num_samples = 5
+    service = (
+        node.service_builder(service_name)
+        .publish_subscribe(iox2.Slice[ctypes.c_uint64])
+        .subscriber_max_borrowed_samples(num_samples)
+        .subscriber_max_buffer_size(num_samples)
+        .open_or_create()
+    )
+    publisher = (
+        service.publisher_builder()
+        .initial_max_slice_len(4)
+        .max_loaned_samples(num_samples)
+        .create()
+    )
+    subscriber = service.subscriber_builder().create()
+
+    saved = []
+    for i in range(num_samples):
+        loan = publisher.loan_slice_uninit(4)
+        for j in range(4):
+            loan.payload()[j] = (i + 1) * 1_000_000 + j
+        loan.assume_init().send()
+
+        sample = subscriber.receive()
+        assert sample is not None
+        saved.append(sample.payload())
+
+    gc.collect()
+
+    for i, payload in enumerate(saved):
+        for j in range(4):
+            expected = (i + 1) * 1_000_000 + j
+            actual = payload[j]
+            assert (
+                actual == expected
+            ), f"iox2-1548: saved[{i}][{j}] = {actual}, expected {expected}"
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_dropping_payload_returns_chunk_to_pool(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+    service_name = iox2.testing.generate_service_name()
+    max_borrowed = 2
+    service = (
+        node.service_builder(service_name)
+        .publish_subscribe(iox2.Slice[ctypes.c_uint64])
+        .subscriber_max_borrowed_samples(max_borrowed)
+        .subscriber_max_buffer_size(5)
+        .open_or_create()
+    )
+    publisher = (
+        service.publisher_builder()
+        .initial_max_slice_len(4)
+        .max_loaned_samples(5)
+        .create()
+    )
+    subscriber = service.subscriber_builder().create()
+
+    for i in range(3):
+        loan = publisher.loan_slice_uninit(4)
+        loan.payload()[0] = i + 1
+        loan.assume_init().send()
+
+    s1 = subscriber.receive()
+    assert s1 is not None
+    p1 = s1.payload()
+    del s1
+
+    s2 = subscriber.receive()
+    assert s2 is not None
+    p2 = s2.payload()
+    del s2
+
+    with pytest.raises(Exception) as exc_info:
+        _ = subscriber.receive()
+    assert "ExceedsMaxBorrows" in str(
+        exc_info.value
+    ), f"expected ExceedsMaxBorrows, got {exc_info.value}"
+
+    del p1
+    gc.collect()
+
+    s3 = subscriber.receive()
+    assert s3 is not None, (
+        "after releasing the last reference to a payload, the Sample's "
+        "chunk should return to the pool and receive() should succeed"
+    )
+    assert p2[0] == 2
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_payload_survives_slice_reallocation(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+    service_name = iox2.testing.generate_service_name()
+    num_samples = 5
+    service = (
+        node.service_builder(service_name)
+        .publish_subscribe(iox2.Slice[ctypes.c_uint64])
+        .subscriber_max_borrowed_samples(num_samples)
+        .subscriber_max_buffer_size(num_samples)
+        .open_or_create()
+    )
+    publisher = (
+        service.publisher_builder()
+        .initial_max_slice_len(4)
+        .max_loaned_samples(num_samples)
+        .allocation_strategy(iox2.AllocationStrategy.PowerOfTwo)
+        .create()
+    )
+    subscriber = service.subscriber_builder().create()
+
+    saved = []
+    for i in range(1, num_samples + 1):
+        size = i * 3
+        loan = publisher.loan_slice_uninit(size)
+        loan.payload()[0] = i * 10
+        loan.assume_init().send()
+
+        sample = subscriber.receive()
+        assert sample is not None
+        saved.append(sample.payload())
+
+    gc.collect()
+
+    for i, payload in enumerate(saved, start=1):
+        assert (
+            payload[0] == i * 10
+        ), f"iox2-1548: payload[{i-1}][0] = {payload[0]}, expected {i*10}"


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This is a Python-only fix — `Sample` is already wrapped in `Parc<SampleType>` (= `Arc<Mutex<T>>`) on the Rust side, so the change is simply to give each returned payload view a strong Python back-reference (`_owner`) to its source `Sample` PyClass instance.

With that anchor in place, payload references retained by user code (e.g. appended to a list) keep the underlying `Sample` alive until they are released; once the last reference goes away the chunk is returned to the pool, just as it already does on the Rust side.

Regression tests in `tests/iox2_1548_payload_lifetime_tests.py` coverboth directions (held refs survive sample drop, released refs free the chunk) across `Ipc` and `Local` service types — 8 cases total, all passing.

<img width="2842" height="798" alt="image" src="https://github.com/user-attachments/assets/673025b9-8271-4d58-998f-0547ca99e099" />


## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1548

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
