### PR TITLE
[#925] Fix dev_permissions for new event handling

### DIFF
--- a/iceoryx2-cal/src/event/trigger/unix_datagram_socket.rs
+++ b/iceoryx2-cal/src/event/trigger/unix_datagram_socket.rs
@@ -27,6 +27,7 @@ use iceoryx2_bb_posix::{
     file::{CreationMode, File, FileRemoveError},
     file_descriptor::FileDescriptorBased,
     file_descriptor_set::SynchronousMultiplexing,
+    permission::Permission,
     unix_datagram_socket::{
         UnixDatagramReceiveError, UnixDatagramReceiver, UnixDatagramReceiverBuilder,
         UnixDatagramReceiverCreationError, UnixDatagramSendError, UnixDatagramSender,
@@ -37,6 +38,12 @@ use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_log::fail;
 
 const RECEIVE_BUFFER_SIZE: u64 = 32;
+
+#[cfg(not(feature = "dev_permissions"))]
+const SOCKET_PERMISSIONS: Permission = Permission::OWNER_ALL;
+
+#[cfg(feature = "dev_permissions")]
+const SOCKET_PERMISSIONS: Permission = Permission::ALL;
 
 #[derive(Debug)]
 pub struct UnixDatagramHandle<E: EventState, Storage: DynamicStorage<State<E, ()>>> {
@@ -226,6 +233,7 @@ impl<E: EventState, Storage: DynamicStorage<State<E, ()>>> WaiterInterface<E, ()
         let full_path = config.path_for(name);
         let receiver = match UnixDatagramReceiverBuilder::new(&full_path)
             .creation_mode(CreationMode::CreateExclusive)
+            .permission(SOCKET_PERMISSIONS)
             .create()
         {
             Ok(v) => v,


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR fixes the dev_permissions for the event refactoring from last week.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [ x Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #925 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
