### PR TITLE
[#1735] Handle arbitrary discovery order in e2e test

### DIFF
--- a/integrations/zenoh/tunnel-cli/end-to-end-tests/test_e2e_iox2_tunnel_zenoh_reactive.exp
+++ b/integrations/zenoh/tunnel-cli/end-to-end-tests/test_e2e_iox2_tunnel_zenoh_reactive.exp
@@ -37,8 +37,10 @@ set id_publisher $spawn_id
 expect_output_from $id_publisher "send message"
 
 #### Test Assertion
-expect_output_from $id_iox2_tunnel "Opening mirror (Local): PublishSubscribe(EventBasedCommService)"
-expect_output_from $id_iox2_tunnel "Opening mirror (Local): Event(EventBasedCommService)"
+expect_outputs_from_any_order $id_iox2_tunnel {
+    {Opening mirror (Local): PublishSubscribe(EventBasedCommService)}
+    {Opening mirror (Local): Event(EventBasedCommService)}
+}
 expect_output_from $id_iox2_tunnel "Propagated PublishSubscribe(EventBasedCommService)"
 expect_output_from $id_iox2_tunnel "Propagated Event(EventBasedCommService)"
 

--- a/internal/end-to-end-testing/common.exp
+++ b/internal/end-to-end-testing/common.exp
@@ -56,6 +56,28 @@ proc expect_output_from { SPAWN_ID EXPECTED_OUTPUT } {
     }
 }
 
+proc expect_outputs_from_any_order { SPAWN_ID EXPECTED_OUTPUTS } {
+    set remaining ${EXPECTED_OUTPUTS}
+
+    while { [llength ${remaining}] > 0 } {
+        expect {
+            -i ${SPAWN_ID} -ex [lindex ${remaining} 0] { }
+            timeout { handle_timeout ${remaining} }
+            eof { handle_end_of_file ${remaining} }
+        }
+
+        set consumed $expect_out(buffer)
+        set still_expected {}
+        foreach pattern ${remaining} {
+            if { [string first ${pattern} ${consumed}] == -1 } {
+                lappend still_expected ${pattern}
+            }
+        }
+
+        set remaining ${still_expected}
+    }
+}
+
 proc expect_pattern_from { SPAWN_ID REGEX_PATTERN DESCRIPTION } {
     expect {
         -i ${SPAWN_ID} -re ${REGEX_PATTERN} { }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Allow for arbitrary discovery order in reactive tunnel e2e test.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] ~~Tests follow the [best practice for testing][testing]~~
* [ ] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1735 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
