### PR TITLE
[#1739] Make sure MSVC defines __cplusplus with accurate value

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -37,6 +37,7 @@
 * [#1708](https://github.com/eclipse-iceoryx/iceoryx2/issues/1708) Remove `services` from tunnel conformance test crate to fix a linker error on macOS.
 * [#1724](https://github.com/eclipse-iceoryx/iceoryx2/issues/1724) Fix chunk leak when offset cannot be translated to dynamic data segment.
 * [#1733](https://github.com/eclipse-iceoryx/iceoryx2/issues/1733) `iox2 service replay` sends full payload for dynamic data.
+* [#1739](https://github.com/eclipse-iceoryx/iceoryx2/issues/1739) Make sure MSVC defines __cplusplus with accurate value
 
 ### Refactoring
 

--- a/iceoryx2-cmake-modules/platform/win/modules/Iceoryx2PlatformSettings.cmake
+++ b/iceoryx2-cmake-modules/platform/win/modules/Iceoryx2PlatformSettings.cmake
@@ -18,7 +18,9 @@ set(ICEORYX2_CXX_FLAGS CACHE INTERNAL "")
 set(ICEORYX2_TEST_CXX_FLAGS CACHE INTERNAL "")
 
 if(CMAKE_C_COMPILER_ID MATCHES MSVC)
-    set(ICEORYX2_CXX_FLAGS      "/EHsc" CACHE INTERNAL "") # TODO same as iceoryx classic; check if we should change the exception handling for iceoryx2
+    # /EHsc: enable synchronous C++ exception handling
+    # /Zc:__cplusplus: define the '__cplusplus' macro with correct value
+    set(ICEORYX2_CXX_FLAGS      "/EHsc;/Zc:__cplusplus" CACHE INTERNAL "") # TODO same as iceoryx classic; check if we should change the exception handling for iceoryx2
     set(ICEORYX2_TEST_CXX_FLAGS "/bigobj" CACHE INTERNAL "")
 endif()
 


### PR DESCRIPTION
MSVC defaults to defining __cplusplus as 199711L regardless of what standard is supported by the compiler (or selected on the command line). Only when passing the /Zc:__cplusplus switch will it use an accurate value.

For background, see:
https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [~] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1739 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
