### PR TITLE
[#4] Add FAQ section about docker and memory overcommittment in linux

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -31,6 +31,7 @@
     * [Unable To Connect Due To `IncompatibleTypes`](#unable-to-connect-due-to-incompatibletypes)
     * [Failed To Create Port Due To `ExceedsMaxSupported**`](#failed-to-create-port-due-to-exceedsmaxsupported)
     * [Insufficient Permission To Remove Shared Memory](#insufficient-permission-to-remove-shared-memory)
+    * [Encountered A `SIGBUS` Signal](#encountered-a-sigbus-signal)
 
 ## Tips And Tricks
 
@@ -153,12 +154,39 @@ applications interoperabel.
 
 ### Docker
 
+#### Small Shared Memory Size
+
 By default, a Docker container has a shared memory size of 64 MB. This can be
 exceeded quickly, since iceoryx2 always pre-allocates memory for the worst-case
 scenario.
 
 The shared memory size can be adjusted with the `--shm-size=` parameter, see:
 [https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)
+
+#### Slow System
+
+iceoryx2 uses the `ICEORYX2_ROOT_PATH` to store operational files for services
+and nodes.
+
+By default, the root path in iceoryx2 is `/tmp/iceoryx2`, which is usually
+located on a tmpfs filesystem. Most Linux distributions mount `/tmp` as tmpfs,
+meaning it resides in virtual memory and does not require hard disk interaction.
+
+In larger setups that run many iceoryx2 nodes, many filesystem operations can
+happen concurrently, for example when starting or stopping many processes.
+
+In Docker, `/tmp` is not mounted as tmpfs by default.
+
+You can check whether `/tmp` is mounted as tmpfs with the following command:
+
+```sh
+df -h --type=tmpfs
+```
+
+There are two ways to use tmpfs in Docker:
+
+1. Mount the host’s `/tmp` folder directly into Docker.
+2. Create a tmpfs mount in Docker: [https://docs.docker.com/engine/storage/tmpfs](https://docs.docker.com/engine/storage/tmpfs)
 
 ### Async API
 
@@ -676,3 +704,21 @@ chmod -t /dev/shm
 
 Do this only during development. Changing permissions on `/dev/shm` can affect
 other applications on the system.
+
+### Encountered a `SIGBUS` Signal
+
+If a process crashes due to a `SIGBUS` signal, it can indicate that the system
+is out of memory. On Linux, this can be caused by the kernel's memory
+overcommitment behavior. Memory pages are only allocated when they are actually
+used, which allows a process to reserve more memory than the system has
+available.
+
+You can disable memory overcommitment as root with the following command:
+
+```sh
+echo 2 > /proc/sys/vm/overcommit_memory
+```
+
+After this adjustment, when creating services, iceoryx2 will immediately return
+an out-of-memory error as soon as a service or port requires more memory than
+the system has available.


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #4

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
