### PR TITLE
[#1137] specify max_active_requests per client instance

### DIFF
--- a/iceoryx2-cxx/include/iox2/client.hpp
+++ b/iceoryx2-cxx/include/iox2/client.hpp
@@ -46,6 +46,9 @@ class Client {
     /// if the [`Server`]s buffer is full.
     auto backpressure_strategy() const -> BackpressureStrategy;
 
+    /// Returns the maximal active requests a [`Client`] can send.
+    auto max_active_requests() const -> uint64_t;
+
     /// Returns the maximum number of elements that can be loaned in a slice.
     template <typename T = RequestPayload, typename = std::enable_if_t<bb::IsSlice<T>::VALUE, void>>
     auto initial_max_slice_len() const -> uint64_t;
@@ -161,6 +164,17 @@ inline auto
 Client<Service, RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader>::backpressure_strategy() const
     -> BackpressureStrategy {
     return iox2::bb::into<BackpressureStrategy>(static_cast<int>(iox2_client_backpressure_strategy(&m_handle)));
+}
+
+template <ServiceType Service,
+          typename RequestPayload,
+          typename RequestUserHeader,
+          typename ResponsePayload,
+          typename ResponseUserHeader>
+inline auto
+Client<Service, RequestPayload, RequestUserHeader, ResponsePayload, ResponseUserHeader>::max_active_requests() const
+    -> uint64_t {
+    return iox2_client_max_active_requests(&m_handle);
 }
 
 template <ServiceType Service,

--- a/iceoryx2-cxx/include/iox2/client_details.hpp
+++ b/iceoryx2-cxx/include/iox2/client_details.hpp
@@ -44,6 +44,9 @@ class ClientDetailsView {
     /// The current maximum length of a slice.
     auto max_slice_len() const -> uint64_t;
 
+    /// The maximal amount of active requests the [`Client`] can send.
+    auto max_active_requests() const -> uint64_t;
+
   private:
     template <typename T, typename>
     friend auto internal::list_ports_callback(void* context, T port_details_view) -> iox2_callback_progression_e;

--- a/iceoryx2-cxx/include/iox2/client_error.hpp
+++ b/iceoryx2-cxx/include/iox2/client_error.hpp
@@ -31,6 +31,9 @@ enum class ClientCreateError : uint8_t {
     FailedToDeployThreadsafetyPolicy,
     /// The tracking port tag, required for cleanup, could not be created.
     UnableToCreatePortTag,
+    /// When the [`Client`] requires more acitve requests than the
+    /// [`Service`] offers, the creation will fail.
+    MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService,
 };
 } // namespace iox2
 #endif

--- a/iceoryx2-cxx/include/iox2/enum_translation.hpp
+++ b/iceoryx2-cxx/include/iox2/enum_translation.hpp
@@ -1800,6 +1800,8 @@ constexpr auto from<int, iox2::ClientCreateError>(const int value) noexcept -> i
         return iox2::ClientCreateError::FailedToDeployThreadsafetyPolicy;
     case iox2_client_create_error_e_UNABLE_TO_CREATE_PORT_TAG:
         return iox2::ClientCreateError::UnableToCreatePortTag;
+    case iox2_client_create_error_e_MAX_ACTIVE_REQUESTS_EXCEEDS_MAX_SUPPORTED_ACTIVE_REQUESTS_OF_SERVICE:
+        return iox2::ClientCreateError::MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService;
     }
 
     IOX2_UNREACHABLE();
@@ -1817,6 +1819,8 @@ constexpr auto from<iox2::ClientCreateError, iox2_client_create_error_e>(const i
         return iox2_client_create_error_e_FAILED_TO_DEPLOY_THREAD_SAFETY_POLICY;
     case iox2::ClientCreateError::UnableToCreatePortTag:
         return iox2_client_create_error_e_UNABLE_TO_CREATE_PORT_TAG;
+    case iox2::ClientCreateError::MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService:
+        return iox2_client_create_error_e_MAX_ACTIVE_REQUESTS_EXCEEDS_MAX_SUPPORTED_ACTIVE_REQUESTS_OF_SERVICE;
     }
 
     IOX2_UNREACHABLE();

--- a/iceoryx2-cxx/include/iox2/port_factory_client.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_client.hpp
@@ -43,6 +43,13 @@ class PortFactoryClient {
 #else
     IOX2_BUILDER_OPTIONAL(BackpressureStrategy, backpressure_strategy);
 #endif
+    /// Defines the required maximal amount of active requests the [`Client`] can send.
+    /// Smallest possible value is `1`.
+#ifdef DOXYGEN_MACRO_FIX
+    auto max_active_requests(const uint64_t value) -> decltype(auto);
+#else
+    IOX2_BUILDER_OPTIONAL(uint64_t, max_active_requests);
+#endif
 
   public:
     PortFactoryClient(const PortFactoryClient&) = delete;
@@ -234,6 +241,10 @@ inline auto PortFactoryClient<Service, RequestPayload, RequestUserHeader, Respon
     if (m_backpressure_handler.has_value()) {
         iox2_port_factory_client_builder_set_backpressure_handler(
             &m_handle, detail::backpressure_handler_delegate, static_cast<void*>(m_backpressure_handler.value()));
+    }
+
+    if (m_max_active_requests.has_value()) {
+        iox2_port_factory_client_builder_set_max_active_requests(&m_handle, m_max_active_requests.value());
     }
 
     iox2_client_h client_handle {};

--- a/iceoryx2-cxx/src/client_details.cpp
+++ b/iceoryx2-cxx/src/client_details.cpp
@@ -55,4 +55,8 @@ auto ClientDetailsView::number_of_requests() const -> uint64_t {
 auto ClientDetailsView::max_slice_len() const -> uint64_t {
     return iox2_client_details_max_slice_len(m_handle);
 }
+
+auto ClientDetailsView::max_active_requests() const -> uint64_t {
+    return iox2_client_details_max_active_requests(m_handle);
+}
 } // namespace iox2

--- a/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
@@ -11,15 +11,19 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 #include "iox2/bb/optional.hpp"
+#include "iox2/client_error.hpp"
 #include "iox2/custom_header_marker.hpp"
 #include "iox2/custom_payload_marker.hpp"
 #include "iox2/message_type_details.hpp"
 #include "iox2/node.hpp"
+#include "iox2/pending_response.hpp"
+#include "iox2/port_error.hpp"
 #include "iox2/service.hpp"
 #include "iox2/type_variant.hpp"
 
 #include "test.hpp"
 #include <array>
+#include <cstdint>
 #include <gtest/gtest.h>
 
 namespace {
@@ -1099,6 +1103,24 @@ TYPED_TEST(ServiceRequestResponseTest, client_applies_initial_max_slice_length) 
     ASSERT_THAT(sut_client.initial_max_slice_len(), Eq(INITIAL_MAX_SLICE_LEN));
 }
 
+TYPED_TEST(ServiceRequestResponseTest, client_applies_max_active_requests) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+
+    const auto service_name = iox2_testing::generate_service_name();
+    constexpr uint64_t MAX_ACTIVE_REQUESTS = 6;
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name)
+                       .template request_response<bb::Slice<uint64_t>, uint64_t>()
+                       .max_active_requests_per_client(2 * MAX_ACTIVE_REQUESTS)
+                       .create()
+                       .value();
+
+    auto sut_client = service.client_builder().max_active_requests(MAX_ACTIVE_REQUESTS).create().value();
+
+    ASSERT_THAT(sut_client.max_active_requests(), Eq(MAX_ACTIVE_REQUESTS));
+}
+
 TYPED_TEST(ServiceRequestResponseTest, number_of_clients_servers_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
 
@@ -1994,14 +2016,22 @@ TYPED_TEST(ServiceRequestResponseTest, listing_all_clients_stops_on_request) {
 TYPED_TEST(ServiceRequestResponseTest, client_details_are_correct) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
     constexpr uint64_t MAX_SLICE_LEN = 9;
+    constexpr uint64_t MAX_ACTIVE_REQUESTS = 13;
 
     const auto service_name = iox2_testing::generate_service_name();
     auto node = NodeBuilder().create<SERVICE_TYPE>().value();
-    auto sut =
-        node.service_builder(service_name).template request_response<bb::Slice<uint64_t>, uint64_t>().create().value();
+    auto sut = node.service_builder(service_name)
+                   .template request_response<bb::Slice<uint64_t>, uint64_t>()
+                   .max_active_requests_per_client(2 * MAX_ACTIVE_REQUESTS)
+                   .create()
+                   .value();
 
     iox2::Client<SERVICE_TYPE, bb::Slice<uint64_t>, void, uint64_t, void> client =
-        sut.client_builder().initial_max_slice_len(MAX_SLICE_LEN).create().value();
+        sut.client_builder()
+            .initial_max_slice_len(MAX_SLICE_LEN)
+            .max_active_requests(MAX_ACTIVE_REQUESTS)
+            .create()
+            .value();
 
     auto counter = 0;
     sut.dynamic_config().list_clients([&](auto client_details_view) -> auto {
@@ -2009,6 +2039,7 @@ TYPED_TEST(ServiceRequestResponseTest, client_details_are_correct) {
         EXPECT_TRUE(client_details_view.client_id() == client.id());
         EXPECT_TRUE(client_details_view.node_id() == node.id());
         EXPECT_TRUE(client_details_view.max_slice_len() == MAX_SLICE_LEN);
+        EXPECT_TRUE(client_details_view.max_active_requests() == MAX_ACTIVE_REQUESTS);
         return CallbackProgression::Stop;
     });
 
@@ -2357,5 +2388,72 @@ TYPED_TEST(ServiceRequestResponseTest, custom_header_payload_marker_send_receive
     }
 }
 // NOLINTEND(readability-function-cognitive-complexity)
+
+TYPED_TEST(ServiceRequestResponseTest, client_can_decrease_max_active_requests) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint64_t MAX_ACTIVE_REQUESTS = 13;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name)
+                       .template request_response<uint64_t, uint64_t>()
+                       .max_active_requests_per_client(MAX_ACTIVE_REQUESTS)
+                       .create()
+                       .value();
+
+    for (uint64_t i = 1; i < MAX_ACTIVE_REQUESTS; ++i) {
+        auto client1 = service.client_builder().create().value();
+        auto client2 = service.client_builder().max_active_requests(i).create().value();
+
+        ASSERT_THAT(client1.max_active_requests(), Eq(MAX_ACTIVE_REQUESTS));
+        ASSERT_THAT(client2.max_active_requests(), Eq(i));
+
+        std::vector<PendingResponse<SERVICE_TYPE, uint64_t, void, uint64_t, void>> pending_responses_client1;
+        for (uint64_t j = 0; j < MAX_ACTIVE_REQUESTS; ++j) {
+            pending_responses_client1.push_back(client1.send_copy(j).value());
+        }
+
+        std::vector<PendingResponse<SERVICE_TYPE, uint64_t, void, uint64_t, void>> pending_responses_client2;
+        for (uint64_t j = 0; j < i; ++j) {
+            pending_responses_client2.push_back(client2.send_copy(j).value());
+        }
+        auto pending_response = client2.send_copy(0);
+        ASSERT_FALSE(pending_response.has_value());
+        ASSERT_THAT(pending_response.error(), Eq(RequestSendError::ExceedsMaxActiveRequests));
+    }
+}
+
+TYPED_TEST(ServiceRequestResponseTest, client_creation_fails_when_max_active_requests_exceeds_service_max) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+    constexpr uint64_t MAX_ACTIVE_REQUESTS = 13;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name)
+                       .template request_response<uint64_t, uint64_t>()
+                       .max_active_requests_per_client(MAX_ACTIVE_REQUESTS)
+                       .create()
+                       .value();
+
+    auto client = service.client_builder().max_active_requests(MAX_ACTIVE_REQUESTS + 1).create();
+
+    ASSERT_FALSE(client.has_value());
+    ASSERT_THAT(client.error(), Eq(ClientCreateError::MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService));
+}
+
+TYPED_TEST(ServiceRequestResponseTest, client_max_active_requests_is_at_least_one) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name).template request_response<uint64_t, uint64_t>().create().value();
+
+    auto client = service.client_builder().max_active_requests(0).create().value();
+
+    ASSERT_THAT(client.max_active_requests(), Eq(1));
+}
 
 } // namespace

--- a/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
+++ b/iceoryx2-cxx/tests/src/service_request_response_tests.cpp
@@ -2013,6 +2013,7 @@ TYPED_TEST(ServiceRequestResponseTest, listing_all_clients_stops_on_request) {
     ASSERT_THAT(counter, Eq(1));
 }
 
+//NOLINTBEGIN(readability-function-cognitive-complexity), false positive caused by ASSERT_THAT
 TYPED_TEST(ServiceRequestResponseTest, client_details_are_correct) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
     constexpr uint64_t MAX_SLICE_LEN = 9;
@@ -2045,6 +2046,7 @@ TYPED_TEST(ServiceRequestResponseTest, client_details_are_correct) {
 
     ASSERT_THAT(counter, Eq(1));
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 TYPED_TEST(ServiceRequestResponseTest, listing_all_servers_works) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
@@ -2389,6 +2391,7 @@ TYPED_TEST(ServiceRequestResponseTest, custom_header_payload_marker_send_receive
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 
+//NOLINTBEGIN(readability-function-cognitive-complexity), false positive caused by ASSERT_THAT
 TYPED_TEST(ServiceRequestResponseTest, client_can_decrease_max_active_requests) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
     constexpr uint64_t MAX_ACTIVE_REQUESTS = 13;
@@ -2410,11 +2413,13 @@ TYPED_TEST(ServiceRequestResponseTest, client_can_decrease_max_active_requests) 
         ASSERT_THAT(client2.max_active_requests(), Eq(i));
 
         std::vector<PendingResponse<SERVICE_TYPE, uint64_t, void, uint64_t, void>> pending_responses_client1;
+        pending_responses_client1.reserve(MAX_ACTIVE_REQUESTS);
         for (uint64_t j = 0; j < MAX_ACTIVE_REQUESTS; ++j) {
             pending_responses_client1.push_back(client1.send_copy(j).value());
         }
 
         std::vector<PendingResponse<SERVICE_TYPE, uint64_t, void, uint64_t, void>> pending_responses_client2;
+        pending_responses_client2.reserve(i);
         for (uint64_t j = 0; j < i; ++j) {
             pending_responses_client2.push_back(client2.send_copy(j).value());
         }
@@ -2423,6 +2428,7 @@ TYPED_TEST(ServiceRequestResponseTest, client_can_decrease_max_active_requests) 
         ASSERT_THAT(pending_response.error(), Eq(RequestSendError::ExceedsMaxActiveRequests));
     }
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 TYPED_TEST(ServiceRequestResponseTest, client_creation_fails_when_max_active_requests_exceeds_service_max) {
     constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
@@ -2454,6 +2460,27 @@ TYPED_TEST(ServiceRequestResponseTest, client_max_active_requests_is_at_least_on
     auto client = service.client_builder().max_active_requests(0).create().value();
 
     ASSERT_THAT(client.max_active_requests(), Eq(1));
+}
+
+TYPED_TEST(ServiceRequestResponseTest, communication_works_when_client_sets_max_active_requests) {
+    constexpr ServiceType SERVICE_TYPE = TestFixture::TYPE;
+
+    const auto service_name = iox2_testing::generate_service_name();
+
+    auto node = NodeBuilder().create<SERVICE_TYPE>().value();
+    auto service = node.service_builder(service_name).template request_response<uint64_t, uint64_t>().create().value();
+
+    auto client = service.client_builder().max_active_requests(1).create().value();
+    auto server = service.server_builder().create().value();
+
+    auto pending_response = client.send_copy(0).value();
+
+    auto active_request = server.receive().value().value();
+    ASSERT_TRUE(active_request.send_copy(1).has_value());
+
+    auto response = pending_response.receive().value();
+    ASSERT_TRUE(response.has_value());
+    ASSERT_THAT(response.value().payload(), Eq(1));
 }
 
 } // namespace

--- a/iceoryx2-ffi/c/src/api/client.rs
+++ b/iceoryx2-ffi/c/src/api/client.rs
@@ -232,6 +232,27 @@ pub unsafe extern "C" fn iox2_client_id(
     }
 }
 
+/// Returns the maximal active requests of the client.
+///
+/// # Arguments
+///
+/// * `handle` obtained by [`iox2_port_factory_client_builder_create`](crate::iox2_port_factory_client_builder_create)
+///
+/// # Safety
+///
+/// * `handle` is valid and non-null
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_client_max_active_requests(handle: iox2_client_h_ref) -> c_size_t {
+    handle.assert_non_null();
+    unsafe {
+        let client = &mut *handle.as_type();
+        match client.service_type {
+            iox2_service_type_e::IPC => client.value.as_ref().ipc.max_active_requests(),
+            iox2_service_type_e::LOCAL => client.value.as_ref().local.max_active_requests(),
+        }
+    }
+}
+
 /// Loans memory from the clients data segment.
 ///
 /// # Arguments

--- a/iceoryx2-ffi/c/src/api/client_details.rs
+++ b/iceoryx2-ffi/c/src/api/client_details.rs
@@ -105,3 +105,16 @@ pub unsafe extern "C" fn iox2_client_details_max_slice_len(
     debug_assert!(!handle.is_null());
     unsafe { (*handle).max_slice_len as _ }
 }
+
+/// Returns the maximal active requests the client can send.
+///
+/// # Safety
+///
+/// * `handle` valid pointer to the client details
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_client_details_max_active_requests(
+    handle: iox2_client_details_ptr,
+) -> c_size_t {
+    debug_assert!(!handle.is_null());
+    unsafe { (*handle).max_active_requests as _ }
+}

--- a/iceoryx2-ffi/c/src/api/port_factory_client_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_client_builder.rs
@@ -37,6 +37,7 @@ pub enum iox2_client_create_error_e {
     EXCEEDS_MAX_SUPPORTED_CLIENTS,
     FAILED_TO_DEPLOY_THREAD_SAFETY_POLICY,
     UNABLE_TO_CREATE_PORT_TAG,
+    MAX_ACTIVE_REQUESTS_EXCEEDS_MAX_SUPPORTED_ACTIVE_REQUESTS_OF_SERVICE,
 }
 
 impl IntoCInt for ClientCreateError {
@@ -53,6 +54,9 @@ impl IntoCInt for ClientCreateError {
             }
             ClientCreateError::UnableToCreatePortTag => {
                 iox2_client_create_error_e::UNABLE_TO_CREATE_PORT_TAG
+            }
+            ClientCreateError::MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService => {
+                iox2_client_create_error_e::MAX_ACTIVE_REQUESTS_EXCEEDS_MAX_SUPPORTED_ACTIVE_REQUESTS_OF_SERVICE
             }
         }) as c_int
     }
@@ -115,7 +119,7 @@ impl PortFactoryClientBuilderUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<PortFactoryClientBuilderUnion>
 pub struct iox2_port_factory_client_builder_storage_t {
-    internal: [u8; 256], // magic number obtained with size_of::<Option<PortFactoryClientBuilderUnion>>()
+    internal: [u8; 272], // magic number obtained with size_of::<Option<PortFactoryClientBuilderUnion>>()
 }
 
 #[repr(C)]
@@ -531,6 +535,42 @@ pub unsafe extern "C" fn iox2_port_factory_client_builder_backpressure_strategy(
 
                 handle.set(PortFactoryClientBuilderUnion::new_local(
                     builder.backpressure_strategy(value.into()),
+                ));
+            }
+        }
+    }
+}
+
+/// Sets the maximal active requests for the client.
+///
+/// # Arguments
+///
+/// * `port_factory_handle` - Must be a valid [`iox2_port_factory_client_builder_h_ref`]
+///   obtained by [`iox2_port_factory_request_response_client_builder`](crate::iox2_port_factory_request_response_client_builder).
+/// * `value` - The value to set the maximal active requests to
+///
+/// # Safety
+///
+/// * `port_factory_handle` must be valid
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn iox2_port_factory_client_builder_set_max_active_requests(
+    port_factory_handle: iox2_port_factory_client_builder_h_ref,
+    value: c_size_t,
+) {
+    port_factory_handle.assert_non_null();
+    unsafe {
+        let handle = &mut *port_factory_handle.as_type();
+        match handle.service_type {
+            iox2_service_type_e::IPC => {
+                let builder = ManuallyDrop::take(&mut handle.value.as_mut().ipc);
+                handle.set(PortFactoryClientBuilderUnion::new_ipc(
+                    builder.max_active_requests(value),
+                ));
+            }
+            iox2_service_type_e::LOCAL => {
+                let builder = ManuallyDrop::take(&mut handle.value.as_mut().local);
+                handle.set(PortFactoryClientBuilderUnion::new_local(
+                    builder.max_active_requests(value),
                 ));
             }
         }

--- a/iceoryx2-ffi/python/src/client.rs
+++ b/iceoryx2-ffi/python/src/client.rs
@@ -158,9 +158,19 @@ impl Client {
             ClientType::Ipc(Some(v)) => v.initial_max_slice_len(),
             ClientType::Local(Some(v)) => v.initial_max_slice_len(),
             _ => {
-                fatal_panic!(from "Client::loan_slice_uninit()",
+                fatal_panic!(from "Client::initial_max_slice_len()",
                     "Accessing a released client.")
             }
+        }
+    }
+
+    #[getter]
+    /// Returns the maximum amount of active requests the `Client` can send.
+    pub fn max_active_requests(&self) -> usize {
+        match &self.value {
+            ClientType::Ipc(Some(v)) => v.max_active_requests(),
+            ClientType::Local(Some(v)) => v.max_active_requests(),
+            _ => fatal_panic!(from "Client::max_active_requests()", "Accessing a released client."),
         }
     }
 }

--- a/iceoryx2-ffi/python/src/port_factory_client.rs
+++ b/iceoryx2-ffi/python/src/port_factory_client.rs
@@ -218,6 +218,23 @@ impl PortFactoryClient {
         }
     }
 
+    /// Defines the maximal active requests the `Client` can send. Smallest possible value is `1`.
+    pub fn max_active_requests(&self, value: usize) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactoryClientType::Ipc(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.max_active_requests(value);
+                self.clone_ipc(this)
+            }
+            PortFactoryClientType::Local(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.max_active_requests(value);
+                self.clone_local(this)
+            }
+        }
+    }
+
     /// Creates a new `Client` or emits a `ClientCreateError` on failure.
     pub fn create(&self) -> PyResult<Client> {
         let _guard = self.factory.lock();

--- a/iceoryx2-ffi/python/tests/client_tests.py
+++ b/iceoryx2-ffi/python/tests/client_tests.py
@@ -134,3 +134,58 @@ def test_deleting_request_mut_removes_it_from_the_service(
         request_uninit = sut.loan_uninit()
     except iox2.LoanError:
         assert False
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_client_applies_max_active_requests(
+    service_type: iox2.ServiceType,
+) -> None:
+    MAX_ACTIVE_REQUESTS = 6
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+    service_name = iox2.testing.generate_service_name()
+    service = (
+        node.service_builder(service_name)
+        .request_response(Payload, Payload)
+        .max_active_requests_per_client(2 * MAX_ACTIVE_REQUESTS)
+        .create()
+    )
+
+    client = service.client_builder().max_active_requests(MAX_ACTIVE_REQUESTS).create()
+
+    assert client.max_active_requests == MAX_ACTIVE_REQUESTS
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_client_creation_fails_when_max_active_requests_exceeds_service_max(
+    service_type: iox2.ServiceType,
+) -> None:
+    MAX_ACTIVE_REQUESTS = 13
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+    service_name = iox2.testing.generate_service_name()
+    service = (
+        node.service_builder(service_name)
+        .request_response(Payload, Payload)
+        .max_active_requests_per_client(MAX_ACTIVE_REQUESTS)
+        .create()
+    )
+
+    with pytest.raises(iox2.ClientCreateError):
+        service.client_builder().max_active_requests(MAX_ACTIVE_REQUESTS + 1).create()
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_client_max_active_requests_is_at_least_one(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+    service_name = iox2.testing.generate_service_name()
+    service = (
+        node.service_builder(service_name).request_response(Payload, Payload).create()
+    )
+
+    client = service.client_builder().max_active_requests(0).create()
+
+    assert client.max_active_requests == 1

--- a/iceoryx2-ffi/python/tests/service_request_response_tests.py
+++ b/iceoryx2-ffi/python/tests/service_request_response_tests.py
@@ -583,3 +583,27 @@ def test_client_can_decrease_max_active_requests(
 
         with pytest.raises(iox2.RequestSendError):
             client2.send_copy(Payload(data=0))
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_communication_works_when_client_sets_max_active_requests(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+
+    service_name = iox2.testing.generate_service_name()
+    service = (
+        node.service_builder(service_name).request_response(Payload, Payload).create()
+    )
+
+    client = service.client_builder().max_active_requests(1).create()
+    server = service.server_builder().create()
+
+    pending_response = client.send_copy(Payload(data=0))
+
+    active_request = server.receive()
+    active_request.send_copy(Payload(data=1))
+
+    response = pending_response.receive()
+    assert response.payload().contents.data == 1

--- a/iceoryx2-ffi/python/tests/service_request_response_tests.py
+++ b/iceoryx2-ffi/python/tests/service_request_response_tests.py
@@ -548,3 +548,38 @@ def test_client_can_request_graceful_disconnect(
 
     assert active_request.is_connected is False
     assert active_request.has_disconnect_hint is False
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_client_can_decrease_max_active_requests(
+    service_type: iox2.ServiceType,
+) -> None:
+    MAX_ACTIVE_REQUESTS = 13
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+
+    service_name = iox2.testing.generate_service_name()
+    service = (
+        node.service_builder(service_name)
+        .request_response(Payload, Payload)
+        .max_active_requests_per_client(MAX_ACTIVE_REQUESTS)
+        .create()
+    )
+
+    for i in range(1, MAX_ACTIVE_REQUESTS):
+        client1 = service.client_builder().create()
+        client2 = service.client_builder().max_active_requests(i).create()
+
+        assert client1.max_active_requests == MAX_ACTIVE_REQUESTS
+        assert client2.max_active_requests == i
+
+        pending_responses_client1 = []
+        for j in range(0, MAX_ACTIVE_REQUESTS):
+            pending_responses_client1.append(client1.send_copy(Payload(data=j)))
+
+        pending_responses_client2 = []
+        for j in range(0, i):
+            pending_responses_client2.append(client2.send_copy(Payload(data=j)))
+
+        with pytest.raises(iox2.RequestSendError):
+            client2.send_copy(Payload(data=0))

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -1714,7 +1714,7 @@ pub mod service_request_response {
 
         let client = service
             .client_builder()
-            .max_active_requests(2)
+            .max_active_requests(1)
             .create()
             .unwrap();
         let server = service.server_builder().create().unwrap();

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -1714,7 +1714,7 @@ pub mod service_request_response {
 
         let client = service
             .client_builder()
-            .max_active_requests(2) // works with 4
+            .max_active_requests(2)
             .create()
             .unwrap();
         let server = service.server_builder().create().unwrap();
@@ -1724,12 +1724,8 @@ pub mod service_request_response {
         let active_request = server.receive().unwrap().unwrap();
         assert_that!(active_request.send_copy(1), is_ok);
 
-        // Client response_receiver und Server response_sender don't connect
-        // because of number_of_channels
-        // server uses required_amount_of_chunks_per_client_data_segment for calculation
-        // request_sender and request_receiver connect, because number_of_channels = 1
         let response = pending_response.receive().unwrap();
         assert_that!(response, is_some);
-        // assert_that!(*response, eq 1);
+        assert_that!(*response.unwrap(), eq 1);
     }
 }

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -1631,7 +1631,7 @@ pub mod service_request_response {
             let client1 = service.client_builder().create().unwrap();
             let client2 = service
                 .client_builder()
-                .set_max_active_requests(i)
+                .max_active_requests(i)
                 .create()
                 .unwrap();
 
@@ -1673,7 +1673,7 @@ pub mod service_request_response {
 
         let client = service
             .client_builder()
-            .set_max_active_requests(MAX_ACTIVE_REQUESTS + 1)
+            .max_active_requests(MAX_ACTIVE_REQUESTS + 1)
             .create();
         assert_that!(client, is_err);
         assert_that!(client.err().unwrap(), eq ClientCreateError::MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService);
@@ -1693,7 +1693,7 @@ pub mod service_request_response {
 
         let client = service
             .client_builder()
-            .set_max_active_requests(0)
+            .max_active_requests(0)
             .create()
             .unwrap();
 

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -1699,4 +1699,37 @@ pub mod service_request_response {
 
         assert_that!(client.max_active_requests(), eq 1);
     }
+
+    #[conformance_test]
+    pub fn communication_works_when_client_sets_max_active_requests<S: Service>() {
+        let test = Test::<S>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<usize, usize>()
+            .create()
+            .unwrap();
+
+        let client = service
+            .client_builder()
+            .max_active_requests(2) // works with 4
+            .create()
+            .unwrap();
+        let server = service.server_builder().create().unwrap();
+
+        let pending_response = client.send_copy(0).unwrap();
+
+        let active_request = server.receive().unwrap().unwrap();
+        assert_that!(active_request.send_copy(1), is_ok);
+
+        // Client response_receiver und Server response_sender don't connect
+        // because of number_of_channels
+        // server uses required_amount_of_chunks_per_client_data_segment for calculation
+        // request_sender and request_receiver connect, because number_of_channels = 1
+        let response = pending_response.receive().unwrap();
+        assert_that!(response, is_some);
+        // assert_that!(*response, eq 1);
+    }
 }

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -19,10 +19,11 @@ pub mod service_request_response {
     use alloc::{vec, vec::Vec};
 
     use iceoryx2::port::LoanError;
-    use iceoryx2::port::client::Client;
+    use iceoryx2::port::client::{Client, RequestSendError};
     use iceoryx2::port::server::Server;
     use iceoryx2::prelude::{PortFactory, *};
     use iceoryx2::service::builder::{CustomHeaderMarker, CustomPayloadMarker};
+    use iceoryx2::service::port_factory::client::ClientCreateError;
     use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_bb_testing_macros::conformance_test;
@@ -1610,5 +1611,92 @@ pub mod service_request_response {
 
         assert_that!(active_request.is_connected(), eq false);
         assert_that!(active_request.has_disconnect_hint(), eq false);
+    }
+
+    #[conformance_test]
+    pub fn client_can_decrease_max_active_requests<S: Service>() {
+        const MAX_ACTIVE_REQUESTS: usize = 13;
+        let test = Test::<S>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<usize, usize>()
+            .max_active_requests_per_client(MAX_ACTIVE_REQUESTS)
+            .create()
+            .unwrap();
+
+        for i in 1..MAX_ACTIVE_REQUESTS {
+            let client1 = service.client_builder().create().unwrap();
+            let client2 = service
+                .client_builder()
+                .set_max_active_requests(i)
+                .create()
+                .unwrap();
+
+            assert_that!(client1.max_active_requests(), eq MAX_ACTIVE_REQUESTS);
+            assert_that!(client2.max_active_requests(), eq i);
+
+            let mut pending_responses_client1 = vec![];
+            for n in 0..MAX_ACTIVE_REQUESTS {
+                let pr = client1.send_copy(n);
+                assert_that!(pr, is_ok);
+                pending_responses_client1.push(pr.unwrap());
+            }
+
+            let mut pending_responses_client2 = vec![];
+            for n in 0..i {
+                let pr = client2.send_copy(n);
+                assert_that!(pr, is_ok);
+                pending_responses_client2.push(pr.unwrap());
+            }
+            let pr = client2.send_copy(0);
+            assert_that!(pr, is_err);
+            assert_that!(pr.err().unwrap(), eq RequestSendError::ExceedsMaxActiveRequests);
+        }
+    }
+
+    #[conformance_test]
+    pub fn client_creation_fails_when_max_active_requests_exceeds_service_max<S: Service>() {
+        const MAX_ACTIVE_REQUESTS: usize = 13;
+        let test = Test::<S>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<usize, usize>()
+            .max_active_requests_per_client(MAX_ACTIVE_REQUESTS)
+            .create()
+            .unwrap();
+
+        let client = service
+            .client_builder()
+            .set_max_active_requests(MAX_ACTIVE_REQUESTS + 1)
+            .create();
+        assert_that!(client, is_err);
+        assert_that!(client.err().unwrap(), eq ClientCreateError::MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService);
+    }
+
+    #[conformance_test]
+    pub fn client_max_active_requests_is_at_least_one<S: Service>() {
+        let test = Test::<S>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<usize, usize>()
+            .create()
+            .unwrap();
+
+        let client = service
+            .client_builder()
+            .set_max_active_requests(0)
+            .create()
+            .unwrap();
+
+        assert_that!(client.max_active_requests(), eq 1);
     }
 }

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -172,6 +172,7 @@ pub(crate) struct ClientSharedState<Service: service::Service> {
     server_list_state: UnsafeCell<ContainerState<ServerDetails>>,
     pub(crate) active_request_counter: AtomicUsize,
     pub(crate) available_channel_ids: UnsafeCell<Queue<ChannelId>>,
+    pub(crate) max_active_requests: usize,
     // IMPORTANT!
     // Fields of a rust struct are dropped in declaration order. Since this tag is our marker that the
     // port exists and might require cleanup after a crash, the tag must be defined as last member of
@@ -410,12 +411,20 @@ impl<
         };
 
         let static_config = client_factory.factory.static_config();
-        // TODO: use max_active_requests (if set) for chunk calculation to decrease size of data segment?
-        let number_of_requests =
-            unsafe { service.static_config().messaging_pattern.request_response() }
+        let number_of_requests = match client_factory.config.max_active_requests {
+            Some(requests) => {
+                unsafe { service.static_config().messaging_pattern.request_response() }
+                    .required_amount_of_chunks_per_client_data_segment(
+                        static_config.max_loaned_requests,
+                        requests,
+                    )
+            }
+            None => unsafe { service.static_config().messaging_pattern.request_response() }
                 .required_amount_of_chunks_per_client_data_segment(
                     static_config.max_loaned_requests,
-                );
+                    static_config.max_active_requests_per_client,
+                ),
+        };
         let number_of_requests = client_factory
             .preallocate_number_of_requests_override
             .call(number_of_requests);
@@ -492,8 +501,8 @@ impl<
             connections: (0..server_list.capacity())
                 .map(|_| UnsafeCell::new(None))
                 .collect(),
-            receiver_max_buffer_size: max_active_requests,
-            receiver_max_borrowed_samples: max_active_requests,
+            receiver_max_buffer_size: static_config.max_active_requests_per_client,
+            receiver_max_borrowed_samples: static_config.max_active_requests_per_client,
             enable_safe_overflow: static_config.enable_safe_overflow_for_requests,
             degradation_handler: client_factory.request_degradation_handler,
             backpressure_handler: client_factory.backpressure_handler,
@@ -564,6 +573,7 @@ impl<
             response_receiver,
             server_list_state: UnsafeCell::new(unsafe { server_list.get_state() }),
             active_request_counter: AtomicUsize::new(0),
+            max_active_requests,
         });
 
         let client_shared_state = match client_shared_state {
@@ -644,10 +654,7 @@ impl<
 
     /// Returns the maximal active requests a [`Client`] can send.
     pub fn max_active_requests(&self) -> usize {
-        self.client_shared_state
-            .lock()
-            .request_sender
-            .receiver_max_borrowed_samples
+        self.client_shared_state.lock().max_active_requests
     }
 }
 

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -221,14 +221,17 @@ impl<Service: service::Service> ClientSharedState<Service> {
         let msg = "Unable to send request";
 
         let active_request_counter = self.active_request_counter.load(Ordering::Relaxed);
-        if self
-            .request_sender
-            .service_state
-            .static_config()
-            .request_response()
-            .max_active_requests_per_client
-            <= active_request_counter
-        {
+        let max_active_requests = match self.config.max_active_requests {
+            Some(requests) => requests,
+            None => {
+                self.request_sender
+                    .service_state
+                    .static_config()
+                    .request_response()
+                    .max_active_requests_per_client
+            }
+        };
+        if max_active_requests <= active_request_counter {
             fail!(from self, with RequestSendError::ExceedsMaxActiveRequests,
                     "{} since the number of active requests is limited to {} and sending this request would exceed the limit.", msg, active_request_counter);
         }
@@ -407,6 +410,7 @@ impl<
         };
 
         let static_config = client_factory.factory.static_config();
+        // TODO: use max_active_requests (if set) for chunk calculation to decrease size of data segment?
         let number_of_requests =
             unsafe { service.static_config().messaging_pattern.request_response() }
                 .required_amount_of_chunks_per_client_data_segment(
@@ -460,6 +464,18 @@ impl<
             max_number_of_segments,
         };
 
+        let max_active_requests = match client_factory.config.max_active_requests {
+            Some(requests) => {
+                if static_config.max_active_requests_per_client < requests {
+                    fail!(from origin, with ClientCreateError::MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService,
+                        "{} since the requested max_active_requests {} exceeds the maximum supported active requests {} of the service.",
+                    msg, requests, static_config.max_active_requests_per_client);
+                }
+                requests
+            }
+            None => static_config.max_active_requests_per_client,
+        };
+
         let request_sender = Sender {
             data_segment,
             segment_states: {
@@ -475,8 +491,8 @@ impl<
             connections: (0..server_list.capacity())
                 .map(|_| UnsafeCell::new(None))
                 .collect(),
-            receiver_max_buffer_size: static_config.max_active_requests_per_client,
-            receiver_max_borrowed_samples: static_config.max_active_requests_per_client,
+            receiver_max_buffer_size: max_active_requests,
+            receiver_max_borrowed_samples: max_active_requests,
             enable_safe_overflow: static_config.enable_safe_overflow_for_requests,
             degradation_handler: client_factory.request_degradation_handler,
             backpressure_handler: client_factory.backpressure_handler,
@@ -623,6 +639,14 @@ impl<
             .lock()
             .request_sender
             .backpressure_strategy
+    }
+
+    /// Returns the maximal active requests a [`Client`] can send.
+    pub fn max_active_requests(&self) -> usize {
+        self.client_shared_state
+            .lock()
+            .request_sender
+            .receiver_max_borrowed_samples
     }
 }
 

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -411,6 +411,12 @@ impl<
         };
 
         let static_config = client_factory.factory.static_config();
+        let number_of_requests_with_max_service_setting =
+            unsafe { service.static_config().messaging_pattern.request_response() }
+                .required_amount_of_chunks_per_client_data_segment(
+                    static_config.max_loaned_requests,
+                    static_config.max_active_requests_per_client,
+                );
         let number_of_requests = match client_factory.config.max_active_requests {
             Some(requests) => {
                 unsafe { service.static_config().messaging_pattern.request_response() }
@@ -419,11 +425,7 @@ impl<
                         requests,
                     )
             }
-            None => unsafe { service.static_config().messaging_pattern.request_response() }
-                .required_amount_of_chunks_per_client_data_segment(
-                    static_config.max_loaned_requests,
-                    static_config.max_active_requests_per_client,
-                ),
+            None => number_of_requests_with_max_service_setting,
         };
         let number_of_requests = client_factory
             .preallocate_number_of_requests_override
@@ -533,20 +535,6 @@ impl<
         let number_of_connections =
             number_of_to_be_removed_connections + number_of_active_connections;
 
-        // The number of channels must be calculated with `max_active_requests_per_client` set on
-        // service creation, because the connection between the client's response_receiver and the
-        // server's response_sender can only be established when the number is the same for both.
-        // This doesn't matter for the request channel since all requests are sent via the same channel.
-        let number_of_responses =
-            unsafe { service.static_config().messaging_pattern.request_response() }
-                .required_amount_of_chunks_per_client_data_segment(
-                    static_config.max_loaned_requests,
-                    static_config.max_active_requests_per_client,
-                );
-        let number_of_responses = client_factory
-            .preallocate_number_of_requests_override
-            .call(number_of_responses);
-
         let response_receiver = Receiver {
             connections: PolymorphicVec::from_fn(
                 HeapAllocator::global(),
@@ -567,7 +555,7 @@ impl<
             receiver_max_borrowed_samples: static_config
                 .max_borrowed_responses_per_pending_response,
             enable_safe_overflow: static_config.enable_safe_overflow_for_responses,
-            number_of_channels: number_of_responses,
+            number_of_channels: number_of_requests_with_max_service_setting,
             connection_storage: UnsafeCell::new(SlotMap::new(number_of_connections)),
             initial_channel_state: CHANNEL_STATE_CLOSED,
         };

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -533,6 +533,20 @@ impl<
         let number_of_connections =
             number_of_to_be_removed_connections + number_of_active_connections;
 
+        // The number of channels must be calculated with `max_active_requests_per_client` set on
+        // service creation, because the connection between the client's response_receiver and the
+        // server's response_sender can only be established when the number is the same for both.
+        // This doesn't matter for the request channel since all requests are sent via the same channel.
+        let number_of_responses =
+            unsafe { service.static_config().messaging_pattern.request_response() }
+                .required_amount_of_chunks_per_client_data_segment(
+                    static_config.max_loaned_requests,
+                    static_config.max_active_requests_per_client,
+                );
+        let number_of_responses = client_factory
+            .preallocate_number_of_requests_override
+            .call(number_of_responses);
+
         let response_receiver = Receiver {
             connections: PolymorphicVec::from_fn(
                 HeapAllocator::global(),
@@ -553,7 +567,7 @@ impl<
             receiver_max_borrowed_samples: static_config
                 .max_borrowed_responses_per_pending_response,
             enable_safe_overflow: static_config.enable_safe_overflow_for_responses,
-            number_of_channels: number_of_requests,
+            number_of_channels: number_of_responses,
             connection_storage: UnsafeCell::new(SlotMap::new(number_of_connections)),
             initial_channel_state: CHANNEL_STATE_CLOSED,
         };

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -454,16 +454,6 @@ impl<
             with ClientCreateError::UnableToCreateDataSegment,
             "{} since the client data segment could not be created.", msg);
 
-        let client_details = ClientDetails {
-            client_id,
-            node_id: *service.shared_node().id(),
-            number_of_requests,
-            response_buffer_size: static_config.max_response_buffer_size,
-            max_slice_len: client_factory.config.initial_max_slice_len,
-            data_segment_type,
-            max_number_of_segments,
-        };
-
         let max_active_requests = match client_factory.config.max_active_requests {
             Some(requests) => {
                 if static_config.max_active_requests_per_client < requests {
@@ -474,6 +464,17 @@ impl<
                 requests
             }
             None => static_config.max_active_requests_per_client,
+        };
+
+        let client_details = ClientDetails {
+            client_id,
+            node_id: *service.shared_node().id(),
+            number_of_requests,
+            response_buffer_size: static_config.max_response_buffer_size,
+            max_slice_len: client_factory.config.initial_max_slice_len,
+            data_segment_type,
+            max_number_of_segments,
+            max_active_requests,
         };
 
         let request_sender = Sender {

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -350,6 +350,7 @@ impl<
             unsafe { service.static_config().messaging_pattern.request_response() }
                 .required_amount_of_chunks_per_client_data_segment(
                     static_config.max_loaned_requests,
+                    static_config.max_active_requests_per_client,
                 );
 
         let number_of_responses =

--- a/iceoryx2/src/service/dynamic_config/request_response.rs
+++ b/iceoryx2/src/service/dynamic_config/request_response.rs
@@ -78,6 +78,9 @@ pub struct ClientDetails {
     /// [`DataSegmentType::Dynamic`] it defines how many segment the
     /// [`Client`](crate::port::client::Client) can have at most.
     pub max_number_of_segments: u8,
+    /// The maximal amount of active request a
+    /// [`Client`](crate::port::client::Client) can send.
+    pub max_active_requests: usize,
 }
 
 #[repr(C)]

--- a/iceoryx2/src/service/port_factory/client.rs
+++ b/iceoryx2/src/service/port_factory/client.rs
@@ -282,7 +282,7 @@ impl<
     }
 
     /// Sets the maximal amount of active requests the [`Client`] can send.
-    pub fn set_max_active_requests(mut self, value: usize) -> Self {
+    pub fn max_active_requests(mut self, value: usize) -> Self {
         self.config.max_active_requests = Some(value.max(1));
         self
     }

--- a/iceoryx2/src/service/port_factory/client.rs
+++ b/iceoryx2/src/service/port_factory/client.rs
@@ -62,6 +62,9 @@ pub enum ClientCreateError {
     FailedToDeployThreadsafetyPolicy,
     /// The tracking port tag, required for cleanup, could not be created.
     UnableToCreatePortTag,
+    /// When the [`Client`] requires more active requests than the
+    /// [`Service`](crate::service::Service) offers, the creation will fail.
+    MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService,
 }
 
 impl core::fmt::Display for ClientCreateError {
@@ -99,6 +102,7 @@ pub(crate) struct LocalClientConfig {
     pub(crate) backpressure_strategy: BackpressureStrategy,
     pub(crate) initial_max_slice_len: usize,
     pub(crate) allocation_strategy: AllocationStrategy,
+    pub(crate) max_active_requests: Option<usize>,
 }
 
 /// Factory to create a new [`Client`] port/endpoint for
@@ -198,6 +202,7 @@ impl<
                 backpressure_strategy: defs.client_backpressure_strategy,
                 initial_max_slice_len: 1,
                 allocation_strategy: defs.client_allocation_strategy,
+                max_active_requests: None,
             },
             preallocate_number_of_requests_override: PreallocatedRequestsOverride::new(|v| v),
             request_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
@@ -273,6 +278,12 @@ impl<
     pub fn set_backpressure_handler<F: BackpressureFn + 'static>(mut self, handler: F) -> Self {
         self.backpressure_handler = Some(BackpressureHandler::new(handler));
 
+        self
+    }
+
+    /// Sets the maximal amount of active requests the [`Client`] can send.
+    pub fn set_max_active_requests(mut self, value: usize) -> Self {
+        self.config.max_active_requests = Some(value.max(1));
         self
     }
 

--- a/iceoryx2/src/service/static_config/request_response.rs
+++ b/iceoryx2/src/service/static_config/request_response.rs
@@ -103,14 +103,15 @@ impl StaticConfig {
     pub(crate) fn required_amount_of_chunks_per_client_data_segment(
         &self,
         client_max_loaned_data: usize,
+        client_max_active_requests: usize,
     ) -> usize {
         // all chunks a server can hold
         self.max_servers * (
             // a client sent so many active requests to a server in parallel
-            self.max_active_requests_per_client +
+            client_max_active_requests +
             // the server can still hold old requests that the client has already dropped. in this case
             // the client can fill up the server's buffer with at most max_active_requests_per_client again
-            self.max_active_requests_per_client
+            client_max_active_requests
         )
         // all chunks a client can loan in parallel
             + client_max_loaned_data


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
See title.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1137 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
