### PR TITLE
[#1752] Map 'InsufficientResources' to 'BufferIsFull'

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -412,8 +412,6 @@ jobs:
       profile: "debug"
 
   freebsd:
-    # Disable job till the FreeBSD Images are upgraded
-    if: false
     needs: [preflight-check]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -432,7 +430,7 @@ jobs:
           mode: "remove-unneeded-software-from-runner"
 
       - name: Build and Test
-        uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # version v1.4.6
+        uses: vmactions/freebsd-vm@bac9cda6a14057f08e3793f6a5e037292b59868f # version v1.4.7
         with:
           release: ${{ matrix.freebsd_version }}
           mem: 16384
@@ -566,6 +564,7 @@ jobs:
         static-code-analysis-cpp,
         sdk-stable-debug,
         integrations-stable-debug,
+        freebsd,
         Bazel,
         x86_32-debug,
         no_std,

--- a/iceoryx2-cal/conformance-tests/tests-common/src/event_trait_tests.rs
+++ b/iceoryx2-cal/conformance-tests/tests-common/src/event_trait_tests.rs
@@ -22,7 +22,6 @@ instantiate_conformance_tests_with_module!(
     iceoryx2_cal::event::SemaphoreShmBitSet
 );
 
-#[cfg(not(target_os = "freebsd"))]
 instantiate_conformance_tests_with_module!(
     unix_datagram_shared_memory_bitset,
     iceoryx2_cal_conformance_tests::event_trait,
@@ -47,7 +46,6 @@ instantiate_conformance_tests_with_module!(
     iceoryx2_cal::event::SemaphoreShmCountingBitSet
 );
 
-#[cfg(not(target_os = "freebsd"))]
 instantiate_conformance_tests_with_module!(
     unix_datagram_shared_memory_counting_bitset,
     iceoryx2_cal_conformance_tests::event_trait,

--- a/iceoryx2-cal/src/event/trigger/unix_datagram_socket.rs
+++ b/iceoryx2-cal/src/event/trigger/unix_datagram_socket.rs
@@ -81,7 +81,7 @@ impl<E: EventState, Storage: DynamicStorage<State<E, ()>>> HandlerInterface<E, (
         let msg = "Unable to send notification";
         match self.sender.try_send(&[0u8]) {
             Ok(true) => Ok(()),
-            Ok(false) => {
+            Ok(false) | Err(UnixDatagramSendError::InsufficientResources) => {
                 fail!(from self, with NotifierNotifyError::BufferIsFull,
                     "{msg} since data could not be sent through the socket.");
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

On FreeBSD, a full buffer is signaled by an `ENOBUFS` errno, which is mapped to an `UnixDatagramSendError::InsufficientResources`. This in turn needs to be mapped to `NotifierNotifyError::BufferIsFull`.

The issue was introduced with the event refactoring and therefore does not need to have an entry in the changelog.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1752

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
