### PR TITLE
[#4] Add docs for pypi.org publishing

### DIFF
--- a/doc/how-to-create-an-iceoryx2-release.md
+++ b/doc/how-to-create-an-iceoryx2-release.md
@@ -78,6 +78,24 @@ There are three scripts to perform the iceoryx2 release
 6. `./internal/scripts/release/release_publish.sh`
 7. Verify that the release looks fine on `docs.rs` (click through the
     documentation to check if everything was generated correctly)
+8. For patch releases, port the changelog back to the main branch and set
+   `PREVIOUS_RELEASE` from `internal/VERSIONS` to the latest patch release
+
+## 3: Publish Python bindings to pypi.org
+
+1. Start a [release workflow](https://github.com/eclipse-iceoryx/iceoryx2/actions/workflows/release.yml)
+   for the new tag
+2. Once finished, the `python-dist-...` artifact needs to be downloaded and
+   extracted
+3. If not yet done, create a API token at <https://pypi.org>
+4. Upload the dist artifacts with the following command. During the execution
+   of the command, the API token is requested
+
+```sh
+poetry --project=path/to/iceoryx2-ffi/python/ upload-dist --dist /full/path/to/extracted/dist/artifacts --repo pypi
+```
+
+Reference for configuration: <https://packaging.python.org/en/latest/specifications/pypirc/>
 
 ### Details
 

--- a/internal/scripts/release/release_publish.sh
+++ b/internal/scripts/release/release_publish.sh
@@ -59,6 +59,10 @@ print_publish_crates_io() {
     echo -e "* Run 'just publish all'"
 }
 
+print_publish_pypi_org() {
+    echo -e "Check out ./doc/how-to-create-an-iceoryx2-release.md for instructions"
+}
+
 print_howto() {
     STEP_COUNTER=0
 
@@ -70,6 +74,9 @@ print_howto() {
 
     print_step "Publish To crates.io"
     print_publish_crates_io
+
+    print_step "Publish To pypi.org"
+    print_publish_pypi_org
 }
 
 while (( "$#" )); do
@@ -152,5 +159,8 @@ if [[ ${SELECTION} == ${YES} ]]; then
 
     show_completion
 fi
+
+print_step "Publish to pypi.org"
+print_publish_pypi_org
 
 echo -e "${C_GREEN}FINISHED${C_OFF}"


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [~] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #4

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
