### PR TITLE
[#77] Backport to release 0.9

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -24,6 +24,7 @@
 
 * [#1757](https://github.com/eclipse-iceoryx/iceoryx2/issues/1757) Enable running multiple iceoryx2 versions in distinct domains in parallel by adding a version suffix to the global mgmt segment
 * [#1763](https://github.com/eclipse-iceoryx/iceoryx2/issues/1763) Close `ActiveRequest-PendingResponse` connection when dead process is cleaned up.
+* [#1765](https://github.com/eclipse-iceoryx/iceoryx2/issues/1765) Remove unnecessary `fsync` on file open
 
 ### Refactoring
 

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -22,7 +22,7 @@
     conflicts when merging.
 -->
 
-* [#1](https://github.com/eclipse-iceoryx/iceoryx2/issues/1) Example text
+* [#1763](https://github.com/eclipse-iceoryx/iceoryx2/issues/1763) Close `ActiveRequest-PendingResponse` connection when dead process is cleaned up.
 
 ### Refactoring
 

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -22,7 +22,7 @@
     conflicts when merging.
 -->
 
-* [#1757](https://github.com/eclipse-iceoryx/iceoryx2/issues/1757) Enable running multiple iceoryx2 versions in parallel by adding a version suffix to the global mgmt segment
+* [#1757](https://github.com/eclipse-iceoryx/iceoryx2/issues/1757) Enable running multiple iceoryx2 versions in distinct domains in parallel by adding a version suffix to the global mgmt segment
 * [#1763](https://github.com/eclipse-iceoryx/iceoryx2/issues/1763) Close `ActiveRequest-PendingResponse` connection when dead process is cleaned up.
 
 ### Refactoring

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -22,6 +22,7 @@
     conflicts when merging.
 -->
 
+* [#1757](https://github.com/eclipse-iceoryx/iceoryx2/issues/1757) Enable running multiple iceoryx2 versions in parallel by adding a version suffix to the global mgmt segment
 * [#1763](https://github.com/eclipse-iceoryx/iceoryx2/issues/1763) Close `ActiveRequest-PendingResponse` connection when dead process is cleaned up.
 
 ### Refactoring

--- a/iceoryx2-bb/posix/src/file.rs
+++ b/iceoryx2-bb/posix/src/file.rs
@@ -305,7 +305,6 @@ pub struct FileBuilder {
     access_mode: AccessMode,
     permission: Permission,
     has_ownership: bool,
-    sync_on_open: bool,
     owner: Option<Uid>,
     group: Option<Gid>,
     truncate_size: Option<usize>,
@@ -320,22 +319,11 @@ impl FileBuilder {
             access_mode: AccessMode::Read,
             permission: Permission::OWNER_ALL,
             has_ownership: false,
-            sync_on_open: true,
             owner: None,
             group: None,
             truncate_size: None,
             creation_mode: None,
         }
-    }
-
-    /// Shall the [`File`] be synced before it is opened so that the user has the most current
-    /// view on it. This could cause some performance impact for large files that have been
-    /// updated.
-    ///
-    /// It is enabled by default.
-    pub fn sync_on_open(mut self, value: bool) -> Self {
-        self.sync_on_open = value;
-        self
     }
 
     /// Defines if the created or opened file is owned by the [`File`] object. If it is owned, the
@@ -593,19 +581,12 @@ impl File {
 
         if let Some(v) = file_descriptor {
             trace!(from config, "opened");
-            let mut new_self = File {
+            let new_self = File {
                 path: Some(config.file_path),
                 file_descriptor: v,
                 has_ownership: AtomicBool::new(config.has_ownership),
                 access_mode: config.access_mode,
             };
-
-            if config.sync_on_open {
-                if let Err(e) = new_self.sync_all() {
-                    debug!(from new_self,
-                        "Unable to sync file before opening it. The file properties and content might be out-of-date. [{e:?}]");
-                }
-            }
 
             return Ok(new_self);
         }

--- a/iceoryx2-cal/conformance-tests/src/zero_copy_connection_trait.rs
+++ b/iceoryx2-cal/conformance-tests/src/zero_copy_connection_trait.rs
@@ -2260,4 +2260,78 @@ pub mod zero_copy_connection_trait {
             sut_receiver.release(offset, ChannelId::new(0)).unwrap();
         }
     }
+
+    #[conformance_test]
+    pub fn removing_receiver_closes_all_channels<Sut: ZeroCopyConnection>() {
+        const BUFFER_SIZE: usize = 10;
+        const NUMBER_OF_CHANNELS: usize = 4;
+
+        let name = generate_file_path().file_name();
+        let config = generate_isolated_config::<Sut>();
+
+        let sut_sender = Sut::Builder::new(&name)
+            .number_of_samples_per_segment(NUMBER_OF_SAMPLES)
+            .number_of_channels(NUMBER_OF_CHANNELS)
+            .buffer_size(BUFFER_SIZE)
+            .config(&config)
+            .create_sender()
+            .unwrap();
+
+        let sut_receiver = Sut::Builder::new(&name)
+            .number_of_samples_per_segment(NUMBER_OF_SAMPLES)
+            .number_of_channels(NUMBER_OF_CHANNELS)
+            .buffer_size(BUFFER_SIZE)
+            .config(&config)
+            .create_receiver()
+            .unwrap();
+
+        for n in 0..NUMBER_OF_CHANNELS {
+            sut_receiver.set_channel_state(ChannelId::new(n), ChannelState::new(1234).unwrap());
+        }
+
+        sut_receiver.abandon();
+
+        unsafe { Sut::remove_receiver(&name, &config).unwrap() };
+
+        for n in 0..NUMBER_OF_CHANNELS {
+            assert_that!(sut_sender.is_channel_closed(ChannelId::new(n)), eq true);
+        }
+    }
+
+    #[conformance_test]
+    pub fn removing_sender_closes_all_channels<Sut: ZeroCopyConnection>() {
+        const BUFFER_SIZE: usize = 10;
+        const NUMBER_OF_CHANNELS: usize = 4;
+
+        let name = generate_file_path().file_name();
+        let config = generate_isolated_config::<Sut>();
+
+        let sut_sender = Sut::Builder::new(&name)
+            .number_of_samples_per_segment(NUMBER_OF_SAMPLES)
+            .number_of_channels(NUMBER_OF_CHANNELS)
+            .buffer_size(BUFFER_SIZE)
+            .config(&config)
+            .create_sender()
+            .unwrap();
+
+        let sut_receiver = Sut::Builder::new(&name)
+            .number_of_samples_per_segment(NUMBER_OF_SAMPLES)
+            .number_of_channels(NUMBER_OF_CHANNELS)
+            .buffer_size(BUFFER_SIZE)
+            .config(&config)
+            .create_receiver()
+            .unwrap();
+
+        for n in 0..NUMBER_OF_CHANNELS {
+            sut_sender.set_channel_state(ChannelId::new(n), ChannelState::new(1234).unwrap());
+        }
+
+        sut_sender.abandon();
+
+        unsafe { Sut::remove_sender(&name, &config).unwrap() };
+
+        for n in 0..NUMBER_OF_CHANNELS {
+            assert_that!(sut_receiver.is_channel_closed(ChannelId::new(n)), eq true);
+        }
+    }
 }

--- a/iceoryx2-cal/src/zero_copy_connection/common.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/common.rs
@@ -1088,7 +1088,11 @@ pub mod details {
             match <<Storage as DynamicStorage<SharedManagementData>>::Builder<'_> as NamedConceptBuilder<
                     Storage>>::new(name)
                        .config(&config.dynamic_storage_config).open(AccessMode::ReadWrite) {
-                           Ok(storage) => { cleanup_shared_memory(&storage, port); Ok(())},
+                           Ok(storage) => {
+                               for channel in storage.get().channels.iter() {
+                                   channel.state.store(CHANNEL_STATE_CLOSED.0, Ordering::Relaxed);
+                               }
+                               cleanup_shared_memory(&storage, port); Ok(())},
                            Err(DynamicStorageOpenError::InitializationNotYetFinalized) => {
                                match unsafe { Storage::remove_cfg(name, &config.dynamic_storage_config) } {
                                    Ok(_) => Ok(()),

--- a/iceoryx2-cal/src/zero_copy_connection/mod.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/mod.rs
@@ -280,6 +280,13 @@ pub trait ZeroCopyPortDetails {
         expected_state.0 == state_without_disconnect_hint_bit
     }
 
+    fn is_channel_closed(&self, channel_id: ChannelId) -> bool {
+        let state = self
+            .__internal_get_channel_state(channel_id)
+            .load(Ordering::Relaxed);
+        state == CHANNEL_STATE_CLOSED.0
+    }
+
     fn close_channel(&self, channel_id: ChannelId, expected_state: ChannelState) {
         match self
             .__internal_get_channel_state(channel_id)

--- a/iceoryx2/conformance-tests/src/node_death.rs
+++ b/iceoryx2/conformance-tests/src/node_death.rs
@@ -1042,4 +1042,86 @@ pub mod node_death {
             },
         );
     }
+
+    #[conformance_test]
+    pub fn connection_state_is_updated_when_dead_client_is_cleaned_up<S: Test>() {
+        test_requires!(does_support_persistency::<S>());
+
+        let test = S::new();
+        let service_name = generate_service_name();
+
+        let bad_node = test.create_bad_node();
+        let bad_service = bad_node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .create()
+            .unwrap();
+        let bad_client = bad_service.client_builder().create().unwrap();
+
+        let good_node = test.create_good_node();
+        let good_service = good_node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .open()
+            .unwrap();
+        let good_server = good_service.server_builder().create().unwrap();
+
+        let bad_pending_response = bad_client.send_copy(0).unwrap();
+        let good_active_request = good_server.receive().unwrap().unwrap();
+
+        assert_that!(good_active_request.is_connected(), eq true);
+
+        bad_pending_response.abandon();
+        bad_client.abandon();
+        bad_service.abandon();
+        bad_node.abandon();
+
+        let cleanup_results = Node::<S::Service>::try_cleanup_dead_nodes(test.config());
+
+        assert_that!(cleanup_results.cleanups, eq 1);
+        assert_that!(cleanup_results.failed_cleanups, eq 0);
+
+        assert_that!(good_active_request.is_connected(), eq false);
+    }
+
+    #[conformance_test]
+    pub fn connection_state_is_updated_when_dead_server_is_cleaned_up<S: Test>() {
+        test_requires!(does_support_persistency::<S>());
+
+        let test = S::new();
+        let service_name = generate_service_name();
+
+        let bad_node = test.create_bad_node();
+        let bad_service = bad_node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .create()
+            .unwrap();
+        let bad_server = bad_service.server_builder().create().unwrap();
+
+        let good_node = test.create_good_node();
+        let good_service = good_node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .open()
+            .unwrap();
+        let good_client = good_service.client_builder().create().unwrap();
+
+        let good_pending_response = good_client.send_copy(0).unwrap();
+        let bad_active_request = bad_server.receive().unwrap().unwrap();
+
+        assert_that!(good_pending_response.is_connected(), eq true);
+
+        bad_active_request.abandon();
+        bad_server.abandon();
+        bad_service.abandon();
+        bad_node.abandon();
+
+        let cleanup_results = Node::<S::Service>::try_cleanup_dead_nodes(test.config());
+
+        assert_that!(cleanup_results.cleanups, eq 1);
+        assert_that!(cleanup_results.failed_cleanups, eq 0);
+
+        assert_that!(good_pending_response.is_connected(), eq false);
+    }
 }

--- a/iceoryx2/src/active_request.rs
+++ b/iceoryx2/src/active_request.rs
@@ -41,6 +41,7 @@
 
 use alloc::sync::Arc;
 use core::{any::TypeId, fmt::Debug, marker::PhantomData, mem::MaybeUninit, ops::Deref};
+use iceoryx2_bb_elementary_traits::testing::abandonable::Abandonable;
 use iceoryx2_cal::zero_copy_connection::ChannelState;
 
 use iceoryx2_bb_concurrency::atomic::AtomicUsize;
@@ -102,6 +103,22 @@ pub struct ActiveRequest<
     pub(crate) connection_id: usize,
     pub(crate) _response_payload: PhantomData<ResponsePayload>,
     pub(crate) _response_header: PhantomData<ResponseHeader>,
+}
+
+impl<
+    Service: crate::service::Service,
+    RequestPayload: Debug + ZeroCopySend + ?Sized,
+    RequestHeader: Debug + ZeroCopySend,
+    ResponsePayload: Debug + ZeroCopySend + ?Sized,
+    ResponseHeader: Debug + ZeroCopySend,
+> Abandonable
+    for ActiveRequest<Service, RequestPayload, RequestHeader, ResponsePayload, ResponseHeader>
+{
+    unsafe fn abandon_in_place(mut this: core::ptr::NonNull<Self>) {
+        let this = unsafe { this.as_mut() };
+        unsafe { core::ptr::drop_in_place(&mut this.shared_state) };
+        unsafe { core::ptr::drop_in_place(&mut this.shared_loan_counter) };
+    }
 }
 
 unsafe impl<

--- a/iceoryx2/src/node/global_management_segment.rs
+++ b/iceoryx2/src/node/global_management_segment.rs
@@ -13,10 +13,13 @@
 use crate::{config::Config, service::Service};
 use iceoryx2_bb_concurrency::atomic::AtomicU32;
 use iceoryx2_bb_concurrency::atomic::Ordering;
+use iceoryx2_bb_container::semantic_string::SemanticString;
+use iceoryx2_bb_elementary::package_version::PackageVersion;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_cal::dynamic_storage::*;
 use iceoryx2_cal::named_concept::*;
 use iceoryx2_log::fail;
+use iceoryx2_log::fatal_panic;
 
 const GLOBAL_MGMT_NAME: FileName = unsafe { FileName::new_unchecked_const(b"node") };
 
@@ -64,9 +67,16 @@ impl<S: Service> GlobalManagementSegment<S> {
     fn dynamic_storage_config(
         global_config: &Config,
     ) -> <S::PersistentDynamicStorage<State> as NamedConceptMgmt>::Configuration {
+        let mut suffix = global_config.global.node.global_mgmt_suffix;
+        let ver = PackageVersion::get();
+        fatal_panic!(
+            from "dynamic_storage_config()",
+            when suffix.push_bytes(format!("_{}_{}_{}", ver.major(), ver.minor(), ver.patch()).as_bytes()),
+            "This should never happen! Failed to added package version suffix to global management segment.");
+
         <S::PersistentDynamicStorage<State> as NamedConceptMgmt>::Configuration::default()
             .prefix(&global_config.global.prefix)
-            .suffix(&global_config.global.node.global_mgmt_suffix)
+            .suffix(&suffix)
             .path_hint(global_config.global.root_path())
     }
 }

--- a/iceoryx2/src/node/global_management_segment.rs
+++ b/iceoryx2/src/node/global_management_segment.rs
@@ -10,7 +10,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+extern crate alloc;
+
 use crate::{config::Config, service::Service};
+use alloc::format;
 use iceoryx2_bb_concurrency::atomic::AtomicU32;
 use iceoryx2_bb_concurrency::atomic::Ordering;
 use iceoryx2_bb_container::semantic_string::SemanticString;
@@ -71,7 +74,7 @@ impl<S: Service> GlobalManagementSegment<S> {
         let ver = PackageVersion::get();
         fatal_panic!(
             from "dynamic_storage_config()",
-            when suffix.push_bytes(format!("_{}_{}_{}", ver.major(), ver.minor(), ver.patch()).as_bytes()),
+            when suffix.insert_bytes(0, format!(".{}_{}_{}", ver.major(), ver.minor(), ver.patch()).as_bytes()),
             "This should never happen! Failed to added package version suffix to global management segment.");
 
         <S::PersistentDynamicStorage<State> as NamedConceptMgmt>::Configuration::default()

--- a/iceoryx2/src/pending_response.rs
+++ b/iceoryx2/src/pending_response.rs
@@ -59,6 +59,8 @@ use core::ops::Deref;
 use core::{fmt::Debug, marker::PhantomData};
 
 use iceoryx2_bb_concurrency::atomic::Ordering;
+use iceoryx2_bb_elementary_traits::non_null::NonNullCompat;
+use iceoryx2_bb_elementary_traits::testing::abandonable::Abandonable;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_cal::arc_sync_policy::ArcSyncPolicy;
 use iceoryx2_log::fail;
@@ -90,6 +92,23 @@ pub struct PendingResponse<
     pub(crate) _service: PhantomData<Service>,
     pub(crate) _response_payload: PhantomData<ResponsePayload>,
     pub(crate) _response_header: PhantomData<ResponseHeader>,
+}
+
+impl<
+    Service: crate::service::Service,
+    RequestPayload: Debug + ZeroCopySend + ?Sized,
+    RequestHeader: Debug + ZeroCopySend,
+    ResponsePayload: Debug + ZeroCopySend + ?Sized,
+    ResponseHeader: Debug + ZeroCopySend,
+> Abandonable
+    for PendingResponse<Service, RequestPayload, RequestHeader, ResponsePayload, ResponseHeader>
+{
+    unsafe fn abandon_in_place(mut this: core::ptr::NonNull<Self>) {
+        let this = unsafe { this.as_mut() };
+        unsafe {
+            RequestMut::abandon_in_place(core::ptr::NonNull::iox2_from_mut(&mut this.request))
+        };
+    }
 }
 
 unsafe impl<

--- a/iceoryx2/src/request_mut.rs
+++ b/iceoryx2/src/request_mut.rs
@@ -40,6 +40,7 @@ use core::{fmt::Debug, marker::PhantomData};
 
 use iceoryx2_bb_concurrency::atomic::AtomicBool;
 use iceoryx2_bb_concurrency::atomic::Ordering;
+use iceoryx2_bb_elementary_traits::testing::abandonable::Abandonable;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_cal::arc_sync_policy::ArcSyncPolicy;
 use iceoryx2_cal::shm_allocator::PointerOffset;
@@ -75,6 +76,21 @@ pub struct RequestMut<
     pub(crate) channel_id: ChannelId,
     pub(crate) _response_payload: PhantomData<ResponsePayload>,
     pub(crate) _response_header: PhantomData<ResponseHeader>,
+}
+
+impl<
+    Service: crate::service::Service,
+    RequestPayload: Debug + ZeroCopySend + ?Sized,
+    RequestHeader: Debug + ZeroCopySend,
+    ResponsePayload: Debug + ZeroCopySend + ?Sized,
+    ResponseHeader: Debug + ZeroCopySend,
+> Abandonable
+    for RequestMut<Service, RequestPayload, RequestHeader, ResponsePayload, ResponseHeader>
+{
+    unsafe fn abandon_in_place(mut this: core::ptr::NonNull<Self>) {
+        let this = unsafe { this.as_mut() };
+        unsafe { core::ptr::drop_in_place(&mut this.client_shared_state) };
+    }
 }
 
 unsafe impl<


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Backport #1757, #1763 and #1765.

The backport does not mean that there is a release imminent.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #77
Relates to #1757
Relates to #1763
Relates to #1765

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
