### PR TITLE
[#3] Add check to Pull-Requests for failed nightly job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -37,6 +37,23 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
+      - name: Check nightly action status
+        run: |
+          COLOR_OFF='\033[0m'
+          COLOR_RED='\033[1;31m'
+          COLOR_GREEN='\033[1;32m'
+          COLOR_YELLOW='\033[1;33m'
+          LAST_RUN_STATUS=$(curl -s "https://api.github.com/repos/eclipse-iceoryx/iceoryx2/actions/workflows/nightly.yml/runs" | jq -r '.workflow_runs[0].conclusion')
+          if [[ "${LAST_RUN_STATUS}" == "success" ]]; then
+            echo -e "Last nightly run status: ${COLOR_GREEN}${LAST_RUN_STATUS}${COLOR_OFF}"
+          else
+            echo -e "Last nightly run status: ${COLOR_RED}${LAST_RUN_STATUS}${COLOR_OFF}"
+            echo -e "${COLOR_RED}Error! The nightly workflow failed on the last run. Please check and fix the nightly workflow before merging this PR.${COLOR_OFF}"
+            echo -e "${COLOR_YELLOW}You can trigger the nightly workflow manually from 'https://github.com/eclipse-iceoryx/iceoryx2/actions/workflows/nightly.yml'.${COLOR_OFF}"
+            echo -e "${COLOR_YELLOW}Just look for the 'Run workflow' button. The branch where the workflow shall run can also be selected.${COLOR_OFF}"
+            exit 1
+          fi
+
       - name: Checkout sources
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # version v6.0.1
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] ~Tests follow the [best practice for testing][testing]~
* [ ] ~Changelog updated [in the unreleased section][changelog] including API breaking changes~

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #3 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
