### PR TITLE
[#1773] Introduce port name

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -22,6 +22,7 @@
 * [#1649](https://github.com/eclipse-iceoryx/iceoryx2/issues/1649) Add `IOX2_DEFINE_TYPE_NAME` to the C++ bindings to set the cross-language type name for types that cannot carry an `IOX2_TYPE_NAME` member
 * [#1707](https://github.com/eclipse-iceoryx/iceoryx2/issues/1707) Expose `CustomHeaderMarker` and `CustomPayloadMarker` in C++ bindings
 * [#1722](https://github.com/eclipse-iceoryx/iceoryx2/issues/1722) Remove allocations in tunnel hot path
+* [#1773](https://github.com/eclipse-iceoryx/iceoryx2/issues/1773) Make ports identifiable by name
 
 ### Bugfixes
 

--- a/iceoryx2-bb/lock-free/src/mpmc/container.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/container.rs
@@ -731,7 +731,7 @@ impl<T: Copy + Debug, const CAPACITY: usize> FixedSizeContainer<T, CAPACITY> {
     /// let owner_id = OwnerId::new(91230).unwrap();
     ///
     /// match unsafe { container.add(1234567, owner_id) } {
-    ///     Ok(index) => {
+    ///     Ok((ptr_to_element, index)) => {
     ///         println!("added at index {:?}", index);
     ///         unsafe { container.remove(index, ReleaseMode::Default) };
     ///     },

--- a/iceoryx2-bb/lock-free/src/mpmc/container.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/container.rs
@@ -316,7 +316,7 @@ impl<T: Copy + Debug> Container<T> {
         &self,
         value: T,
         owner_id: OwnerId,
-    ) -> Result<ContainerHandle, ContainerAddFailure> {
+    ) -> Result<(*const T, ContainerHandle), ContainerAddFailure> {
         self.verify_init("add()");
 
         unsafe {
@@ -362,11 +362,15 @@ impl<T: Copy + Debug> Container<T> {
 
             // MUST HAPPEN AFTER all other operations
             self.change_counter.fetch_add(1, Ordering::Release);
-            Ok(ContainerHandle {
-                index,
-                owner_id,
-                container_id: self.container_id.value(),
-            })
+
+            Ok((
+                (*self.data_ptr.as_ptr().add(index as _)).get().cast(),
+                ContainerHandle {
+                    index,
+                    owner_id,
+                    container_id: self.container_id.value(),
+                },
+            ))
         }
     }
 
@@ -741,7 +745,11 @@ impl<T: Copy + Debug, const CAPACITY: usize> FixedSizeContainer<T, CAPACITY> {
     ///  * Use [`FixedSizeContainer::remove()`] to release the acquired index again. Otherwise,
     ///    the element will leak.
     ///
-    pub fn add(&self, value: T, owner_id: OwnerId) -> Result<ContainerHandle, ContainerAddFailure> {
+    pub fn add(
+        &self,
+        value: T,
+        owner_id: OwnerId,
+    ) -> Result<(*const T, ContainerHandle), ContainerAddFailure> {
         unsafe { self.container.add(value, owner_id) }
     }
 

--- a/iceoryx2-bb/lock-free/tests-common/src/mpmc_container_tests.rs
+++ b/iceoryx2-bb/lock-free/tests-common/src/mpmc_container_tests.rs
@@ -110,11 +110,11 @@ pub mod generic {
         for i in 0..CAPACITY - 1 {
             let index = sut.add((i * 3 + 1).into(), owner_id);
             assert_that!(index, is_ok);
-            stored_indices.push(index.unwrap());
+            stored_indices.push(index.unwrap().1);
 
             let index = sut.add((i * 7 + 5).into(), owner_id);
             assert_that!(index, is_ok);
-            stored_indices.push(index.unwrap());
+            stored_indices.push(index.unwrap().1);
 
             unsafe {
                 sut.remove(
@@ -142,7 +142,7 @@ pub mod generic {
     pub fn double_remove_is_detected<T: Debug + Copy + From<usize> + Into<usize> + ZeroCopySend>() {
         let sut = FixedSizeContainer::<T, CAPACITY>::new();
         let owner_id = OwnerId::new(2).unwrap();
-        let handle = sut.add((123).into(), owner_id).unwrap();
+        let (_, handle) = sut.add((123).into(), owner_id).unwrap();
         assert_that!(unsafe { sut.remove(handle, ReleaseMode::Default) }, is_ok);
 
         assert_that!(unsafe {
@@ -180,11 +180,11 @@ pub mod generic {
         for i in 0..CAPACITY - 1 {
             let index = unsafe { sut.add((i * 3 + 1).into(), owner_id) };
             assert_that!(index, is_ok);
-            stored_indices.push(index.unwrap());
+            stored_indices.push(index.unwrap().1);
 
             let index = unsafe { sut.add((i * 7 + 5).into(), owner_id) };
             assert_that!(index, is_ok);
-            stored_indices.push(index.unwrap());
+            stored_indices.push(index.unwrap().1);
 
             unsafe {
                 sut.remove(
@@ -218,11 +218,11 @@ pub mod generic {
         for i in 0..CAPACITY - 1 {
             let handle = sut.add((i * 3 + 1).into(), owner_id);
             assert_that!(handle, is_ok);
-            stored_handles.push(handle.unwrap());
+            stored_handles.push(handle.unwrap().1);
 
             let handle = sut.add((i * 7 + 5).into(), owner_id);
             assert_that!(handle, is_ok);
-            stored_handles.push(handle.unwrap());
+            stored_handles.push(handle.unwrap().1);
 
             unsafe {
                 sut.remove(
@@ -310,7 +310,7 @@ pub mod generic {
         for i in 0..CAPACITY - 1 {
             let index = sut.add((i * 3 + 1).into(), owner_id);
             assert_that!(index, is_ok);
-            stored_indices.push(index.unwrap());
+            stored_indices.push(index.unwrap().1);
         }
 
         let mut state = sut.get_state();
@@ -340,7 +340,7 @@ pub mod generic {
         for i in 0..CAPACITY - 1 {
             let index = sut.add((i * 3 + 1).into(), owner_id);
             assert_that!(index, is_ok);
-            stored_indices.push(index.unwrap());
+            stored_indices.push(index.unwrap().1);
         }
 
         let mut state = sut.get_state();
@@ -352,7 +352,7 @@ pub mod generic {
         for i in 0..CAPACITY - 1 {
             let index = sut.add((i * 81 + 56).into(), owner_id);
             assert_that!(index, is_ok);
-            results.insert(index.as_ref().unwrap().index(), i * 81 + 56);
+            results.insert(index.as_ref().unwrap().1.index(), i * 81 + 56);
         }
 
         assert_that!(unsafe { sut.update_state(&mut state) }, eq true);
@@ -382,7 +382,7 @@ pub mod generic {
             let index = sut.add(v.into(), owner_id);
             assert_that!(index, is_ok);
             stored_values.push(v);
-            stored_indices.push(index.unwrap());
+            stored_indices.push(index.unwrap().1);
 
             unsafe { sut.update_state(&mut state) };
             let mut contained_values = vec![];
@@ -427,7 +427,7 @@ pub mod generic {
         let owner_id = OwnerId::new(123).unwrap();
 
         let index = sut.add(123.into(), owner_id).unwrap();
-        unsafe { sut.remove(index, ReleaseMode::Default).unwrap() };
+        unsafe { sut.remove(index.1, ReleaseMode::Default).unwrap() };
         assert_that!(unsafe { sut.update_state(&mut state) }, eq true);
     }
 
@@ -478,7 +478,7 @@ pub mod generic {
                                 Err(ContainerAddFailure::OutOfSpace) => {
                                     repetition += 1;
                                     for id in &ids {
-                                        unsafe { sut.remove(*id, ReleaseMode::Default).unwrap() };
+                                        unsafe { sut.remove(id.1, ReleaseMode::Default).unwrap() };
                                     }
                                     ids.clear();
                                 }
@@ -545,12 +545,12 @@ pub mod generic {
         let good_owner_id = OwnerId::new(2).unwrap();
         let bad_owner_id = OwnerId::new(3).unwrap();
         for i in 0..CAPACITY {
-            let handle = sut.add(i.into(), good_owner_id).unwrap();
+            let (_, handle) = sut.add(i.into(), good_owner_id).unwrap();
             stored_handles.push(handle);
         }
 
         for i in 0..CAPACITY {
-            let handle = sut.add((i + CAPACITY).into(), bad_owner_id).unwrap();
+            let (_, handle) = sut.add((i + CAPACITY).into(), bad_owner_id).unwrap();
             stored_handles.push(handle);
         }
 
@@ -579,7 +579,7 @@ pub mod generic {
         let good_owner_id = OwnerId::new(2).unwrap();
         let bad_owner_id = OwnerId::new(3).unwrap();
         for i in 0..CAPACITY {
-            let handle = sut.add(i.into(), good_owner_id).unwrap();
+            let (_, handle) = sut.add(i.into(), good_owner_id).unwrap();
             stored_handles.push(handle);
         }
 
@@ -608,12 +608,12 @@ pub mod generic {
         let good_owner_id = OwnerId::new(2).unwrap();
         let bad_owner_id = OwnerId::new(3).unwrap();
         for i in 0..CAPACITY {
-            let handle = sut.add(i.into(), good_owner_id).unwrap();
+            let (_, handle) = sut.add(i.into(), good_owner_id).unwrap();
             stored_handles.push(handle);
         }
 
         for i in 0..CAPACITY {
-            let handle = sut.add((i + CAPACITY).into(), bad_owner_id).unwrap();
+            let (_, handle) = sut.add((i + CAPACITY).into(), bad_owner_id).unwrap();
             stored_handles.push(handle);
         }
 
@@ -641,7 +641,7 @@ pub mod generic {
 
         let bad_owner_id = OwnerId::new(3).unwrap();
         for i in 0..CAPACITY {
-            let handle = sut.add((i + CAPACITY).into(), bad_owner_id).unwrap();
+            let (_, handle) = sut.add((i + CAPACITY).into(), bad_owner_id).unwrap();
             stored_handles.push(handle);
         }
 
@@ -668,7 +668,7 @@ pub mod generic {
 
         let bad_owner_id = OwnerId::new(3).unwrap();
         for i in 0..CAPACITY {
-            let handle = sut.add(i.into(), bad_owner_id).unwrap();
+            let (_, handle) = sut.add(i.into(), bad_owner_id).unwrap();
             stored_handles.push(handle);
         }
 
@@ -706,7 +706,7 @@ pub mod generic {
 
         let bad_owner_id = OwnerId::new(3).unwrap();
         for i in 0..CAPACITY {
-            let handle = sut.add(i.into(), bad_owner_id).unwrap();
+            let (_, handle) = sut.add(i.into(), bad_owner_id).unwrap();
             stored_handles.push(handle);
         }
 

--- a/iceoryx2-ffi/c/src/api/client.rs
+++ b/iceoryx2-ffi/c/src/api/client.rs
@@ -71,7 +71,7 @@ impl ClientUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<ClientUnion>
 pub struct iox2_client_storage_t {
-    internal: [u8; 248], // magic number obtained with size_of::<Option<ClientUnion>>()
+    internal: [u8; 32], // magic number obtained with size_of::<Option<ClientUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/listener.rs
+++ b/iceoryx2-ffi/c/src/api/listener.rs
@@ -100,7 +100,7 @@ impl ListenerUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<ListenerUnion>
 pub struct iox2_listener_storage_t {
-    internal: [u8; 1656], // magic number obtained with size_of::<Option<ListenerUnion>>()
+    internal: [u8; 1416], // magic number obtained with size_of::<Option<ListenerUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/notifier.rs
+++ b/iceoryx2-ffi/c/src/api/notifier.rs
@@ -71,7 +71,7 @@ impl NotifierUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<NotifierUnion>
 pub struct iox2_notifier_storage_t {
-    internal: [u8; 1656], // magic number obtained with size_of::<Option<NotifierUnion>>()
+    internal: [u8; 1440], // magic number obtained with size_of::<Option<NotifierUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/port_factory_client_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_client_builder.rs
@@ -119,7 +119,7 @@ impl PortFactoryClientBuilderUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<PortFactoryClientBuilderUnion>
 pub struct iox2_port_factory_client_builder_storage_t {
-    internal: [u8; 272], // magic number obtained with size_of::<Option<PortFactoryClientBuilderUnion>>()
+    internal: [u8; 352], // magic number obtained with size_of::<Option<PortFactoryClientBuilderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/port_factory_listener_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_listener_builder.rs
@@ -80,7 +80,7 @@ impl PortFactoryListenerBuilderUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<PortFactoryListenerBuilderUnion>
 pub struct iox2_port_factory_listener_builder_storage_t {
-    internal: [u8; 24], // magic number obtained with size_of::<Option<PortFactoryListenerBuilderUnion>>()
+    internal: [u8; 96], // magic number obtained with size_of::<Option<PortFactoryListenerBuilderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/port_factory_notifier_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_notifier_builder.rs
@@ -76,7 +76,7 @@ impl PortFactoryNotifierBuilderUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<PortFactoryNotifierBuilderUnion>
 pub struct iox2_port_factory_notifier_builder_storage_t {
-    internal: [u8; 24], // magic number obtained with size_of::<Option<PortFactoryNotifierBuilderUnion>>()
+    internal: [u8; 104], // magic number obtained with size_of::<Option<PortFactoryNotifierBuilderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
@@ -146,7 +146,7 @@ impl PortFactoryPublisherBuilderUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<PortFactoryPublisherBuilderUnion>
 pub struct iox2_port_factory_publisher_builder_storage_t {
-    internal: [u8; 208], // magic number obtained with size_of::<Option<PortFactoryPublisherBuilderUnion>>()
+    internal: [u8; 288], // magic number obtained with size_of::<Option<PortFactoryPublisherBuilderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/port_factory_reader_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_reader_builder.rs
@@ -77,7 +77,7 @@ impl PortFactoryReaderBuilderUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<PortFactoryReaderBuilderUnion>
 pub struct iox2_port_factory_reader_builder_storage_t {
-    internal: [u8; 16], // magic number obtained with size_of::<Option<PortFactoryReaderBuilderUnion>>()
+    internal: [u8; 96], // magic number obtained with size_of::<Option<PortFactoryReaderBuilderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/port_factory_server_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_server_builder.rs
@@ -116,7 +116,7 @@ impl PortFactoryServerBuilderUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<PortFactoryServerBuilderUnion>
 pub struct iox2_port_factory_server_builder_storage_t {
-    internal: [u8; 256], // magic number obtained with size_of::<Option<PortFactoryServerBuilderUnion>>()
+    internal: [u8; 336], // magic number obtained with size_of::<Option<PortFactoryServerBuilderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/port_factory_subscriber_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_subscriber_builder.rs
@@ -99,7 +99,7 @@ impl PortFactorySubscriberBuilderUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<PortFactorySubscriberBuilderUnion>
 pub struct iox2_port_factory_subscriber_builder_storage_t {
-    internal: [u8; 112], // magic number obtained with size_of::<Option<PortFactorySubscriberBuilderUnion>>()
+    internal: [u8; 192], // magic number obtained with size_of::<Option<PortFactorySubscriberBuilderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/port_factory_writer_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_writer_builder.rs
@@ -80,7 +80,7 @@ impl PortFactoryWriterBuilderUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<PortFactoryWriterBuilderUnion>
 pub struct iox2_port_factory_writer_builder_storage_t {
-    internal: [u8; 16], // magic number obtained with size_of::<Option<PortFactoryWriterBuilderUnion>>()
+    internal: [u8; 96], // magic number obtained with size_of::<Option<PortFactoryWriterBuilderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/publisher.rs
+++ b/iceoryx2-ffi/c/src/api/publisher.rs
@@ -121,7 +121,7 @@ impl PublisherUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<PublisherUnion>
 pub struct iox2_publisher_storage_t {
-    internal: [u8; 248], // magic number obtained with size_of::<Option<PublisherUnion>>()
+    internal: [u8; 48], // magic number obtained with size_of::<Option<PublisherUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/reader.rs
+++ b/iceoryx2-ffi/c/src/api/reader.rs
@@ -66,7 +66,7 @@ impl ReaderUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<ReaderUnion>
 pub struct iox2_reader_storage_t {
-    internal: [u8; 144], // magic number obtained with size_of::<Option<ReaderUnion>>()
+    internal: [u8; 48], // magic number obtained with size_of::<Option<ReaderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/reader.rs
+++ b/iceoryx2-ffi/c/src/api/reader.rs
@@ -66,7 +66,7 @@ impl ReaderUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<ReaderUnion>
 pub struct iox2_reader_storage_t {
-    internal: [u8; 64], // magic number obtained with size_of::<Option<ReaderUnion>>()
+    internal: [u8; 144], // magic number obtained with size_of::<Option<ReaderUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/server.rs
+++ b/iceoryx2-ffi/c/src/api/server.rs
@@ -56,7 +56,7 @@ impl ServerUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<ServerUnion>
 pub struct iox2_server_storage_t {
-    internal: [u8; 248], // magic number obtained with size_of::<Option<ServerUnion>>()
+    internal: [u8; 40], // magic number obtained with size_of::<Option<ServerUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/subscriber.rs
+++ b/iceoryx2-ffi/c/src/api/subscriber.rs
@@ -98,7 +98,7 @@ impl SubscriberUnion {
 #[repr(C)]
 #[repr(align(16))] // alignment of Option<SubscriberUnion>
 pub struct iox2_subscriber_storage_t {
-    internal: [u8; 1232], // magic number obtained with size_of::<Option<SubscriberUnion>>()
+    internal: [u8; 48], // magic number obtained with size_of::<Option<SubscriberUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/writer.rs
+++ b/iceoryx2-ffi/c/src/api/writer.rs
@@ -68,7 +68,7 @@ impl WriterUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<WriterUnion>
 pub struct iox2_writer_storage_t {
-    internal: [u8; 1392], // magic number obtained with size_of::<Option<WriterUnion>>()
+    internal: [u8; 1472], // magic number obtained with size_of::<Option<WriterUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/writer.rs
+++ b/iceoryx2-ffi/c/src/api/writer.rs
@@ -68,7 +68,7 @@ impl WriterUnion {
 #[repr(C)]
 #[repr(align(8))] // alignment of Option<WriterUnion>
 pub struct iox2_writer_storage_t {
-    internal: [u8; 1472], // magic number obtained with size_of::<Option<WriterUnion>>()
+    internal: [u8; 1384], // magic number obtained with size_of::<Option<WriterUnion>>()
 }
 
 #[repr(C)]

--- a/iceoryx2-services/tunnel/src/bridge.rs
+++ b/iceoryx2-services/tunnel/src/bridge.rs
@@ -29,6 +29,7 @@ use crate::tunnel::{DiscoveryError, PropagateError};
 
 /// A bidirectional bridge for a single service: the local iceoryx2 ports on one
 /// side and the backend relay on the other.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub(crate) enum Bridge<S: Service, B: Backend<S>> {
     PublishSubscribe {

--- a/iceoryx2/conformance-tests/src/client.rs
+++ b/iceoryx2/conformance-tests/src/client.rs
@@ -146,6 +146,43 @@ pub mod client {
     }
 
     #[conformance_test]
+    pub fn client_name_is_empty_by_default<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .create()?;
+
+        let sut = service.client_builder().create()?;
+
+        assert_that!(sut.name(), eq "");
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn client_name_can_be_set<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .create()?;
+
+        let client_name = PortName::new("bruce").unwrap();
+        let sut = service.client_builder().name(&client_name).create()?;
+
+        assert_that!(sut.name(), eq client_name);
+
+        Ok(())
+    }
+
+    #[conformance_test]
     pub fn override_preallocated_requests_to_one_works<Sut: Service>() {
         let test = Test::<Sut>::new();
         let service_name = generate_service_name();

--- a/iceoryx2/conformance-tests/src/client.rs
+++ b/iceoryx2/conformance-tests/src/client.rs
@@ -177,7 +177,7 @@ pub mod client {
         let client_name = PortName::new("bruce").unwrap();
         let sut = service.client_builder().name(&client_name).create()?;
 
-        assert_that!(sut.name(), eq client_name);
+        assert_that!(*sut.name(), eq client_name);
 
         Ok(())
     }

--- a/iceoryx2/conformance-tests/src/listener.rs
+++ b/iceoryx2/conformance-tests/src/listener.rs
@@ -18,7 +18,9 @@ pub mod listener {
     use alloc::collections::BTreeSet;
     use alloc::{format, vec};
 
-    use iceoryx2::{port::listener::ListenerCreateError, service::Service};
+    use iceoryx2::{
+        port::listener::ListenerCreateError, port::port_name::PortName, service::Service,
+    };
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_bb_testing_macros::conformance_test;
     use iceoryx2_testing::*;
@@ -53,5 +55,36 @@ pub mod listener {
             assert_that!(listener_id_set.insert(listener.id()), eq true);
             listeners.push(listener);
         }
+    }
+
+    #[conformance_test]
+    pub fn listener_name_is_empty_by_default<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node.service_builder(&service_name).event().create()?;
+
+        let sut = service.listener_builder().create()?;
+
+        assert_that!(sut.name(), eq "");
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn listener_name_can_be_set<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node.service_builder(&service_name).event().create()?;
+
+        let listener_name = PortName::new("wiretap").unwrap();
+        let sut = service.listener_builder().name(&listener_name).create()?;
+
+        assert_that!(sut.name(), eq listener_name);
+
+        Ok(())
     }
 }

--- a/iceoryx2/conformance-tests/src/listener.rs
+++ b/iceoryx2/conformance-tests/src/listener.rs
@@ -83,7 +83,7 @@ pub mod listener {
         let listener_name = PortName::new("wiretap").unwrap();
         let sut = service.listener_builder().name(&listener_name).create()?;
 
-        assert_that!(sut.name(), eq listener_name);
+        assert_that!(*sut.name(), eq listener_name);
 
         Ok(())
     }

--- a/iceoryx2/conformance-tests/src/notifier.rs
+++ b/iceoryx2/conformance-tests/src/notifier.rs
@@ -93,7 +93,7 @@ pub mod notifier {
         let notifier_name = PortName::new("yell").unwrap();
         let sut = service.notifier_builder().name(&notifier_name).create()?;
 
-        assert_that!(sut.name(), eq notifier_name);
+        assert_that!(*sut.name(), eq notifier_name);
 
         Ok(())
     }

--- a/iceoryx2/conformance-tests/src/notifier.rs
+++ b/iceoryx2/conformance-tests/src/notifier.rs
@@ -21,6 +21,7 @@ pub mod notifier {
     use iceoryx2::{
         node::NodeBuilder,
         port::notifier::{NotifierCreateError, NotifierNotifyError},
+        port::port_name::PortName,
         service::Service,
     };
     use iceoryx2_bb_testing::assert_that;
@@ -64,5 +65,36 @@ pub mod notifier {
             assert_that!(listener_id_set.insert(listener.id()), eq true);
             listeners.push(listener);
         }
+    }
+
+    #[conformance_test]
+    pub fn notifier_name_is_empty_by_default<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node.service_builder(&service_name).event().create()?;
+
+        let sut = service.notifier_builder().create()?;
+
+        assert_that!(sut.name(), eq "");
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn notifier_name_can_be_set<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node.service_builder(&service_name).event().create()?;
+
+        let notifier_name = PortName::new("yell").unwrap();
+        let sut = service.notifier_builder().name(&notifier_name).create()?;
+
+        assert_that!(sut.name(), eq notifier_name);
+
+        Ok(())
     }
 }

--- a/iceoryx2/conformance-tests/src/publisher.rs
+++ b/iceoryx2/conformance-tests/src/publisher.rs
@@ -77,6 +77,43 @@ pub mod publisher {
     }
 
     #[conformance_test]
+    pub fn publisher_name_is_empty_by_default<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .publish_subscribe::<u64>()
+            .create()?;
+
+        let sut = service.publisher_builder().create()?;
+
+        assert_that!(sut.name(), eq "");
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn publisher_name_can_be_set<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .publish_subscribe::<u64>()
+            .create()?;
+
+        let publisher_name = PortName::new("hypnotoad").unwrap();
+        let sut = service.publisher_builder().name(&publisher_name).create()?;
+
+        assert_that!(sut.name(), eq publisher_name);
+
+        Ok(())
+    }
+
+    #[conformance_test]
     pub fn override_preallocated_samples_to_one_works<Sut: Service>()
     -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
         let test = Test::<Sut>::new();

--- a/iceoryx2/conformance-tests/src/publisher.rs
+++ b/iceoryx2/conformance-tests/src/publisher.rs
@@ -108,7 +108,7 @@ pub mod publisher {
         let publisher_name = PortName::new("hypnotoad").unwrap();
         let sut = service.publisher_builder().name(&publisher_name).create()?;
 
-        assert_that!(sut.name(), eq publisher_name);
+        assert_that!(*sut.name(), eq publisher_name);
 
         Ok(())
     }

--- a/iceoryx2/conformance-tests/src/reader.rs
+++ b/iceoryx2/conformance-tests/src/reader.rs
@@ -90,7 +90,7 @@ pub mod reader {
         let reader_name = PortName::new("scheherazade").unwrap();
         let sut = service.reader_builder().name(&reader_name).create()?;
 
-        assert_that!(sut.name(), eq reader_name);
+        assert_that!(*sut.name(), eq reader_name);
 
         Ok(())
     }

--- a/iceoryx2/conformance-tests/src/reader.rs
+++ b/iceoryx2/conformance-tests/src/reader.rs
@@ -57,6 +57,45 @@ pub mod reader {
     }
 
     #[conformance_test]
+    pub fn reader_name_is_empty_by_default<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .blackboard_creator::<u64>()
+            .add::<u64>(0, 0)
+            .create()?;
+
+        let sut = service.reader_builder().create()?;
+
+        assert_that!(sut.name(), eq "");
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn reader_name_can_be_set<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .blackboard_creator::<u64>()
+            .add::<u64>(0, 0)
+            .create()?;
+
+        let reader_name = PortName::new("scheherazade").unwrap();
+        let sut = service.reader_builder().name(&reader_name).create()?;
+
+        assert_that!(sut.name(), eq reader_name);
+
+        Ok(())
+    }
+
+    #[conformance_test]
     pub fn handle_can_be_acquired_for_existing_key_value_pair<Sut: Service>() {
         type ValueType = u64;
         let test = Test::<Sut>::new();

--- a/iceoryx2/conformance-tests/src/server.rs
+++ b/iceoryx2/conformance-tests/src/server.rs
@@ -262,7 +262,7 @@ pub mod server {
         let server_name = PortName::new("alfred").unwrap();
         let sut = service.server_builder().name(&server_name).create()?;
 
-        assert_that!(sut.name(), eq server_name);
+        assert_that!(*sut.name(), eq server_name);
 
         Ok(())
     }

--- a/iceoryx2/conformance-tests/src/server.rs
+++ b/iceoryx2/conformance-tests/src/server.rs
@@ -231,6 +231,43 @@ pub mod server {
     }
 
     #[conformance_test]
+    pub fn server_name_is_empty_by_default<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .create()?;
+
+        let sut = service.server_builder().create()?;
+
+        assert_that!(sut.name(), eq "");
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn server_name_can_be_set<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .create()?;
+
+        let server_name = PortName::new("alfred").unwrap();
+        let sut = service.server_builder().name(&server_name).create()?;
+
+        assert_that!(sut.name(), eq server_name);
+
+        Ok(())
+    }
+
+    #[conformance_test]
     pub fn override_preallocated_responses_to_one_works<Sut: Service>() {
         let service_name = generate_service_name();
         let test = Test::<Sut>::new();

--- a/iceoryx2/conformance-tests/src/subscriber.rs
+++ b/iceoryx2/conformance-tests/src/subscriber.rs
@@ -18,7 +18,9 @@ pub mod subscriber {
     use alloc::collections::BTreeSet;
     use alloc::{format, vec};
     use iceoryx2::port::ReceiveError;
-    use iceoryx2::{port::subscriber::SubscriberCreateError, service::Service};
+    use iceoryx2::{
+        port::port_name::PortName, port::subscriber::SubscriberCreateError, service::Service,
+    };
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_bb_testing_macros::conformance_test;
     use iceoryx2_testing::*;
@@ -59,6 +61,46 @@ pub mod subscriber {
             assert_that!(subscriber_id_set.insert(subscriber.id()), eq true);
             subscribers.push(subscriber);
         }
+    }
+
+    #[conformance_test]
+    pub fn subscriber_name_is_empty_by_default<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .publish_subscribe::<u64>()
+            .create()?;
+
+        let sut = service.subscriber_builder().create()?;
+
+        assert_that!(sut.name(), eq "");
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn subscriber_name_can_be_set<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .publish_subscribe::<u64>()
+            .create()?;
+
+        let subscriber_name = PortName::new("brainslug").unwrap();
+        let sut = service
+            .subscriber_builder()
+            .name(&subscriber_name)
+            .create()?;
+
+        assert_that!(sut.name(), eq subscriber_name);
+
+        Ok(())
     }
 
     #[conformance_test]

--- a/iceoryx2/conformance-tests/src/subscriber.rs
+++ b/iceoryx2/conformance-tests/src/subscriber.rs
@@ -98,7 +98,7 @@ pub mod subscriber {
             .name(&subscriber_name)
             .create()?;
 
-        assert_that!(sut.name(), eq subscriber_name);
+        assert_that!(*sut.name(), eq subscriber_name);
 
         Ok(())
     }

--- a/iceoryx2/conformance-tests/src/writer.rs
+++ b/iceoryx2/conformance-tests/src/writer.rs
@@ -35,6 +35,45 @@ pub mod writer {
     use iceoryx2_testing::*;
 
     #[conformance_test]
+    pub fn writer_name_is_empty_by_default<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .blackboard_creator::<u64>()
+            .add::<u64>(0, 0)
+            .create()?;
+
+        let sut = service.writer_builder().create()?;
+
+        assert_that!(sut.name(), eq "");
+
+        Ok(())
+    }
+
+    #[conformance_test]
+    pub fn writer_name_can_be_set<Sut: Service>()
+    -> core::result::Result<(), alloc::boxed::Box<dyn core::error::Error>> {
+        let test = Test::<Sut>::new();
+        let service_name = generate_service_name();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&service_name)
+            .blackboard_creator::<u64>()
+            .add::<u64>(0, 0)
+            .create()?;
+
+        let writer_name = PortName::new("homer").unwrap();
+        let sut = service.writer_builder().name(&writer_name).create()?;
+
+        assert_that!(sut.name(), eq writer_name);
+
+        Ok(())
+    }
+
+    #[conformance_test]
     pub fn handle_can_be_acquired_for_existing_key_value_pair<Sut: Service>() {
         let test = Test::<Sut>::new();
         let node = test.create_node();

--- a/iceoryx2/conformance-tests/src/writer.rs
+++ b/iceoryx2/conformance-tests/src/writer.rs
@@ -68,7 +68,7 @@ pub mod writer {
         let writer_name = PortName::new("homer").unwrap();
         let sut = service.writer_builder().name(&writer_name).create()?;
 
-        assert_that!(sut.name(), eq writer_name);
+        assert_that!(*sut.name(), eq writer_name);
 
         Ok(())
     }

--- a/iceoryx2/src/constants.rs
+++ b/iceoryx2/src/constants.rs
@@ -26,6 +26,9 @@ pub const MAX_ATTRIBUTE_VALUE_LENGTH: usize = 256;
 /// Defines the maximum length of a [`NodeName`](crate::node::node_name::NodeName)
 pub const MAX_NODE_NAME_LENGTH: usize = 128;
 
+/// Defines the maximum length of a [`PortName`](crate::port::port_name::PortName)
+pub const MAX_PORT_NAME_LENGTH: usize = 64;
+
 /// Defines the maximum length of a [`TypeName`](crate::service::static_config::message_type_details::TypeName)
 pub const MAX_TYPE_NAME_LENGTH: usize = 256;
 

--- a/iceoryx2/src/node/node_name.rs
+++ b/iceoryx2/src/node/node_name.rs
@@ -42,7 +42,7 @@ impl NodeName {
 
     /// Returns a str reference to the [`NodeName`]
     pub fn as_str(&self) -> &str {
-        // SAFETY: `ServieName` was created from a `&str` and therefore this conversion is safe
+        // SAFETY: `NodeName` was created from a `&str` and therefore this conversion is safe
         unsafe { core::str::from_utf8_unchecked(self.value.as_bytes()) }
     }
 

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -98,7 +98,10 @@ use crate::active_request::RequestId;
 use crate::{
     identifiers::UniqueClientId,
     pending_response::PendingResponse,
-    port::{details::data_segment::DataSegment, update_connections::UpdateConnections},
+    port::{
+        details::data_segment::DataSegment, port_name::PortName,
+        update_connections::UpdateConnections,
+    },
     prelude::{BackpressureStrategy, PortFactory},
     raw_sample::RawSampleMut,
     request_mut::RequestMut,
@@ -499,6 +502,7 @@ impl<
                 v
             },
             sender_port_id: client_id.value(),
+            sender_port_name: PortName::new_empty(),
             shared_node: service.shared_node().clone(),
             connections: (0..server_list.capacity())
                 .map(|_| UnsafeCell::new(None))

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -183,6 +183,7 @@ pub(crate) struct ClientSharedState<Service: service::Service> {
     // Otherwise the process might crash during cleanup, has already removed the tag but other resources
     // are still existing. This would make a cleanup from another process impossible.
     port_tag: Service::StaticStorage,
+    client_details: &'static ClientDetails,
 }
 
 impl<Service: service::Service> Abandonable for ClientSharedState<Service> {
@@ -503,7 +504,6 @@ impl<
                 v
             },
             sender_port_id: client_id.value(),
-            sender_port_name: client_factory.config.port_name,
             shared_node: service.shared_node().clone(),
             connections: (0..server_list.capacity())
                 .map(|_| UnsafeCell::new(None))
@@ -548,7 +548,6 @@ impl<
             )
             .expect("Heap allocator provides memory."),
             receiver_port_id: client_id.value(),
-            receiver_port_name: client_factory.config.port_name,
             service_state: service.clone(),
             buffer_size: static_config.max_response_buffer_size,
             tagger: CyclicTagger::new(),
@@ -564,6 +563,23 @@ impl<
             number_of_channels: number_of_requests_with_max_service_setting,
             connection_storage: UnsafeCell::new(SlotMap::new(number_of_connections)),
             initial_channel_state: CHANNEL_STATE_CLOSED,
+        };
+
+        // !MUST! be the last task otherwise a client is added to the dynamic config without the
+        // creation of all required resources
+        let (details, handle) = match service
+            .dynamic_storage()
+            .get()
+            .request_response()
+            .add_client_id(client_details)
+        {
+            Some(v) => v,
+            None => {
+                fail!(from origin,
+                      with ClientCreateError::ExceedsMaxSupportedClients,
+                      "{} since it would exceed the maximum support amount of clients of {}.",
+                      msg, service.static_config().request_response().max_clients());
+            }
         };
 
         let client_shared_state = Service::ArcThreadSafetyPolicy::new(ClientSharedState {
@@ -582,6 +598,7 @@ impl<
             server_list_state: UnsafeCell::new(unsafe { server_list.get_state() }),
             active_request_counter: AtomicUsize::new(0),
             max_active_requests,
+            client_details: unsafe { &*details },
         });
 
         let client_shared_state = match client_shared_state {
@@ -592,6 +609,13 @@ impl<
             }
         };
 
+        if let Err(e) = client_shared_state.lock().force_update_connections() {
+            warn!(from origin,
+                "The new Client port is unable to connect to every Server port, caused by {:?}.", e);
+        }
+
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+
         let new_self = Self {
             request_id_counter: AtomicU64::new(0),
             client_shared_state,
@@ -601,36 +625,7 @@ impl<
             _response_payload: PhantomData,
             _response_header: PhantomData,
         };
-
-        if let Err(e) = new_self
-            .client_shared_state
-            .lock()
-            .force_update_connections()
-        {
-            warn!(from new_self,
-                "The new Client port is unable to connect to every Server port, caused by {:?}.", e);
-        }
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
-        // !MUST! be the last task otherwise a client is added to the dynamic config without the
-        // creation of all required resources
-        unsafe {
-            *new_self.client_shared_state.lock().client_handle.get() = match service
-                .dynamic_storage()
-                .get()
-                .request_response()
-                .add_client_id(client_details)
-            {
-                Some(handle) => Some(handle),
-                None => {
-                    fail!(from origin,
-                      with ClientCreateError::ExceedsMaxSupportedClients,
-                      "{} since it would exceed the maximum support amount of clients of {}.",
-                      msg, service.static_config().request_response().max_clients());
-                }
-            }
-        };
+        unsafe { *new_self.client_shared_state.lock().client_handle.get() = Some(handle) };
 
         Ok(new_self)
     }
@@ -641,11 +636,8 @@ impl<
     }
 
     /// Returns the [`PortName`] of the [`Client`]
-    pub fn name(&self) -> PortName {
-        self.client_shared_state
-            .lock()
-            .request_sender
-            .sender_port_name
+    pub fn name(&self) -> &PortName {
+        &self.client_shared_state.lock().client_details.client_name
     }
 
     fn next_request_id(&self) -> RequestId {

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -183,7 +183,6 @@ pub(crate) struct ClientSharedState<Service: service::Service> {
     // Otherwise the process might crash during cleanup, has already removed the tag but other resources
     // are still existing. This would make a cleanup from another process impossible.
     port_tag: Service::StaticStorage,
-    client_details: &'static ClientDetails,
 }
 
 impl<Service: service::Service> Abandonable for ClientSharedState<Service> {
@@ -330,6 +329,7 @@ pub struct Client<
 > {
     client_id: UniqueClientId,
     client_shared_state: Service::ArcThreadSafetyPolicy<ClientSharedState<Service>>,
+    client_details: &'static ClientDetails,
     request_id_counter: AtomicU64,
     _request_payload: PhantomData<RequestPayload>,
     _request_header: PhantomData<RequestHeader>,
@@ -565,23 +565,6 @@ impl<
             initial_channel_state: CHANNEL_STATE_CLOSED,
         };
 
-        // !MUST! be the last task otherwise a client is added to the dynamic config without the
-        // creation of all required resources
-        let (details, handle) = match service
-            .dynamic_storage()
-            .get()
-            .request_response()
-            .add_client_id(client_details)
-        {
-            Some(v) => v,
-            None => {
-                fail!(from origin,
-                      with ClientCreateError::ExceedsMaxSupportedClients,
-                      "{} since it would exceed the maximum support amount of clients of {}.",
-                      msg, service.static_config().request_response().max_clients());
-            }
-        };
-
         let client_shared_state = Service::ArcThreadSafetyPolicy::new(ClientSharedState {
             port_tag,
             config: client_factory.config,
@@ -598,7 +581,6 @@ impl<
             server_list_state: UnsafeCell::new(unsafe { server_list.get_state() }),
             active_request_counter: AtomicUsize::new(0),
             max_active_requests,
-            client_details: unsafe { &*details },
         });
 
         let client_shared_state = match client_shared_state {
@@ -616,18 +598,35 @@ impl<
 
         core::sync::atomic::compiler_fence(Ordering::SeqCst);
 
-        let new_self = Self {
+        // !MUST! be the last task otherwise a client is added to the dynamic config without the
+        // creation of all required resources
+        let (details, handle) = match service
+            .dynamic_storage()
+            .get()
+            .request_response()
+            .add_client_id(client_details)
+        {
+            Some(v) => v,
+            None => {
+                fail!(from origin,
+                      with ClientCreateError::ExceedsMaxSupportedClients,
+                      "{} since it would exceed the maximum support amount of clients of {}.",
+                      msg, service.static_config().request_response().max_clients());
+            }
+        };
+
+        unsafe { *client_shared_state.lock().client_handle.get() = Some(handle) };
+
+        Ok(Self {
             request_id_counter: AtomicU64::new(0),
             client_shared_state,
+            client_details: unsafe { &*details },
             client_id,
             _request_payload: PhantomData,
             _request_header: PhantomData,
             _response_payload: PhantomData,
             _response_header: PhantomData,
-        };
-        unsafe { *new_self.client_shared_state.lock().client_handle.get() = Some(handle) };
-
-        Ok(new_self)
+        })
     }
 
     /// Returns the [`UniqueClientId`] of the [`Client`]
@@ -637,7 +636,7 @@ impl<
 
     /// Returns the [`PortName`] of the [`Client`]
     pub fn name(&self) -> &PortName {
-        &self.client_shared_state.lock().client_details.client_name
+        &self.client_details.client_name
     }
 
     fn next_request_id(&self) -> RequestId {

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -547,6 +547,7 @@ impl<
             )
             .expect("Heap allocator provides memory."),
             receiver_port_id: client_id.value(),
+            receiver_port_name: PortName::new_empty(),
             service_state: service.clone(),
             buffer_size: static_config.max_response_buffer_size,
             tagger: CyclicTagger::new(),

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -489,6 +489,7 @@ impl<
             data_segment_type,
             max_number_of_segments,
             max_active_requests,
+            client_name: client_factory.config.port_name,
         };
 
         let request_sender = Sender {
@@ -502,7 +503,7 @@ impl<
                 v
             },
             sender_port_id: client_id.value(),
-            sender_port_name: PortName::new_empty(),
+            sender_port_name: client_factory.config.port_name,
             shared_node: service.shared_node().clone(),
             connections: (0..server_list.capacity())
                 .map(|_| UnsafeCell::new(None))
@@ -547,7 +548,7 @@ impl<
             )
             .expect("Heap allocator provides memory."),
             receiver_port_id: client_id.value(),
-            receiver_port_name: PortName::new_empty(),
+            receiver_port_name: client_factory.config.port_name,
             service_state: service.clone(),
             buffer_size: static_config.max_response_buffer_size,
             tagger: CyclicTagger::new(),
@@ -637,6 +638,14 @@ impl<
     /// Returns the [`UniqueClientId`] of the [`Client`]
     pub fn id(&self) -> UniqueClientId {
         self.client_id
+    }
+
+    /// Returns the [`PortName`] of the [`Client`]
+    pub fn name(&self) -> PortName {
+        self.client_shared_state
+            .lock()
+            .request_sender
+            .sender_port_name
     }
 
     fn next_request_id(&self) -> RequestId {

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -327,7 +327,6 @@ pub struct Client<
     ResponsePayload: Debug + ZeroCopySend + ?Sized,
     ResponseHeader: Debug + ZeroCopySend,
 > {
-    client_id: UniqueClientId,
     client_shared_state: Service::ArcThreadSafetyPolicy<ClientSharedState<Service>>,
     client_details: &'static ClientDetails,
     request_id_counter: AtomicU64,
@@ -621,7 +620,6 @@ impl<
             request_id_counter: AtomicU64::new(0),
             client_shared_state,
             client_details: unsafe { &*details },
-            client_id,
             _request_payload: PhantomData,
             _request_header: PhantomData,
             _response_payload: PhantomData,
@@ -631,7 +629,7 @@ impl<
 
     /// Returns the [`UniqueClientId`] of the [`Client`]
     pub fn id(&self) -> UniqueClientId {
-        self.client_id
+        self.client_details.client_id
     }
 
     /// Returns the [`PortName`] of the [`Client`]

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -28,6 +28,7 @@ use iceoryx2_log::{error, fail, warn};
 
 use crate::port::DegradationCause;
 use crate::port::DegradationInfo;
+use crate::port::port_name::PortName;
 use crate::port::update_connections::ConnectionFailure;
 use crate::port::{DegradationAction, DegradationHandler, ReceiveError};
 use crate::service::NoResource;
@@ -135,6 +136,7 @@ impl<Service: service::Service> Connection<Service> {
 pub(crate) struct Receiver<Service: service::Service> {
     pub(crate) connections: PolymorphicVec<'static, UnsafeCell<Option<SlotMapKey>>, HeapAllocator>,
     pub(crate) receiver_port_id: u128,
+    pub(crate) receiver_port_name: PortName,
     pub(crate) service_state: SharedServiceState<Service, NoResource>,
     pub(crate) buffer_size: usize,
     pub(crate) tagger: CyclicTagger,

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -28,7 +28,6 @@ use iceoryx2_log::{error, fail, warn};
 
 use crate::port::DegradationCause;
 use crate::port::DegradationInfo;
-use crate::port::port_name::PortName;
 use crate::port::update_connections::ConnectionFailure;
 use crate::port::{DegradationAction, DegradationHandler, ReceiveError};
 use crate::service::NoResource;
@@ -136,7 +135,6 @@ impl<Service: service::Service> Connection<Service> {
 pub(crate) struct Receiver<Service: service::Service> {
     pub(crate) connections: PolymorphicVec<'static, UnsafeCell<Option<SlotMapKey>>, HeapAllocator>,
     pub(crate) receiver_port_id: u128,
-    pub(crate) receiver_port_name: PortName,
     pub(crate) service_state: SharedServiceState<Service, NoResource>,
     pub(crate) buffer_size: usize,
     pub(crate) tagger: CyclicTagger,

--- a/iceoryx2/src/port/details/sender.rs
+++ b/iceoryx2/src/port/details/sender.rs
@@ -34,7 +34,7 @@ use iceoryx2_log::{error, fail, fatal_panic, warn};
 use crate::node::SharedNode;
 use crate::port::{
     BackpressureHandler, BackpressureInfo, DegradationAction, DegradationCause, DegradationHandler,
-    DegradationInfo, LoanError, SendError, port_name::PortName,
+    DegradationInfo, LoanError, SendError,
 };
 use crate::prelude::BackpressureStrategy;
 use crate::service::config_scheme::connection_config;
@@ -123,7 +123,6 @@ pub(crate) struct Sender<Service: service::Service> {
     pub(crate) data_segment: DataSegment<Service>,
     pub(crate) connections: Vec<UnsafeCell<Option<Connection<Service>>>>,
     pub(crate) sender_port_id: u128,
-    pub(crate) sender_port_name: PortName,
     pub(crate) shared_node: SharedNode<Service>,
     pub(crate) receiver_max_buffer_size: usize,
     pub(crate) receiver_max_borrowed_samples: usize,

--- a/iceoryx2/src/port/details/sender.rs
+++ b/iceoryx2/src/port/details/sender.rs
@@ -34,7 +34,7 @@ use iceoryx2_log::{error, fail, fatal_panic, warn};
 use crate::node::SharedNode;
 use crate::port::{
     BackpressureHandler, BackpressureInfo, DegradationAction, DegradationCause, DegradationHandler,
-    DegradationInfo, LoanError, SendError,
+    DegradationInfo, LoanError, SendError, port_name::PortName,
 };
 use crate::prelude::BackpressureStrategy;
 use crate::service::config_scheme::connection_config;
@@ -123,6 +123,7 @@ pub(crate) struct Sender<Service: service::Service> {
     pub(crate) data_segment: DataSegment<Service>,
     pub(crate) connections: Vec<UnsafeCell<Option<Connection<Service>>>>,
     pub(crate) sender_port_id: u128,
+    pub(crate) sender_port_name: PortName,
     pub(crate) shared_node: SharedNode<Service>,
     pub(crate) receiver_max_buffer_size: usize,
     pub(crate) receiver_max_borrowed_samples: usize,

--- a/iceoryx2/src/port/listener.rs
+++ b/iceoryx2/src/port/listener.rs
@@ -59,9 +59,11 @@
 //! ```
 
 use crate::config::Config;
+use crate::port::port_name::PortName;
 use crate::service::config_scheme::event_config;
 use crate::service::dynamic_config::event::ListenerDetails;
 use crate::service::naming_scheme::event_concept_name;
+use crate::service::port_factory::listener::ListenerConfig;
 use crate::service::{NoResource, SharedServiceState};
 use crate::{identifiers::UniqueListenerId, service};
 use alloc::format;
@@ -116,6 +118,7 @@ pub struct Listener<Service: service::Service> {
     >,
     service_state: SharedServiceState<Service, NoResource>,
     listener_id: UniqueListenerId,
+    listener_name: PortName,
     // IMPORTANT!
     // Fields of a rust struct are dropped in declaration order. Since this tag is our marker that the
     // port exists and might require cleanup after a crash, the tag must be defined as last member of
@@ -190,6 +193,7 @@ impl<Service: service::Service> Drop for Listener<Service> {
 impl<Service: service::Service> Listener<Service> {
     pub(crate) fn new(
         service: SharedServiceState<Service, NoResource>,
+        config: ListenerConfig,
     ) -> Result<Self, ListenerCreateError> {
         let msg = "Failed to create listener";
         let origin = "Listener::new()";
@@ -233,6 +237,7 @@ impl<Service: service::Service> Listener<Service> {
             dynamic_listener_handle: None,
             listener,
             listener_id,
+            listener_name: config.port_name,
         };
 
         core::sync::atomic::compiler_fence(Ordering::SeqCst);
@@ -242,6 +247,7 @@ impl<Service: service::Service> Listener<Service> {
         let dynamic_listener_handle = match service.dynamic_storage().get().event().add_listener_id(
             ListenerDetails {
                 listener_id,
+                listener_name: config.port_name,
                 node_id: *service.shared_node().id(),
             },
         ) {
@@ -256,6 +262,11 @@ impl<Service: service::Service> Listener<Service> {
         new_self.dynamic_listener_handle = Some(dynamic_listener_handle);
 
         Ok(new_self)
+    }
+
+    /// Returns the [`PortName`] of the [`Listener`]
+    pub fn name(&self) -> PortName {
+        self.listener_name
     }
 
     /// Returns the deadline of the corresponding [`Service`](crate::service::Service).

--- a/iceoryx2/src/port/listener.rs
+++ b/iceoryx2/src/port/listener.rs
@@ -229,6 +229,8 @@ impl<Service: service::Service> Listener<Service> {
             }
         };
 
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+
         // !MUST! be the last task otherwise a listener is added to the dynamic config without
         // the creation of all required channels
         let (details, handle) = match service.dynamic_storage().get().event().add_listener_id(
@@ -246,18 +248,14 @@ impl<Service: service::Service> Listener<Service> {
             }
         };
 
-        let new_self = Self {
+        Ok(Self {
             port_tag,
             service_state: service.clone(),
             dynamic_listener_handle: handle,
             listener_details: unsafe { &*details },
             listener,
             listener_id,
-        };
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
-        Ok(new_self)
+        })
     }
 
     /// Returns the [`PortName`] of the [`Listener`]

--- a/iceoryx2/src/port/listener.rs
+++ b/iceoryx2/src/port/listener.rs
@@ -112,13 +112,13 @@ impl core::error::Error for ListenerCreateError {}
 /// Represents the receiving endpoint of an event based communication.
 #[derive(Debug)]
 pub struct Listener<Service: service::Service> {
-    dynamic_listener_handle: Option<ContainerHandle>,
+    dynamic_listener_handle: ContainerHandle,
     listener: Service::ArcThreadSafetyPolicy<
         <Service::Event as iceoryx2_cal::event::Event<RelocatableCountingBitSet>>::Listener,
     >,
     service_state: SharedServiceState<Service, NoResource>,
     listener_id: UniqueListenerId,
-    listener_name: PortName,
+    listener_details: &'static ListenerDetails,
     // IMPORTANT!
     // Fields of a rust struct are dropped in declaration order. Since this tag is our marker that the
     // port exists and might require cleanup after a crash, the tag must be defined as last member of
@@ -180,13 +180,11 @@ impl<Service: service::Service> Abandonable for Listener<Service> {
 
 impl<Service: service::Service> Drop for Listener<Service> {
     fn drop(&mut self) {
-        if let Some(handle) = self.dynamic_listener_handle {
-            self.service_state
-                .dynamic_storage()
-                .get()
-                .event()
-                .release_listener_handle(handle)
-        }
+        self.service_state
+            .dynamic_storage()
+            .get()
+            .event()
+            .release_listener_handle(self.dynamic_listener_handle)
     }
 }
 
@@ -231,27 +229,16 @@ impl<Service: service::Service> Listener<Service> {
             }
         };
 
-        let mut new_self = Self {
-            port_tag,
-            service_state: service.clone(),
-            dynamic_listener_handle: None,
-            listener,
-            listener_id,
-            listener_name: config.port_name,
-        };
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
         // !MUST! be the last task otherwise a listener is added to the dynamic config without
         // the creation of all required channels
-        let dynamic_listener_handle = match service.dynamic_storage().get().event().add_listener_id(
+        let (details, handle) = match service.dynamic_storage().get().event().add_listener_id(
             ListenerDetails {
                 listener_id,
                 listener_name: config.port_name,
                 node_id: *service.shared_node().id(),
             },
         ) {
-            Some(unique_index) => unique_index,
+            Some(v) => v,
             None => {
                 fail!(from origin, with ListenerCreateError::ExceedsMaxSupportedListeners,
                                  "{} since it would exceed the maximum supported amount of listeners of {}.",
@@ -259,14 +246,23 @@ impl<Service: service::Service> Listener<Service> {
             }
         };
 
-        new_self.dynamic_listener_handle = Some(dynamic_listener_handle);
+        let new_self = Self {
+            port_tag,
+            service_state: service.clone(),
+            dynamic_listener_handle: handle,
+            listener_details: unsafe { &*details },
+            listener,
+            listener_id,
+        };
+
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
 
         Ok(new_self)
     }
 
     /// Returns the [`PortName`] of the [`Listener`]
-    pub fn name(&self) -> PortName {
-        self.listener_name
+    pub fn name(&self) -> &PortName {
+        &self.listener_details.listener_name
     }
 
     /// Returns the deadline of the corresponding [`Service`](crate::service::Service).

--- a/iceoryx2/src/port/listener.rs
+++ b/iceoryx2/src/port/listener.rs
@@ -117,7 +117,6 @@ pub struct Listener<Service: service::Service> {
         <Service::Event as iceoryx2_cal::event::Event<RelocatableCountingBitSet>>::Listener,
     >,
     service_state: SharedServiceState<Service, NoResource>,
-    listener_id: UniqueListenerId,
     listener_details: &'static ListenerDetails,
     // IMPORTANT!
     // Fields of a rust struct are dropped in declaration order. Since this tag is our marker that the
@@ -254,7 +253,6 @@ impl<Service: service::Service> Listener<Service> {
             dynamic_listener_handle: handle,
             listener_details: unsafe { &*details },
             listener,
-            listener_id,
         })
     }
 
@@ -314,7 +312,7 @@ impl<Service: service::Service> Listener<Service> {
 
     /// Returns the [`UniqueListenerId`] of the [`Listener`]
     pub fn id(&self) -> UniqueListenerId {
-        self.listener_id
+        self.listener_details.listener_id
     }
 }
 

--- a/iceoryx2/src/port/mod.rs
+++ b/iceoryx2/src/port/mod.rs
@@ -30,6 +30,8 @@ pub mod event_id;
 pub mod listener;
 /// Sending endpoint (port) for event based communication
 pub mod notifier;
+/// The name for a port.
+pub mod port_name;
 /// Sending endpoint (port) for publish-subscribe based communication
 pub mod publisher;
 /// Reading endpoint (port) for blackboard based communication

--- a/iceoryx2/src/port/notifier.rs
+++ b/iceoryx2/src/port/notifier.rs
@@ -57,12 +57,14 @@ use iceoryx2_log::{debug, fail, warn};
 use crate::service::SharedServiceState;
 use crate::{
     identifiers::{UniqueListenerId, UniqueNodeId, UniqueNotifierId},
+    port::port_name::PortName,
     port::update_connections::UpdateConnections,
     service::{
         self, NoResource,
         config_scheme::event_config,
         dynamic_config::event::{ListenerDetails, NotifierDetails},
         naming_scheme::event_concept_name,
+        port_factory::notifier::NotifierConfig,
     },
 };
 
@@ -271,6 +273,7 @@ pub struct Notifier<Service: service::Service> {
     event_id_max_value: usize,
     dynamic_notifier_handle: Option<ContainerHandle>,
     notifier_id: UniqueNotifierId,
+    notifier_name: PortName,
     on_drop_notification: Option<EventId>,
     node_id: UniqueNodeId,
     // IMPORTANT!
@@ -337,10 +340,9 @@ impl<Service: service::Service> UpdateConnections for Notifier<Service> {
 impl<Service: service::Service> Notifier<Service> {
     pub(crate) fn new(
         service: SharedServiceState<Service, NoResource>,
-        default_event_id: EventId,
+        config: NotifierConfig,
     ) -> Result<Self, NotifierCreateError> {
-        let mut new_self =
-            Self::new_without_auto_event_emission(service.clone(), default_event_id)?;
+        let mut new_self = Self::new_without_auto_event_emission(service.clone(), config)?;
 
         let static_config = service.static_config().event();
         new_self.on_drop_notification = static_config
@@ -368,7 +370,7 @@ impl<Service: service::Service> Notifier<Service> {
 
     pub(crate) fn new_without_auto_event_emission(
         service: SharedServiceState<Service, NoResource>,
-        default_event_id: EventId,
+        config: NotifierConfig,
     ) -> Result<Self, NotifierCreateError> {
         let msg = "Unable to create Notifier port";
         let origin = "Notifier::new()";
@@ -409,10 +411,11 @@ impl<Service: service::Service> Notifier<Service> {
         let mut new_self = Self {
             port_tag,
             listener_connections,
-            default_event_id,
+            default_event_id: config.default_event_id,
             event_id_max_value: static_config.event_id_max_value,
             dynamic_notifier_handle: None,
             notifier_id,
+            notifier_name: config.port_name,
             on_drop_notification: None,
             node_id,
         };
@@ -436,6 +439,7 @@ impl<Service: service::Service> Notifier<Service> {
             .add_notifier_id(NotifierDetails {
                 notifier_id,
                 node_id,
+                notifier_name: config.port_name,
             }) {
             Some(handle) => handle,
             None => {
@@ -452,6 +456,11 @@ impl<Service: service::Service> Notifier<Service> {
     /// Returns the [`UniqueNotifierId`] of the [`Notifier`]
     pub fn id(&self) -> UniqueNotifierId {
         self.notifier_id
+    }
+
+    /// Returns the [`PortName`] of the [`Notifier`]
+    pub fn name(&self) -> PortName {
+        self.notifier_name
     }
 
     /// Notifies all [`crate::port::listener::Listener`] connected to the service with the default

--- a/iceoryx2/src/port/notifier.rs
+++ b/iceoryx2/src/port/notifier.rs
@@ -271,9 +271,9 @@ pub struct Notifier<Service: service::Service> {
     listener_connections: Service::ArcThreadSafetyPolicy<ListenerConnections<Service>>,
     default_event_id: EventId,
     event_id_max_value: usize,
-    dynamic_notifier_handle: Option<ContainerHandle>,
+    dynamic_notifier_handle: ContainerHandle,
+    notifier_details: &'static NotifierDetails,
     notifier_id: UniqueNotifierId,
-    notifier_name: PortName,
     on_drop_notification: Option<EventId>,
     node_id: UniqueNodeId,
     // IMPORTANT!
@@ -318,15 +318,13 @@ impl<Service: service::Service> Drop for Notifier<Service> {
             }
         }
 
-        if let Some(handle) = self.dynamic_notifier_handle {
-            self.listener_connections
-                .lock()
-                .service_state
-                .dynamic_storage()
-                .get()
-                .event()
-                .release_notifier_handle(handle)
-        }
+        self.listener_connections
+            .lock()
+            .service_state
+            .dynamic_storage()
+            .get()
+            .event()
+            .release_notifier_handle(self.dynamic_notifier_handle)
     }
 }
 
@@ -408,29 +406,11 @@ impl<Service: service::Service> Notifier<Service> {
             }
         };
 
-        let mut new_self = Self {
-            port_tag,
-            listener_connections,
-            default_event_id: config.default_event_id,
-            event_id_max_value: static_config.event_id_max_value,
-            dynamic_notifier_handle: None,
-            notifier_id,
-            notifier_name: config.port_name,
-            on_drop_notification: None,
-            node_id,
-        };
-
-        new_self
-            .listener_connections
-            .lock()
-            .populate_listener_channels();
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+        listener_connections.lock().populate_listener_channels();
 
         // !MUST! be the last task otherwise a notifier is added to the dynamic config without
         // the creation of all required channels
-        let dynamic_notifier_handle = match new_self
-            .listener_connections
+        let (details, handle) = match listener_connections
             .lock()
             .service_state
             .dynamic_storage()
@@ -441,14 +421,27 @@ impl<Service: service::Service> Notifier<Service> {
                 node_id,
                 notifier_name: config.port_name,
             }) {
-            Some(handle) => handle,
+            Some(v) => v,
             None => {
                 fail!(from origin, with NotifierCreateError::ExceedsMaxSupportedNotifiers,
                             "{} since it would exceed the maximum supported amount of notifiers of {}.",
                             msg, service.static_config().event().max_notifiers);
             }
         };
-        new_self.dynamic_notifier_handle = Some(dynamic_notifier_handle);
+
+        let new_self = Self {
+            port_tag,
+            listener_connections,
+            default_event_id: config.default_event_id,
+            event_id_max_value: static_config.event_id_max_value,
+            dynamic_notifier_handle: handle,
+            notifier_details: unsafe { &*details },
+            notifier_id,
+            on_drop_notification: None,
+            node_id,
+        };
+
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
 
         Ok(new_self)
     }
@@ -459,8 +452,8 @@ impl<Service: service::Service> Notifier<Service> {
     }
 
     /// Returns the [`PortName`] of the [`Notifier`]
-    pub fn name(&self) -> PortName {
-        self.notifier_name
+    pub fn name(&self) -> &PortName {
+        &self.notifier_details.notifier_name
     }
 
     /// Notifies all [`crate::port::listener::Listener`] connected to the service with the default

--- a/iceoryx2/src/port/notifier.rs
+++ b/iceoryx2/src/port/notifier.rs
@@ -408,6 +408,8 @@ impl<Service: service::Service> Notifier<Service> {
 
         listener_connections.lock().populate_listener_channels();
 
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+
         // !MUST! be the last task otherwise a notifier is added to the dynamic config without
         // the creation of all required channels
         let (details, handle) = match listener_connections
@@ -429,7 +431,7 @@ impl<Service: service::Service> Notifier<Service> {
             }
         };
 
-        let new_self = Self {
+        Ok(Self {
             port_tag,
             listener_connections,
             default_event_id: config.default_event_id,
@@ -439,11 +441,7 @@ impl<Service: service::Service> Notifier<Service> {
             notifier_id,
             on_drop_notification: None,
             node_id,
-        };
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
-        Ok(new_self)
+        })
     }
 
     /// Returns the [`UniqueNotifierId`] of the [`Notifier`]

--- a/iceoryx2/src/port/notifier.rs
+++ b/iceoryx2/src/port/notifier.rs
@@ -273,9 +273,7 @@ pub struct Notifier<Service: service::Service> {
     event_id_max_value: usize,
     dynamic_notifier_handle: ContainerHandle,
     notifier_details: &'static NotifierDetails,
-    notifier_id: UniqueNotifierId,
     on_drop_notification: Option<EventId>,
-    node_id: UniqueNodeId,
     // IMPORTANT!
     // Fields of a rust struct are dropped in declaration order. Since this tag is our marker that the
     // port exists and might require cleanup after a crash, the tag must be defined as last member of
@@ -438,15 +436,13 @@ impl<Service: service::Service> Notifier<Service> {
             event_id_max_value: static_config.event_id_max_value,
             dynamic_notifier_handle: handle,
             notifier_details: unsafe { &*details },
-            notifier_id,
             on_drop_notification: None,
-            node_id,
         })
     }
 
     /// Returns the [`UniqueNotifierId`] of the [`Notifier`]
     pub fn id(&self) -> UniqueNotifierId {
-        self.notifier_id
+        self.notifier_details.notifier_id
     }
 
     /// Returns the [`PortName`] of the [`Notifier`]
@@ -517,7 +513,7 @@ impl<Service: service::Service> Notifier<Service> {
 
         for i in 0..listener_connections.len() {
             if let Some(connection) = listener_connections.get(i) {
-                if !(skip_self_deliver && connection.node_id == self.node_id) {
+                if !(skip_self_deliver && connection.node_id == self.notifier_details.node_id) {
                     match connection.notifier.notify(value) {
                         Err(iceoryx2_cal::event::NotifierNotifyError::Disconnected) => {
                             listener_connections.remove(i);

--- a/iceoryx2/src/port/port_name.rs
+++ b/iceoryx2/src/port/port_name.rs
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::format;
+
+use iceoryx2_bb_container::{semantic_string::SemanticStringError, string::*};
+use iceoryx2_bb_derive_macros::{PlacementDefault, ZeroCopySend};
+use iceoryx2_bb_elementary_traits::placement_default::PlacementDefault;
+use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
+use iceoryx2_log::fail;
+
+use crate::constants::MAX_PORT_NAME_LENGTH;
+
+use serde::{Deserialize, Serialize, de::Visitor};
+
+type PortNameString = StaticString<MAX_PORT_NAME_LENGTH>;
+
+/// Represents the name for a port like [`crate::port::publisher::Publisher`], [`crate::port::server::Server`] or [`crate::port::listener::Listener`].
+#[derive(
+    PlacementDefault, ZeroCopySend, Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord,
+)]
+#[repr(C)]
+pub struct PortName {
+    value: PortNameString,
+}
+
+impl PortName {
+    /// Creates a new [`PortName`].
+    /// If the provided name does not contain a valid [`PortName`] it will return a
+    /// [`SemanticStringError`] otherwise the [`PortName`].
+    pub fn new(name: &str) -> Result<Self, SemanticStringError> {
+        Ok(Self {
+            value: fail!(from "PortName::new()",
+                         when PortNameString::try_from(name),
+                         "The string \"{}\" is not a valid port name.",
+                         name),
+        })
+    }
+
+    /// Creates a new empty [`PortName`].
+    pub fn new_empty() -> Self {
+        Self {
+            value: PortNameString::default(),
+        }
+    }
+
+    /// Returns a str reference to the [`PortName`]
+    pub fn as_str(&self) -> &str {
+        // SAFETY: `PortName` was created from a `&str` and therefore this conversion is safe
+        unsafe { core::str::from_utf8_unchecked(self.value.as_bytes()) }
+    }
+
+    /// Returns the maximum length of [`PortName`]
+    pub fn max_len() -> usize {
+        PortNameString::capacity()
+    }
+}
+
+impl core::fmt::Display for PortName {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+impl TryInto<PortName> for &str {
+    type Error = SemanticStringError;
+
+    fn try_into(self) -> Result<PortName, Self::Error> {
+        PortName::new(self)
+    }
+}
+
+impl PartialEq<&str> for PortName {
+    fn eq(&self, other: &&str) -> bool {
+        *self.as_str() == **other
+    }
+}
+
+impl PartialEq<&str> for &PortName {
+    fn eq(&self, other: &&str) -> bool {
+        *self.as_str() == **other
+    }
+}
+
+impl core::ops::Deref for PortName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+struct PortNameVisitor;
+
+impl Visitor<'_> for PortNameVisitor {
+    type Value = PortName;
+
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+        formatter.write_str("a string containing the service name")
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match PortName::new(v) {
+            Ok(v) => Ok(v),
+            Err(v) => Err(E::custom(format!("invalid port name provided {v:?}."))),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PortName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(PortNameVisitor)
+    }
+}
+
+impl Serialize for PortName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(core::str::from_utf8(self.as_bytes()).unwrap())
+    }
+}

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -561,15 +561,13 @@ impl<
             }
         };
 
-        let new_self = Self {
+        Ok(Self {
             publisher_shared_state,
             dynamic_publisher_handle: handle,
             publisher_details: unsafe { &*details },
             _payload: PhantomData,
             _user_header: PhantomData,
-        };
-
-        Ok(new_self)
+        })
     }
 
     /// Returns the [`UniquePublisherId`] of the [`Publisher`]

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -332,7 +332,8 @@ pub struct Publisher<
 > {
     pub(crate) publisher_shared_state:
         Service::ArcThreadSafetyPolicy<PublisherSharedState<Service>>,
-    dynamic_publisher_handle: Option<ContainerHandle>,
+    dynamic_publisher_handle: ContainerHandle,
+    publisher_details: &'static PublisherDetails,
     _payload: PhantomData<Payload>,
     _user_header: PhantomData<UserHeader>,
 }
@@ -382,15 +383,13 @@ impl<
     fn drop(&mut self) {
         let shared_state = self.publisher_shared_state.lock();
         shared_state.is_active.store(false, Ordering::Relaxed);
-        if let Some(handle) = self.dynamic_publisher_handle {
-            shared_state
-                .sender
-                .service_state
-                .dynamic_storage()
-                .get()
-                .publish_subscribe()
-                .release_publisher_handle(handle)
-        }
+        shared_state
+            .sender
+            .service_state
+            .dynamic_storage()
+            .get()
+            .publish_subscribe()
+            .release_publisher_handle(self.dynamic_publisher_handle)
     }
 }
 
@@ -505,7 +504,6 @@ impl<
                         .map(|_| UnsafeCell::new(None))
                         .collect(),
                     sender_port_id: port_id.value(),
-                    sender_port_name: config.port_name,
                     shared_node: service.shared_node().clone(),
                     receiver_max_buffer_size: static_config.subscriber_max_buffer_size,
                     receiver_max_borrowed_samples: static_config.subscriber_max_borrowed_samples,
@@ -540,19 +538,8 @@ impl<
             }
         };
 
-        let mut new_self = Self {
-            publisher_shared_state,
-            dynamic_publisher_handle: None,
-            _payload: PhantomData,
-            _user_header: PhantomData,
-        };
-
-        if let Err(e) = new_self
-            .publisher_shared_state
-            .lock()
-            .force_update_connections()
-        {
-            warn!(from new_self,
+        if let Err(e) = publisher_shared_state.lock().force_update_connections() {
+            warn!(from origin,
                 "The new Publisher port is unable to connect to every Subscriber port, caused by {:?}.", e);
         }
 
@@ -560,13 +547,13 @@ impl<
 
         // !MUST! be the last task otherwise a publisher is added to the dynamic config without the
         // creation of all required resources
-        let dynamic_publisher_handle = match service
+        let (details, handle) = match service
             .dynamic_storage()
             .get()
             .publish_subscribe()
             .add_publisher_id(publisher_details)
         {
-            Some(unique_index) => unique_index,
+            Some(v) => v,
             None => {
                 fail!(from origin, with PublisherCreateError::ExceedsMaxSupportedPublishers,
                             "{} since it would exceed the maximum supported amount of publishers of {}.",
@@ -574,7 +561,13 @@ impl<
             }
         };
 
-        new_self.dynamic_publisher_handle = Some(dynamic_publisher_handle);
+        let new_self = Self {
+            publisher_shared_state,
+            dynamic_publisher_handle: handle,
+            publisher_details: unsafe { &*details },
+            _payload: PhantomData,
+            _user_header: PhantomData,
+        };
 
         Ok(new_self)
     }
@@ -587,8 +580,8 @@ impl<
     }
 
     /// Returns the [`PortName`] of the [`Publisher`]
-    pub fn name(&self) -> PortName {
-        self.publisher_shared_state.lock().sender.sender_port_name
+    pub fn name(&self) -> &PortName {
+        &self.publisher_details.publisher_name
     }
 
     /// Returns the strategy the [`Publisher`] follows when a [`SampleMut`] cannot be delivered

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -118,7 +118,6 @@ use iceoryx2_bb_elementary_traits::non_null::NonNullCompat;
 use iceoryx2_bb_elementary_traits::testing::abandonable::Abandonable;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_bb_lock_free::mpmc::container::{ContainerHandle, ContainerState};
-use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_cal::arc_sync_policy::ArcSyncPolicy;
 use iceoryx2_cal::dynamic_storage::DynamicStorage;
 use iceoryx2_cal::shm_allocator::{AllocationStrategy, PointerOffset};
@@ -572,9 +571,7 @@ impl<
 
     /// Returns the [`UniquePublisherId`] of the [`Publisher`]
     pub fn id(&self) -> UniquePublisherId {
-        UniquePublisherId(UniqueSystemId::from(
-            self.publisher_shared_state.lock().sender.sender_port_id,
-        ))
+        self.publisher_details.publisher_id
     }
 
     /// Returns the [`PortName`] of the [`Publisher`]

--- a/iceoryx2/src/port/publisher.rs
+++ b/iceoryx2/src/port/publisher.rs
@@ -128,6 +128,7 @@ use iceoryx2_cal::zero_copy_connection::{
 use iceoryx2_log::{fail, warn};
 
 use crate::port::details::sender::*;
+use crate::port::port_name::PortName;
 use crate::port::update_connections::{ConnectionFailure, UpdateConnections};
 use crate::prelude::BackpressureStrategy;
 use crate::raw_sample::RawSampleMut;
@@ -456,6 +457,7 @@ impl<
         let publisher_details = PublisherDetails {
             data_segment_type,
             publisher_id: port_id,
+            publisher_name: config.port_name,
             number_of_samples,
             max_slice_len,
             node_id: *service.shared_node().id(),
@@ -503,6 +505,7 @@ impl<
                         .map(|_| UnsafeCell::new(None))
                         .collect(),
                     sender_port_id: port_id.value(),
+                    sender_port_name: config.port_name,
                     shared_node: service.shared_node().clone(),
                     receiver_max_buffer_size: static_config.subscriber_max_buffer_size,
                     receiver_max_borrowed_samples: static_config.subscriber_max_borrowed_samples,
@@ -581,6 +584,11 @@ impl<
         UniquePublisherId(UniqueSystemId::from(
             self.publisher_shared_state.lock().sender.sender_port_id,
         ))
+    }
+
+    /// Returns the [`PortName`] of the [`Publisher`]
+    pub fn name(&self) -> PortName {
+        self.publisher_shared_state.lock().sender.sender_port_name
     }
 
     /// Returns the strategy the [`Publisher`] follows when a [`SampleMut`] cannot be delivered

--- a/iceoryx2/src/port/reader.rs
+++ b/iceoryx2/src/port/reader.rs
@@ -166,9 +166,9 @@ pub struct Reader<
     KeyType: Send + Sync + Eq + Clone + Copy + Debug + 'static + Hash + ZeroCopySend,
 > {
     shared_state: Service::ArcThreadSafetyPolicy<ReaderSharedState<Service, KeyType>>,
-    dynamic_reader_handle: Option<ContainerHandle>,
+    dynamic_reader_handle: ContainerHandle,
+    reader_details: &'static ReaderDetails,
     reader_id: UniqueReaderId,
-    reader_name: PortName,
 }
 
 impl<
@@ -192,15 +192,13 @@ impl<
 > Drop for Reader<Service, KeyType>
 {
     fn drop(&mut self) {
-        if let Some(handle) = self.dynamic_reader_handle {
-            self.shared_state
-                .lock()
-                .service_state
-                .dynamic_storage()
-                .get()
-                .blackboard()
-                .release_reader_handle(handle)
-        }
+        self.shared_state
+            .lock()
+            .service_state
+            .dynamic_storage()
+            .get()
+            .blackboard()
+            .release_reader_handle(self.dynamic_reader_handle)
     }
 }
 
@@ -244,27 +242,18 @@ impl<
             }
         };
 
-        let mut new_self = Self {
-            shared_state,
-            reader_id,
-            reader_name: config.port_name,
-            dynamic_reader_handle: None,
-        };
-
         core::sync::atomic::compiler_fence(Ordering::SeqCst);
 
         // !MUST! be the last task otherwise a reader is added to the dynamic config without the
         // creation of all required resources
-        let dynamic_reader_handle = match service
-            .dynamic_storage()
-            .get()
-            .blackboard()
-            .add_reader_id(ReaderDetails {
+        let (details, handle) = match service.dynamic_storage().get().blackboard().add_reader_id(
+            ReaderDetails {
                 reader_id,
                 reader_name: config.port_name,
                 node_id: *service.shared_node().id(),
-            }) {
-            Some(unique_index) => unique_index,
+            },
+        ) {
+            Some(v) => v,
             None => {
                 fail!(from origin, with ReaderCreateError::ExceedsMaxSupportedReaders,
                             "{} since it would exceed the maximum supported amount of readers of {}.",
@@ -272,7 +261,13 @@ impl<
             }
         };
 
-        new_self.dynamic_reader_handle = Some(dynamic_reader_handle);
+        let new_self = Self {
+            shared_state,
+            reader_id,
+            reader_details: unsafe { &*details },
+            dynamic_reader_handle: handle,
+        };
+
         Ok(new_self)
     }
 
@@ -282,8 +277,8 @@ impl<
     }
 
     /// Returns the [`PortName`] of the [`Reader`]
-    pub fn name(&self) -> PortName {
-        self.reader_name
+    pub fn name(&self) -> &PortName {
+        &self.reader_details.reader_name
     }
 
     /// Creates a [`EntryHandle`] for direct read access to the value.

--- a/iceoryx2/src/port/reader.rs
+++ b/iceoryx2/src/port/reader.rs
@@ -261,14 +261,12 @@ impl<
             }
         };
 
-        let new_self = Self {
+        Ok(Self {
             shared_state,
             reader_id,
             reader_details: unsafe { &*details },
             dynamic_reader_handle: handle,
-        };
-
-        Ok(new_self)
+        })
     }
 
     /// Returns the [`UniqueReaderId`] of the [`Reader`]

--- a/iceoryx2/src/port/reader.rs
+++ b/iceoryx2/src/port/reader.rs
@@ -168,7 +168,6 @@ pub struct Reader<
     shared_state: Service::ArcThreadSafetyPolicy<ReaderSharedState<Service, KeyType>>,
     dynamic_reader_handle: ContainerHandle,
     reader_details: &'static ReaderDetails,
-    reader_id: UniqueReaderId,
 }
 
 impl<
@@ -263,7 +262,6 @@ impl<
 
         Ok(Self {
             shared_state,
-            reader_id,
             reader_details: unsafe { &*details },
             dynamic_reader_handle: handle,
         })
@@ -271,7 +269,7 @@ impl<
 
     /// Returns the [`UniqueReaderId`] of the [`Reader`]
     pub fn id(&self) -> UniqueReaderId {
-        self.reader_id
+        self.reader_details.reader_id
     }
 
     /// Returns the [`PortName`] of the [`Reader`]

--- a/iceoryx2/src/port/reader.rs
+++ b/iceoryx2/src/port/reader.rs
@@ -37,10 +37,12 @@
 
 use crate::constants::MAX_BLACKBOARD_KEY_SIZE;
 use crate::identifiers::UniqueReaderId;
+use crate::port::port_name::PortName;
 use crate::prelude::EventId;
 use crate::service::builder::CustomKeyMarker;
 use crate::service::builder::blackboard::{BlackboardResources, KeyMemory};
 use crate::service::dynamic_config::blackboard::ReaderDetails;
+use crate::service::port_factory::reader::ReaderConfig;
 use crate::service::static_config::message_type_details::{TypeDetail, TypeVariant};
 use crate::service::{self, SharedServiceState};
 use core::alloc::Layout;
@@ -166,6 +168,7 @@ pub struct Reader<
     shared_state: Service::ArcThreadSafetyPolicy<ReaderSharedState<Service, KeyType>>,
     dynamic_reader_handle: Option<ContainerHandle>,
     reader_id: UniqueReaderId,
+    reader_name: PortName,
 }
 
 impl<
@@ -208,6 +211,7 @@ impl<
 {
     pub(crate) fn new(
         service: SharedServiceState<Service, BlackboardResources<Service>>,
+        config: ReaderConfig,
     ) -> Result<Self, ReaderCreateError> {
         let origin = "Reader::new()";
         let msg = "Unable to create Reader port";
@@ -243,6 +247,7 @@ impl<
         let mut new_self = Self {
             shared_state,
             reader_id,
+            reader_name: config.port_name,
             dynamic_reader_handle: None,
         };
 
@@ -256,6 +261,7 @@ impl<
             .blackboard()
             .add_reader_id(ReaderDetails {
                 reader_id,
+                reader_name: config.port_name,
                 node_id: *service.shared_node().id(),
             }) {
             Some(unique_index) => unique_index,
@@ -273,6 +279,11 @@ impl<
     /// Returns the [`UniqueReaderId`] of the [`Reader`]
     pub fn id(&self) -> UniqueReaderId {
         self.reader_id
+    }
+
+    /// Returns the [`PortName`] of the [`Reader`]
+    pub fn name(&self) -> PortName {
+        self.reader_name
     }
 
     /// Creates a [`EntryHandle`] for direct read access to the value.

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -522,7 +522,9 @@ impl<
             }
         };
 
-        let new_self = Self {
+        unsafe { *shared_state.lock().server_handle.get() = Some(handle) };
+
+        Ok(Self {
             max_loaned_responses_per_request: server_factory
                 .config
                 .max_loaned_responses_per_request,
@@ -536,10 +538,7 @@ impl<
             _request_header: PhantomData,
             _response_payload: PhantomData,
             _response_header: PhantomData,
-        };
-        unsafe { *new_self.shared_state.lock().server_handle.get() = Some(handle) };
-
-        Ok(new_self)
+        })
     }
 
     /// Returns the [`UniqueServerId`] of the [`Server`]

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -104,7 +104,6 @@ use iceoryx2_bb_elementary_traits::testing::abandonable::Abandonable;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_bb_lock_free::mpmc::container::{ContainerHandle, ContainerState};
 use iceoryx2_bb_memory::heap_allocator::HeapAllocator;
-use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_cal::arc_sync_policy::ArcSyncPolicy;
 use iceoryx2_cal::dynamic_storage::DynamicStorage;
 use iceoryx2_cal::zero_copy_connection::{CHANNEL_STATE_CLOSED, CHANNEL_STATE_OPEN, ChannelId};
@@ -543,9 +542,7 @@ impl<
 
     /// Returns the [`UniqueServerId`] of the [`Server`]
     pub fn id(&self) -> UniqueServerId {
-        UniqueServerId(UniqueSystemId::from(
-            self.shared_state.lock().request_receiver.receiver_port_id,
-        ))
+        self.server_details.server_id
     }
 
     /// Returns the [`PortName`] of the [`Server`]

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -73,6 +73,7 @@
 //! # }
 //! ```
 
+use crate::port::port_name::PortName;
 use crate::port::update_connections::UpdateConnections;
 use crate::prelude::BackpressureStrategy;
 use crate::service::builder::CustomPayloadMarker;
@@ -450,6 +451,7 @@ impl<
                 .map(|_| UnsafeCell::new(None))
                 .collect(),
             sender_port_id: server_id.value(),
+            sender_port_name: PortName::new_empty(),
             shared_node: service.shared_node().clone(),
             receiver_max_buffer_size: static_config.max_response_buffer_size,
             receiver_max_borrowed_samples: static_config

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -250,6 +250,7 @@ pub struct Server<
     shared_state: Service::ArcThreadSafetyPolicy<SharedServerState<Service>>,
     max_loaned_responses_per_request: usize,
     enable_fire_and_forget: bool,
+    server_details: &'static ServerDetails,
     _request_payload: PhantomData<RequestPayload>,
     _request_header: PhantomData<RequestHeader>,
     _response_payload: PhantomData<ResponsePayload>,
@@ -383,7 +384,6 @@ impl<
             )
             .expect("Heap allocator provides memory."),
             receiver_port_id: server_id.value(),
-            receiver_port_name: server_factory.config.port_name,
             service_state: service.clone(),
             message_type_details: static_config.request_message_type_details,
             receiver_max_borrowed_samples: static_config.max_active_requests_per_client,
@@ -452,7 +452,6 @@ impl<
                 .map(|_| UnsafeCell::new(None))
                 .collect(),
             sender_port_id: server_id.value(),
-            sender_port_name: server_factory.config.port_name,
             shared_node: service.shared_node().clone(),
             receiver_max_buffer_size: static_config.max_response_buffer_size,
             receiver_max_borrowed_samples: static_config
@@ -492,6 +491,37 @@ impl<
             }
         };
 
+        if let Err(e) = shared_state.lock().force_update_connections() {
+            warn!(from origin, "The new server is unable to connect to every client, caused by {:?}.", e);
+        }
+
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+
+        // !MUST! be the last task otherwise a server is added to the dynamic config without the
+        // creation of all required resources
+        let (details, handle) = match service
+            .dynamic_storage()
+            .get()
+            .request_response()
+            .add_server_id(ServerDetails {
+                server_id,
+                node_id: *service.shared_node().id(),
+                request_buffer_size: static_config.max_active_requests_per_client,
+                number_of_responses,
+                max_slice_len: server_factory.config.initial_max_slice_len,
+                data_segment_type,
+                max_number_of_segments,
+                server_name: server_factory.config.port_name,
+            }) {
+            Some(v) => v,
+            None => {
+                fail!(from origin,
+                    with ServerCreateError::ExceedsMaxSupportedServers,
+                    "{} since it would exceed the maximum supported amount of servers of {}.",
+                    msg, service.static_config().request_response().max_servers());
+            }
+        };
+
         let new_self = Self {
             max_loaned_responses_per_request: server_factory
                 .config
@@ -501,44 +531,13 @@ impl<
                 .request_response()
                 .enable_fire_and_forget_requests,
             shared_state,
+            server_details: unsafe { &*details },
             _request_payload: PhantomData,
             _request_header: PhantomData,
             _response_payload: PhantomData,
             _response_header: PhantomData,
         };
-
-        if let Err(e) = new_self.shared_state.lock().force_update_connections() {
-            warn!(from new_self, "The new server is unable to connect to every client, caused by {:?}.", e);
-        }
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
-        // !MUST! be the last task otherwise a server is added to the dynamic config without the
-        // creation of all required resources
-        unsafe {
-            *new_self.shared_state.lock().server_handle.get() = match service
-                .dynamic_storage()
-                .get()
-                .request_response()
-                .add_server_id(ServerDetails {
-                    server_id,
-                    node_id: *service.shared_node().id(),
-                    request_buffer_size: static_config.max_active_requests_per_client,
-                    number_of_responses,
-                    max_slice_len: server_factory.config.initial_max_slice_len,
-                    data_segment_type,
-                    max_number_of_segments,
-                    server_name: server_factory.config.port_name,
-                }) {
-                Some(v) => Some(v),
-                None => {
-                    fail!(from origin,
-                    with ServerCreateError::ExceedsMaxSupportedServers,
-                    "{} since it would exceed the maximum supported amount of servers of {}.",
-                    msg, service.static_config().request_response().max_servers());
-                }
-            }
-        };
+        unsafe { *new_self.shared_state.lock().server_handle.get() = Some(handle) };
 
         Ok(new_self)
     }
@@ -551,8 +550,8 @@ impl<
     }
 
     /// Returns the [`PortName`] of the [`Server`]
-    pub fn name(&self) -> PortName {
-        self.shared_state.lock().request_receiver.receiver_port_name
+    pub fn name(&self) -> &PortName {
+        &self.server_details.server_name
     }
 
     /// Returns true if the [`Server`] has [`RequestMut`](crate::request_mut::RequestMut)s in its buffer.

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -383,6 +383,7 @@ impl<
             )
             .expect("Heap allocator provides memory."),
             receiver_port_id: server_id.value(),
+            receiver_port_name: PortName::new_empty(),
             service_state: service.clone(),
             message_type_details: static_config.request_message_type_details,
             receiver_max_borrowed_samples: static_config.max_active_requests_per_client,

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -383,7 +383,7 @@ impl<
             )
             .expect("Heap allocator provides memory."),
             receiver_port_id: server_id.value(),
-            receiver_port_name: PortName::new_empty(),
+            receiver_port_name: server_factory.config.port_name,
             service_state: service.clone(),
             message_type_details: static_config.request_message_type_details,
             receiver_max_borrowed_samples: static_config.max_active_requests_per_client,
@@ -452,7 +452,7 @@ impl<
                 .map(|_| UnsafeCell::new(None))
                 .collect(),
             sender_port_id: server_id.value(),
-            sender_port_name: PortName::new_empty(),
+            sender_port_name: server_factory.config.port_name,
             shared_node: service.shared_node().clone(),
             receiver_max_buffer_size: static_config.max_response_buffer_size,
             receiver_max_borrowed_samples: static_config
@@ -528,6 +528,7 @@ impl<
                     max_slice_len: server_factory.config.initial_max_slice_len,
                     data_segment_type,
                     max_number_of_segments,
+                    server_name: server_factory.config.port_name,
                 }) {
                 Some(v) => Some(v),
                 None => {
@@ -547,6 +548,11 @@ impl<
         UniqueServerId(UniqueSystemId::from(
             self.shared_state.lock().request_receiver.receiver_port_id,
         ))
+    }
+
+    /// Returns the [`PortName`] of the [`Server`]
+    pub fn name(&self) -> PortName {
+        self.shared_state.lock().request_receiver.receiver_port_name
     }
 
     /// Returns true if the [`Server`] has [`RequestMut`](crate::request_mut::RequestMut)s in its buffer.

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -47,7 +47,6 @@ use iceoryx2_bb_elementary_traits::testing::abandonable::Abandonable;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_bb_lock_free::mpmc::container::{ContainerHandle, ContainerState};
 use iceoryx2_bb_memory::heap_allocator::HeapAllocator;
-use iceoryx2_bb_posix::unique_system_id::UniqueSystemId;
 use iceoryx2_cal::arc_sync_policy::ArcSyncPolicy;
 use iceoryx2_cal::dynamic_storage::DynamicStorage;
 use iceoryx2_cal::zero_copy_connection::{CHANNEL_STATE_OPEN, ChannelId};
@@ -394,12 +393,7 @@ impl<
 
     /// Returns the [`UniqueSubscriberId`] of the [`Subscriber`]
     pub fn id(&self) -> UniqueSubscriberId {
-        UniqueSubscriberId(UniqueSystemId::from(
-            self.subscriber_shared_state
-                .lock()
-                .receiver
-                .receiver_port_id(),
-        ))
+        self.subscriber_details.subscriber_id
     }
 
     /// Returns the [`PortName`] of the [`Subscriber`]

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -322,6 +322,12 @@ impl<
             }
         };
 
+        if let Err(e) = Self::force_update_connections(&subscriber_shared_state.lock()) {
+            warn!(from origin, "The new subscriber is unable to connect to every publisher, caused by {:?}.", e);
+        }
+
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+
         // !MUST! be the last task otherwise a subscriber is added to the dynamic config without
         // the creation of all required channels
         let (details, handle) = match service
@@ -343,26 +349,16 @@ impl<
             }
         };
 
-        let new_self = Self {
+        Ok(Self {
             subscriber_shared_state,
             dynamic_subscriber_handle: handle,
             subscriber_details: unsafe { &*details },
             _payload: PhantomData,
             _user_header: PhantomData,
-        };
-
-        if let Err(e) = new_self.force_update_connections(&new_self.subscriber_shared_state.lock())
-        {
-            warn!(from new_self, "The new subscriber is unable to connect to every publisher, caused by {:?}.", e);
-        }
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
-        Ok(new_self)
+        })
     }
 
     fn force_update_connections(
-        &self,
         subscriber_shared_state: &SubscriberSharedState<Service>,
     ) -> Result<(), ConnectionFailure> {
         subscriber_shared_state
@@ -456,7 +452,7 @@ impl<
                 .publishers
                 .update_state(&mut *subscriber_shared_state.publisher_list_state.get())
         } {
-            fail!(from self, when self.force_update_connections(&subscriber_shared_state),
+            fail!(from self, when Self::force_update_connections(&subscriber_shared_state),
                 "Connections were updated only partially since at least one connection to a publisher failed.");
         }
 

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -53,6 +53,7 @@ use iceoryx2_cal::dynamic_storage::DynamicStorage;
 use iceoryx2_cal::zero_copy_connection::{CHANNEL_STATE_OPEN, ChannelId};
 use iceoryx2_log::{fail, warn};
 
+use crate::port::port_name::PortName;
 use crate::port::update_connections::UpdateConnections;
 use crate::service::builder::CustomPayloadMarker;
 use crate::service::dynamic_config::publish_subscribe::{PublisherDetails, SubscriberDetails};
@@ -293,6 +294,7 @@ impl<
                 )
                 .expect("Heap allocator provides memory."),
                 receiver_port_id: subscriber_id.value(),
+                receiver_port_name: config.port_name,
                 service_state: service.clone(),
                 message_type_details: static_config.message_type_details,
                 receiver_max_borrowed_samples: subscriber_max_borrowed_samples,
@@ -347,6 +349,7 @@ impl<
                 buffer_size,
                 history_request,
                 node_id: *service.shared_node().id(),
+                subscriber_name: config.port_name,
             }) {
             Some(unique_index) => unique_index,
             None => {
@@ -404,6 +407,14 @@ impl<
                 .receiver
                 .receiver_port_id(),
         ))
+    }
+
+    /// Returns the [`PortName`] of the [`Subscriber`]
+    pub fn name(&self) -> PortName {
+        self.subscriber_shared_state
+            .lock()
+            .receiver
+            .receiver_port_name
     }
 
     /// Returns the internal buffer size of the [`Subscriber`].

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -132,7 +132,8 @@ pub struct Subscriber<
     Payload: Debug + ZeroCopySend + ?Sized + 'static,
     UserHeader: Debug + ZeroCopySend,
 > {
-    dynamic_subscriber_handle: Option<ContainerHandle>,
+    dynamic_subscriber_handle: ContainerHandle,
+    subscriber_details: &'static SubscriberDetails,
     subscriber_shared_state: Service::ArcThreadSafetyPolicy<SubscriberSharedState<Service>>,
 
     _payload: PhantomData<Payload>,
@@ -182,16 +183,14 @@ impl<
 > Drop for Subscriber<Service, Payload, UserHeader>
 {
     fn drop(&mut self) {
-        if let Some(handle) = self.dynamic_subscriber_handle {
-            self.subscriber_shared_state
-                .lock()
-                .receiver
-                .service_state
-                .dynamic_storage()
-                .get()
-                .publish_subscribe()
-                .release_subscriber_handle(handle)
-        }
+        self.subscriber_shared_state
+            .lock()
+            .receiver
+            .service_state
+            .dynamic_storage()
+            .get()
+            .publish_subscribe()
+            .release_subscriber_handle(self.dynamic_subscriber_handle)
     }
 }
 
@@ -294,7 +293,6 @@ impl<
                 )
                 .expect("Heap allocator provides memory."),
                 receiver_port_id: subscriber_id.value(),
-                receiver_port_name: config.port_name,
                 service_state: service.clone(),
                 message_type_details: static_config.message_type_details,
                 receiver_max_borrowed_samples: subscriber_max_borrowed_samples,
@@ -324,23 +322,9 @@ impl<
             }
         };
 
-        let mut new_self = Self {
-            subscriber_shared_state,
-            dynamic_subscriber_handle: None,
-            _payload: PhantomData,
-            _user_header: PhantomData,
-        };
-
-        if let Err(e) = new_self.force_update_connections(&new_self.subscriber_shared_state.lock())
-        {
-            warn!(from new_self, "The new subscriber is unable to connect to every publisher, caused by {:?}.", e);
-        }
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
         // !MUST! be the last task otherwise a subscriber is added to the dynamic config without
         // the creation of all required channels
-        let dynamic_subscriber_handle = match service
+        let (details, handle) = match service
             .dynamic_storage()
             .get()
             .publish_subscribe()
@@ -351,15 +335,28 @@ impl<
                 node_id: *service.shared_node().id(),
                 subscriber_name: config.port_name,
             }) {
-            Some(unique_index) => unique_index,
+            Some(v) => v,
             None => {
-                fail!(from new_self, with SubscriberCreateError::ExceedsMaxSupportedSubscribers,
+                fail!(from origin, with SubscriberCreateError::ExceedsMaxSupportedSubscribers,
                                 "{} since it would exceed the maximum supported amount of subscribers of {}.",
                                 msg, service.static_config().publish_subscribe().max_subscribers);
             }
         };
 
-        new_self.dynamic_subscriber_handle = Some(dynamic_subscriber_handle);
+        let new_self = Self {
+            subscriber_shared_state,
+            dynamic_subscriber_handle: handle,
+            subscriber_details: unsafe { &*details },
+            _payload: PhantomData,
+            _user_header: PhantomData,
+        };
+
+        if let Err(e) = new_self.force_update_connections(&new_self.subscriber_shared_state.lock())
+        {
+            warn!(from new_self, "The new subscriber is unable to connect to every publisher, caused by {:?}.", e);
+        }
+
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
 
         Ok(new_self)
     }
@@ -410,11 +407,8 @@ impl<
     }
 
     /// Returns the [`PortName`] of the [`Subscriber`]
-    pub fn name(&self) -> PortName {
-        self.subscriber_shared_state
-            .lock()
-            .receiver
-            .receiver_port_name
+    pub fn name(&self) -> &PortName {
+        &self.subscriber_details.subscriber_name
     }
 
     /// Returns the internal buffer size of the [`Subscriber`].

--- a/iceoryx2/src/port/writer.rs
+++ b/iceoryx2/src/port/writer.rs
@@ -42,10 +42,12 @@
 
 use crate::constants::MAX_BLACKBOARD_KEY_SIZE;
 use crate::identifiers::UniqueWriterId;
+use crate::port::port_name::PortName;
 use crate::prelude::EventId;
 use crate::service::builder::CustomKeyMarker;
 use crate::service::builder::blackboard::{BlackboardResources, KeyMemory};
 use crate::service::dynamic_config::blackboard::WriterDetails;
+use crate::service::port_factory::writer::WriterConfig;
 use crate::service::static_config::message_type_details::{TypeDetail, TypeVariant};
 use crate::service::{self, SharedServiceState};
 use core::alloc::Layout;
@@ -149,6 +151,7 @@ pub struct Writer<
 > {
     shared_state: Service::ArcThreadSafetyPolicy<WriterSharedState<Service, KeyType>>,
     writer_id: UniqueWriterId,
+    writer_name: PortName,
     // IMPORTANT!
     // Fields of a rust struct are dropped in declaration order. Since this tag is our marker that the
     // port exists and might require cleanup after a crash, the tag must be defined as last member of
@@ -183,6 +186,7 @@ impl<
 {
     pub(crate) fn new(
         service: SharedServiceState<Service, BlackboardResources<Service>>,
+        config: WriterConfig,
     ) -> Result<Self, WriterCreateError> {
         let origin = "Writer::new()";
         let msg = "Unable to create Writer port";
@@ -218,6 +222,7 @@ impl<
             shared_state,
             writer_id,
             port_tag,
+            writer_name: config.port_name,
         };
 
         core::sync::atomic::compiler_fence(Ordering::SeqCst);
@@ -230,6 +235,7 @@ impl<
             .blackboard()
             .add_writer_id(WriterDetails {
                 writer_id,
+                writer_name: config.port_name,
                 node_id: *service.shared_node().id(),
             }) {
             Some(unique_index) => unique_index,
@@ -249,6 +255,11 @@ impl<
     /// Returns the [`UniqueWriterId`] of the [`Writer`]
     pub fn id(&self) -> UniqueWriterId {
         self.writer_id
+    }
+
+    /// Returns the [`PortName`] of the [`Writer`]
+    pub fn name(&self) -> PortName {
+        self.writer_name
     }
 
     /// Creates a [`EntryHandleMut`] for direct write access to the value. There can be only one

--- a/iceoryx2/src/port/writer.rs
+++ b/iceoryx2/src/port/writer.rs
@@ -150,7 +150,6 @@ pub struct Writer<
     KeyType: Send + Sync + Eq + Clone + Copy + Debug + 'static + Hash + ZeroCopySend,
 > {
     shared_state: Service::ArcThreadSafetyPolicy<WriterSharedState<Service, KeyType>>,
-    writer_id: UniqueWriterId,
     writer_details: &'static WriterDetails,
     // IMPORTANT!
     // Fields of a rust struct are dropped in declaration order. Since this tag is our marker that the
@@ -242,14 +241,13 @@ impl<
         Ok(Self {
             shared_state,
             writer_details: unsafe { &*details },
-            writer_id,
             port_tag,
         })
     }
 
     /// Returns the [`UniqueWriterId`] of the [`Writer`]
     pub fn id(&self) -> UniqueWriterId {
-        self.writer_id
+        self.writer_details.writer_id
     }
 
     /// Returns the [`PortName`] of the [`Writer`]

--- a/iceoryx2/src/port/writer.rs
+++ b/iceoryx2/src/port/writer.rs
@@ -218,6 +218,8 @@ impl<
             }
         };
 
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+
         // !MUST! be the last task otherwise a writer is added to the dynamic config without the
         // creation of all required resources
         let (details, handle) = match service.dynamic_storage().get().blackboard().add_writer_id(
@@ -235,17 +237,14 @@ impl<
             }
         };
 
-        let new_self = Self {
+        unsafe { *shared_state.lock().dynamic_writer_handle.get() = Some(handle) };
+
+        Ok(Self {
             shared_state,
             writer_details: unsafe { &*details },
             writer_id,
             port_tag,
-        };
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
-        unsafe { *new_self.shared_state.lock().dynamic_writer_handle.get() = Some(handle) };
-        Ok(new_self)
+        })
     }
 
     /// Returns the [`UniqueWriterId`] of the [`Writer`]

--- a/iceoryx2/src/port/writer.rs
+++ b/iceoryx2/src/port/writer.rs
@@ -151,7 +151,7 @@ pub struct Writer<
 > {
     shared_state: Service::ArcThreadSafetyPolicy<WriterSharedState<Service, KeyType>>,
     writer_id: UniqueWriterId,
-    writer_name: PortName,
+    writer_details: &'static WriterDetails,
     // IMPORTANT!
     // Fields of a rust struct are dropped in declaration order. Since this tag is our marker that the
     // port exists and might require cleanup after a crash, the tag must be defined as last member of
@@ -218,26 +218,15 @@ impl<
             }
         };
 
-        let new_self = Self {
-            shared_state,
-            writer_id,
-            port_tag,
-            writer_name: config.port_name,
-        };
-
-        core::sync::atomic::compiler_fence(Ordering::SeqCst);
-
         // !MUST! be the last task otherwise a writer is added to the dynamic config without the
         // creation of all required resources
-        let dynamic_writer_handle = match service
-            .dynamic_storage()
-            .get()
-            .blackboard()
-            .add_writer_id(WriterDetails {
+        let (details, handle) = match service.dynamic_storage().get().blackboard().add_writer_id(
+            WriterDetails {
                 writer_id,
                 writer_name: config.port_name,
                 node_id: *service.shared_node().id(),
-            }) {
+            },
+        ) {
             Some(unique_index) => unique_index,
             None => {
                 fail!(from origin, with WriterCreateError::ExceedsMaxSupportedWriters,
@@ -246,9 +235,16 @@ impl<
             }
         };
 
-        unsafe {
-            *new_self.shared_state.lock().dynamic_writer_handle.get() = Some(dynamic_writer_handle)
+        let new_self = Self {
+            shared_state,
+            writer_details: unsafe { &*details },
+            writer_id,
+            port_tag,
         };
+
+        core::sync::atomic::compiler_fence(Ordering::SeqCst);
+
+        unsafe { *new_self.shared_state.lock().dynamic_writer_handle.get() = Some(handle) };
         Ok(new_self)
     }
 
@@ -258,8 +254,8 @@ impl<
     }
 
     /// Returns the [`PortName`] of the [`Writer`]
-    pub fn name(&self) -> PortName {
-        self.writer_name
+    pub fn name(&self) -> &PortName {
+        &self.writer_details.writer_name
     }
 
     /// Creates a [`EntryHandleMut`] for direct write access to the value. There can be only one

--- a/iceoryx2/src/prelude.rs
+++ b/iceoryx2/src/prelude.rs
@@ -12,8 +12,10 @@
 
 pub use crate::config::Config;
 pub use crate::node::{Node, NodeBuilder, NodeState, node_name::NodeName};
-pub use crate::port::EventActivation;
-pub use crate::port::{backpressure_strategy::BackpressureStrategy, event_id::EventId};
+pub use crate::port::{
+    EventActivation, backpressure_strategy::BackpressureStrategy, event_id::EventId,
+    port_name::PortName,
+};
 pub use crate::service::messaging_pattern::MessagingPattern;
 pub use crate::service::{
     Service, ServiceDetails, attribute::AttributeSet, attribute::AttributeSpecifier,

--- a/iceoryx2/src/service/dynamic_config/blackboard.rs
+++ b/iceoryx2/src/service/dynamic_config/blackboard.rs
@@ -53,6 +53,8 @@ pub(crate) struct DynamicConfigSettings {
 pub struct ReaderDetails {
     /// The [`UniqueReaderId`] of the [`Reader`](crate::port::reader::Reader).
     pub reader_id: UniqueReaderId,
+    /// The [`PortName`] of the [`Reader`](crate::port::reader::Reader).
+    pub reader_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Reader`](crate::port::reader::Reader) was created.
     pub node_id: UniqueNodeId,

--- a/iceoryx2/src/service/dynamic_config/blackboard.rs
+++ b/iceoryx2/src/service/dynamic_config/blackboard.rs
@@ -29,6 +29,7 @@
 //! ```
 
 use crate::identifiers::{UniqueNodeId, UniquePortId, UniqueReaderId, UniqueWriterId};
+use crate::port::port_name::PortName;
 use iceoryx2_bb_container::queue::RelocatableContainer;
 use iceoryx2_bb_derive_macros::ZeroCopySend;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
@@ -64,6 +65,8 @@ pub struct ReaderDetails {
 pub struct WriterDetails {
     /// The [`UniqueWriterId`] of the [`Writer`](crate::port::writer::Writer).
     pub writer_id: UniqueWriterId,
+    /// The [`PortName`] of the [`Writer`](crate::port::writer::Writer).
+    pub writer_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Writer`](crate::port::writer::Writer) was created.
     pub node_id: UniqueNodeId,

--- a/iceoryx2/src/service/dynamic_config/blackboard.rs
+++ b/iceoryx2/src/service/dynamic_config/blackboard.rs
@@ -170,7 +170,10 @@ impl DynamicConfig {
         }
     }
 
-    pub(crate) fn add_reader_id(&self, details: ReaderDetails) -> Option<ContainerHandle> {
+    pub(crate) fn add_reader_id(
+        &self,
+        details: ReaderDetails,
+    ) -> Option<(*const ReaderDetails, ContainerHandle)> {
         unsafe { self.readers.add(details, details.node_id.owner_id()).ok() }
     }
 
@@ -180,7 +183,10 @@ impl DynamicConfig {
         }
     }
 
-    pub(crate) fn add_writer_id(&self, details: WriterDetails) -> Option<ContainerHandle> {
+    pub(crate) fn add_writer_id(
+        &self,
+        details: WriterDetails,
+    ) -> Option<(*const WriterDetails, ContainerHandle)> {
         unsafe { self.writers.add(details, details.node_id.owner_id()).ok() }
     }
 

--- a/iceoryx2/src/service/dynamic_config/event.rs
+++ b/iceoryx2/src/service/dynamic_config/event.rs
@@ -36,6 +36,7 @@ use iceoryx2_bb_memory::bump_allocator::BumpAllocator;
 use iceoryx2_log::{error, fatal_panic};
 
 use crate::identifiers::{UniqueListenerId, UniqueNodeId, UniqueNotifierId, UniquePortId};
+use crate::port::port_name::PortName;
 
 use super::PortCleanupAction;
 
@@ -75,6 +76,8 @@ pub struct ListenerDetails {
 pub struct NotifierDetails {
     /// The [`UniqueNotifierId`] of the [`Notifier`](crate::port::notifier::Notifier).
     pub notifier_id: UniqueNotifierId,
+    /// The [`PortName`] of the [`Notifier`](crate::port::notifier::Notifier).
+    pub notifier_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Notifier`](crate::port::notifier::Notifier) was created.
     pub node_id: UniqueNodeId,

--- a/iceoryx2/src/service/dynamic_config/event.rs
+++ b/iceoryx2/src/service/dynamic_config/event.rs
@@ -180,7 +180,10 @@ impl DynamicConfig {
         }
     }
 
-    pub(crate) fn add_listener_id(&self, details: ListenerDetails) -> Option<ContainerHandle> {
+    pub(crate) fn add_listener_id(
+        &self,
+        details: ListenerDetails,
+    ) -> Option<(*const ListenerDetails, ContainerHandle)> {
         unsafe { self.listeners.add(details, details.node_id.owner_id()).ok() }
     }
 
@@ -190,7 +193,10 @@ impl DynamicConfig {
         }
     }
 
-    pub(crate) fn add_notifier_id(&self, details: NotifierDetails) -> Option<ContainerHandle> {
+    pub(crate) fn add_notifier_id(
+        &self,
+        details: NotifierDetails,
+    ) -> Option<(*const NotifierDetails, ContainerHandle)> {
         unsafe { self.notifiers.add(details, details.node_id.owner_id()).ok() }
     }
 

--- a/iceoryx2/src/service/dynamic_config/event.rs
+++ b/iceoryx2/src/service/dynamic_config/event.rs
@@ -64,6 +64,8 @@ pub struct DynamicConfig {
 pub struct ListenerDetails {
     /// The [`UniqueListenerId`] of the [`Listener`](crate::port::listener::Listener).
     pub listener_id: UniqueListenerId,
+    /// The [`PortName`] of the [`Listener`](crate::port::listener::Listener).
+    pub listener_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Listener`](crate::port::listener::Listener) was created.
     pub node_id: UniqueNodeId,

--- a/iceoryx2/src/service/dynamic_config/mod.rs
+++ b/iceoryx2/src/service/dynamic_config/mod.rs
@@ -186,7 +186,7 @@ impl DynamicConfig {
     ) -> Result<ContainerHandle, RegisterNodeResult> {
         let msg = "Unable to register NodeId in service";
         match unsafe { self.nodes.add(node_id, node_id.owner_id()) } {
-            Ok(handle) => Ok(handle),
+            Ok(handle) => Ok(handle.1),
             Err(ContainerAddFailure::IsLocked) => {
                 fail!(from self, with RegisterNodeResult::MarkedForDestruction,
                     "{msg} since the service is already marked for destruction.");

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -29,6 +29,7 @@
 use crate::{
     identifiers::{UniqueNodeId, UniquePortId, UniquePublisherId, UniqueSubscriberId},
     port::details::data_segment::DataSegmentType,
+    port::port_name::PortName,
 };
 use iceoryx2_bb_derive_macros::ZeroCopySend;
 use iceoryx2_bb_elementary_traits::relocatable_container::RelocatableContainer;
@@ -53,6 +54,8 @@ pub(crate) struct DynamicConfigSettings {
 pub struct PublisherDetails {
     /// The [`UniquePublisherId`] of the [`Publisher`](crate::port::publisher::Publisher).
     pub publisher_id: UniquePublisherId,
+    /// The [`PortName`] of the [`Publisher`](crate::port::publisher::Publisher).
+    pub publisher_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Publisher`](crate::port::publisher::Publisher) was created.
     pub node_id: UniqueNodeId,

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -80,6 +80,8 @@ pub struct PublisherDetails {
 pub struct SubscriberDetails {
     /// The [`UniqueSubscriberId`] of the [`Subscriber`](crate::port::subscriber::Subscriber).
     pub subscriber_id: UniqueSubscriberId,
+    /// The [`PortName`] of the [`Subscriber`](crate::port::subscriber::Subscriber).
+    pub subscriber_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Subscriber`](crate::port::subscriber::Subscriber) was created.
     pub node_id: UniqueNodeId,

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -195,7 +195,10 @@ impl DynamicConfig {
         state.for_each(|_, details| callback(details));
     }
 
-    pub(crate) fn add_subscriber_id(&self, details: SubscriberDetails) -> Option<ContainerHandle> {
+    pub(crate) fn add_subscriber_id(
+        &self,
+        details: SubscriberDetails,
+    ) -> Option<(*const SubscriberDetails, ContainerHandle)> {
         unsafe {
             self.subscribers
                 .add(details, details.node_id.owner_id())
@@ -209,7 +212,10 @@ impl DynamicConfig {
         }
     }
 
-    pub(crate) fn add_publisher_id(&self, details: PublisherDetails) -> Option<ContainerHandle> {
+    pub(crate) fn add_publisher_id(
+        &self,
+        details: PublisherDetails,
+    ) -> Option<(*const PublisherDetails, ContainerHandle)> {
         unsafe {
             self.publishers
                 .add(details, details.node_id.owner_id())

--- a/iceoryx2/src/service/dynamic_config/request_response.rs
+++ b/iceoryx2/src/service/dynamic_config/request_response.rs
@@ -64,6 +64,8 @@ pub struct ServerDetails {
 pub struct ClientDetails {
     /// The [`UniqueClientId`] of the [`Client`](crate::port::client::Client).
     pub client_id: UniqueClientId,
+    /// The [`PortName`] of the [`Clinet`](crate::port::client::Client).
+    pub client_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Client`](crate::port::client::Client) was created.
     pub node_id: UniqueNodeId,

--- a/iceoryx2/src/service/dynamic_config/request_response.rs
+++ b/iceoryx2/src/service/dynamic_config/request_response.rs
@@ -171,7 +171,10 @@ impl DynamicConfig {
         }
     }
 
-    pub(crate) fn add_client_id(&self, details: ClientDetails) -> Option<ContainerHandle> {
+    pub(crate) fn add_client_id(
+        &self,
+        details: ClientDetails,
+    ) -> Option<(*const ClientDetails, ContainerHandle)> {
         unsafe { self.clients.add(details, details.node_id.owner_id()).ok() }
     }
 
@@ -181,7 +184,10 @@ impl DynamicConfig {
         }
     }
 
-    pub(crate) fn add_server_id(&self, details: ServerDetails) -> Option<ContainerHandle> {
+    pub(crate) fn add_server_id(
+        &self,
+        details: ServerDetails,
+    ) -> Option<(*const ServerDetails, ContainerHandle)> {
         unsafe { self.servers.add(details, details.node_id.owner_id()).ok() }
     }
 

--- a/iceoryx2/src/service/dynamic_config/request_response.rs
+++ b/iceoryx2/src/service/dynamic_config/request_response.rs
@@ -24,6 +24,7 @@ use iceoryx2_log::{error, fatal_panic};
 use crate::{
     identifiers::{UniqueClientId, UniqueNodeId, UniquePortId, UniqueServerId},
     port::details::data_segment::DataSegmentType,
+    port::port_name::PortName,
 };
 
 use super::PortCleanupAction;
@@ -35,6 +36,8 @@ use super::PortCleanupAction;
 pub struct ServerDetails {
     /// The [`UniqueServerId`] of the [`Server`](crate::port::server::Server).
     pub server_id: UniqueServerId,
+    /// The [`PortName`] of the [`Server`](crate::port::server::Server).
+    pub server_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Server`](crate::port::server::Server) was created.
     pub node_id: UniqueNodeId,

--- a/iceoryx2/src/service/mod.rs
+++ b/iceoryx2/src/service/mod.rs
@@ -311,7 +311,7 @@ use iceoryx2_cal::static_storage::*;
 use iceoryx2_cal::zero_copy_connection::ZeroCopyConnection;
 use iceoryx2_log::error;
 use iceoryx2_log::{debug, fail, trace, warn};
-use port_factory::PortFactory;
+use port_factory::{PortFactory, notifier::NotifierConfig};
 use service_hash::ServiceHash;
 
 use self::dynamic_config::DeregisterNodeState;
@@ -567,7 +567,9 @@ impl<S: Service, R: ServiceResource> Drop for ServiceState<S, R> {
 
 #[doc(hidden)]
 pub mod internal {
-    use crate::service::stale_resource_cleanup::ServiceRemoveTagError;
+    use crate::{
+        port::port_name::PortName, service::stale_resource_cleanup::ServiceRemoveTagError,
+    };
 
     use super::*;
     fn send_dead_node_signal<S: Service>(service_hash: &ServiceHash, config: &config::Config) {
@@ -623,7 +625,10 @@ pub mod internal {
 
         let notifier = match Notifier::new_without_auto_event_emission(
             service.service,
-            EventId::new(0),
+            NotifierConfig {
+                default_event_id: EventId::new(0),
+                port_name: PortName::new_empty(),
+            },
         ) {
             Ok(notifier) => notifier,
             Err(e) => {

--- a/iceoryx2/src/service/port_factory/client.rs
+++ b/iceoryx2/src/service/port_factory/client.rs
@@ -33,7 +33,7 @@ use super::request_response::PortFactory;
 use crate::{
     port::{
         BackpressureFn, BackpressureHandler, DegradationAction, DegradationFn, DegradationHandler,
-        client::Client,
+        client::Client, port_name::PortName,
     },
     prelude::BackpressureStrategy,
     service,
@@ -103,6 +103,7 @@ pub(crate) struct LocalClientConfig {
     pub(crate) initial_max_slice_len: usize,
     pub(crate) allocation_strategy: AllocationStrategy,
     pub(crate) max_active_requests: Option<usize>,
+    pub(crate) port_name: PortName,
 }
 
 /// Factory to create a new [`Client`] port/endpoint for
@@ -203,6 +204,7 @@ impl<
                 initial_max_slice_len: 1,
                 allocation_strategy: defs.client_allocation_strategy,
                 max_active_requests: None,
+                port_name: PortName::new_empty(),
             },
             preallocate_number_of_requests_override: PreallocatedRequestsOverride::new(|v| v),
             request_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
@@ -284,6 +286,12 @@ impl<
     /// Sets the maximal amount of active requests the [`Client`] can send.
     pub fn max_active_requests(mut self, value: usize) -> Self {
         self.config.max_active_requests = Some(value.max(1));
+        self
+    }
+
+    /// Sets the [`PortName`] of the  [`Client`].
+    pub fn name(mut self, name: &PortName) -> Self {
+        self.config.port_name = *name;
         self
     }
 

--- a/iceoryx2/src/service/port_factory/event.rs
+++ b/iceoryx2/src/service/port_factory/event.rs
@@ -161,6 +161,6 @@ impl<Service: service::Service> PortFactory<Service> {
     /// # }
     /// ```
     pub fn listener_builder(&self) -> PortFactoryListener<'_, Service> {
-        PortFactoryListener { factory: self }
+        PortFactoryListener::new(self)
     }
 }

--- a/iceoryx2/src/service/port_factory/listener.rs
+++ b/iceoryx2/src/service/port_factory/listener.rs
@@ -29,10 +29,15 @@ use core::fmt::Debug;
 
 use iceoryx2_log::fail;
 
-use crate::port::{listener::Listener, listener::ListenerCreateError};
+use crate::port::{listener::Listener, listener::ListenerCreateError, port_name::PortName};
 use crate::service;
 
 use super::event::PortFactory;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ListenerConfig {
+    pub(crate) port_name: PortName,
+}
 
 /// Factory to create a new [`Listener`] port/endpoint for
 /// [`MessagingPattern::Event`](crate::service::messaging_pattern::MessagingPattern::Event) based
@@ -40,15 +45,31 @@ use super::event::PortFactory;
 #[derive(Debug, Clone)]
 pub struct PortFactoryListener<'factory, Service: service::Service> {
     pub(crate) factory: &'factory PortFactory<Service>,
+    config: ListenerConfig,
 }
 
 unsafe impl<Service: service::Service> Send for PortFactoryListener<'_, Service> {}
 
-impl<Service: service::Service> PortFactoryListener<'_, Service> {
+impl<'factory, Service: service::Service> PortFactoryListener<'factory, Service> {
+    pub(crate) fn new(factory: &'factory PortFactory<Service>) -> Self {
+        Self {
+            factory,
+            config: ListenerConfig {
+                port_name: PortName::new_empty(),
+            },
+        }
+    }
+
+    /// Sets the [`PortName`] of the  [`Listener`].
+    pub fn name(mut self, name: &PortName) -> Self {
+        self.config.port_name = *name;
+        self
+    }
+
     /// Creates the [`Listener`] port or returns a [`ListenerCreateError`] on failure.
     pub fn create(self) -> Result<Listener<Service>, ListenerCreateError> {
         Ok(
-            fail!(from self, when Listener::new(self.factory.service.clone()),
+            fail!(from self, when Listener::new(self.factory.service.clone(), self.config.clone()),
                     "Failed to create new Listener port."),
         )
     }

--- a/iceoryx2/src/service/port_factory/notifier.rs
+++ b/iceoryx2/src/service/port_factory/notifier.rs
@@ -30,12 +30,20 @@
 //! ```
 use core::fmt::Debug;
 
-use crate::port::{event_id::EventId, notifier::Notifier, notifier::NotifierCreateError};
+use crate::port::{
+    event_id::EventId, notifier::Notifier, notifier::NotifierCreateError, port_name::PortName,
+};
 use iceoryx2_log::fail;
 
 use crate::service;
 
 use super::event::PortFactory;
+
+#[derive(Debug, Clone)]
+pub(crate) struct NotifierConfig {
+    pub(crate) default_event_id: EventId,
+    pub(crate) port_name: PortName,
+}
 
 /// Factory to create a new [`Notifier`] port/endpoint for
 /// [`MessagingPattern::Event`](crate::service::messaging_pattern::MessagingPattern::Event) based
@@ -43,7 +51,7 @@ use super::event::PortFactory;
 #[derive(Debug, Clone)]
 pub struct PortFactoryNotifier<'factory, Service: service::Service> {
     pub(crate) factory: &'factory PortFactory<Service>,
-    default_event_id: EventId,
+    config: NotifierConfig,
 }
 
 unsafe impl<Service: service::Service> Send for PortFactoryNotifier<'_, Service> {}
@@ -52,21 +60,30 @@ impl<'factory, Service: service::Service> PortFactoryNotifier<'factory, Service>
     pub(crate) fn new(factory: &'factory PortFactory<Service>) -> Self {
         Self {
             factory,
-            default_event_id: EventId::default(),
+            config: NotifierConfig {
+                default_event_id: EventId::default(),
+                port_name: PortName::new_empty(),
+            },
         }
     }
 
     /// Sets a default [`EventId`] for the [`Notifier`] that is used in
     /// [`Notifier::notify()`]
     pub fn default_event_id(mut self, value: EventId) -> Self {
-        self.default_event_id = value;
+        self.config.default_event_id = value;
+        self
+    }
+
+    /// Sets the [`PortName`] of the  [`Notifier`].
+    pub fn name(mut self, name: &PortName) -> Self {
+        self.config.port_name = *name;
         self
     }
 
     /// Creates a new [`Notifier`] port or returns a [`NotifierCreateError`] on failure.
     pub fn create(self) -> Result<Notifier<Service>, NotifierCreateError> {
         Ok(
-            fail!(from self, when Notifier::new(self.factory.service.clone(), self.default_event_id),
+            fail!(from self, when Notifier::new(self.factory.service.clone(), self.config.clone()),
                     "Failed to create new Notifier port."),
         )
     }

--- a/iceoryx2/src/service/port_factory/publisher.rs
+++ b/iceoryx2/src/service/port_factory/publisher.rs
@@ -58,6 +58,7 @@ use crate::{
     port::{
         BackpressureFn, BackpressureHandler, DegradationAction, DegradationFn, DegradationHandler,
         backpressure_strategy::BackpressureStrategy,
+        port_name::PortName,
         publisher::{Publisher, PublisherCreateError},
     },
     service,
@@ -99,6 +100,7 @@ pub(crate) struct LocalPublisherConfig {
     pub(crate) backpressure_strategy: BackpressureStrategy,
     pub(crate) initial_max_slice_len: usize,
     pub(crate) allocation_strategy: AllocationStrategy,
+    pub(crate) port_name: PortName,
 }
 
 /// Factory to create a new [`Publisher`] port/endpoint for
@@ -168,6 +170,7 @@ impl<
                 initial_max_slice_len: 1,
                 max_loaned_samples: defaults.publisher_max_loaned_samples,
                 backpressure_strategy: defaults.backpressure_strategy,
+                port_name: PortName::new_empty(),
             },
             degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             backpressure_handler: None,
@@ -230,6 +233,12 @@ impl<
     pub fn set_backpressure_handler<F: BackpressureFn + 'static>(mut self, handler: F) -> Self {
         self.backpressure_handler = Some(BackpressureHandler::new(handler));
 
+        self
+    }
+
+    /// Sets the [`PortName`] of the  [`Publisher`].
+    pub fn name(mut self, name: &PortName) -> Self {
+        self.config.port_name = *name;
         self
     }
 

--- a/iceoryx2/src/service/port_factory/reader.rs
+++ b/iceoryx2/src/service/port_factory/reader.rs
@@ -38,8 +38,14 @@ use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_log::fail;
 
 use super::blackboard::PortFactory;
+use crate::port::port_name::PortName;
 use crate::port::reader::{Reader, ReaderCreateError};
 use crate::service;
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReaderConfig {
+    pub(crate) port_name: PortName,
+}
 
 /// Factory to create a new [`Reader`] port/endpoint for
 /// [`MessagingPattern::Blackboard`](crate::service::messaging_pattern::MessagingPattern::Blackboard)
@@ -51,6 +57,7 @@ pub struct PortFactoryReader<
     KeyType: Send + Sync + Eq + Clone + Copy + Debug + 'static + Hash + ZeroCopySend,
 > {
     pub(crate) factory: &'factory PortFactory<Service, KeyType>,
+    config: ReaderConfig,
 }
 
 impl<
@@ -60,14 +67,25 @@ impl<
 > PortFactoryReader<'factory, Service, KeyType>
 {
     pub(crate) fn new(factory: &'factory PortFactory<Service, KeyType>) -> Self {
-        Self { factory }
+        Self {
+            factory,
+            config: ReaderConfig {
+                port_name: PortName::new_empty(),
+            },
+        }
+    }
+
+    /// Sets the [`PortName`] of the  [`Reader`].
+    pub fn name(mut self, name: &PortName) -> Self {
+        self.config.port_name = *name;
+        self
     }
 
     /// Creates a new [`Reader`] or returns a [`ReaderCreateError`] on failure.
     pub fn create(self) -> Result<Reader<Service, KeyType>, ReaderCreateError> {
         let origin = format!("{self:?}");
         Ok(
-            fail!(from origin, when Reader::new(self.factory.service.clone()),"Failed to create new Reader port."),
+            fail!(from origin, when Reader::new(self.factory.service.clone(), self.config.clone()),"Failed to create new Reader port."),
         )
     }
 }

--- a/iceoryx2/src/service/port_factory/server.rs
+++ b/iceoryx2/src/service/port_factory/server.rs
@@ -37,7 +37,7 @@ use super::request_response::PortFactory;
 use crate::{
     port::{
         BackpressureFn, BackpressureHandler, DegradationAction, DegradationFn, DegradationHandler,
-        server::Server,
+        port_name::PortName, server::Server,
     },
     prelude::BackpressureStrategy,
     service,
@@ -55,6 +55,7 @@ pub(crate) struct LocalServerConfig {
     pub(crate) initial_max_slice_len: usize,
     pub(crate) allocation_strategy: AllocationStrategy,
     pub(crate) max_loaned_responses_per_request: usize,
+    pub(crate) port_name: PortName,
 }
 
 /// Defines a failure that can occur when a [`Server`] is created with
@@ -204,6 +205,7 @@ impl<
                 initial_max_slice_len: 1,
                 allocation_strategy: defs.server_allocation_strategy,
                 max_loaned_responses_per_request: defs.server_max_loaned_responses_per_request,
+                port_name: PortName::new_empty(),
             },
             request_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
             response_degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
@@ -291,6 +293,12 @@ impl<
     pub fn set_backpressure_handler<F: BackpressureFn + 'static>(mut self, handler: F) -> Self {
         self.backpressure_handler = Some(BackpressureHandler::new(handler));
 
+        self
+    }
+
+    /// Sets the [`PortName`] of the  [`Server`].
+    pub fn name(mut self, name: &PortName) -> Self {
+        self.config.port_name = *name;
         self
     }
 

--- a/iceoryx2/src/service/port_factory/subscriber.rs
+++ b/iceoryx2/src/service/port_factory/subscriber.rs
@@ -38,6 +38,7 @@ use iceoryx2_log::fail;
 use crate::{
     port::{
         DegradationAction, DegradationFn, DegradationHandler,
+        port_name::PortName,
         subscriber::{Subscriber, SubscriberCreateError},
     },
     service,
@@ -50,6 +51,7 @@ pub(crate) struct SubscriberConfig {
     pub(crate) buffer_size: Option<usize>,
     pub(crate) history_request: Option<usize>,
     pub(crate) degradation_handler: DegradationHandler<'static>,
+    pub(crate) port_name: PortName,
 }
 
 /// Factory to create a new [`Subscriber`] port/endpoint for
@@ -91,6 +93,7 @@ impl<
                 buffer_size: self.config.buffer_size,
                 history_request: self.config.history_request,
                 degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
+                port_name: self.config.port_name,
             },
             factory: self.factory,
         }
@@ -102,6 +105,7 @@ impl<
                 buffer_size: None,
                 history_request: None,
                 degradation_handler: DegradationHandler::new_with(DegradationAction::Warn),
+                port_name: PortName::new_empty(),
             },
             factory,
         }
@@ -126,6 +130,12 @@ impl<
     pub fn set_degradation_handler<F: DegradationFn + 'static>(mut self, handler: F) -> Self {
         self.config.degradation_handler = DegradationHandler::new(handler);
 
+        self
+    }
+
+    /// Sets the [`PortName`] of the  [`Subscriber`].
+    pub fn name(mut self, name: &PortName) -> Self {
+        self.config.port_name = *name;
         self
     }
 

--- a/iceoryx2/src/service/port_factory/writer.rs
+++ b/iceoryx2/src/service/port_factory/writer.rs
@@ -38,8 +38,14 @@ use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_log::fail;
 
 use super::blackboard::PortFactory;
+use crate::port::port_name::PortName;
 use crate::port::writer::{Writer, WriterCreateError};
 use crate::service;
+
+#[derive(Debug, Clone)]
+pub(crate) struct WriterConfig {
+    pub(crate) port_name: PortName,
+}
 
 /// Factory to create a new [`Writer`] port/endpoint for
 /// [`MessagingPattern::Blackboard`](crate::service::messaging_pattern::MessagingPattern::Blackboard)
@@ -51,6 +57,7 @@ pub struct PortFactoryWriter<
     KeyType: Send + Sync + Eq + Clone + Copy + Debug + 'static + Hash + ZeroCopySend,
 > {
     pub(crate) factory: &'factory PortFactory<Service, KeyType>,
+    config: WriterConfig,
 }
 
 impl<
@@ -60,14 +67,25 @@ impl<
 > PortFactoryWriter<'factory, Service, KeyType>
 {
     pub(crate) fn new(factory: &'factory PortFactory<Service, KeyType>) -> Self {
-        Self { factory }
+        Self {
+            factory,
+            config: WriterConfig {
+                port_name: PortName::new_empty(),
+            },
+        }
+    }
+
+    /// Sets the [`PortName`] of the  [`Writer`].
+    pub fn name(mut self, name: &PortName) -> Self {
+        self.config.port_name = *name;
+        self
     }
 
     /// Creates a new [`Writer`] or returns a [`WriterCreateError`] on failure.
     pub fn create(self) -> Result<Writer<Service, KeyType>, WriterCreateError> {
         let origin = format!("{self:?}");
         Ok(
-            fail!(from origin, when Writer::new(self.factory.service.clone()),"Failed to create new Writer port."),
+            fail!(from origin, when Writer::new(self.factory.service.clone(), self.config.clone()),"Failed to create new Writer port."),
         )
     }
 }

--- a/iceoryx2/tests-common/src/lib.rs
+++ b/iceoryx2/tests-common/src/lib.rs
@@ -17,6 +17,7 @@ extern crate iceoryx2_bb_loggers;
 
 pub mod attribute_tests;
 pub mod node_name_tests;
+pub mod port_name_tests;
 pub mod service_event_thread_safety_tests;
 pub mod service_publish_subscribe_thread_safety_tests;
 pub mod service_request_response_thread_safety_tests;

--- a/iceoryx2/tests-common/src/port_name_tests.rs
+++ b/iceoryx2/tests-common/src/port_name_tests.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::format;
+
+use iceoryx2::prelude::*;
+use iceoryx2_bb_testing::assert_that;
+use iceoryx2_bb_testing_macros::test;
+
+#[test]
+fn creating_fails() {
+    let value = "ö la palöma blanca";
+    let sut = PortName::new(value);
+
+    assert_that!(sut.is_err(), eq true);
+    assert_that!(sut.err(), eq Some(SemanticStringError::InvalidContent));
+}
+
+#[test]
+fn creating_empty_works() {
+    let value = "";
+    let sut = PortName::new_empty();
+
+    assert_that!(sut, eq value);
+    assert_that!(&sut, eq value);
+}
+
+#[test]
+fn creating_works() {
+    let value = "oe la paloema blanca";
+    let sut = PortName::new(value).unwrap();
+
+    assert_that!(sut, eq value);
+    assert_that!(&sut, eq value);
+}
+
+#[test]
+fn display_works() {
+    let value = "eim just a boerd in se sky";
+    let sut = PortName::new(value).unwrap();
+
+    assert_that!(format!("{}", sut), eq value);
+}
+
+#[test]
+fn try_into_works() {
+    let value = "oever se maundaen I fly";
+    let sut: PortName = value.try_into().unwrap();
+
+    assert_that!(sut, eq value);
+    assert_that!(&sut, eq value);
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Introduce port name for all ports. The name is optional and it is not checked whether multiple ports have the same name.

Language bindings will follow with the next PR.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #1773

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
