### PR TITLE
[#1776] Improve AtomicCopy and ByteAtomic documentation

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -51,6 +51,7 @@
 -->
 
 * [#996](https://github.com/eclipse-iceoryx/iceoryx2/issues/996) Move BumpAllocator from iceoryx2-bb-memory into iceoryx2-bb-elementary
+* [#1776](https://github.com/eclipse-iceoryx/iceoryx2/issues/1776) Rename AtomicCopy::__for_each_field() to for_each_field()
 
 ### Workflow
 
@@ -105,13 +106,13 @@
 1. The `bump_allocator` module in the `iceoryx2-cal` package
  has been renamed to shm_bump_allocator.
 
-  ```rust
-  // old
-  use iceoryx2_cal::shm_allocator::bump_allocator::BumpAllocator;
+    ```rust
+    // old
+    use iceoryx2_cal::shm_allocator::bump_allocator::BumpAllocator;
 
-  // new
-  use iceoryx2_cal::shm_allocator::shm_bump_allocator::BumpAllocator;
-  ```
+    // new
+    use iceoryx2_cal::shm_allocator::shm_bump_allocator::BumpAllocator;
+    ```
 
 1. `Listener::{try|timed|blocking}_wait_one` has been removed and `Listener::{try|timed|blocking}_wail_all`
    has been renamed to `Listener::{try|timed|blocking}_wait`. The input argument has changed from `EventId`
@@ -156,6 +157,32 @@
         super::TestBackend<super::Ipc>,
         super::Testing
     );
+    ```
+
+1. `AtomicCopy::__for_each_field()` was renamed to `for_each_field()`.
+
+    ```rust
+    // old
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct Foo {
+        bar: u8,
+        baz: u64,
+    }
+    
+    unsafe impl AtomicCopy for Foo {
+        fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+            // ...
+        }
+    }
+    
+    // new
+    // ...
+    unsafe impl AtomicCopy for Foo {
+        fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+            // ...
+        }
+    }
     ```
 
 <!-- markdownlint-enable MD013 -->

--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -24,18 +24,68 @@
 //!
 //! # User Examples
 //!
+//! ## Use the [`FixedSizeByteAtomic`](crate::byte_atomic::FixedSizeByteAtomic)
+//!
 //! ```
 //! use iceoryx2_bb_container::byte_atomic::FixedSizeByteAtomic;
+//! use iceoryx2_bb_derive_macros::AtomicCopy;
+//! use iceoryx2_bb_elementary_traits::atomic_copy::AtomicCopy;
 //!
-//! const SIZE: usize = size_of::<u64>();
-//! let wrapper = FixedSizeByteAtomic::<u64, SIZE>::new(0).unwrap();
-//!
-//! let new_value: u64 = 752389;
-//! unsafe {
-//!     wrapper.write(new_value);
-//!     assert_eq!(wrapper.read().assume_init(), new_value);
+//! #[repr(C)]
+//! #[derive(AtomicCopy, Clone, Copy)]
+//! struct Foo {
+//!     bar: u8,
+//!     baz: u64,
 //! }
 //!
+//! const SIZE: usize = size_of::<Foo>();
+//! let wrapper = FixedSizeByteAtomic::<Foo, SIZE>::new(Foo { bar: 0, baz: 0 }).unwrap();
+//!
+//! let new_value = Foo { bar: 4, baz: 6 };
+//! unsafe {
+//!     wrapper.write(new_value);
+//!     let read_value = wrapper.read().assume_init();
+//!     assert_eq!(read_value.bar, new_value.bar);
+//!     assert_eq!(read_value.baz, new_value.baz);
+//! }
+//! ```
+//!
+//! ## Use the [`RelocatableByteAtomic`](crate::byte_atomic::RelocatableByteAtomic)
+//!
+//! ```
+//! use iceoryx2_bb_container::byte_atomic::RelocatableByteAtomic;
+//! use iceoryx2_bb_derive_macros::AtomicCopy;
+//! use iceoryx2_bb_elementary::bump_allocator::BumpAllocator;
+//! use iceoryx2_bb_elementary_traits::atomic_copy::AtomicCopy;
+//! use iceoryx2_bb_elementary_traits::non_null::NonNullCompat;
+//!
+//! #[repr(C)]
+//! #[derive(AtomicCopy, Clone, Copy)]
+//! struct Foo {
+//!     bar: u8,
+//!     baz: u64,
+//! }
+//!
+//! let value = Foo { bar: 0, baz: 0 };
+//! let new_value = Foo { bar: 4, baz: 6 };
+//!
+//! const SIZE: usize = RelocatableByteAtomic::<Foo>::const_memory_size();
+//! let memory = [0u8; SIZE];
+//! let allocator = BumpAllocator::new(
+//!     core::ptr::NonNull::<u8>::iox2_from_ref(&memory[0]),
+//!     memory.len(),
+//! );
+//! unsafe {
+//!     let mut wrapper = RelocatableByteAtomic::new_uninit();
+//!     wrapper
+//!         .init(&allocator, value)
+//!         .expect("RelocatableByteAtomic initialized.");
+//!
+//!     wrapper.write(new_value);
+//!     let read_value = wrapper.read().assume_init();
+//!     assert_eq!(read_value.bar, new_value.bar);
+//!     assert_eq!(read_value.baz, new_value.baz);
+//! }
 //! ```
 
 use core::alloc::Layout;

--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -194,7 +194,7 @@ impl<T: AtomicCopy, const SIZE: usize> FixedSizeByteAtomic<T, SIZE> {
 
         let value_ptr = (&value as *const T) as *const u8;
 
-        // The passed value may contain padding bytes. Reading or copying these padding bytes
+        // The passed value may contain padding bytes. Reading these padding bytes
         // would lead to undefined behavior. Therefore, we first set all bytes to zero and
         // then copy only the fields, i.e. the initialized bytes, of the passed value.
         let mut bytes = [0u8; SIZE];

--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -123,7 +123,7 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
         }
 
         let value_ptr = (&value as *const T) as *const u8;
-        value.__for_each_field(0, &mut |offset, size| {
+        value.for_each_field(0, &mut |offset, size| {
             for i in offset..offset + size {
                 unsafe {
                     (*self.data_ptr.as_ptr().add(i)).store(*value_ptr.add(i), Ordering::Relaxed);
@@ -198,7 +198,7 @@ impl<T: AtomicCopy, const SIZE: usize> FixedSizeByteAtomic<T, SIZE> {
         // would lead to undefined behavior. Therefore, we first set all bytes to zero and
         // then copy only the fields, i.e. the initialized bytes, of the passed value.
         let mut bytes = [0u8; SIZE];
-        value.__for_each_field(0, &mut |offset, size| {
+        value.for_each_field(0, &mut |offset, size| {
             for (i, byte) in bytes.iter_mut().enumerate().skip(offset).take(size) {
                 *byte = unsafe { *value_ptr.add(i) };
             }
@@ -243,7 +243,7 @@ unsafe fn read_impl<T: AtomicCopy>(src_data_ptr: *const AtomicU8) -> MaybeUninit
 
 unsafe fn write_impl<T: AtomicCopy>(dest_data_ptr: *const AtomicU8, value: T) {
     let value_ptr = (&value as *const T) as *const u8;
-    value.__for_each_field(0, &mut |offset, size| {
+    value.for_each_field(0, &mut |offset, size| {
         for i in offset..offset + size {
             unsafe {
                 (*dest_data_ptr.add(i)).store(*value_ptr.add(i), Ordering::Relaxed);

--- a/iceoryx2-bb/container/src/string/static_string.rs
+++ b/iceoryx2-bb/container/src/string/static_string.rs
@@ -66,7 +66,7 @@ pub struct StaticString<const CAPACITY: usize> {
 }
 
 unsafe impl<const CAPACITY: usize> AtomicCopy for StaticString<CAPACITY> {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         let aligned_base_offset = align_to::<Self>(base_offset);
         callback(
             aligned_base_offset + core::mem::offset_of!(Self, data),

--- a/iceoryx2-bb/derive-macros/src/lib.rs
+++ b/iceoryx2-bb/derive-macros/src/lib.rs
@@ -390,17 +390,17 @@ pub fn atomic_copy_derive(input: TokenStream) -> TokenStream {
                         // Since struct fields can also be structs, we must traverse the fields recursively. The
                         // callback must still be applied to field offsets relative to the root struct. So we
                         // convert "local" offsets (relative to the field) into "absolute" offsets (relative to
-                        // the root struct) and pass these to `__for_each_field`.
+                        // the root struct) and pass these to `for_each_field`.
                         let rel_offset = core::mem::offset_of!(#struct_name #ty_generics, #field_name);
                         let abs_offset = base_offset + rel_offset;
                         let size = core::mem::size_of::<#field_type>();
-                        AtomicCopy::__for_each_field(&self.#field_name, abs_offset, callback);
+                        AtomicCopy::for_each_field(&self.#field_name, abs_offset, callback);
                     };
                     field_offsets_and_sizes.push(block);
                 }
 
                 quote! {
-                    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+                    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
                         #(#field_offsets_and_sizes)*
                     }
                 }
@@ -415,17 +415,17 @@ pub fn atomic_copy_derive(input: TokenStream) -> TokenStream {
                         // Since struct fields can also be structs, we must traverse the fields recursively. The
                         // callback must still be applied to field offsets relative to the root struct. So we
                         // convert "local" offsets (relative to the field) into "absolute" offsets (relative to
-                        // the root struct) and pass these to `__for_each_field`.
+                        // the root struct) and pass these to `for_each_field`.
                         let rel_offset = core::mem::offset_of!(#struct_name #ty_generics, #field_index);
                         let abs_offset = base_offset + rel_offset;
                         let size = core::mem::size_of::<#field_type>();
-                        AtomicCopy::__for_each_field(&self.#field_index, abs_offset, callback);
+                        AtomicCopy::for_each_field(&self.#field_index, abs_offset, callback);
                     };
                     field_offsets_and_sizes.push(block);
                 }
 
                 quote! {
-                    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+                    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
                         #(#field_offsets_and_sizes)*
                     }
                 }

--- a/iceoryx2-bb/derive-macros/tests-common/src/atomic_copy_tests.rs
+++ b/iceoryx2-bb/derive-macros/tests-common/src/atomic_copy_tests.rs
@@ -23,7 +23,7 @@ use iceoryx2_bb_testing_macros::test;
 #[derive(Copy, Clone)]
 struct Foo(u16);
 unsafe impl AtomicCopy for Foo {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(align_to::<u16>(base_offset), 2);
     }
 }
@@ -44,7 +44,7 @@ pub fn field_offsets_and_sizes_are_correct_for_named_struct() {
     let sut = NamedTestStruct { a: 0, b: Foo(0) };
 
     let mut v = Vec::new();
-    sut.__for_each_field(0, &mut |offset, size| {
+    sut.for_each_field(0, &mut |offset, size| {
         v.push((offset, size));
     });
 
@@ -68,7 +68,7 @@ pub fn field_offsets_and_sizes_are_correct_for_generic_named_struct() {
     let sut = GenericNamedTestStruct { a: 0u8, b: 0i32 };
 
     let mut v = Vec::new();
-    sut.__for_each_field(0, &mut |offset, size| {
+    sut.for_each_field(0, &mut |offset, size| {
         v.push((offset, size));
     });
 
@@ -87,7 +87,7 @@ pub fn field_offsets_and_sizes_are_correct_for_generic_named_struct() {
 pub fn field_offsets_and_sizes_are_correct_for_unnamed_struct() {
     let mut v = Vec::new();
     let sut = NestedUnnamedTestStruct(0, 0, Foo(0));
-    sut.__for_each_field(0, &mut |offset, size| {
+    sut.for_each_field(0, &mut |offset, size| {
         v.push((offset, size));
     });
 
@@ -117,7 +117,7 @@ pub fn field_offsets_and_sizes_are_correct_for_generic_unnamed_struct() {
     let sut = GenericUnnamedTestStruct(0u64, NestedUnnamedTestStruct(0, 0, Foo(0)));
 
     let mut v = Vec::new();
-    sut.__for_each_field(0, &mut |offset, size| {
+    sut.for_each_field(0, &mut |offset, size| {
         v.push((offset, size));
     });
 
@@ -171,7 +171,7 @@ pub fn field_offsets_and_sizes_are_correct_when_alignment_changes_inner_padding(
         a: 3,
         b: AlignedU32(9),
     };
-    sut.__for_each_field(0, &mut |offset, size| {
+    sut.for_each_field(0, &mut |offset, size| {
         v.push((offset, size));
     });
 
@@ -212,7 +212,7 @@ pub fn field_offsets_and_sizes_are_correct_for_nested_structs() {
             c: SomeUnnamedStruct(5),
         },
     };
-    sut.__for_each_field(0, &mut |offset, size| {
+    sut.for_each_field(0, &mut |offset, size| {
         v.push((offset, size));
     });
 
@@ -230,7 +230,7 @@ pub fn field_offsets_are_correct_with_custom_implementation() {
     #[derive(Clone, Copy)]
     struct Foo(u32, u8);
     unsafe impl AtomicCopy for Foo {
-        fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+        fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
             let aligned_base_offset = align_to::<Self>(base_offset);
             callback(aligned_base_offset + core::mem::offset_of!(Foo, 0), 4);
             callback(aligned_base_offset + core::mem::offset_of!(Foo, 1), 1);
@@ -243,7 +243,7 @@ pub fn field_offsets_are_correct_with_custom_implementation() {
 
     let mut v = Vec::new();
     let sut = Bar(0, Foo(0, 0));
-    sut.__for_each_field(0, &mut |offset, size| {
+    sut.for_each_field(0, &mut |offset, size| {
         v.push((offset, size));
     });
 

--- a/iceoryx2-bb/elementary-traits/src/atomic_copy.rs
+++ b/iceoryx2-bb/elementary-traits/src/atomic_copy.rs
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-/// Trait for types that can be byte-wise atomically copied.
+//! Trait for types that can be byte-wise atomically copied.
 ///
 /// This trait provides a method to apply a callback to each offset-size pair of every field
 /// of the type.
@@ -20,7 +20,6 @@
 /// * Implementations of this trait must ensure that the offset and size of each field are
 ///   calculated correctly. Otherwise, undefined behavior may occur.
 pub unsafe trait AtomicCopy: Copy + 'static {
-    #[doc(hidden)]
     /// Iterates over the fields of the type, calculates the offset relative to the provided
     /// base_offset, and applies the provided callback to each offset-size pair of the field.
     /// The base offset is needed because __for_each_field can be called recursively, e.g. in

--- a/iceoryx2-bb/elementary-traits/src/atomic_copy.rs
+++ b/iceoryx2-bb/elementary-traits/src/atomic_copy.rs
@@ -22,14 +22,14 @@
 pub unsafe trait AtomicCopy: Copy + 'static {
     /// Iterates over the fields of the type, calculates the offset relative to the provided
     /// base_offset, and applies the provided callback to each offset-size pair of the field.
-    /// The base offset is needed because __for_each_field can be called recursively, e.g. in
+    /// The base offset is needed because for_each_field can be called recursively, e.g. in
     /// a nested struct. In this case, the callback must be applied to the field offsets
     /// relative to the root type and not relative to Self.
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, _base_offset: usize, _callback: &mut F);
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F);
 }
 
 unsafe impl AtomicCopy for usize {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<usize>()),
             size_of::<usize>(),
@@ -37,12 +37,12 @@ unsafe impl AtomicCopy for usize {
     }
 }
 unsafe impl AtomicCopy for u8 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(base_offset, size_of::<u8>());
     }
 }
 unsafe impl AtomicCopy for u16 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<u16>()),
             size_of::<u16>(),
@@ -50,7 +50,7 @@ unsafe impl AtomicCopy for u16 {
     }
 }
 unsafe impl AtomicCopy for u32 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<u32>()),
             size_of::<u32>(),
@@ -58,7 +58,7 @@ unsafe impl AtomicCopy for u32 {
     }
 }
 unsafe impl AtomicCopy for u64 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<u64>()),
             size_of::<u64>(),
@@ -67,7 +67,7 @@ unsafe impl AtomicCopy for u64 {
 }
 
 unsafe impl AtomicCopy for isize {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<isize>()),
             size_of::<isize>(),
@@ -75,12 +75,12 @@ unsafe impl AtomicCopy for isize {
     }
 }
 unsafe impl AtomicCopy for i8 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(base_offset, size_of::<i8>());
     }
 }
 unsafe impl AtomicCopy for i16 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<i16>()),
             size_of::<i16>(),
@@ -88,7 +88,7 @@ unsafe impl AtomicCopy for i16 {
     }
 }
 unsafe impl AtomicCopy for i32 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<i32>()),
             size_of::<i32>(),
@@ -96,7 +96,7 @@ unsafe impl AtomicCopy for i32 {
     }
 }
 unsafe impl AtomicCopy for i64 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<i64>()),
             size_of::<i64>(),
@@ -105,7 +105,7 @@ unsafe impl AtomicCopy for i64 {
 }
 
 unsafe impl AtomicCopy for f32 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<f32>()),
             size_of::<f32>(),
@@ -113,7 +113,7 @@ unsafe impl AtomicCopy for f32 {
     }
 }
 unsafe impl AtomicCopy for f64 {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<f64>()),
             size_of::<f64>(),
@@ -122,7 +122,7 @@ unsafe impl AtomicCopy for f64 {
 }
 
 unsafe impl AtomicCopy for bool {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<bool>()),
             size_of::<bool>(),
@@ -130,7 +130,7 @@ unsafe impl AtomicCopy for bool {
     }
 }
 unsafe impl AtomicCopy for char {
-    fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
+    fn for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
         callback(
             base_offset.next_multiple_of(align_of::<char>()),
             size_of::<char>(),


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
Additionally to the documentation improvements, `AtomicCopy::__for_each_field()` was renamed to `for_each_field()`.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* ~[ ] Tests follow the [best practice for testing][testing]~
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1776
<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
