### PR TITLE
[#77] Backport python logging fix to release 0.9

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "750e7bed270ff9784a32633236066555701b77980e6660624247f3638fb85b36",
+  "checksum": "62721c6df8bd6f3e995ff03ebd13d4529f0884aa64913b66df31960c9f05ad60",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -629,6 +629,54 @@
         "data_glob": [
           "**"
         ]
+      },
+      "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "arc-swap 1.9.1": {
+      "name": "arc-swap",
+      "version": "1.9.1",
+      "package_url": "https://github.com/vorner/arc-swap",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/arc-swap/1.9.1/download",
+          "sha256": "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "arc_swap",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "arc_swap",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "edition": "2018",
+        "proc_macro_deps": {
+          "common": [
+            {
+              "id": "rustversion 1.0.20",
+              "target": "rustversion"
+            }
+          ],
+          "selects": {}
+        },
+        "version": "1.9.1"
       },
       "license": "MIT OR Apache-2.0",
       "license_ids": [
@@ -5987,6 +6035,10 @@
             {
               "id": "pyo3 0.29.0",
               "target": "pyo3"
+            },
+            {
+              "id": "pyo3-log 0.13.4",
+              "target": "pyo3_log"
             }
           ],
           "selects": {}
@@ -7524,6 +7576,12 @@
         "compile_data_glob": [
           "**"
         ],
+        "crate_features": {
+          "common": [
+            "std"
+          ],
+          "selects": {}
+        },
         "edition": "2021",
         "version": "0.4.22"
       },
@@ -8874,6 +8932,62 @@
         "links": "python"
       },
       "license": "MIT OR Apache-2.0",
+      "license_ids": [
+        "Apache-2.0",
+        "MIT"
+      ],
+      "license_file": "LICENSE-APACHE"
+    },
+    "pyo3-log 0.13.4": {
+      "name": "pyo3-log",
+      "version": "0.13.4",
+      "package_url": "https://github.com/vorner/pyo3-log",
+      "repository": {
+        "Http": {
+          "url": "https://static.crates.io/crates/pyo3-log/0.13.4/download",
+          "sha256": "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
+        }
+      },
+      "targets": [
+        {
+          "Library": {
+            "crate_name": "pyo3_log",
+            "crate_root": "src/lib.rs",
+            "srcs": {
+              "allow_empty": true,
+              "include": [
+                "**/*.rs"
+              ]
+            }
+          }
+        }
+      ],
+      "library_target_name": "pyo3_log",
+      "common_attrs": {
+        "compile_data_glob": [
+          "**"
+        ],
+        "deps": {
+          "common": [
+            {
+              "id": "arc-swap 1.9.1",
+              "target": "arc_swap"
+            },
+            {
+              "id": "log 0.4.22",
+              "target": "log"
+            },
+            {
+              "id": "pyo3 0.29.0",
+              "target": "pyo3"
+            }
+          ],
+          "selects": {}
+        },
+        "edition": "2018",
+        "version": "0.13.4"
+      },
+      "license": "Apache-2.0 OR MIT",
       "license_ids": [
         "Apache-2.0",
         "MIT"
@@ -16336,6 +16450,7 @@
     "postcard 1.1.3",
     "proc-macro2 1.0.106",
     "pyo3 0.29.0",
+    "pyo3-log 0.13.4",
     "quote 1.0.45",
     "ron 0.11.0",
     "serde 1.0.228",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1394,7 @@ dependencies = [
  "iceoryx2",
  "iceoryx2-log",
  "pyo3",
+ "pyo3-log",
 ]
 
 [[package]]
@@ -1846,6 +1856,17 @@ checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -25,6 +25,7 @@
 * [#1757](https://github.com/eclipse-iceoryx/iceoryx2/issues/1757) Enable running multiple iceoryx2 versions in distinct domains in parallel by adding a version suffix to the global mgmt segment
 * [#1763](https://github.com/eclipse-iceoryx/iceoryx2/issues/1763) Close `ActiveRequest-PendingResponse` connection when dead process is cleaned up.
 * [#1765](https://github.com/eclipse-iceoryx/iceoryx2/issues/1765) Remove unnecessary `fsync` on file open
+* [#1770](https://github.com/eclipse-iceoryx/iceoryx2/issues/1770) Fix logging in python module.
 
 ### Refactoring
 

--- a/iceoryx2-ffi/python/Cargo.toml
+++ b/iceoryx2-ffi/python/Cargo.toml
@@ -17,10 +17,13 @@ name = "_iceoryx2"
 crate-type = ["cdylib"]
 
 [dependencies]
-iceoryx2 = { workspace = true, features = ["std", "log"] }
+iceoryx2 = { workspace = true, features = ["std"] }
 iceoryx2-log = { workspace = true, features = ["std"] }
 pyo3-log = "0.13.4"
 
 [dependencies.pyo3]
 version = "0.29.0"
 features = ["abi3-py38"]
+
+[features]
+log = ["iceoryx2/log"]

--- a/iceoryx2-ffi/python/Cargo.toml
+++ b/iceoryx2-ffi/python/Cargo.toml
@@ -17,8 +17,9 @@ name = "_iceoryx2"
 crate-type = ["cdylib"]
 
 [dependencies]
-iceoryx2 = { workspace = true, features = ["std"] }
+iceoryx2 = { workspace = true, features = ["std", "log"] }
 iceoryx2-log = { workspace = true, features = ["std"] }
+pyo3-log = "0.13.4"
 
 [dependencies.pyo3]
 version = "0.29.0"

--- a/iceoryx2-ffi/python/pyproject.toml
+++ b/iceoryx2-ffi/python/pyproject.toml
@@ -44,7 +44,7 @@ requires = ["maturin>=1.8,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["log", "pyo3/extension-module"]
 python-source = "python-src"
 bindings = "pyo3"
 module-name = "iceoryx2._iceoryx2"

--- a/iceoryx2-ffi/python/src/lib.rs
+++ b/iceoryx2-ffi/python/src/lib.rs
@@ -117,6 +117,9 @@ pub(crate) use service_type::LocalService;
 /// iceoryx2 Python language bindings
 #[pymodule]
 fn _iceoryx2(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Init pyo3 log module so all the logs get redirected into python's logging system.
+    pyo3_log::init();
+
     m.add_wrapped(wrap_pymodule!(crate::config::config))?;
     m.add_wrapped(wrap_pymodule!(crate::testing::testing))?;
     m.add_wrapped(wrap_pyfunction!(crate::log::set_log_level))?;


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #77 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
