### PR TITLE
[#1761] Make reference counting of RCL structs visible

### DIFF
--- a/integrations/ros2/tunnel-backend/src/backend.rs
+++ b/integrations/ros2/tunnel-backend/src/backend.rs
@@ -22,7 +22,7 @@ use crate::NODE_NAME;
 use crate::config::Config;
 use crate::{
     discovery::Discovery,
-    rcl,
+    rcl::{RclNode, RclNodeBuilder},
     relays::{Factory, event, publish_subscribe},
     typesupport::TypeSupportRegistry,
 };
@@ -43,7 +43,7 @@ impl core::error::Error for CreationError {}
 
 #[derive(Debug)]
 pub struct Ros2Backend<S: Service> {
-    node: Rc<rcl::Node>,
+    node: Rc<RclNode>,
     /// Typesupport for all configured topics, loaded on initialization.
     type_registry: TypeSupportRegistry,
     discovery: Discovery<S>,
@@ -115,7 +115,7 @@ impl<S: Service> BackendBuilder<S> for Builder<'_, S> {
         let origin = "Ros2Backend::create";
 
         let node = Rc::new(fail!(from origin,
-            when rcl::Node::new(NODE_NAME).create(),
+            when RclNodeBuilder::new(NODE_NAME).create(),
             with CreationError::Node,
             "Failed to create ROS 2 node"
         ));

--- a/integrations/ros2/tunnel-backend/src/backend.rs
+++ b/integrations/ros2/tunnel-backend/src/backend.rs
@@ -10,6 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use std::rc::Rc;
 use std::sync::Arc;
 
 use iceoryx2::service::{Service, local_threadsafe};
@@ -42,7 +43,7 @@ impl core::error::Error for CreationError {}
 
 #[derive(Debug)]
 pub struct Ros2Backend<S: Service> {
-    node: rcl::NodeHandle,
+    node: Rc<rcl::Node>,
     /// Typesupport for all configured topics, loaded on initialization.
     type_registry: TypeSupportRegistry,
     discovery: Discovery<S>,
@@ -76,7 +77,11 @@ impl<S: Service> Backend<S> for Ros2Backend<S> {
     }
 
     fn relay_builder(&self) -> Self::RelayFactory<'_> {
-        Factory::new(self.node.clone(), &self.type_registry, self.wake.clone())
+        Factory::new(
+            Rc::clone(&self.node),
+            &self.type_registry,
+            self.wake.clone(),
+        )
     }
 
     fn discovery(&self) -> &impl iceoryx2_services_tunnel_backend::traits::Discovery {
@@ -109,11 +114,11 @@ impl<S: Service> BackendBuilder<S> for Builder<'_, S> {
     fn create(self) -> Result<Self::Backend, Self::CreationError> {
         let origin = "Ros2Backend::create";
 
-        let node = fail!(from origin,
-            when rcl::NodeHandle::new(NODE_NAME).create(),
+        let node = Rc::new(fail!(from origin,
+            when rcl::Node::new(NODE_NAME).create(),
             with CreationError::Node,
             "Failed to create ROS 2 node"
-        );
+        ));
 
         // Load all typesupport libraries for configured topics during
         // initialization.
@@ -127,7 +132,7 @@ impl<S: Service> BackendBuilder<S> for Builder<'_, S> {
             );
         }
 
-        let discovery = Discovery::new(node.clone(), &self.config.topics);
+        let discovery = Discovery::new(Rc::clone(&node), &self.config.topics);
 
         Ok(Ros2Backend {
             node,

--- a/integrations/ros2/tunnel-backend/src/discovery.rs
+++ b/integrations/ros2/tunnel-backend/src/discovery.rs
@@ -26,9 +26,9 @@ use iceoryx2_log::fail;
 use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
 
 use crate::config::TopicConfig;
-use crate::rcl::{TopicName, TypeName};
+use crate::mapping;
+use crate::rcl::{RclNode, TopicName, TypeName};
 use crate::ros_header::RosHeader;
-use crate::{mapping, rcl};
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum DiscoveryError {
@@ -60,7 +60,7 @@ impl core::error::Error for AnnouncementError {}
 /// Reports liveness status of the configured topics in the ROS graph.
 #[derive(Debug)]
 pub struct Discovery<S: Service> {
-    node: Rc<rcl::Node>,
+    node: Rc<RclNode>,
     /// The configured allowlist.
     allowlist: HashMap<TopicName, TypeName>,
     /// Configured topics detected as live in the ROS graph, with the service
@@ -70,15 +70,15 @@ pub struct Discovery<S: Service> {
 }
 
 impl<S: Service> Discovery<S> {
-    pub(crate) fn new(node: Rc<rcl::Node>, topics: &[TopicConfig]) -> Self {
+    pub(crate) fn new(node: Rc<RclNode>, topics: &[TopicConfig]) -> Self {
         Self {
             node,
             allowlist: topics
                 .iter()
                 .map(|topic| {
                     (
-                        rcl::TopicName::from(&topic.topic),
-                        rcl::TypeName::from(&topic.type_name),
+                        TopicName::from(&topic.topic),
+                        TypeName::from(&topic.type_name),
                     )
                 })
                 .collect(),

--- a/integrations/ros2/tunnel-backend/src/discovery.rs
+++ b/integrations/ros2/tunnel-backend/src/discovery.rs
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use core::error::Error;
 
@@ -59,7 +60,7 @@ impl core::error::Error for AnnouncementError {}
 /// Reports liveness status of the configured topics in the ROS graph.
 #[derive(Debug)]
 pub struct Discovery<S: Service> {
-    node: rcl::NodeHandle,
+    node: Rc<rcl::Node>,
     /// The configured allowlist.
     allowlist: HashMap<TopicName, TypeName>,
     /// Configured topics detected as live in the ROS graph, with the service
@@ -69,7 +70,7 @@ pub struct Discovery<S: Service> {
 }
 
 impl<S: Service> Discovery<S> {
-    pub(crate) fn new(node: rcl::NodeHandle, topics: &[TopicConfig]) -> Self {
+    pub(crate) fn new(node: Rc<rcl::Node>, topics: &[TopicConfig]) -> Self {
         Self {
             node,
             allowlist: topics

--- a/integrations/ros2/tunnel-backend/src/rcl/mod.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/mod.rs
@@ -21,6 +21,6 @@ pub(crate) mod subscription;
 
 pub(crate) use error::RclError;
 pub(crate) use names::*;
-pub(crate) use node::Node;
-pub(crate) use publisher::Publisher;
-pub(crate) use subscription::{MessageInfo, Subscription};
+pub(crate) use node::{RclNode, RclNodeBuilder};
+pub(crate) use publisher::{RclPublisher, RclPublisherBuilder};
+pub(crate) use subscription::{MessageInfo, RclSubscription, RclSubscriptionBuilder};

--- a/integrations/ros2/tunnel-backend/src/rcl/mod.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/mod.rs
@@ -21,6 +21,6 @@ pub(crate) mod subscription;
 
 pub(crate) use error::RclError;
 pub(crate) use names::*;
-pub(crate) use node::NodeHandle;
+pub(crate) use node::Node;
 pub(crate) use publisher::Publisher;
 pub(crate) use subscription::{MessageInfo, Subscription};

--- a/integrations/ros2/tunnel-backend/src/rcl/node.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/node.rs
@@ -11,7 +11,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::ffi::CStr;
-use std::rc::Rc;
 
 use r2r_rcl::{
     RCL_RET_OK, rcl_context_fini, rcl_context_t, rcl_get_topic_names_and_types,
@@ -25,8 +24,7 @@ use r2r_rcl::{
 use iceoryx2_bb_concurrency::cell::UnsafeCell;
 use iceoryx2_log::{fail, warn};
 
-use crate::rcl::{NodeName, NodeNamespace, RclError, TopicName, TypeName, publisher, subscription};
-use crate::typesupport::TypeSupportHandle;
+use crate::rcl::{NodeName, NodeNamespace, RclError, TopicName, TypeName};
 
 /// rcl is initialized without forwarding any command-line arguments.
 const NO_ARGS: core::ffi::c_int = 0;
@@ -65,19 +63,67 @@ impl core::error::Error for GraphError {}
 
 /// An rcl node together with the context it belongs to. The tunnel is a single
 /// node, so it can be coupled to the context.
+///
+/// The node is shared: everything that needs it to stay alive - endpoints,
+/// discovery, the backend itself - holds a share of one `Rc<Node>`.
 #[derive(Debug)]
-pub(crate) struct NodeInner {
+pub struct Node {
     node: Box<UnsafeCell<rcl_node_t>>,
     context: Box<UnsafeCell<rcl_context_t>>,
 }
 
-impl NodeInner {
+impl Node {
+    /// Begins building a node with the given name. The namespace defaults to
+    /// the root namespace unless set via [`Builder::namespace`].
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(name: NodeName) -> Builder {
+        Builder::new(name)
+    }
+
     pub(crate) fn handle(&self) -> *mut rcl_node_t {
         self.node.get()
     }
+
+    /// Query the ROS graph for all topics visible to this node and their type names.
+    pub fn topic_names_and_types(&self) -> Result<Vec<(TopicName, Vec<TypeName>)>, GraphError> {
+        let origin = "Node::topic_names_and_types";
+
+        unsafe {
+            let mut allocator = rcutils_get_default_allocator();
+            let mut rcl_names_and_types: rcl_names_and_types_t = core::mem::zeroed();
+            let ret = rcl_get_topic_names_and_types(
+                self.node.get(),
+                &mut allocator,
+                NO_DEMANGLE,
+                &mut rcl_names_and_types,
+            );
+            if ret != RCL_RET_OK as i32 {
+                fail!(
+                    from origin,
+                    with GraphError::Query,
+                    "Failed to query topic names and types: {}",
+                    RclError::from(ret)
+                );
+            }
+
+            let mut names_and_types = Vec::with_capacity(rcl_names_and_types.names.size);
+            for i in 0..rcl_names_and_types.names.size {
+                let topic = TopicName::from_c_str_unchecked(cstr_at(&rcl_names_and_types.names, i));
+                let types = collect_cstrs(&*rcl_names_and_types.types.add(i))
+                    .into_iter()
+                    .map(|type_name| TypeName::from_c_str_unchecked(type_name))
+                    .collect();
+                names_and_types.push((topic, types));
+            }
+
+            let _ = rcl_names_and_types_fini(&mut rcl_names_and_types);
+
+            Ok(names_and_types)
+        }
+    }
 }
 
-impl Drop for NodeInner {
+impl Drop for Node {
     fn drop(&mut self) {
         unsafe {
             let ret = rcl_node_fini(self.node.get());
@@ -98,24 +144,7 @@ impl Drop for NodeInner {
     }
 }
 
-/// A handle to an rcl node.
-///
-/// The node and its context stay alive until the last handle is dropped.
-#[derive(Clone)]
-pub struct NodeHandle {
-    inner: Rc<NodeInner>,
-}
-
-impl core::fmt::Debug for NodeHandle {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Node")
-            .field("node", &self.inner.node.get())
-            .field("context", &self.inner.context.get())
-            .finish()
-    }
-}
-
-/// Builder for [`NodeHandle`].
+/// Builder for [`Node`].
 #[derive(Debug)]
 pub struct Builder {
     name: NodeName,
@@ -136,7 +165,7 @@ impl Builder {
         self
     }
 
-    pub fn create(self) -> Result<NodeHandle, CreationError> {
+    pub fn create(self) -> Result<Node, CreationError> {
         let origin = "Node::create";
 
         unsafe {
@@ -183,78 +212,7 @@ impl Builder {
                 );
             }
 
-            Ok(NodeHandle {
-                inner: Rc::new(NodeInner { node, context }),
-            })
-        }
-    }
-}
-
-impl NodeHandle {
-    /// Begins building a node with the given name. The namespace defaults to
-    /// the root namespace unless set via [`Builder::namespace`].
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(name: NodeName) -> Builder {
-        Builder::new(name)
-    }
-
-    /// Build a publisher on this node for the given topic and typesupport.
-    pub fn publisher_builder<'a>(
-        &self,
-        topic: &'a TopicName,
-        type_support: TypeSupportHandle,
-    ) -> publisher::Builder<'a> {
-        publisher::Builder::new(Rc::clone(&self.inner), topic, type_support)
-    }
-
-    /// Build a subscription on this node for the given topic and typesupport.
-    pub fn subscription_builder<'a>(
-        &self,
-        topic: &'a TopicName,
-        type_support: TypeSupportHandle,
-    ) -> subscription::Builder<'a> {
-        subscription::Builder::new(Rc::clone(&self.inner), topic, type_support)
-    }
-
-    pub(crate) fn handle(&self) -> *mut rcl_node_t {
-        self.inner.handle()
-    }
-
-    /// Query the ROS graph for all topics visible to this node and their type names.
-    pub fn topic_names_and_types(&self) -> Result<Vec<(TopicName, Vec<TypeName>)>, GraphError> {
-        let origin = "Node::topic_names_and_types";
-
-        unsafe {
-            let mut allocator = rcutils_get_default_allocator();
-            let mut rcl_names_and_types: rcl_names_and_types_t = core::mem::zeroed();
-            let ret = rcl_get_topic_names_and_types(
-                self.inner.node.get(),
-                &mut allocator,
-                NO_DEMANGLE,
-                &mut rcl_names_and_types,
-            );
-            if ret != RCL_RET_OK as i32 {
-                fail!(
-                    from origin,
-                    with GraphError::Query,
-                    "Failed to query topic names and types: {}",
-                    RclError::from(ret)
-                );
-            }
-
-            let mut names_and_types = Vec::with_capacity(rcl_names_and_types.names.size);
-            for i in 0..rcl_names_and_types.names.size {
-                let topic = TopicName::from_c_str_unchecked(cstr_at(&rcl_names_and_types.names, i));
-                let types = collect_cstrs(&*rcl_names_and_types.types.add(i))
-                    .into_iter()
-                    .map(|type_name| TypeName::from_c_str_unchecked(type_name))
-                    .collect();
-                names_and_types.push((topic, types));
-            }
-
-            let _ = rcl_names_and_types_fini(&mut rcl_names_and_types);
-
-            Ok(names_and_types)
+            Ok(Node { node, context })
         }
     }
 }

--- a/integrations/ros2/tunnel-backend/src/rcl/node.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/node.rs
@@ -65,28 +65,21 @@ impl core::error::Error for GraphError {}
 /// node, so it can be coupled to the context.
 ///
 /// The node is shared: everything that needs it to stay alive - endpoints,
-/// discovery, the backend itself - holds a share of one `Rc<Node>`.
+/// discovery, the backend itself - holds a share of one `Rc<RclNode>`.
 #[derive(Debug)]
-pub struct Node {
+pub struct RclNode {
     node: Box<UnsafeCell<rcl_node_t>>,
     context: Box<UnsafeCell<rcl_context_t>>,
 }
 
-impl Node {
-    /// Begins building a node with the given name. The namespace defaults to
-    /// the root namespace unless set via [`Builder::namespace`].
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(name: NodeName) -> Builder {
-        Builder::new(name)
-    }
-
+impl RclNode {
     pub(crate) fn handle(&self) -> *mut rcl_node_t {
         self.node.get()
     }
 
     /// Query the ROS graph for all topics visible to this node and their type names.
     pub fn topic_names_and_types(&self) -> Result<Vec<(TopicName, Vec<TypeName>)>, GraphError> {
-        let origin = "Node::topic_names_and_types";
+        let origin = "RclNode::topic_names_and_types";
 
         unsafe {
             let mut allocator = rcutils_get_default_allocator();
@@ -123,7 +116,7 @@ impl Node {
     }
 }
 
-impl Drop for Node {
+impl Drop for RclNode {
     fn drop(&mut self) {
         unsafe {
             let ret = rcl_node_fini(self.node.get());
@@ -144,15 +137,17 @@ impl Drop for Node {
     }
 }
 
-/// Builder for [`Node`].
+/// Builder for [`RclNode`].
 #[derive(Debug)]
-pub struct Builder {
+pub struct RclNodeBuilder {
     name: NodeName,
     namespace: NodeNamespace,
 }
 
-impl Builder {
-    fn new(name: NodeName) -> Self {
+impl RclNodeBuilder {
+    /// Begins building a node with the given name. The namespace defaults to
+    /// the root namespace unless set via [`RclNodeBuilder::namespace`].
+    pub fn new(name: NodeName) -> Self {
         Self {
             name,
             namespace: NodeNamespace::root(),
@@ -165,8 +160,8 @@ impl Builder {
         self
     }
 
-    pub fn create(self) -> Result<Node, CreationError> {
-        let origin = "Node::create";
+    pub fn create(self) -> Result<RclNode, CreationError> {
+        let origin = "RclNodeBuilder::create";
 
         unsafe {
             let mut init_options = rcl_get_zero_initialized_init_options();
@@ -212,7 +207,7 @@ impl Builder {
                 );
             }
 
-            Ok(Node { node, context })
+            Ok(RclNode { node, context })
         }
     }
 }

--- a/integrations/ros2/tunnel-backend/src/rcl/publisher.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/publisher.rs
@@ -21,7 +21,7 @@ use r2r_rcl::{
 use iceoryx2_bb_concurrency::cell::UnsafeCell;
 use iceoryx2_log::fail;
 
-use crate::rcl::node::NodeInner;
+use crate::rcl::node::Node;
 use crate::rcl::{RclError, TopicName};
 use crate::typesupport::TypeSupportHandle;
 
@@ -54,17 +54,13 @@ impl core::error::Error for PublishError {}
 /// Builder for [`Publisher`].
 #[derive(Debug)]
 pub struct Builder<'a> {
-    node: Rc<NodeInner>,
+    node: Rc<Node>,
     topic: &'a TopicName,
     type_support: TypeSupportHandle,
 }
 
 impl<'a> Builder<'a> {
-    pub(crate) fn new(
-        node: Rc<NodeInner>,
-        topic: &'a TopicName,
-        type_support: TypeSupportHandle,
-    ) -> Self {
+    fn new(node: Rc<Node>, topic: &'a TopicName, type_support: TypeSupportHandle) -> Self {
         Self {
             node,
             topic,
@@ -106,7 +102,7 @@ impl<'a> Builder<'a> {
 
 /// Publishes pre-serialized messages on a ROS 2 topic.
 pub struct Publisher {
-    node: Rc<NodeInner>,
+    node: Rc<Node>,
     publisher: Box<UnsafeCell<r2r_rcl::rcl_publisher_t>>,
     /// Keeps the typesupport library loaded while the endpoint uses it.
     _type_support: TypeSupportHandle,
@@ -123,6 +119,17 @@ impl core::fmt::Debug for Publisher {
 }
 
 impl Publisher {
+    /// Begins building a publisher on `node` for the given topic and
+    /// typesupport.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a>(
+        node: Rc<Node>,
+        topic: &'a TopicName,
+        type_support: TypeSupportHandle,
+    ) -> Builder<'a> {
+        Builder::new(node, topic, type_support)
+    }
+
     /// Publishes the payload as-is; it must be a serialized message of the
     /// publisher's type.
     pub fn publish(&self, payload: &[u8]) -> Result<(), PublishError> {

--- a/integrations/ros2/tunnel-backend/src/rcl/publisher.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/publisher.rs
@@ -21,7 +21,7 @@ use r2r_rcl::{
 use iceoryx2_bb_concurrency::cell::UnsafeCell;
 use iceoryx2_log::fail;
 
-use crate::rcl::node::Node;
+use crate::rcl::node::RclNode;
 use crate::rcl::{RclError, TopicName};
 use crate::typesupport::TypeSupport;
 
@@ -51,16 +51,18 @@ impl core::fmt::Display for PublishError {
 
 impl core::error::Error for PublishError {}
 
-/// Builder for [`Publisher`].
+/// Builder for [`RclPublisher`].
 #[derive(Debug)]
-pub struct Builder<'a> {
-    node: Rc<Node>,
+pub struct RclPublisherBuilder<'a> {
+    node: Rc<RclNode>,
     topic: &'a TopicName,
     type_support: Rc<TypeSupport>,
 }
 
-impl<'a> Builder<'a> {
-    fn new(node: Rc<Node>, topic: &'a TopicName, type_support: Rc<TypeSupport>) -> Self {
+impl<'a> RclPublisherBuilder<'a> {
+    /// Begins building a publisher on `node` for the given topic and
+    /// typesupport.
+    pub fn new(node: Rc<RclNode>, topic: &'a TopicName, type_support: Rc<TypeSupport>) -> Self {
         Self {
             node,
             topic,
@@ -68,8 +70,8 @@ impl<'a> Builder<'a> {
         }
     }
 
-    pub fn create(self) -> Result<Publisher, CreationError> {
-        let origin = "Publisher::Builder::create";
+    pub fn create(self) -> Result<RclPublisher, CreationError> {
+        let origin = "RclPublisherBuilder::create";
 
         unsafe {
             let publisher = Box::new(UnsafeCell::new(rcl_get_zero_initialized_publisher()));
@@ -91,7 +93,7 @@ impl<'a> Builder<'a> {
                 );
             }
 
-            Ok(Publisher {
+            Ok(RclPublisher {
                 node: self.node,
                 publisher,
                 _type_support: self.type_support,
@@ -101,16 +103,16 @@ impl<'a> Builder<'a> {
 }
 
 /// Publishes pre-serialized messages on a ROS 2 topic.
-pub struct Publisher {
-    node: Rc<Node>,
+pub struct RclPublisher {
+    node: Rc<RclNode>,
     publisher: Box<UnsafeCell<r2r_rcl::rcl_publisher_t>>,
     /// Keeps the typesupport library loaded while the endpoint uses it.
     _type_support: Rc<TypeSupport>,
 }
 
-impl core::fmt::Debug for Publisher {
+impl core::fmt::Debug for RclPublisher {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Publisher")
+        f.debug_struct("RclPublisher")
             .field("publisher", &self.publisher.get())
             .field("node", &self.node)
             .field("_type_support", &self._type_support)
@@ -118,22 +120,11 @@ impl core::fmt::Debug for Publisher {
     }
 }
 
-impl Publisher {
-    /// Begins building a publisher on `node` for the given topic and
-    /// typesupport.
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new<'a>(
-        node: Rc<Node>,
-        topic: &'a TopicName,
-        type_support: Rc<TypeSupport>,
-    ) -> Builder<'a> {
-        Builder::new(node, topic, type_support)
-    }
-
+impl RclPublisher {
     /// Publishes the payload as-is; it must be a serialized message of the
     /// publisher's type.
     pub fn publish(&self, payload: &[u8]) -> Result<(), PublishError> {
-        let origin = "Publisher::publish";
+        let origin = "RclPublisher::publish";
 
         let message = rcl_serialized_message_t {
             buffer: payload.as_ptr() as *mut u8,
@@ -158,7 +149,7 @@ impl Publisher {
     }
 }
 
-impl Drop for Publisher {
+impl Drop for RclPublisher {
     fn drop(&mut self) {
         unsafe {
             let _ = rcl_publisher_fini(self.publisher.get(), self.node.handle());

--- a/integrations/ros2/tunnel-backend/src/rcl/publisher.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/publisher.rs
@@ -23,7 +23,7 @@ use iceoryx2_log::fail;
 
 use crate::rcl::node::Node;
 use crate::rcl::{RclError, TopicName};
-use crate::typesupport::TypeSupportHandle;
+use crate::typesupport::TypeSupport;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum CreationError {
@@ -56,11 +56,11 @@ impl core::error::Error for PublishError {}
 pub struct Builder<'a> {
     node: Rc<Node>,
     topic: &'a TopicName,
-    type_support: TypeSupportHandle,
+    type_support: Rc<TypeSupport>,
 }
 
 impl<'a> Builder<'a> {
-    fn new(node: Rc<Node>, topic: &'a TopicName, type_support: TypeSupportHandle) -> Self {
+    fn new(node: Rc<Node>, topic: &'a TopicName, type_support: Rc<TypeSupport>) -> Self {
         Self {
             node,
             topic,
@@ -105,7 +105,7 @@ pub struct Publisher {
     node: Rc<Node>,
     publisher: Box<UnsafeCell<r2r_rcl::rcl_publisher_t>>,
     /// Keeps the typesupport library loaded while the endpoint uses it.
-    _type_support: TypeSupportHandle,
+    _type_support: Rc<TypeSupport>,
 }
 
 impl core::fmt::Debug for Publisher {
@@ -125,7 +125,7 @@ impl Publisher {
     pub fn new<'a>(
         node: Rc<Node>,
         topic: &'a TopicName,
-        type_support: TypeSupportHandle,
+        type_support: Rc<TypeSupport>,
     ) -> Builder<'a> {
         Builder::new(node, topic, type_support)
     }

--- a/integrations/ros2/tunnel-backend/src/rcl/subscription.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/subscription.rs
@@ -24,7 +24,7 @@ use r2r_rcl::{
 
 use iceoryx2_log::fail;
 
-use crate::rcl::node::Node;
+use crate::rcl::node::RclNode;
 use crate::rcl::{RclError, TopicName};
 use crate::typesupport::TypeSupport;
 
@@ -94,16 +94,18 @@ impl From<&rmw_message_info_t> for MessageInfo {
     }
 }
 
-/// Builder for [`Subscription`].
+/// Builder for [`RclSubscription`].
 #[derive(Debug)]
-pub struct Builder<'a> {
-    node: Rc<Node>,
+pub struct RclSubscriptionBuilder<'a> {
+    node: Rc<RclNode>,
     topic: &'a TopicName,
     type_support: Rc<TypeSupport>,
 }
 
-impl<'a> Builder<'a> {
-    fn new(node: Rc<Node>, topic: &'a TopicName, type_support: Rc<TypeSupport>) -> Self {
+impl<'a> RclSubscriptionBuilder<'a> {
+    /// Begins building a subscription on `node` for the given topic and
+    /// typesupport.
+    pub fn new(node: Rc<RclNode>, topic: &'a TopicName, type_support: Rc<TypeSupport>) -> Self {
         Self {
             node,
             topic,
@@ -111,8 +113,8 @@ impl<'a> Builder<'a> {
         }
     }
 
-    pub fn create(self) -> Result<Subscription, CreationError> {
-        let origin = "Subscription::Builder::create";
+    pub fn create(self) -> Result<RclSubscription, CreationError> {
+        let origin = "RclSubscriptionBuilder::create";
 
         unsafe {
             let mut subscription = Box::new(rcl_get_zero_initialized_subscription());
@@ -134,7 +136,7 @@ impl<'a> Builder<'a> {
                 );
             }
 
-            Ok(Subscription {
+            Ok(RclSubscription {
                 subscription: Box::into_raw(subscription),
                 callback: None,
                 node: self.node,
@@ -145,19 +147,19 @@ impl<'a> Builder<'a> {
 }
 
 /// Receives serialized messages from a ROS 2 topic.
-pub struct Subscription {
+pub struct RclSubscription {
     subscription: *mut r2r_rcl::rcl_subscription_t,
     /// The new-message callback while one is registered, kept alive and pinned
     /// so the `user_data` pointer rcl holds stays valid until it is cleared.
     callback: Option<Pin<Box<NewMessageCallback>>>,
-    node: Rc<Node>,
+    node: Rc<RclNode>,
     /// Keeps the typesupport library loaded while the endpoint uses it.
     _type_support: Rc<TypeSupport>,
 }
 
-impl core::fmt::Debug for Subscription {
+impl core::fmt::Debug for RclSubscription {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Subscription")
+        f.debug_struct("RclSubscription")
             .field("subscription", &self.subscription)
             .field("callback", &self.callback.is_some())
             .field("node", &self.node)
@@ -165,24 +167,13 @@ impl core::fmt::Debug for Subscription {
     }
 }
 
-impl Subscription {
-    /// Begins building a subscription on `node` for the given topic and
-    /// typesupport.
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new<'a>(
-        node: Rc<Node>,
-        topic: &'a TopicName,
-        type_support: Rc<TypeSupport>,
-    ) -> Builder<'a> {
-        Builder::new(node, topic, type_support)
-    }
-
+impl RclSubscription {
     /// Registers `callback` to be invoked whenever new messages arrive on
     /// the subscription, with the number of new messages. It is invoked by
     /// the RMW from a middleware thread and must not panic; a previously
     /// registered callback is replaced.
     pub fn on_new_message(&mut self, callback: NewMessageCallback) -> Result<(), CallbackError> {
-        let origin = "Subscription::on_new_message";
+        let origin = "RclSubscription::on_new_message";
 
         // Pin to a stable heap address, then pass rcl a thin pointer to the
         // boxed closure as `user_data`.
@@ -225,7 +216,7 @@ impl Subscription {
     where
         F: FnOnce(usize) -> Option<*mut u8>,
     {
-        let origin = "Subscription::take_into";
+        let origin = "RclSubscription::take_into";
 
         let mut loan: Option<F> = Some(loan);
         let mut message = rcl_serialized_message_t {
@@ -270,7 +261,7 @@ impl Subscription {
     }
 }
 
-impl Drop for Subscription {
+impl Drop for RclSubscription {
     fn drop(&mut self) {
         unsafe {
             // Clear the callback before the closure is dropped: a middleware
@@ -291,7 +282,7 @@ impl Drop for Subscription {
 
 /// The C entry point rcl invokes when messages arrive; recovers the
 /// [`NewMessageCallback`] from the `user_data` pointer registered in
-/// [`Subscription::on_new_message`] and calls it.
+/// [`RclSubscription::on_new_message`] and calls it.
 unsafe extern "C" fn on_new_message_trampoline(user_data: *const c_void, number_of_events: usize) {
     let callback = unsafe { &*(user_data as *const NewMessageCallback) };
     callback(number_of_events);

--- a/integrations/ros2/tunnel-backend/src/rcl/subscription.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/subscription.rs
@@ -26,7 +26,7 @@ use iceoryx2_log::fail;
 
 use crate::rcl::node::Node;
 use crate::rcl::{RclError, TopicName};
-use crate::typesupport::TypeSupportHandle;
+use crate::typesupport::TypeSupport;
 
 /// A callback invoked with the number of newly-arrived messages. The RMW
 /// calls it from a middleware thread.
@@ -99,11 +99,11 @@ impl From<&rmw_message_info_t> for MessageInfo {
 pub struct Builder<'a> {
     node: Rc<Node>,
     topic: &'a TopicName,
-    type_support: TypeSupportHandle,
+    type_support: Rc<TypeSupport>,
 }
 
 impl<'a> Builder<'a> {
-    fn new(node: Rc<Node>, topic: &'a TopicName, type_support: TypeSupportHandle) -> Self {
+    fn new(node: Rc<Node>, topic: &'a TopicName, type_support: Rc<TypeSupport>) -> Self {
         Self {
             node,
             topic,
@@ -152,7 +152,7 @@ pub struct Subscription {
     callback: Option<Pin<Box<NewMessageCallback>>>,
     node: Rc<Node>,
     /// Keeps the typesupport library loaded while the endpoint uses it.
-    _type_support: TypeSupportHandle,
+    _type_support: Rc<TypeSupport>,
 }
 
 impl core::fmt::Debug for Subscription {
@@ -172,7 +172,7 @@ impl Subscription {
     pub fn new<'a>(
         node: Rc<Node>,
         topic: &'a TopicName,
-        type_support: TypeSupportHandle,
+        type_support: Rc<TypeSupport>,
     ) -> Builder<'a> {
         Builder::new(node, topic, type_support)
     }

--- a/integrations/ros2/tunnel-backend/src/rcl/subscription.rs
+++ b/integrations/ros2/tunnel-backend/src/rcl/subscription.rs
@@ -24,7 +24,7 @@ use r2r_rcl::{
 
 use iceoryx2_log::fail;
 
-use crate::rcl::node::NodeInner;
+use crate::rcl::node::Node;
 use crate::rcl::{RclError, TopicName};
 use crate::typesupport::TypeSupportHandle;
 
@@ -97,17 +97,13 @@ impl From<&rmw_message_info_t> for MessageInfo {
 /// Builder for [`Subscription`].
 #[derive(Debug)]
 pub struct Builder<'a> {
-    node: Rc<NodeInner>,
+    node: Rc<Node>,
     topic: &'a TopicName,
     type_support: TypeSupportHandle,
 }
 
 impl<'a> Builder<'a> {
-    pub(crate) fn new(
-        node: Rc<NodeInner>,
-        topic: &'a TopicName,
-        type_support: TypeSupportHandle,
-    ) -> Self {
+    fn new(node: Rc<Node>, topic: &'a TopicName, type_support: TypeSupportHandle) -> Self {
         Self {
             node,
             topic,
@@ -154,7 +150,7 @@ pub struct Subscription {
     /// The new-message callback while one is registered, kept alive and pinned
     /// so the `user_data` pointer rcl holds stays valid until it is cleared.
     callback: Option<Pin<Box<NewMessageCallback>>>,
-    node: Rc<NodeInner>,
+    node: Rc<Node>,
     /// Keeps the typesupport library loaded while the endpoint uses it.
     _type_support: TypeSupportHandle,
 }
@@ -170,6 +166,17 @@ impl core::fmt::Debug for Subscription {
 }
 
 impl Subscription {
+    /// Begins building a subscription on `node` for the given topic and
+    /// typesupport.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a>(
+        node: Rc<Node>,
+        topic: &'a TopicName,
+        type_support: TypeSupportHandle,
+    ) -> Builder<'a> {
+        Builder::new(node, topic, type_support)
+    }
+
     /// Registers `callback` to be invoked whenever new messages arrive on
     /// the subscription, with the number of new messages. It is invoked by
     /// the RMW from a middleware thread and must not panic; a previously

--- a/integrations/ros2/tunnel-backend/src/relays/factory.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/factory.rs
@@ -10,6 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use std::rc::Rc;
 use std::sync::Arc;
 
 use iceoryx2::service::{Service, local_threadsafe, static_config::StaticConfig};
@@ -22,7 +23,7 @@ use crate::typesupport::TypeSupportRegistry;
 /// Factory for creating relay builders.
 #[derive(Debug)]
 pub struct Factory<'a, S: Service> {
-    node: rcl::NodeHandle,
+    node: Rc<rcl::Node>,
     type_registry: &'a TypeSupportRegistry,
     /// Wake handle to be signaled by relays when new data arrives.
     /// `None` when the backend was constructed in polled mode.
@@ -32,7 +33,7 @@ pub struct Factory<'a, S: Service> {
 
 impl<'a, S: Service> Factory<'a, S> {
     pub fn new(
-        node: rcl::NodeHandle,
+        node: Rc<rcl::Node>,
         type_registry: &'a TypeSupportRegistry,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Self {
@@ -67,7 +68,7 @@ impl<S: Service> RelayFactory<S> for Factory<'_, S> {
         Self: 'a,
     {
         publish_subscribe::Builder::new(
-            self.node.clone(),
+            Rc::clone(&self.node),
             self.type_registry,
             static_config,
             self.wake.clone(),

--- a/integrations/ros2/tunnel-backend/src/relays/factory.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/factory.rs
@@ -16,14 +16,14 @@ use std::sync::Arc;
 use iceoryx2::service::{Service, local_threadsafe, static_config::StaticConfig};
 use iceoryx2_services_tunnel_backend::{traits::RelayFactory, types::wake::WakeHandle};
 
-use crate::rcl;
+use crate::rcl::RclNode;
 use crate::relays::{event, publish_subscribe};
 use crate::typesupport::TypeSupportRegistry;
 
 /// Factory for creating relay builders.
 #[derive(Debug)]
 pub struct Factory<'a, S: Service> {
-    node: Rc<rcl::Node>,
+    node: Rc<RclNode>,
     type_registry: &'a TypeSupportRegistry,
     /// Wake handle to be signaled by relays when new data arrives.
     /// `None` when the backend was constructed in polled mode.
@@ -33,7 +33,7 @@ pub struct Factory<'a, S: Service> {
 
 impl<'a, S: Service> Factory<'a, S> {
     pub fn new(
-        node: Rc<rcl::Node>,
+        node: Rc<RclNode>,
         type_registry: &'a TypeSupportRegistry,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Self {

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -21,9 +21,13 @@ use iceoryx2_services_tunnel_backend::types::publish_subscribe::{
 };
 use iceoryx2_services_tunnel_backend::types::wake::WakeHandle;
 
+use crate::rcl::{
+    RclNode, RclPublisher, RclPublisherBuilder, RclSubscription, RclSubscriptionBuilder, TopicName,
+    subscription::TakeError,
+};
 use crate::ros_header::RosHeader;
 use crate::typesupport::TypeSupportRegistry;
-use crate::{mapping, payload, rcl};
+use crate::{mapping, payload};
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum CreationError {
@@ -74,8 +78,8 @@ impl core::error::Error for ReceiveError {}
 /// Relays publish-subscribe payloads between iceoryx2 and a ROS 2 topic.
 #[derive(Debug)]
 pub struct Relay<S: Service> {
-    publisher: rcl::Publisher,
-    subscription: rcl::Subscription,
+    publisher: RclPublisher,
+    subscription: RclSubscription,
     /// Whether the service's user-header type is [`RosHeader`], i.e. the
     /// relay may write the remote origin into received samples.
     write_ros_header: bool,
@@ -134,8 +138,8 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
                 Ok(Some(payload::assume_init(sample)))
             }
             Ok(None) => Ok(None),
-            Err(rcl::subscription::TakeError::LoanDeclined) => Err(ReceiveError::Loan),
-            Err(rcl::subscription::TakeError::Take) => Err(ReceiveError::Take),
+            Err(TakeError::LoanDeclined) => Err(ReceiveError::Loan),
+            Err(TakeError::Take) => Err(ReceiveError::Take),
         }
     }
 }
@@ -143,7 +147,7 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
 /// Builder for publish-subscribe [`Relay`]s.
 #[derive(Debug)]
 pub struct Builder<'a, S: Service> {
-    node: Rc<rcl::Node>,
+    node: Rc<RclNode>,
     type_registry: &'a TypeSupportRegistry,
     static_config: &'a StaticConfig,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
@@ -152,7 +156,7 @@ pub struct Builder<'a, S: Service> {
 
 impl<'a, S: Service> Builder<'a, S> {
     pub fn new(
-        node: Rc<rcl::Node>,
+        node: Rc<RclNode>,
         type_registry: &'a TypeSupportRegistry,
         static_config: &'a StaticConfig,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
@@ -200,19 +204,19 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
             type_name
         );
         let topic_name = fail!(from origin,
-            when rcl::TopicName::new(topic),
+            when TopicName::new(topic),
             with CreationError::InvalidTopic,
             "Invalid ROS 2 topic name '{}'",
             topic
         );
         let publisher = fail!(from origin,
-            when rcl::Publisher::new(Rc::clone(&self.node), &topic_name, Rc::clone(&type_support)).create(),
+            when RclPublisherBuilder::new(Rc::clone(&self.node), &topic_name, Rc::clone(&type_support)).create(),
             with CreationError::Publisher,
             "Failed to create ROS 2 publisher for topic '{}'",
             topic
         );
         let mut subscription = fail!(from origin,
-            when rcl::Subscription::new(Rc::clone(&self.node), &topic_name, type_support).create(),
+            when RclSubscriptionBuilder::new(Rc::clone(&self.node), &topic_name, type_support).create(),
             with CreationError::Subscription,
             "Failed to create ROS 2 subscription for topic '{}'",
             topic

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -10,6 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use std::rc::Rc;
 use std::sync::Arc;
 
 use iceoryx2::service::{Service, local_threadsafe, static_config::StaticConfig};
@@ -142,7 +143,7 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
 /// Builder for publish-subscribe [`Relay`]s.
 #[derive(Debug)]
 pub struct Builder<'a, S: Service> {
-    node: rcl::NodeHandle,
+    node: Rc<rcl::Node>,
     type_registry: &'a TypeSupportRegistry,
     static_config: &'a StaticConfig,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
@@ -151,7 +152,7 @@ pub struct Builder<'a, S: Service> {
 
 impl<'a, S: Service> Builder<'a, S> {
     pub fn new(
-        node: rcl::NodeHandle,
+        node: Rc<rcl::Node>,
         type_registry: &'a TypeSupportRegistry,
         static_config: &'a StaticConfig,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
@@ -205,13 +206,13 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
             topic
         );
         let publisher = fail!(from origin,
-            when self.node.publisher_builder(&topic_name, type_support.clone()).create(),
+            when rcl::Publisher::new(Rc::clone(&self.node), &topic_name, type_support.clone()).create(),
             with CreationError::Publisher,
             "Failed to create ROS 2 publisher for topic '{}'",
             topic
         );
         let mut subscription = fail!(from origin,
-            when self.node.subscription_builder(&topic_name, type_support).create(),
+            when rcl::Subscription::new(Rc::clone(&self.node), &topic_name, type_support).create(),
             with CreationError::Subscription,
             "Failed to create ROS 2 subscription for topic '{}'",
             topic

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -206,7 +206,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
             topic
         );
         let publisher = fail!(from origin,
-            when rcl::Publisher::new(Rc::clone(&self.node), &topic_name, type_support.clone()).create(),
+            when rcl::Publisher::new(Rc::clone(&self.node), &topic_name, Rc::clone(&type_support)).create(),
             with CreationError::Publisher,
             "Failed to create ROS 2 publisher for topic '{}'",
             topic

--- a/integrations/ros2/tunnel-backend/src/typesupport.rs
+++ b/integrations/ros2/tunnel-backend/src/typesupport.rs
@@ -39,14 +39,6 @@ impl core::fmt::Display for LoadError {
 
 impl core::error::Error for LoadError {}
 
-/// Owns a resolved typesupport handle together with the [`Library`] it points
-/// into, keeping that library loaded for as long as the handle is used.
-#[derive(Debug)]
-struct TypeSupportInner {
-    handle: *const rosidl_message_type_support_t,
-    _library: Library,
-}
-
 /// A resolved ROS 2 *typesupport* handle.
 ///
 /// In ROS 2 a "typesupport" is the per-message-type descriptor that rcl and
@@ -65,15 +57,18 @@ struct TypeSupportInner {
 /// will match.
 ///
 /// The handle points into the loaded library's memory, so the `Library` is
-/// kept alive here; it stays loaded as long as any clone is alive.
-#[derive(Debug, Clone)]
-pub struct TypeSupportHandle {
-    inner: Rc<TypeSupportInner>,
+/// kept alive here. The typesupport is shared: the registry cache and every
+/// endpoint using it hold a share of one `Rc<TypeSupport>`, keeping the
+/// library loaded as long as any share is alive.
+#[derive(Debug)]
+pub struct TypeSupport {
+    handle: *const rosidl_message_type_support_t,
+    _library: Library,
 }
 
-impl TypeSupportHandle {
+impl TypeSupport {
     pub(crate) fn handle(&self) -> *const rosidl_message_type_support_t {
-        self.inner.handle
+        self.handle
     }
 }
 
@@ -81,19 +76,19 @@ impl TypeSupportHandle {
 /// registry must outlive all endpoints created from its handles.
 #[derive(Debug, Default)]
 pub struct TypeSupportRegistry {
-    entries: RefCell<HashMap<String, TypeSupportHandle>>,
+    entries: RefCell<HashMap<String, Rc<TypeSupport>>>,
 }
 
 impl TypeSupportRegistry {
-    pub fn load(&self, type_name: &str) -> Result<TypeSupportHandle, LoadError> {
+    pub fn load(&self, type_name: &str) -> Result<Rc<TypeSupport>, LoadError> {
         if let Some(type_support) = self.entries.borrow().get(type_name) {
-            return Ok(type_support.clone());
+            return Ok(Rc::clone(type_support));
         }
 
-        let type_support = load_typesupport_library(type_name)?;
+        let type_support = Rc::new(load_typesupport_library(type_name)?);
         self.entries
             .borrow_mut()
-            .insert(type_name.to_string(), type_support.clone());
+            .insert(type_name.to_string(), Rc::clone(&type_support));
 
         Ok(type_support)
     }
@@ -101,7 +96,7 @@ impl TypeSupportRegistry {
 
 /// Loads the typesupport library of the type's package and looks up the
 /// type's handle in it.
-fn load_typesupport_library(type_name: &str) -> Result<TypeSupportHandle, LoadError> {
+fn load_typesupport_library(type_name: &str) -> Result<TypeSupport, LoadError> {
     let origin = "TypeSupportRegistry::load";
 
     let (package, message) = fail!(
@@ -145,11 +140,9 @@ fn load_typesupport_library(type_name: &str) -> Result<TypeSupportHandle, LoadEr
         );
     }
 
-    Ok(TypeSupportHandle {
-        inner: Rc::new(TypeSupportInner {
-            handle,
-            _library: library,
-        }),
+    Ok(TypeSupport {
+        handle,
+        _library: library,
     })
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

1. Do not hide `Rc` behind `NodeInner`/`TypeSupportInner` structs
2. Explicitly `Rc::clone` references when sharing between endpoints
3. Prefix RCL wrapper structs with Rcl e.g. `Node` -> `RclNode`

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] ~~`Tests follow the [best practice for testing][testing]~~
* [ ] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #1761 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
