### PR TITLE
[#1786] Disable transport_compression feature in zenoh

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -42,6 +42,7 @@
 * [#1763](https://github.com/eclipse-iceoryx/iceoryx2/issues/1763) Close `ActiveRequest-PendingResponse` connection when dead process is cleaned up.
 * [#1765](https://github.com/eclipse-iceoryx/iceoryx2/issues/1765) Remove unnecessary `fsync` on file open
 * [#1770](https://github.com/eclipse-iceoryx/iceoryx2/issues/1770) Fix logging in python module.
+* [#1786](https://github.com/eclipse-iceoryx/iceoryx2/issues/1786) Disable transport_compression feature in Zenoh.
 
 ### Refactoring
 

--- a/integrations/zenoh/Cargo.toml
+++ b/integrations/zenoh/Cargo.toml
@@ -44,4 +44,18 @@ clap = { version = "4.5.4", features = ["derive"] }
 flume = { version = "0.12.0" }
 human-panic = { version = "2.0.5" }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-zenoh = { version = "1.9.0", features = ["default", "unstable"] }
+# Mitigate https://rustsec.org/advisories/RUSTSEC-2026-0041 by not enabling
+# transport_compression feature until a new version of lz4_flex is available in zenoh
+zenoh = { version = "1.9.0", default-features = false, features = [
+    "unstable",
+    "auth_pubkey",
+    "auth_usrpwd",
+    "transport_multilink",
+    "transport_quic",
+    "transport_quic_datagram",
+    "transport_tcp",
+    "transport_tls",
+    "transport_udp",
+    "transport_unixsock-stream",
+    "transport_ws",
+] }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

- feature list in zenoh: https://github.com/eclipse-zenoh/zenoh/blob/5dd1a2f764b28a70ce6f12801e1d4dca2321bbc2/zenoh/Cargo.toml#L34

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #1786 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
