### PR TITLE
[#1742] Describe services independently of `StaticConfig`

### DIFF
--- a/Cargo.Bazel.lock
+++ b/Cargo.Bazel.lock
@@ -1,5 +1,5 @@
 {
-  "checksum": "3c20ded4aafe9898600a7b76682cc4bad1e18a21432fc9a047da033599ede4e1",
+  "checksum": "144a7e6515f06f98c9ee65975dc0b3e6d6bb2be520ffdd6f7651556554a28686",
   "crates": {
     "addr2line 0.25.1": {
       "name": "addr2line",
@@ -6856,6 +6856,15 @@
           "common": [
             "default",
             "std"
+          ],
+          "selects": {}
+        },
+        "deps": {
+          "common": [
+            {
+              "id": "serde 1.0.228",
+              "target": "serde"
+            }
           ],
           "selects": {}
         },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,8 @@ version = "0.9.999"
 dependencies = [
  "iceoryx2",
  "iceoryx2-bb-posix",
- "iceoryx2-services-common",
+ "iceoryx2-bb-testing",
+ "serde",
 ]
 
 [[package]]

--- a/iceoryx2-services/tunnel-backend/BUILD.bazel
+++ b/iceoryx2-services/tunnel-backend/BUILD.bazel
@@ -33,5 +33,6 @@ rust_library(
         "//iceoryx2:iceoryx2",
         "//iceoryx2-bb/posix:iceoryx2-bb-posix",
         "//iceoryx2-bb/testing:iceoryx2-bb-testing",
+        "@crate_index//:serde",
     ],
 )

--- a/iceoryx2-services/tunnel-backend/Cargo.toml
+++ b/iceoryx2-services/tunnel-backend/Cargo.toml
@@ -14,13 +14,11 @@ version = { workspace = true }
 default = ["std"]
 
 std = [
-  "iceoryx2-services-common/std",
   "iceoryx2/std",
   "iceoryx2-bb-posix/std"
 ]
 
 [dependencies]
-iceoryx2-services-common = { workspace = true }
 iceoryx2 = { workspace = true }
 iceoryx2-bb-posix = { workspace = true }
 serde = { workspace = true }

--- a/iceoryx2-services/tunnel-backend/Cargo.toml
+++ b/iceoryx2-services/tunnel-backend/Cargo.toml
@@ -23,3 +23,7 @@ std = [
 iceoryx2-services-common = { workspace = true }
 iceoryx2 = { workspace = true }
 iceoryx2-bb-posix = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+iceoryx2-bb-testing = { workspace = true }

--- a/iceoryx2-services/tunnel-backend/src/traits/discovery.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/discovery.rs
@@ -12,7 +12,7 @@
 
 use core::error::Error;
 
-use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
+use crate::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 
 /// Service discovery interface for discoverying and announcing
 /// [`Service`](iceoryx2::service::Service)s over the [`Backend`](crate::traits::Backend)
@@ -23,8 +23,9 @@ use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
 /// [`Backend`](crate::traits::Backend) and announce local services
 /// so they can be discovered remotely. Implementations query the
 /// [`Backend`](crate::traits::Backend)'s communication layer to find active
-/// [`Service`](iceoryx2::service::Service) and provide their
-/// [`iceoryx2::service::static_config::StaticConfig`]s to be processed by the caller.
+/// [`Service`](iceoryx2::service::Service)s and provide their
+/// [`ServiceDescription`](crate::types::service_description::ServiceDescription)s
+/// to be processed by the caller.
 ///
 /// # Examples
 ///
@@ -55,7 +56,7 @@ use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
 ///
 /// ```no_run
 /// use iceoryx2_services_tunnel_backend::traits::Discovery;
-/// use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
+/// use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 ///
 /// struct MyDiscovery {
 ///     // Discovery state
@@ -83,20 +84,19 @@ use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
 ///     type DiscoveryError = MyDiscoveryError;
 ///     type AnnouncementError = MyAnnouncementError;
 ///
-///     fn announce(&self, discovery: DiscoveryEventRef<'_>)
+///     fn announce(&self, update: DiscoveryUpdateRef<'_>)
 ///         -> Result<(), Self::AnnouncementError> {
-///         // Make the service described by the provided static config
-///         // discoverable over the backend
+///         // Make the described service discoverable over the backend
 ///         Ok(())
 ///     }
 ///
-///     fn discover<E: core::error::Error, F: FnMut(DiscoveryEvent) -> Result<(), E>>(
+///     fn discover<E: core::error::Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
 ///         &self,
 ///         process_discovery: F,
 ///     ) -> Result<(), Self::DiscoveryError> {
 ///         // Query backend for available services
 ///         // For each service found, call process_discovery with the
-///         // corresponding discovery event
+///         // corresponding discovery update
 ///         Ok(())
 ///     }
 /// }
@@ -117,24 +117,24 @@ pub trait Discovery {
     ///
     /// # Parameters
     ///
-    /// * `event` - The [`DiscoveryEventRef`] to announce over the
+    /// * `update` - The [`DiscoveryUpdateRef`] to announce over the
     ///   [`crate::traits::Backend`].
-    fn announce(&self, event: DiscoveryEventRef<'_>) -> Result<(), Self::AnnouncementError>;
+    fn announce(&self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError>;
 
     /// Discovers services available remotely and processes each one with the
     /// provided callback.
     ///
     /// This method queries the backend's communication mechanism for all
     /// available [`Service`](iceoryx2::service::Service)s, then invokes
-    /// `process_discovery` for [`DiscoveryEvent`]s.
+    /// `process_discovery` for [`DiscoveryUpdate`]s.
     ///
     /// Discovery continues until all services are processed or an error occurs.
     ///
     /// # Parameters
     ///
     /// * `process_discovery` - Callback provided by the caller to process
-    ///   [`DiscoveryEvent`]s received over the [`crate::traits::Backend`].
-    fn discover<E: Error, F: FnMut(DiscoveryEvent) -> Result<(), E>>(
+    ///   [`DiscoveryUpdate`]s received over the [`crate::traits::Backend`].
+    fn discover<E: Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
         &self,
         process_discovery: F,
     ) -> Result<(), Self::DiscoveryError>;

--- a/iceoryx2-services/tunnel-backend/src/traits/relay/factory.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/relay/factory.rs
@@ -13,10 +13,11 @@
 use core::error::Error;
 use core::fmt::Debug;
 
-use iceoryx2::service::{Service, static_config::StaticConfig};
+use iceoryx2::service::Service;
 
 use crate::traits::EventRelay;
 use crate::traits::PublishSubscribeRelay;
+use crate::types::service_description::ServiceDescription;
 
 /// Builder pattern for constructing relay instances.
 ///
@@ -89,7 +90,7 @@ pub trait RelayBuilder {
 /// Factory for creating relay builders for supported messaging patterns.
 ///
 /// [`RelayFactory`] produces [`RelayBuilder`]s for the supported [`MessagingPattern`](iceoryx2::service::messaging_pattern::MessagingPattern)s.
-/// Each [`RelayBuilder`] is configured with the [`Service`]'s [`StaticConfig`] and can be further customized before
+/// Each [`RelayBuilder`] is configured with the [`Service`]'s [`ServiceDescription`] and can be further customized before
 /// creating the relay.
 ///
 /// # Type Parameters
@@ -102,13 +103,14 @@ pub trait RelayBuilder {
 /// [`MessagingPattern::PublishSubscribe`](iceoryx2::service::messaging_pattern::MessagingPattern::PublishSubscribe) relay:
 ///
 /// ```no_run
-/// # use iceoryx2::service::{Service, static_config::StaticConfig};
+/// # use iceoryx2::service::Service;
 /// # use iceoryx2_services_tunnel_backend::traits::{RelayFactory, RelayBuilder};
+/// # use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 /// # fn example<'a, S: Service, F: RelayFactory<S>>(
 /// #     factory: &F,
-/// #     static_config: &'a StaticConfig
+/// #     description: &'a ServiceDescription
 /// # ) -> Result<F::PublishSubscribeRelay, <<F as RelayFactory<S>>::PublishSubscribeBuilder<'a> as RelayBuilder>::CreationError> {
-/// let builder = factory.publish_subscribe(static_config);
+/// let builder = factory.publish_subscribe(description);
 /// let relay = builder.create()?;
 /// # Ok(relay)
 /// # }
@@ -117,13 +119,14 @@ pub trait RelayBuilder {
 /// Creating an [`MessagingPattern::Event`](iceoryx2::service::messaging_pattern::MessagingPattern::Event) relay:
 ///
 /// ```no_run
-/// # use iceoryx2::service::{Service, static_config::StaticConfig};
+/// # use iceoryx2::service::Service;
 /// # use iceoryx2_services_tunnel_backend::traits::{RelayFactory, RelayBuilder};
+/// # use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 /// # fn example<'a, S: Service, F: RelayFactory<S>>(
 /// #     factory: &F,
-/// #     config: &'a StaticConfig
+/// #     description: &'a ServiceDescription
 /// # ) -> Result<F::EventRelay, <<F as RelayFactory<S>>::EventBuilder<'a> as RelayBuilder>::CreationError> {
-/// let builder = factory.event(config);
+/// let builder = factory.event(description);
 /// let relay = builder.create()?;
 /// # Ok(relay)
 /// # }
@@ -154,16 +157,16 @@ pub trait RelayFactory<S: Service> {
     ///
     /// # Parameters
     ///
-    /// * `static_config` - The [`Service`]'s [`StaticConfig`] for which a builder will be created
+    /// * `description` - The [`Service`]'s [`ServiceDescription`] for which a builder will be created
     ///
     /// # Returns
     ///
-    /// A [`RelayBuilder`] configured with the [`Service`]'s [`StaticConfig`].
+    /// A [`RelayBuilder`] configured with the [`Service`]'s [`ServiceDescription`].
     /// The [`RelayBuilder`] can be further customized before calling [`RelayBuilder::create()`].
     ///
     fn publish_subscribe<'a>(
         &self,
-        static_config: &'a StaticConfig,
+        description: &'a ServiceDescription,
     ) -> Self::PublishSubscribeBuilder<'a>
     where
         Self: 'a;
@@ -173,13 +176,13 @@ pub trait RelayFactory<S: Service> {
     ///
     /// # Parameters
     ///
-    /// * `static_config` - The [`Service`]'s [`StaticConfig`] for which a builder will be created
+    /// * `description` - The [`Service`]'s [`ServiceDescription`] for which a builder will be created
     ///
     /// # Returns
     ///
-    /// A [`RelayBuilder`] configured with the [`Service`]'s [`StaticConfig`].
+    /// A [`RelayBuilder`] configured with the [`Service`]'s [`ServiceDescription`].
     /// The [`RelayBuilder`] can be further customized before calling [`RelayBuilder::create()`].
-    fn event<'a>(&self, static_config: &'a StaticConfig) -> Self::EventBuilder<'a>
+    fn event<'a>(&self, description: &'a ServiceDescription) -> Self::EventBuilder<'a>
     where
         Self: 'a;
 }

--- a/iceoryx2-services/tunnel-backend/src/types/discovery.rs
+++ b/iceoryx2-services/tunnel-backend/src/types/discovery.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use iceoryx2::service::service_hash::ServiceHash;
+
+use crate::types::service_description::ServiceDescription;
+
+/// A change to the set of services offered on one side of the tunnel.
+///
+/// Owning variant.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum DiscoveryUpdate {
+    /// A service became available; carries its description.
+    Added(ServiceDescription),
+    /// A service disappeared; carries its identity.
+    Removed(ServiceHash),
+}
+
+/// A change to the set of services offered on one side of the tunnel.
+///
+/// Non-owning variant.
+#[derive(Debug, Clone, Copy)]
+pub enum DiscoveryUpdateRef<'a> {
+    /// A service became available; carries its description.
+    Added(&'a ServiceDescription),
+    /// A service disappeared; carries its identity.
+    Removed(&'a ServiceHash),
+}
+
+impl<'a> From<&'a DiscoveryUpdate> for DiscoveryUpdateRef<'a> {
+    fn from(update: &'a DiscoveryUpdate) -> Self {
+        match update {
+            DiscoveryUpdate::Added(description) => DiscoveryUpdateRef::Added(description),
+            DiscoveryUpdate::Removed(hash) => DiscoveryUpdateRef::Removed(hash),
+        }
+    }
+}

--- a/iceoryx2-services/tunnel-backend/src/types/mod.rs
+++ b/iceoryx2-services/tunnel-backend/src/types/mod.rs
@@ -10,5 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+pub mod discovery;
 pub mod publish_subscribe;
+pub mod service_description;
 pub mod wake;

--- a/iceoryx2-services/tunnel-backend/src/types/service_description.rs
+++ b/iceoryx2-services/tunnel-backend/src/types/service_description.rs
@@ -50,20 +50,25 @@ impl core::fmt::Display for PatternDescription {
     }
 }
 
+/// Settings for a messaging pattern, either known or absent.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum PatternSettings<T> {
+    Value(T),
+    UnknownApplyDefaults,
+}
+
 /// Description of a publish-subscribe service.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PublishSubscribeDescription {
     pub user_header: TypeDescription,
     pub payload: TypeDescription,
-    /// `None` means unknown; the tunnel then applies local defaults.
-    pub settings: Option<PublishSubscribeSettings>,
+    pub settings: PatternSettings<PublishSubscribeSettings>,
 }
 
 /// Description of an event service.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EventDescription {
-    /// `None` means unknown; the tunnel then applies local defaults.
-    pub settings: Option<EventSettings>,
+    pub settings: PatternSettings<EventSettings>,
 }
 
 /// Description of a services type(s).
@@ -125,7 +130,7 @@ impl TryFrom<&StaticConfig> for ServiceDescription {
                 PatternDescription::PublishSubscribe(PublishSubscribeDescription {
                     payload: (&types.payload).into(),
                     user_header: (&types.user_header).into(),
-                    settings: Some(PublishSubscribeSettings {
+                    settings: PatternSettings::Value(PublishSubscribeSettings {
                         max_subscribers: config.max_subscribers(),
                         max_publishers: config.max_publishers(),
                         max_nodes: config.max_nodes(),
@@ -137,7 +142,7 @@ impl TryFrom<&StaticConfig> for ServiceDescription {
                 })
             }
             MessagingPattern::Event(config) => PatternDescription::Event(EventDescription {
-                settings: Some(EventSettings {
+                settings: PatternSettings::Value(EventSettings {
                     max_notifiers: config.max_notifiers(),
                     max_listeners: config.max_listeners(),
                     max_nodes: config.max_nodes(),
@@ -282,7 +287,7 @@ mod tests {
             eq PatternDescription::PublishSubscribe(PublishSubscribeDescription {
                 user_header: (&TypeDetail::new::<()>(TypeVariant::FixedSize)).into(),
                 payload: (&TypeDetail::new::<u64>(TypeVariant::FixedSize)).into(),
-                settings: Some(PublishSubscribeSettings {
+                settings: PatternSettings::Value(PublishSubscribeSettings {
                     max_subscribers: MAX_SUBSCRIBERS,
                     max_publishers: MAX_PUBLISHERS,
                     max_nodes: MAX_NODES,
@@ -338,7 +343,7 @@ mod tests {
         assert_that!(
             sut.pattern,
             eq PatternDescription::Event(EventDescription {
-                settings: Some(EventSettings {
+                settings: PatternSettings::Value(EventSettings {
                     max_notifiers: MAX_NOTIFIERS,
                     max_listeners: MAX_LISTENERS,
                     max_nodes: MAX_NODES,
@@ -380,7 +385,9 @@ mod tests {
         let PatternDescription::Event(description) = sut.pattern else {
             panic!("expected an event pattern description");
         };
-        let settings = description.settings.unwrap();
+        let PatternSettings::Value(settings) = description.settings else {
+            panic!("expected provided event settings");
+        };
         assert_that!(settings.deadline, eq None);
         assert_that!(settings.notifier_created_event, eq None);
         assert_that!(settings.notifier_dropped_event, eq None);

--- a/iceoryx2-services/tunnel-backend/src/types/service_description.rs
+++ b/iceoryx2-services/tunnel-backend/src/types/service_description.rs
@@ -1,0 +1,414 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use alloc::string::String;
+use core::time::Duration;
+
+use iceoryx2::service::service_hash::ServiceHash;
+use iceoryx2::service::service_name::ServiceName;
+use iceoryx2::service::static_config::StaticConfig;
+use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
+use iceoryx2::service::static_config::messaging_pattern::MessagingPattern;
+
+use serde::{Deserialize, Serialize};
+
+/// Description of a service for creation of both local iceoryx endpoints
+/// and remote backend endpoints.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ServiceDescription {
+    /// The service's identity: keys bridges, discovery state and backend
+    /// wire entries. Computed from (name, pattern) via
+    /// [`ServiceHash::new()`] with the
+    /// [`Service`](iceoryx2::service::Service)'s name hasher.
+    pub service_hash: ServiceHash,
+    pub name: ServiceName,
+    pub pattern: PatternDescription,
+}
+
+/// Description of a services messaging pattern.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum PatternDescription {
+    PublishSubscribe(PublishSubscribeDescription),
+    Event(EventDescription),
+}
+
+impl core::fmt::Display for PatternDescription {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            PatternDescription::PublishSubscribe(_) => write!(f, "PublishSubscribe"),
+            PatternDescription::Event(_) => write!(f, "Event"),
+        }
+    }
+}
+
+/// Description of a publish-subscribe service.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PublishSubscribeDescription {
+    pub user_header: TypeDescription,
+    pub payload: TypeDescription,
+    /// `None` means unknown; the tunnel then applies local defaults.
+    pub settings: Option<PublishSubscribeSettings>,
+}
+
+/// Description of an event service.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EventDescription {
+    /// `None` means unknown; the tunnel then applies local defaults.
+    pub settings: Option<EventSettings>,
+}
+
+/// Description of a services type(s).
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TypeDescription {
+    pub variant: TypeVariant,
+    pub type_name: String,
+    pub size: usize,
+    pub alignment: usize,
+}
+
+/// Settings for publish-subscribe services.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PublishSubscribeSettings {
+    pub max_subscribers: usize,
+    pub max_publishers: usize,
+    pub max_nodes: usize,
+    pub history_size: usize,
+    pub subscriber_max_buffer_size: usize,
+    pub subscriber_max_borrowed_samples: usize,
+    pub safe_overflow: bool,
+}
+
+/// Settings for event services.
+///
+/// `None` in the optional fields means the origin service has the feature
+/// disabled, not that it is unknown.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct EventSettings {
+    pub max_notifiers: usize,
+    pub max_listeners: usize,
+    pub max_nodes: usize,
+    pub event_id_max_value: usize,
+    pub deadline: Option<Duration>,
+    pub notifier_created_event: Option<usize>,
+    pub notifier_dropped_event: Option<usize>,
+    pub notifier_dead_event: Option<usize>,
+}
+
+/// A [`StaticConfig`] whose messaging pattern the tunnel does not support.
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub struct UnsupportedPattern;
+
+impl core::fmt::Display for UnsupportedPattern {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "UnsupportedPattern")
+    }
+}
+
+impl core::error::Error for UnsupportedPattern {}
+
+impl TryFrom<&StaticConfig> for ServiceDescription {
+    type Error = UnsupportedPattern;
+
+    fn try_from(static_config: &StaticConfig) -> Result<Self, Self::Error> {
+        let pattern = match static_config.messaging_pattern() {
+            MessagingPattern::PublishSubscribe(config) => {
+                let types = config.message_type_details();
+                PatternDescription::PublishSubscribe(PublishSubscribeDescription {
+                    payload: (&types.payload).into(),
+                    user_header: (&types.user_header).into(),
+                    settings: Some(PublishSubscribeSettings {
+                        max_subscribers: config.max_subscribers(),
+                        max_publishers: config.max_publishers(),
+                        max_nodes: config.max_nodes(),
+                        history_size: config.history_size(),
+                        subscriber_max_buffer_size: config.subscriber_max_buffer_size(),
+                        subscriber_max_borrowed_samples: config.subscriber_max_borrowed_samples(),
+                        safe_overflow: config.has_safe_overflow(),
+                    }),
+                })
+            }
+            MessagingPattern::Event(config) => PatternDescription::Event(EventDescription {
+                settings: Some(EventSettings {
+                    max_notifiers: config.max_notifiers(),
+                    max_listeners: config.max_listeners(),
+                    max_nodes: config.max_nodes(),
+                    event_id_max_value: config.event_id_max_value(),
+                    deadline: config.deadline(),
+                    notifier_created_event: config.notifier_created_event().map(|id| id.as_value()),
+                    notifier_dropped_event: config.notifier_dropped_event().map(|id| id.as_value()),
+                    notifier_dead_event: config.notifier_dead_event().map(|id| id.as_value()),
+                }),
+            }),
+            _ => return Err(UnsupportedPattern),
+        };
+
+        Ok(Self {
+            service_hash: *static_config.service_hash(),
+            name: *static_config.name(),
+            pattern,
+        })
+    }
+}
+
+impl From<&TypeDetail> for TypeDescription {
+    fn from(detail: &TypeDetail) -> Self {
+        Self {
+            variant: detail.variant(),
+            type_name: String::from_utf8_lossy(detail.type_name()).into_owned(),
+            size: detail.size(),
+            alignment: detail.alignment(),
+        }
+    }
+}
+
+/// A [`TypeDescription`] that cannot be represented as a core
+/// [`TypeDetail`].
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum InvalidTypeDescription {
+    TypeNameTooLong,
+}
+
+impl core::fmt::Display for InvalidTypeDescription {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "InvalidTypeDescription::{self:?}")
+    }
+}
+
+impl core::error::Error for InvalidTypeDescription {}
+
+impl TryFrom<&TypeDescription> for TypeDetail {
+    type Error = InvalidTypeDescription;
+
+    fn try_from(description: &TypeDescription) -> Result<Self, Self::Error> {
+        TypeDetail::__internal_new_from_parts(
+            description.variant,
+            &description.type_name,
+            description.size,
+            description.alignment,
+        )
+        .map_err(|_| InvalidTypeDescription::TypeNameTooLong)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use iceoryx2::constants::MAX_TYPE_NAME_LENGTH;
+    use iceoryx2::prelude::*;
+    use iceoryx2::service::Service as _;
+    use iceoryx2::service::local::Service;
+    use iceoryx2::service::messaging_pattern::MessagingPattern;
+    use iceoryx2::testing::*;
+    use iceoryx2_bb_testing::assert_that;
+
+    #[test]
+    fn round_trips_type_detail() {
+        let detail = TypeDetail::new::<u64>(TypeVariant::FixedSize);
+
+        let description = TypeDescription::from(&detail);
+        assert_that!(description.variant, eq TypeVariant::FixedSize);
+        assert_that!(description.type_name, eq "u64");
+        assert_that!(description.size, eq core::mem::size_of::<u64>());
+        assert_that!(description.alignment, eq core::mem::align_of::<u64>());
+
+        let round_tripped = TypeDetail::try_from(&description).unwrap();
+        assert_that!(round_tripped, eq detail);
+    }
+
+    #[test]
+    fn rejects_overlong_type_name() {
+        let description = TypeDescription {
+            variant: TypeVariant::FixedSize,
+            type_name: "x".repeat(MAX_TYPE_NAME_LENGTH + 1),
+            size: 1,
+            alignment: 1,
+        };
+
+        let result = TypeDetail::try_from(&description);
+        assert_that!(result, eq Err(InvalidTypeDescription::TypeNameTooLong));
+    }
+
+    #[test]
+    fn maps_publish_subscribe_static_config() {
+        const MAX_SUBSCRIBERS: usize = 11;
+        const MAX_PUBLISHERS: usize = 7;
+        const MAX_NODES: usize = 19;
+        const HISTORY_SIZE: usize = 9;
+        const SUBSCRIBER_MAX_BUFFER_SIZE: usize = 13;
+        const SUBSCRIBER_MAX_BORROWED_SAMPLES: usize = 3;
+        const SAFE_OVERFLOW: bool = true;
+
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new()
+            .config(&config)
+            .create::<Service>()
+            .unwrap();
+        let service_name = generate_service_name();
+
+        let _service = node
+            .service_builder(&service_name)
+            .publish_subscribe::<u64>()
+            .max_subscribers(MAX_SUBSCRIBERS)
+            .max_publishers(MAX_PUBLISHERS)
+            .max_nodes(MAX_NODES)
+            .history_size(HISTORY_SIZE)
+            .subscriber_max_buffer_size(SUBSCRIBER_MAX_BUFFER_SIZE)
+            .subscriber_max_borrowed_samples(SUBSCRIBER_MAX_BORROWED_SAMPLES)
+            .enable_safe_overflow(SAFE_OVERFLOW)
+            .create()
+            .unwrap();
+
+        let static_config =
+            Service::details(&service_name, &config, MessagingPattern::PublishSubscribe)
+                .unwrap()
+                .unwrap()
+                .static_details;
+        let sut = ServiceDescription::try_from(&static_config).unwrap();
+
+        assert_that!(sut.name, eq service_name);
+        assert_that!(sut.service_hash, eq * static_config.service_hash());
+        assert_that!(
+            sut.pattern,
+            eq PatternDescription::PublishSubscribe(PublishSubscribeDescription {
+                user_header: (&TypeDetail::new::<()>(TypeVariant::FixedSize)).into(),
+                payload: (&TypeDetail::new::<u64>(TypeVariant::FixedSize)).into(),
+                settings: Some(PublishSubscribeSettings {
+                    max_subscribers: MAX_SUBSCRIBERS,
+                    max_publishers: MAX_PUBLISHERS,
+                    max_nodes: MAX_NODES,
+                    history_size: HISTORY_SIZE,
+                    subscriber_max_buffer_size: SUBSCRIBER_MAX_BUFFER_SIZE,
+                    subscriber_max_borrowed_samples: SUBSCRIBER_MAX_BORROWED_SAMPLES,
+                    safe_overflow: SAFE_OVERFLOW,
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn maps_event_static_config() {
+        const MAX_NOTIFIERS: usize = 7;
+        const MAX_LISTENERS: usize = 11;
+        const MAX_NODES: usize = 19;
+        const EVENT_ID_MAX_VALUE: usize = 37;
+        const DEADLINE: Duration = Duration::from_millis(100);
+        const NOTIFIER_CREATED_EVENT: usize = 21;
+        const NOTIFIER_DROPPED_EVENT: usize = 22;
+        const NOTIFIER_DEAD_EVENT: usize = 23;
+
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new()
+            .config(&config)
+            .create::<Service>()
+            .unwrap();
+        let service_name = generate_service_name();
+
+        let _service = node
+            .service_builder(&service_name)
+            .event()
+            .max_notifiers(MAX_NOTIFIERS)
+            .max_listeners(MAX_LISTENERS)
+            .max_nodes(MAX_NODES)
+            .event_id_max_value(EVENT_ID_MAX_VALUE)
+            .deadline(DEADLINE)
+            .notifier_created_event(EventId::new(NOTIFIER_CREATED_EVENT))
+            .notifier_dropped_event(EventId::new(NOTIFIER_DROPPED_EVENT))
+            .notifier_dead_event(EventId::new(NOTIFIER_DEAD_EVENT))
+            .create()
+            .unwrap();
+
+        let static_config = Service::details(&service_name, &config, MessagingPattern::Event)
+            .unwrap()
+            .unwrap()
+            .static_details;
+        let sut = ServiceDescription::try_from(&static_config).unwrap();
+
+        assert_that!(sut.name, eq service_name);
+        assert_that!(sut.service_hash, eq * static_config.service_hash());
+        assert_that!(
+            sut.pattern,
+            eq PatternDescription::Event(EventDescription {
+                settings: Some(EventSettings {
+                    max_notifiers: MAX_NOTIFIERS,
+                    max_listeners: MAX_LISTENERS,
+                    max_nodes: MAX_NODES,
+                    event_id_max_value: EVENT_ID_MAX_VALUE,
+                    deadline: Some(DEADLINE),
+                    notifier_created_event: Some(NOTIFIER_CREATED_EVENT),
+                    notifier_dropped_event: Some(NOTIFIER_DROPPED_EVENT),
+                    notifier_dead_event: Some(NOTIFIER_DEAD_EVENT),
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn maps_disabled_event_features_to_none() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new()
+            .config(&config)
+            .create::<Service>()
+            .unwrap();
+        let service_name = generate_service_name();
+
+        let _service = node
+            .service_builder(&service_name)
+            .event()
+            .disable_deadline()
+            .disable_notifier_created_event()
+            .disable_notifier_dropped_event()
+            .disable_notifier_dead_event()
+            .create()
+            .unwrap();
+
+        let static_config = Service::details(&service_name, &config, MessagingPattern::Event)
+            .unwrap()
+            .unwrap()
+            .static_details;
+        let sut = ServiceDescription::try_from(&static_config).unwrap();
+
+        let PatternDescription::Event(description) = sut.pattern else {
+            panic!("expected an event pattern description");
+        };
+        let settings = description.settings.unwrap();
+        assert_that!(settings.deadline, eq None);
+        assert_that!(settings.notifier_created_event, eq None);
+        assert_that!(settings.notifier_dropped_event, eq None);
+        assert_that!(settings.notifier_dead_event, eq None);
+    }
+
+    #[test]
+    fn rejects_unsupported_messaging_pattern() {
+        let config = generate_isolated_config();
+        let node = NodeBuilder::new()
+            .config(&config)
+            .create::<Service>()
+            .unwrap();
+        let service_name = generate_service_name();
+
+        let _service = node
+            .service_builder(&service_name)
+            .request_response::<u64, u64>()
+            .create()
+            .unwrap();
+
+        let static_config =
+            Service::details(&service_name, &config, MessagingPattern::RequestResponse)
+                .unwrap()
+                .unwrap()
+                .static_details;
+        let result = ServiceDescription::try_from(&static_config);
+
+        assert_that!(result, eq Err(UnsupportedPattern));
+    }
+}

--- a/iceoryx2-services/tunnel-testing/src/backend/discovery.rs
+++ b/iceoryx2-services/tunnel-testing/src/backend/discovery.rs
@@ -15,7 +15,7 @@
 #![warn(clippy::std_instead_of_core)]
 
 use alloc::rc::Rc;
-use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
+use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 
 use crate::backend::session::Session;
 
@@ -62,32 +62,32 @@ impl iceoryx2_services_tunnel_backend::traits::Discovery for Discovery {
 
     type AnnouncementError = AnnouncementError;
 
-    fn announce(&self, event: DiscoveryEventRef<'_>) -> Result<(), Self::AnnouncementError> {
-        match event {
-            DiscoveryEventRef::Added(static_config) => self
+    fn announce(&self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
+        match update {
+            DiscoveryUpdateRef::Added(description) => self
                 .session
-                .announce_added(static_config)
+                .announce_added(description)
                 .map_err(AnnouncementError::AnnounceAdded),
-            DiscoveryEventRef::Removed(service_hash) => self
+            DiscoveryUpdateRef::Removed(service_hash) => self
                 .session
                 .announce_removed(service_hash)
                 .map_err(AnnouncementError::AnnounceRemoved),
         }
     }
 
-    fn discover<E: core::error::Error, F: FnMut(DiscoveryEvent) -> Result<(), E>>(
+    fn discover<E: core::error::Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
         &self,
         mut process_discovery: F,
     ) -> Result<(), Self::DiscoveryError> {
         self.session.discover();
         let (added, removed) = self.session.pending_discoveries();
 
-        for static_config in added {
-            process_discovery(DiscoveryEvent::Added(static_config))
+        for description in added {
+            process_discovery(DiscoveryUpdate::Added(description))
                 .map_err(|_| DiscoveryError::Processing)?;
         }
         for service_hash in removed {
-            process_discovery(DiscoveryEvent::Removed(service_hash))
+            process_discovery(DiscoveryUpdate::Removed(service_hash))
                 .map_err(|_| DiscoveryError::Processing)?;
         }
 

--- a/iceoryx2-services/tunnel-testing/src/backend/relays/event.rs
+++ b/iceoryx2-services/tunnel-testing/src/backend/relays/event.rs
@@ -17,9 +17,10 @@
 use alloc::rc::Rc;
 use iceoryx2::{
     port::event_id::EventId,
-    service::{Service, service_hash::ServiceHash, static_config::StaticConfig},
+    service::{Service, service_hash::ServiceHash},
 };
 use iceoryx2_services_tunnel_backend::traits::{EventRelay, RelayBuilder};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 
 use crate::backend::session::{self, Session};
 
@@ -63,15 +64,15 @@ impl core::error::Error for ReceiveError {}
 #[derive(Debug)]
 pub struct Builder<'a, S: Service> {
     session: Rc<Session>,
-    static_config: &'a StaticConfig,
+    description: &'a ServiceDescription,
     _phantom: core::marker::PhantomData<S>,
 }
 
 impl<'a, S: Service> Builder<'a, S> {
-    pub fn new(session: Rc<Session>, static_config: &'a StaticConfig) -> Self {
+    pub fn new(session: Rc<Session>, description: &'a ServiceDescription) -> Self {
         Self {
             session,
-            static_config,
+            description,
             _phantom: core::marker::PhantomData,
         }
     }
@@ -84,7 +85,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
     fn create(self) -> Result<Self::Relay, Self::CreationError> {
         Ok(Relay {
             session: self.session,
-            service_hash: *self.static_config.service_hash(),
+            service_hash: self.description.service_hash,
             _phantom: core::marker::PhantomData,
         })
     }

--- a/iceoryx2-services/tunnel-testing/src/backend/relays/factory.rs
+++ b/iceoryx2-services/tunnel-testing/src/backend/relays/factory.rs
@@ -17,6 +17,7 @@
 use alloc::rc::Rc;
 use iceoryx2::service::Service;
 use iceoryx2_services_tunnel_backend::traits::RelayFactory;
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 
 use crate::backend::{
     relays::{event, publish_subscribe},
@@ -53,21 +54,18 @@ impl<S: Service> RelayFactory<S> for Factory<S> {
 
     fn publish_subscribe<'a>(
         &self,
-        static_config: &'a iceoryx2::service::static_config::StaticConfig,
+        description: &'a ServiceDescription,
     ) -> Self::PublishSubscribeBuilder<'a>
     where
         Self: 'a,
     {
-        publish_subscribe::Builder::new(self.session.clone(), static_config)
+        publish_subscribe::Builder::new(self.session.clone(), description)
     }
 
-    fn event<'a>(
-        &self,
-        static_config: &'a iceoryx2::service::static_config::StaticConfig,
-    ) -> Self::EventBuilder<'a>
+    fn event<'a>(&self, description: &'a ServiceDescription) -> Self::EventBuilder<'a>
     where
         Self: 'a,
     {
-        event::Builder::new(self.session.clone(), static_config)
+        event::Builder::new(self.session.clone(), description)
     }
 }

--- a/iceoryx2-services/tunnel-testing/src/backend/relays/publish_subscribe.rs
+++ b/iceoryx2-services/tunnel-testing/src/backend/relays/publish_subscribe.rs
@@ -16,9 +16,12 @@
 
 use alloc::rc::Rc;
 use alloc::vec::Vec;
+use iceoryx2::service::Service;
 use iceoryx2::service::marker::CustomHeaderMarker;
-use iceoryx2::service::{Service, static_config::StaticConfig};
 use iceoryx2_services_tunnel_backend::traits::{PublishSubscribeRelay, RelayBuilder};
+use iceoryx2_services_tunnel_backend::types::service_description::{
+    PatternDescription, ServiceDescription,
+};
 
 use crate::backend::session::{self, Session};
 
@@ -63,15 +66,15 @@ impl core::error::Error for ReceiveError {}
 #[derive(Debug)]
 pub struct Builder<'a, S: Service> {
     session: Rc<Session>,
-    static_config: &'a StaticConfig,
+    description: &'a ServiceDescription,
     _phantom: core::marker::PhantomData<S>,
 }
 
 impl<'a, S: Service> Builder<'a, S> {
-    pub fn new(session: Rc<Session>, static_config: &'a StaticConfig) -> Self {
+    pub fn new(session: Rc<Session>, description: &'a ServiceDescription) -> Self {
         Self {
             session,
-            static_config,
+            description,
             _phantom: core::marker::PhantomData,
         }
     }
@@ -84,7 +87,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
     fn create(self) -> Result<Self::Relay, Self::CreationError> {
         Ok(Relay {
             session: self.session,
-            static_config: self.static_config.clone(),
+            description: self.description.clone(),
             _phantom: core::marker::PhantomData,
         })
     }
@@ -93,7 +96,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
 #[derive(Debug)]
 pub struct Relay<S: Service> {
     session: Rc<Session>,
-    static_config: StaticConfig,
+    description: ServiceDescription,
     _phantom: core::marker::PhantomData<S>,
 }
 
@@ -112,7 +115,7 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
         let header_bytes: Vec<u8> = unsafe {
             core::slice::from_raw_parts(
                 user_header as *const CustomHeaderMarker as *const u8,
-                user_header_size(&self.static_config),
+                user_header_size(&self.description),
             )
         }
         .to_vec();
@@ -121,11 +124,7 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
                 .to_vec();
 
         self.session
-            .send_sample(
-                self.static_config.service_hash(),
-                header_bytes,
-                payload_bytes,
-            )
+            .send_sample(&self.description.service_hash, header_bytes, payload_bytes)
             .map_err(SendError::SendSample)
     }
 
@@ -142,7 +141,7 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
     > {
         let received = match self
             .session
-            .recv_sample(self.static_config.service_hash())
+            .recv_sample(&self.description.service_hash)
             .map_err(ReceiveError::ReceiveSample)?
         {
             Some(s) => s,
@@ -151,7 +150,7 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
 
         let mut sample = loan(received.payload.len()).map_err(|_| ReceiveError::LoanSample)?;
 
-        let header_size = user_header_size(&self.static_config);
+        let header_size = user_header_size(&self.description);
         debug_assert_eq!(received.header.len(), header_size);
         debug_assert!(sample.payload_mut().len() >= received.payload.len());
 
@@ -171,10 +170,9 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
     }
 }
 
-fn user_header_size(static_config: &StaticConfig) -> usize {
-    static_config
-        .publish_subscribe()
-        .message_type_details()
-        .user_header
-        .size()
+fn user_header_size(description: &ServiceDescription) -> usize {
+    let PatternDescription::PublishSubscribe(description) = &description.pattern else {
+        unreachable!("relay is only built for publish-subscribe descriptions")
+    };
+    description.user_header.size
 }

--- a/iceoryx2-services/tunnel-testing/src/backend/session.rs
+++ b/iceoryx2-services/tunnel-testing/src/backend/session.rs
@@ -22,7 +22,6 @@ use serde::{Deserialize, Serialize};
 
 use iceoryx2::prelude::SemanticStringError;
 use iceoryx2::service::service_hash::ServiceHash;
-use iceoryx2::service::static_config::StaticConfig;
 use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_bb_elementary::math::ToB64;
 use iceoryx2_bb_posix::creation_mode::CreationMode;
@@ -45,6 +44,7 @@ use iceoryx2_bb_posix::unix_datagram_socket::{
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;
 use iceoryx2_bb_system_types::path::Path;
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 
 use crate::backend::settings::{
     LOCKFILE_NAME, MAX_DATAGRAM, ROOT_DIR, SERVICES_DIR_NAME, SESSIONS_DIR_NAME, SOCKET_NAME,
@@ -118,7 +118,7 @@ type SessionId = String;
 
 #[derive(Debug, Default)]
 struct PendingDiscovery {
-    added: Vec<StaticConfig>,
+    added: Vec<ServiceDescription>,
     removed: Vec<ServiceHash>,
 }
 
@@ -275,9 +275,9 @@ impl Session {
     }
 
     /// Make a service offered by this session discoverable to peers.
-    pub fn announce_added(&self, static_config: &StaticConfig) -> Result<(), AnnounceError> {
+    pub fn announce_added(&self, description: &ServiceDescription) -> Result<(), AnnounceError> {
         let path = file_path_in_directory(
-            static_config.service_hash().as_str().as_bytes(),
+            description.service_hash.as_str().as_bytes(),
             &self.services_dir_path,
         )
         .map_err(AnnounceError::Path)?;
@@ -293,7 +293,7 @@ impl Session {
             .create()
             .map_err(AnnounceError::FileCreate)?;
 
-        let bytes = postcard::to_allocvec(static_config).map_err(|_| AnnounceError::Encode)?;
+        let bytes = postcard::to_allocvec(description).map_err(|_| AnnounceError::Encode)?;
         file.write(&bytes).map_err(AnnounceError::FileWrite)?;
 
         Ok(())
@@ -343,7 +343,7 @@ impl Session {
 
     /// Drain (added, removed) service-discovery events accumulated since the
     /// last call.
-    pub fn pending_discoveries(&self) -> (Vec<StaticConfig>, Vec<ServiceHash>) {
+    pub fn pending_discoveries(&self) -> (Vec<ServiceDescription>, Vec<ServiceHash>) {
         let mut pending = self.pending_discoveries.borrow_mut();
         let added = core::mem::take(&mut pending.added);
         let removed = core::mem::take(&mut pending.removed);
@@ -544,7 +544,9 @@ impl Session {
     }
 
     /// Return the services a peer is currently announcing.
-    fn discover_peer_services(services_dir_path: &Path) -> BTreeMap<ServiceHash, StaticConfig> {
+    fn discover_peer_services(
+        services_dir_path: &Path,
+    ) -> BTreeMap<ServiceHash, ServiceDescription> {
         let mut discovered_services = BTreeMap::new();
 
         let services_dir = match Directory::new(services_dir_path) {
@@ -570,11 +572,11 @@ impl Session {
             if file.read_to_vector(&mut bytes).is_err() {
                 continue;
             }
-            let static_config: StaticConfig = match postcard::from_bytes(&bytes) {
+            let description: ServiceDescription = match postcard::from_bytes(&bytes) {
                 Ok(c) => c,
                 Err(_) => continue,
             };
-            discovered_services.insert(*static_config.service_hash(), static_config);
+            discovered_services.insert(description.service_hash, description);
         }
 
         discovered_services

--- a/iceoryx2-services/tunnel/src/bridge.rs
+++ b/iceoryx2-services/tunnel/src/bridge.rs
@@ -15,13 +15,14 @@ use alloc::format;
 use iceoryx2::identifiers::UniqueNodeId;
 use iceoryx2::node::Node;
 use iceoryx2::service::Service;
-use iceoryx2::service::static_config::StaticConfig;
-use iceoryx2::service::static_config::messaging_pattern::MessagingPattern;
 use iceoryx2_log::{fail, info};
 use iceoryx2_services_tunnel_backend::traits::{
     Backend, EventRelay, PublishSubscribeRelay, RelayBuilder, RelayFactory,
 };
 use iceoryx2_services_tunnel_backend::types::publish_subscribe::LoanFn;
+use iceoryx2_services_tunnel_backend::types::service_description::{
+    PatternDescription, ServiceDescription,
+};
 
 use crate::ports::event::EventPorts;
 use crate::ports::publish_subscribe::PublishSubscribePorts;
@@ -44,51 +45,44 @@ pub(crate) enum Bridge<S: Service, B: Backend<S>> {
 
 impl<S: Service, B: Backend<S>> Bridge<S, B> {
     /// Creates the ports and relay matching the messaging pattern of
-    /// `static_config`.
+    /// `description`.
     pub(crate) fn open(
         node: &Node<S>,
         backend: &B,
-        static_config: &StaticConfig,
+        description: &ServiceDescription,
     ) -> Result<Self, DiscoveryError> {
         let origin = "Bridge::open";
 
-        match static_config.messaging_pattern() {
-            MessagingPattern::PublishSubscribe(_) => {
+        match &description.pattern {
+            PatternDescription::PublishSubscribe(pattern_description) => {
                 let ports = fail!(
                     from origin,
-                    when PublishSubscribePorts::new(static_config, node),
+                    when PublishSubscribePorts::new(&description.name, pattern_description, node),
                     with DiscoveryError::PublishSubscribePortCreation,
                     "Failed to create publish-subscribe ports"
                 );
                 let relay = fail!(
                     from origin,
-                    when backend.relay_builder().publish_subscribe(static_config).create(),
+                    when backend.relay_builder().publish_subscribe(description).create(),
                     with DiscoveryError::PublishSubscribeRelayCreation,
                     "Failed to create publish-subscribe relay"
                 );
                 Ok(Bridge::PublishSubscribe { ports, relay })
             }
-            MessagingPattern::Event(_) => {
+            PatternDescription::Event(pattern_description) => {
                 let ports = fail!(
                     from origin,
-                    when EventPorts::new(static_config, node),
+                    when EventPorts::new(&description.name, pattern_description, node),
                     with DiscoveryError::EventPortsCreation,
                     "Failed to create event ports"
                 );
                 let relay = fail!(
                     from origin,
-                    when backend.relay_builder().event(static_config).create(),
+                    when backend.relay_builder().event(description).create(),
                     with DiscoveryError::EventRelayCreation,
                     "Failed to create event relay"
                 );
                 Ok(Bridge::Event { ports, relay })
-            }
-            pattern => {
-                fail!(
-                    from origin,
-                    with DiscoveryError::UnsupportedMessagingPattern,
-                    "Cannot open bridge for unsupported messaging pattern: {}", pattern
-                );
             }
         }
     }
@@ -120,12 +114,7 @@ fn propagate_publish_subscribe_payloads<S: Service, B: Backend<S>>(
         "Failed to receive publish-subscribe payload for propagation"
     );
     if propagated {
-        info!(
-            from origin,
-            "Propagated {}({})",
-            port.static_config.messaging_pattern(),
-            port.static_config.name()
-        );
+        info!(from origin, "Propagated PublishSubscribe({})", port.name);
     }
 
     let ingested = fail!(
@@ -138,12 +127,7 @@ fn propagate_publish_subscribe_payloads<S: Service, B: Backend<S>>(
         "Failed to ingest publish-subscribe payload received from backend"
     );
     if ingested {
-        info!(
-            from origin,
-            "Ingested {}({})",
-            port.static_config.messaging_pattern(),
-            port.static_config.name()
-        );
+        info!(from origin, "Ingested PublishSubscribe({})", port.name);
     }
 
     Ok(())
@@ -165,12 +149,7 @@ fn propagate_events<S: Service, B: Backend<S>>(
         "Failed to receive events for propagation"
     );
     if propagated {
-        info!(
-            from origin,
-            "Propagated {}({})",
-            port.static_config.messaging_pattern(),
-            port.static_config.name()
-        );
+        info!(from origin, "Propagated Event({})", port.name);
     }
 
     let ingested = fail!(
@@ -182,12 +161,7 @@ fn propagate_events<S: Service, B: Backend<S>>(
         "Failed to ingest event received from backend"
     );
     if ingested {
-        info!(
-            from origin,
-            "Ingested {}({})",
-            port.static_config.messaging_pattern(),
-            port.static_config.name()
-        );
+        info!(from origin, "Ingested Event({})", port.name);
     }
 
     Ok(())

--- a/iceoryx2-services/tunnel/src/discovery/state.rs
+++ b/iceoryx2-services/tunnel/src/discovery/state.rs
@@ -13,7 +13,7 @@
 use alloc::collections::BTreeMap;
 
 use iceoryx2::service::service_hash::ServiceHash;
-use iceoryx2::service::static_config::StaticConfig;
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 
 /// Side of the system that a discovery event refers to.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -26,7 +26,7 @@ pub(crate) enum Origin {
 
 #[derive(Debug)]
 struct OfferedService {
-    static_config: StaticConfig,
+    description: ServiceDescription,
     last_seen: u64,
 }
 
@@ -44,50 +44,50 @@ impl OfferedServices {
         self.epoch
     }
 
-    /// Records `config` as offered, stamping it with `epoch`. The caller passes
-    /// its session epoch so all updates in a session share one stamp.
-    fn insert(&mut self, config: StaticConfig, epoch: u64) {
+    /// Records `description` as offered, stamping it with `epoch`. The caller
+    /// passes its session epoch so all updates in a session share one stamp.
+    fn insert(&mut self, description: ServiceDescription, epoch: u64) {
         self.offered.insert(
-            *config.service_hash(),
+            description.service_hash,
             OfferedService {
-                static_config: config,
+                description,
                 last_seen: epoch,
             },
         );
     }
 
-    /// Removes `hash`, returning its [`StaticConfig`] if it was offered.
-    fn remove(&mut self, hash: &ServiceHash) -> Option<StaticConfig> {
-        self.offered.remove(hash).map(|o| o.static_config)
+    /// Removes `hash`, returning its [`ServiceDescription`] if it was offered.
+    fn remove(&mut self, hash: &ServiceHash) -> Option<ServiceDescription> {
+        self.offered.remove(hash).map(|o| o.description)
     }
 
     fn contains(&self, hash: &ServiceHash) -> bool {
         self.offered.contains_key(hash)
     }
 
-    fn iter(&self) -> impl Iterator<Item = (&ServiceHash, &StaticConfig)> {
+    fn iter(&self) -> impl Iterator<Item = (&ServiceHash, &ServiceDescription)> {
         self.offered
             .iter()
-            .map(|(hash, offered_service)| (hash, &offered_service.static_config))
+            .map(|(hash, offered_service)| (hash, &offered_service.description))
     }
 
     /// Reconciles the offered services, taking an external collection as the
     /// target.
-    fn reconcile<'c, E>(
+    fn reconcile<E>(
         &mut self,
-        target: impl Iterator<Item = &'c StaticConfig>,
-        mut on_added: impl FnMut(&StaticConfig) -> Result<(), E>,
-        mut on_removed: impl FnMut(&StaticConfig) -> Result<(), E>,
+        target: impl Iterator<Item = ServiceDescription>,
+        mut on_added: impl FnMut(&ServiceDescription) -> Result<(), E>,
+        mut on_removed: impl FnMut(&ServiceDescription) -> Result<(), E>,
     ) -> Result<(), E> {
         let epoch = self.next_epoch();
 
-        for static_config in target {
-            let hash = *static_config.service_hash();
+        for description in target {
+            let hash = description.service_hash;
             if let Some(offered_service) = self.offered.get_mut(&hash) {
                 offered_service.last_seen = epoch;
             } else {
-                on_added(static_config)?;
-                self.insert(static_config.clone(), epoch);
+                on_added(&description)?;
+                self.insert(description, epoch);
             }
         }
 
@@ -97,7 +97,7 @@ impl OfferedServices {
                 true
             } else {
                 if result.is_ok() {
-                    result = on_removed(&offered_service.static_config);
+                    result = on_removed(&offered_service.description);
                 }
                 false
             }
@@ -115,7 +115,7 @@ pub(crate) struct Snapshot<'a> {
 impl<'a> Snapshot<'a> {
     /// All offered services. A service offered by both sides
     /// appears only once.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&'a ServiceHash, &'a StaticConfig)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&'a ServiceHash, &'a ServiceDescription)> {
         let local = self.local;
         local.iter().chain(
             self.remote
@@ -149,14 +149,14 @@ impl DeltaUpdate<'_> {
         self.offered_services.contains(hash)
     }
 
-    /// Records `static_config` as offered, stamped with this handle's epoch.
-    pub(crate) fn set_offered(&mut self, static_config: StaticConfig) {
-        self.offered_services.insert(static_config, self.epoch);
+    /// Records `description` as offered, stamped with this handle's epoch.
+    pub(crate) fn set_offered(&mut self, description: ServiceDescription) {
+        self.offered_services.insert(description, self.epoch);
     }
 
-    /// Marks `hash` as no longer offered, returning its [`StaticConfig`] if it
-    /// was offered.
-    pub(crate) fn set_not_offered(&mut self, hash: &ServiceHash) -> Option<StaticConfig> {
+    /// Marks `hash` as no longer offered, returning its [`ServiceDescription`]
+    /// if it was offered.
+    pub(crate) fn set_not_offered(&mut self, hash: &ServiceHash) -> Option<ServiceDescription> {
         self.offered_services.remove(hash)
     }
 }
@@ -187,12 +187,12 @@ impl DiscoveryState {
 
     /// Forces `origin`'s offerings to match an external target set, calling
     /// the provided callbacks on addition or removal.
-    pub(crate) fn force_update<'c, E>(
+    pub(crate) fn force_update<E>(
         &mut self,
         origin: Origin,
-        target: impl Iterator<Item = &'c StaticConfig>,
-        on_added: impl FnMut(&StaticConfig) -> Result<(), E>,
-        on_removed: impl FnMut(&StaticConfig) -> Result<(), E>,
+        target: impl Iterator<Item = ServiceDescription>,
+        on_added: impl FnMut(&ServiceDescription) -> Result<(), E>,
+        on_removed: impl FnMut(&ServiceDescription) -> Result<(), E>,
     ) -> Result<(), E> {
         match origin {
             Origin::Local => self.local.reconcile(target, on_added, on_removed),

--- a/iceoryx2-services/tunnel/src/discovery/subscriber.rs
+++ b/iceoryx2-services/tunnel/src/discovery/subscriber.rs
@@ -15,10 +15,12 @@ use alloc::format;
 use iceoryx2::node::Node;
 use iceoryx2::prelude::ServiceName;
 use iceoryx2::{port::subscriber::Subscriber, service::Service};
+use iceoryx2_log::debug;
 use iceoryx2_log::fail;
-
-use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
+use iceoryx2_services_common::DiscoveryEvent;
 use iceoryx2_services_tunnel_backend::traits::Discovery;
+use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum CreationError {
@@ -90,37 +92,56 @@ impl<S: Service> Discovery for DiscoverySubscriber<S> {
     type DiscoveryError = DiscoveryError;
     type AnnouncementError = AnnouncementError;
 
-    fn announce(&self, _event: DiscoveryEventRef<'_>) -> Result<(), Self::AnnouncementError> {
+    fn announce(&self, _update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
         // Nothing to do - local announcement handled by creating `iceoryx2`
         // [`Service`](iceoryx2::service::Service)s.
         Ok(())
     }
 
-    fn discover<E: core::error::Error, F: FnMut(DiscoveryEvent) -> Result<(), E>>(
+    fn discover<E: core::error::Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
         &self,
         mut process_discovery: F,
     ) -> Result<(), Self::DiscoveryError> {
         let subscriber = &self.0;
+
         loop {
-            match subscriber.receive() {
-                Ok(Some(sample)) => {
-                    // Clone: Owning copy to allow the sample to be freed.
-                    fail!(
-                        from self,
-                        when process_discovery(sample.payload().clone()),
-                        with DiscoveryError::DiscoveryProcessing,
-                        "Failed to process discovery event"
-                    );
-                }
-                Ok(None) => break Ok(()),
-                Err(_) => {
-                    fail!(
-                        from self,
-                        with DiscoveryError::ReceivingFromIceoryx,
-                        "Failed to receive from discovery subscriber"
-                    );
-                }
-            }
+            let sample = fail!(
+                from self,
+                when subscriber.receive(),
+                with DiscoveryError::ReceivingFromIceoryx,
+                "Failed to receive from discovery subscriber"
+            );
+            let Some(sample) = sample else {
+                return Ok(());
+            };
+            let Some(update) = to_discovery_update(sample.payload()) else {
+                continue;
+            };
+
+            fail!(
+                from self,
+                when process_discovery(update),
+                with DiscoveryError::DiscoveryProcessing,
+                "Failed to process discovery event"
+            );
         }
+    }
+}
+
+// TODO: Consider merging these structs
+/// Converts a discovery-service event into a tunnel [`DiscoveryUpdate`].
+fn to_discovery_update(event: &DiscoveryEvent) -> Option<DiscoveryUpdate> {
+    match event {
+        DiscoveryEvent::Added(static_config) => match ServiceDescription::try_from(static_config) {
+            Ok(description) => Some(DiscoveryUpdate::Added(description)),
+            Err(_) => {
+                debug!(
+                    "Skipping service with unsupported messaging pattern: {}",
+                    static_config.name()
+                );
+                None
+            }
+        },
+        DiscoveryEvent::Removed(hash) => Some(DiscoveryUpdate::Removed(*hash)),
     }
 }

--- a/iceoryx2-services/tunnel/src/ports/event.rs
+++ b/iceoryx2-services/tunnel/src/ports/event.rs
@@ -21,7 +21,7 @@ use iceoryx2::{
 };
 use iceoryx2_log::{fail, trace};
 use iceoryx2_services_tunnel_backend::types::service_description::{
-    EventDescription, EventSettings,
+    EventDescription, EventSettings, PatternSettings,
 };
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -84,9 +84,8 @@ impl<S: Service> EventPorts<S> {
 
         let builder = node.service_builder(name).event();
         let builder = match &description.settings {
-            Some(settings) => apply_settings(builder, settings),
-            // Use defaults if no settings specified.
-            None => builder,
+            PatternSettings::Value(settings) => apply_settings(builder, settings),
+            PatternSettings::UnknownApplyDefaults => builder,
         };
 
         let service = fail!(

--- a/iceoryx2-services/tunnel/src/ports/event.rs
+++ b/iceoryx2-services/tunnel/src/ports/event.rs
@@ -17,9 +17,12 @@ use iceoryx2::{
     node::Node,
     port::{listener::Listener, notifier::Notifier},
     prelude::EventId,
-    service::{Service, static_config::StaticConfig},
+    service::{Service, builder::event, service_name::ServiceName},
 };
 use iceoryx2_log::{fail, trace};
+use iceoryx2_services_tunnel_backend::types::service_description::{
+    EventDescription, EventSettings,
+};
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum CreationError {
@@ -66,46 +69,46 @@ impl core::error::Error for ReceiveError {}
 
 #[derive(Debug)]
 pub(crate) struct EventPorts<S: Service> {
-    pub(crate) static_config: StaticConfig,
+    pub(crate) name: ServiceName,
     pub(crate) notifier: Notifier<S>,
     pub(crate) listener: Listener<S>,
 }
 
 impl<S: Service> EventPorts<S> {
-    pub(crate) fn new(static_config: &StaticConfig, node: &Node<S>) -> Result<Self, CreationError> {
+    pub(crate) fn new(
+        name: &ServiceName,
+        description: &EventDescription,
+        node: &Node<S>,
+    ) -> Result<Self, CreationError> {
         let origin = format!("EventPorts<{}>::new", core::any::type_name::<S>());
 
-        let event_config = static_config.event();
+        let builder = node.service_builder(name).event();
+        let builder = match &description.settings {
+            Some(settings) => apply_settings(builder, settings),
+            // Use defaults if no settings specified.
+            None => builder,
+        };
+
         let service = fail!(
             from origin,
-            when node
-                .service_builder(static_config.name())
-                .event()
-                .max_nodes(event_config.max_nodes())
-                .max_listeners(event_config.max_listeners())
-                .max_notifiers(event_config.max_notifiers())
-                .event_id_max_value(event_config.event_id_max_value())
-                .open_or_create(),
+            when builder.open_or_create(),
             with CreationError::Service,
-            "Failed to open or create service {}({})", static_config.messaging_pattern(), static_config.name()
+            "Failed to open or create service Event({})", name
         );
-
         let notifier = fail!(
             from origin,
             when service.notifier_builder().create(),
             with CreationError::Notifier,
-            "Failed to create Notifier for {}({})", static_config.messaging_pattern(), static_config.name()
+            "Failed to create Notifier for Event({})", name
         );
-
         let listener = fail!(
             from origin,
             when service.listener_builder().create(),
             with CreationError::Listener,
-            "Failed to create Listener for {}({})", static_config.messaging_pattern(), static_config.name()
+            "Failed to create Listener for Event({})", name
         );
-
         Ok(EventPorts {
-            static_config: static_config.clone(),
+            name: *name,
             notifier,
             listener,
         })
@@ -129,12 +132,7 @@ impl<S: Service> EventPorts<S> {
 
             match event_id {
                 Some(event_id) => {
-                    trace!(
-                        from self,
-                        "Sending {}({})",
-                        self.static_config.messaging_pattern(),
-                        self.static_config.name()
-                    );
+                    trace!(from self, "Sending Event({})", self.name);
 
                     fail!(
                         from self,
@@ -173,12 +171,7 @@ impl<S: Service> EventPorts<S> {
 
         // Notify all ids once
         for event_id in received_ids {
-            trace!(
-                from self,
-                "Received {}({})",
-                self.static_config.messaging_pattern(),
-                self.static_config.name()
-            );
+            trace!(from self, "Received Event({})", self.name);
             fail!(
                 from self,
                 when propagate(event_id),
@@ -190,5 +183,32 @@ impl<S: Service> EventPorts<S> {
         }
 
         Ok(propagated)
+    }
+}
+
+fn apply_settings<S: Service>(
+    builder: event::Builder<S>,
+    settings: &EventSettings,
+) -> event::Builder<S> {
+    let builder = builder
+        .max_nodes(settings.max_nodes)
+        .max_listeners(settings.max_listeners)
+        .max_notifiers(settings.max_notifiers)
+        .event_id_max_value(settings.event_id_max_value);
+    let builder = match settings.deadline {
+        Some(deadline) => builder.deadline(deadline),
+        None => builder.disable_deadline(),
+    };
+    let builder = match settings.notifier_created_event {
+        Some(value) => builder.notifier_created_event(EventId::new(value)),
+        None => builder.disable_notifier_created_event(),
+    };
+    let builder = match settings.notifier_dropped_event {
+        Some(value) => builder.notifier_dropped_event(EventId::new(value)),
+        None => builder.disable_notifier_dropped_event(),
+    };
+    match settings.notifier_dead_event {
+        Some(value) => builder.notifier_dead_event(EventId::new(value)),
+        None => builder.disable_notifier_dead_event(),
     }
 }

--- a/iceoryx2-services/tunnel/src/ports/publish_subscribe.rs
+++ b/iceoryx2-services/tunnel/src/ports/publish_subscribe.rs
@@ -25,7 +25,7 @@ use iceoryx2_services_tunnel_backend::types::publish_subscribe::{
     Header, LoanFn, Payload, Publisher, Sample, SampleMut, Subscriber,
 };
 use iceoryx2_services_tunnel_backend::types::service_description::{
-    PublishSubscribeDescription, PublishSubscribeSettings,
+    PatternSettings, PublishSubscribeDescription, PublishSubscribeSettings,
 };
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -112,9 +112,8 @@ impl<S: Service> PublishSubscribePorts<S> {
                 .__internal_set_payload_type_details(&payload_details)
         };
         let builder = match &description.settings {
-            Some(settings) => apply_settings(builder, settings),
-            // Use defaults if no settings specified.
-            None => builder,
+            PatternSettings::Value(settings) => apply_settings(builder, settings),
+            PatternSettings::UnknownApplyDefaults => builder,
         };
 
         let service = fail!(

--- a/iceoryx2-services/tunnel/src/ports/publish_subscribe.rs
+++ b/iceoryx2-services/tunnel/src/ports/publish_subscribe.rs
@@ -16,14 +16,21 @@ use iceoryx2::identifiers::UniqueNodeId;
 use iceoryx2::node::Node;
 use iceoryx2::port::LoanError;
 use iceoryx2::prelude::AllocationStrategy;
-use iceoryx2::service::{Service, static_config::StaticConfig};
+use iceoryx2::service::Service;
+use iceoryx2::service::builder::publish_subscribe;
+use iceoryx2::service::service_name::ServiceName;
+use iceoryx2::service::static_config::message_type_details::TypeDetail;
 use iceoryx2_log::{fail, trace};
 use iceoryx2_services_tunnel_backend::types::publish_subscribe::{
     Header, LoanFn, Payload, Publisher, Sample, SampleMut, Subscriber,
 };
+use iceoryx2_services_tunnel_backend::types::service_description::{
+    PublishSubscribeDescription, PublishSubscribeSettings,
+};
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum CreationError {
+    TypeDetails,
     Service,
     Publisher,
     Subscriber,
@@ -67,46 +74,55 @@ impl core::error::Error for ReceiveError {}
 
 #[derive(Debug)]
 pub(crate) struct PublishSubscribePorts<S: Service> {
-    pub(crate) static_config: StaticConfig,
+    pub(crate) name: ServiceName,
+    pub(crate) description: PublishSubscribeDescription,
     pub(crate) publisher: Publisher<S>,
     pub(crate) subscriber: Subscriber<S>,
 }
 
 impl<S: Service> PublishSubscribePorts<S> {
-    pub(crate) fn new(static_config: &StaticConfig, node: &Node<S>) -> Result<Self, CreationError> {
+    pub(crate) fn new(
+        name: &ServiceName,
+        description: &PublishSubscribeDescription,
+        node: &Node<S>,
+    ) -> Result<Self, CreationError> {
         let origin = format!(
             "PublishSubscribePorts<{}>::new",
             core::any::type_name::<S>()
         );
 
-        let port_config = static_config.publish_subscribe();
-        let service = unsafe {
-            fail!(
-                from origin,
-                when node.service_builder(static_config.name())
-                        .publish_subscribe::<Payload>()
-                        .user_header::<Header>()
-                        .__internal_set_user_header_type_details(
-                            &port_config.message_type_details().user_header,
-                        )
-                        .__internal_set_payload_type_details(
-                            &port_config.message_type_details().payload,
-                        )
-                        .enable_safe_overflow(port_config.has_safe_overflow())
-                        .history_size(port_config.history_size())
-                        .max_nodes(port_config.max_nodes())
-                        .max_publishers(port_config.max_publishers())
-                        .max_subscribers(port_config.max_subscribers())
-                        .subscriber_max_buffer_size(port_config.subscriber_max_buffer_size())
-                        .subscriber_max_borrowed_samples(
-                            port_config.subscriber_max_borrowed_samples(),
-                        )
-                        .open_or_create(),
-                with CreationError::Service,
-                "Failed to open or create service {}({})", static_config.messaging_pattern(), static_config.name()
-            )
+        let payload_details = fail!(
+            from origin,
+            when TypeDetail::try_from(&description.payload),
+            with CreationError::TypeDetails,
+            "Payload type of PublishSubscribe({}) cannot be represented as a TypeDetail", name
+        );
+        let user_header_details = fail!(
+            from origin,
+            when TypeDetail::try_from(&description.user_header),
+            with CreationError::TypeDetails,
+            "User header type of PublishSubscribe({}) cannot be represented as a TypeDetail", name
+        );
+
+        let builder = unsafe {
+            node.service_builder(name)
+                .publish_subscribe::<Payload>()
+                .user_header::<Header>()
+                .__internal_set_user_header_type_details(&user_header_details)
+                .__internal_set_payload_type_details(&payload_details)
+        };
+        let builder = match &description.settings {
+            Some(settings) => apply_settings(builder, settings),
+            // Use defaults if no settings specified.
+            None => builder,
         };
 
+        let service = fail!(
+            from origin,
+            when builder.open_or_create(),
+            with CreationError::Service,
+            "Failed to open or create service PublishSubscribe({})", name
+        );
         let publisher = fail!(
             from origin,
             when service
@@ -114,18 +130,18 @@ impl<S: Service> PublishSubscribePorts<S> {
                 .allocation_strategy(AllocationStrategy::PowerOfTwo)
                 .create(),
             with CreationError::Publisher,
-            "Failed to create Publisher for {}({})", static_config.messaging_pattern(), static_config.name()
+            "Failed to create Publisher for PublishSubscribe({})", name
         );
-
         let subscriber = fail!(
             from origin,
             when service.subscriber_builder().create(),
             with CreationError::Subscriber,
-            "Failed to create Subscriber for {}({})", static_config.messaging_pattern(), static_config.name()
+            "Failed to create Subscriber for PublishSubscribe({})", name
         );
 
         Ok(PublishSubscribePorts {
-            static_config: static_config.clone(),
+            name: *name,
+            description: description.clone(),
             publisher,
             subscriber,
         })
@@ -142,14 +158,9 @@ impl<S: Service> PublishSubscribePorts<S> {
     {
         let mut ingested = false;
 
-        let type_details = self
-            .static_config
-            .publish_subscribe()
-            .message_type_details();
-
         loop {
             let sample = ingest(&mut |number_of_bytes| {
-                let number_of_elements = number_of_bytes / type_details.payload.size();
+                let number_of_elements = number_of_bytes / self.description.payload.size;
 
                 let sample = unsafe { self.publisher.loan_custom_payload(number_of_elements) };
                 let sample = fail!(
@@ -170,12 +181,7 @@ impl<S: Service> PublishSubscribePorts<S> {
 
             match sample {
                 Some(sample) => {
-                    trace!(
-                        from self,
-                        "Sending {}({})",
-                        self.static_config.messaging_pattern(),
-                        self.static_config.name()
-                    );
+                    trace!(from self, "Sending PublishSubscribe({})", self.name);
 
                     fail!(
                         from self,
@@ -214,12 +220,7 @@ impl<S: Service> PublishSubscribePorts<S> {
 
             match sample {
                 Some(sample) => {
-                    trace!(
-                        from self,
-                        "Received {}({})",
-                        self.static_config.messaging_pattern(),
-                        self.static_config.name()
-                    );
+                    trace!(from self, "Received PublishSubscribe({})", self.name);
 
                     if sample.header().node_id() == *node_id {
                         // Ignore samples published by the gateway itself to avoid loopback.
@@ -241,4 +242,18 @@ impl<S: Service> PublishSubscribePorts<S> {
 
         Ok(propagated)
     }
+}
+
+fn apply_settings<S: Service>(
+    builder: publish_subscribe::Builder<Payload, Header, S>,
+    settings: &PublishSubscribeSettings,
+) -> publish_subscribe::Builder<Payload, Header, S> {
+    builder
+        .max_subscribers(settings.max_subscribers)
+        .max_publishers(settings.max_publishers)
+        .max_nodes(settings.max_nodes)
+        .history_size(settings.history_size)
+        .subscriber_max_buffer_size(settings.subscriber_max_buffer_size)
+        .subscriber_max_borrowed_samples(settings.subscriber_max_borrowed_samples)
+        .enable_safe_overflow(settings.safe_overflow)
 }

--- a/iceoryx2-services/tunnel/src/tunnel.rs
+++ b/iceoryx2-services/tunnel/src/tunnel.rs
@@ -23,11 +23,10 @@ use iceoryx2::node::{Node, NodeState, NodeView};
 use iceoryx2::service::Service;
 use iceoryx2::service::ServiceDetails;
 use iceoryx2::service::service_hash::ServiceHash;
-use iceoryx2::service::static_config::StaticConfig;
-use iceoryx2::service::static_config::messaging_pattern::MessagingPattern;
 use iceoryx2_log::{fail, info};
-use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
 use iceoryx2_services_tunnel_backend::traits::{Backend, Discovery};
+use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 
 use crate::bridge::Bridge;
 use crate::discovery::LocalDiscoveryStrategy;
@@ -62,7 +61,6 @@ pub enum DiscoveryError {
     EventPortsCreation,
     EventRelayCreation,
     DiscoveryAnnouncement,
-    UnsupportedMessagingPattern,
 }
 
 impl core::fmt::Display for DiscoveryError {
@@ -195,7 +193,7 @@ impl<S: Service, B: for<'a> Backend<S> + Debug> Tunnel<S, B> {
         fail!(
             from origin,
             when backend.discovery().discover(|event| {
-                on_discovery_event::<S, B>(node, backend, &mut update, services_filter, event)
+                on_discovery_update::<S, B>(node, backend, &mut update, services_filter, event)
             }),
             with DiscoveryError::DiscoveryOverBackend,
             "Failed to discover services via Backend"
@@ -220,7 +218,7 @@ impl<S: Service, B: for<'a> Backend<S> + Debug> Tunnel<S, B> {
         fail!(
             from origin,
             when subscriber.discover(|event| {
-                on_discovery_event::<S, B>(node, backend, &mut update, services_filter, event)
+                on_discovery_update::<S, B>(node, backend, &mut update, services_filter, event)
             }),
             with DiscoveryError::DiscoveryOverService,
             "Failed to discover services via subscriber to discovery service"
@@ -256,13 +254,11 @@ impl<S: Service, B: for<'a> Backend<S> + Debug> Tunnel<S, B> {
             Origin::Local,
             tracker
                 .iter()
-                .filter(|details| {
-                    is_locally_offered(details, node.id())
-                        && allowed(&details.static_details, services_filter)
-                })
-                .map(|details| &details.static_details),
-            |config| announce_added::<S, B>(node, backend, config),
-            |config| announce_removed::<S, B>(node, backend, config),
+                .filter(|details| is_locally_offered(details, node.id()))
+                .filter_map(|details| ServiceDescription::try_from(&details.static_details).ok())
+                .filter(|description| allowed(description, services_filter)),
+            |description| announce_added::<S, B>(node, backend, description),
+            |description| announce_removed::<S, B>(node, backend, description),
         )
     }
 
@@ -282,17 +278,17 @@ impl<S: Service, B: for<'a> Backend<S> + Debug> Tunnel<S, B> {
         });
 
         // Open bridges for newly-offered services.
-        for (hash, static_config) in snapshot.iter() {
+        for (hash, description) in snapshot.iter() {
             if self.bridges.contains_key(hash) {
                 continue;
             }
             info!(
                 from log_origin,
                 "Opening bridge: {}({})",
-                static_config.messaging_pattern(),
-                static_config.name()
+                description.pattern,
+                description.name
             );
-            let bridge = Bridge::open(&self.node, &self.backend, static_config)?;
+            let bridge = Bridge::open(&self.node, &self.backend, description)?;
             self.bridges.insert(*hash, bridge);
         }
 
@@ -320,34 +316,33 @@ impl<S: Service, B: for<'a> Backend<S> + Debug> Tunnel<S, B> {
 
 /// Updates the discovery state and announces local-side 0 → 1 and 1 → 0
 /// transitions.
-fn on_discovery_event<S: Service, B: Backend<S>>(
+fn on_discovery_update<S: Service, B: Backend<S>>(
     node: &Node<S>,
     backend: &B,
-    update: &mut DeltaUpdate<'_>,
-    services_filter: &Option<BTreeSet<String>>,
-    event: DiscoveryEvent,
+    state: &mut DeltaUpdate<'_>,
+    allowlist: &Option<BTreeSet<String>>,
+    update: DiscoveryUpdate,
 ) -> Result<(), DiscoveryError> {
-    match event {
-        DiscoveryEvent::Added(static_config) => {
-            if !allowed(&static_config, services_filter) {
+    match update {
+        DiscoveryUpdate::Added(description) => {
+            if !allowed(&description, allowlist) {
                 return Ok(());
             }
 
             // Announce on local 0 → 1 transitions, then record as offered.
-            let hash = *static_config.service_hash();
-            let newly_offered_locally =
-                update.origin() == Origin::Local && !update.is_offered(&hash);
+            let hash = description.service_hash;
+            let newly_offered_locally = state.origin() == Origin::Local && !state.is_offered(&hash);
             if newly_offered_locally {
-                announce_added::<S, B>(node, backend, &static_config)?;
+                announce_added::<S, B>(node, backend, &description)?;
             }
-            update.set_offered(static_config);
+            state.set_offered(description);
         }
-        DiscoveryEvent::Removed(hash) => {
+        DiscoveryUpdate::Removed(hash) => {
             // Announce on local 1 → 0 transitions.
-            let removed_config = update.set_not_offered(&hash);
-            if update.origin() == Origin::Local {
-                if let Some(static_config) = &removed_config {
-                    announce_removed::<S, B>(node, backend, static_config)?;
+            let removed_description = state.set_not_offered(&hash);
+            if state.origin() == Origin::Local {
+                if let Some(description) = &removed_description {
+                    announce_removed::<S, B>(node, backend, description)?;
                 }
             }
         }
@@ -356,38 +351,32 @@ fn on_discovery_event<S: Service, B: Backend<S>>(
     Ok(())
 }
 
-/// Whether the tunnel should offer `static_config`: a supported messaging
-/// pattern (publish-subscribe or event) that passes the optional services
-/// allowlist.
-fn allowed(static_config: &StaticConfig, services_filter: &Option<BTreeSet<String>>) -> bool {
-    let supported_pattern = matches!(
-        static_config.messaging_pattern(),
-        MessagingPattern::PublishSubscribe(_) | MessagingPattern::Event(_)
-    );
-    let in_allowlist = match services_filter {
-        Some(allowlist) => allowlist.contains(static_config.name().as_str()),
+/// Whether the tunnel should offer `description` i.e. passes the optional
+/// services allowlist.
+fn allowed(description: &ServiceDescription, allowlist: &Option<BTreeSet<String>>) -> bool {
+    match allowlist {
+        Some(allowlist) => allowlist.contains(description.name.as_str()),
         None => true,
-    };
-    supported_pattern && in_allowlist
+    }
 }
 
 /// Broadcasts a service's availability to remote peers over the backend.
 fn announce_added<S: Service, B: Backend<S>>(
     node: &Node<S>,
     backend: &B,
-    static_config: &StaticConfig,
+    description: &ServiceDescription,
 ) -> Result<(), DiscoveryError> {
     let origin = format!("Tunnel({})::announce_added", node.id());
 
     info!(
         from origin,
         "Announcing addition: {}({})",
-        static_config.messaging_pattern(),
-        static_config.name()
+        description.pattern,
+        description.name
     );
     fail!(
         from origin,
-        when backend.discovery().announce(DiscoveryEventRef::Added(static_config)),
+        when backend.discovery().announce(DiscoveryUpdateRef::Added(description)),
         with DiscoveryError::DiscoveryAnnouncement,
         "Failed to announce service over backend"
     );
@@ -398,18 +387,18 @@ fn announce_added<S: Service, B: Backend<S>>(
 fn announce_removed<S: Service, B: Backend<S>>(
     node: &Node<S>,
     backend: &B,
-    static_config: &StaticConfig,
+    description: &ServiceDescription,
 ) -> Result<(), DiscoveryError> {
     let origin = format!("Tunnel({})::announce_removed", node.id());
     info!(
         from origin,
         "Announcing removal: {}({})",
-        static_config.messaging_pattern(),
-        static_config.name()
+        description.pattern,
+        description.name
     );
     fail!(
         from origin,
-        when backend.discovery().announce(DiscoveryEventRef::Removed(static_config.service_hash())),
+        when backend.discovery().announce(DiscoveryUpdateRef::Removed(&description.service_hash)),
         with DiscoveryError::DiscoveryAnnouncement,
         "Failed to announce service removal over backend"
     );

--- a/iceoryx2/src/service/service_hash.rs
+++ b/iceoryx2/src/service/service_hash.rs
@@ -39,7 +39,12 @@ impl Display for ServiceHash {
 }
 
 impl ServiceHash {
-    pub(crate) fn new<Hasher: Hash>(
+    /// Creates the [`ServiceHash`] identifying the
+    /// [`Service`](crate::service::Service) with the provided name and
+    /// messaging pattern. `Hasher` must be the
+    /// [`Service::ServiceNameHasher`](crate::service::Service::ServiceNameHasher)
+    /// of the [`Service`](crate::service::Service) variant in use.
+    pub fn new<Hasher: Hash>(
         service_name: &ServiceName,
         messaging_pattern: MessagingPattern,
     ) -> Self {

--- a/iceoryx2/src/service/service_hash.rs
+++ b/iceoryx2/src/service/service_hash.rs
@@ -39,11 +39,9 @@ impl Display for ServiceHash {
 }
 
 impl ServiceHash {
-    /// Creates the [`ServiceHash`] identifying the
-    /// [`Service`](crate::service::Service) with the provided name and
-    /// messaging pattern. `Hasher` must be the
-    /// [`Service::ServiceNameHasher`](crate::service::Service::ServiceNameHasher)
-    /// of the [`Service`](crate::service::Service) variant in use.
+    /// Creates the [`ServiceHash`] which identifies a
+    /// service name and messaging pattern pair used by a
+    /// [`Service`](crate::service::Service).
     pub fn new<Hasher: Hash>(
         service_name: &ServiceName,
         messaging_pattern: MessagingPattern,

--- a/iceoryx2/src/service/static_config/mod.rs
+++ b/iceoryx2/src/service/static_config/mod.rs
@@ -115,32 +115,6 @@ impl StaticConfig {
         }
     }
 
-    /// Creates the [`StaticConfig`] of a publish-subscribe
-    /// [`Service`](crate::service::Service) with the provided message type
-    /// details; all other values are taken from the defaults in `config`,
-    /// but this might need to be revised to be more precise.
-    ///
-    /// Intended for infrastructure that describes services it does not
-    /// create itself, e.g. tunnels. Not part of the stable public API.
-    #[doc(hidden)]
-    pub fn __internal_new_publish_subscribe_with_details<Hasher: Hash>(
-        service_name: &ServiceName,
-        config: &config::Config,
-        payload: message_type_details::TypeDetail,
-        user_header: message_type_details::TypeDetail,
-    ) -> Self {
-        let mut new_self = Self::new_publish_subscribe::<Hasher>(service_name, config);
-        match &mut new_self.messaging_pattern {
-            MessagingPattern::PublishSubscribe(pattern_config) => {
-                pattern_config.message_type_details.user_header = user_header;
-                pattern_config.message_type_details.payload = payload;
-            }
-            // new_publish_subscribe always creates this pattern
-            _ => unreachable!(),
-        }
-        new_self
-    }
-
     pub(crate) fn new_blackboard<Hasher: Hash>(
         service_name: &ServiceName,
         config: &config::Config,

--- a/integrations/ros2/Cargo.lock
+++ b/integrations/ros2/Cargo.lock
@@ -481,7 +481,7 @@ version = "0.9.999"
 dependencies = [
  "iceoryx2",
  "iceoryx2-bb-posix",
- "iceoryx2-services-common",
+ "serde",
 ]
 
 [[package]]

--- a/integrations/ros2/Cargo.lock
+++ b/integrations/ros2/Cargo.lock
@@ -185,6 +185,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,11 +214,13 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 name = "iceoryx2"
 version = "0.9.999"
 dependencies = [
+ "flatbuffers",
  "iceoryx2-bb-concurrency",
  "iceoryx2-bb-container",
  "iceoryx2-bb-derive-macros",
  "iceoryx2-bb-elementary",
  "iceoryx2-bb-elementary-traits",
+ "iceoryx2-bb-flatbuffers",
  "iceoryx2-bb-lock-free",
  "iceoryx2-bb-loggers",
  "iceoryx2-bb-memory",
@@ -268,6 +280,17 @@ dependencies = [
 [[package]]
 name = "iceoryx2-bb-elementary-traits"
 version = "0.9.999"
+
+[[package]]
+name = "iceoryx2-bb-flatbuffers"
+version = "0.9.999"
+dependencies = [
+ "iceoryx2-bb-container",
+ "iceoryx2-bb-elementary",
+ "iceoryx2-bb-posix",
+ "iceoryx2-bb-system-types",
+ "iceoryx2-log",
+]
 
 [[package]]
 name = "iceoryx2-bb-linux"
@@ -650,6 +673,21 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"

--- a/integrations/ros2/tunnel-backend/src/discovery.rs
+++ b/integrations/ros2/tunnel-backend/src/discovery.rs
@@ -15,15 +15,17 @@ use std::rc::Rc;
 
 use core::error::Error;
 
-use iceoryx2::config::Config as IceoryxConfig;
 use iceoryx2::service::Service;
+use iceoryx2::service::messaging_pattern::MessagingPattern;
 use iceoryx2::service::service_hash::ServiceHash;
 use iceoryx2::service::service_name::ServiceName;
-use iceoryx2::service::static_config::StaticConfig;
-use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
+use iceoryx2::service::static_config::message_type_details::TypeVariant;
 use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_log::fail;
-use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
+use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
+use iceoryx2_services_tunnel_backend::types::service_description::{
+    PatternDescription, PublishSubscribeDescription, ServiceDescription, TypeDescription,
+};
 
 use crate::config::TopicConfig;
 use crate::mapping;
@@ -34,7 +36,6 @@ use crate::ros_header::RosHeader;
 pub enum DiscoveryError {
     Graph,
     InvalidServiceName,
-    InvalidTypeName,
     Processing,
 }
 
@@ -92,7 +93,7 @@ impl<S: Service> iceoryx2_services_tunnel_backend::traits::Discovery for Discove
     type DiscoveryError = DiscoveryError;
     type AnnouncementError = AnnouncementError;
 
-    fn announce(&self, _event: DiscoveryEventRef<'_>) -> Result<(), Self::AnnouncementError> {
+    fn announce(&self, _update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
         // Nothing to announce explicitly. The tunnel creates a relay for
         // every service it discovers on iceoryx2, and relay creation
         // registers the ROS 2 endpoints, which DDS discovery (SEDP) broadcasts
@@ -100,7 +101,7 @@ impl<S: Service> iceoryx2_services_tunnel_backend::traits::Discovery for Discove
         Ok(())
     }
 
-    fn discover<E: Error, F: FnMut(DiscoveryEvent) -> Result<(), E>>(
+    fn discover<E: Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
         &self,
         mut process_discovery: F,
     ) -> Result<(), Self::DiscoveryError> {
@@ -117,15 +118,15 @@ impl<S: Service> iceoryx2_services_tunnel_backend::traits::Discovery for Discove
             let discovered = self.discovered.borrow().contains_key(topic);
 
             if live && !discovered {
-                let static_config = fail!(from origin,
-                    when static_config::<S>(topic, type_name),
-                    "Failed to synthesize the static config for topic '{}'",
+                let description = fail!(from origin,
+                    when service_description::<S>(topic, type_name),
+                    "Failed to describe the service for topic '{}'",
                     topic.as_str()
                 );
 
-                let service_hash = *static_config.service_hash();
+                let service_hash = description.service_hash;
                 fail!(from origin,
-                    when process_discovery(DiscoveryEvent::Added(static_config)),
+                    when process_discovery(DiscoveryUpdate::Added(description)),
                     with DiscoveryError::Processing,
                     "Failed to process discovery 'Added' event for topic '{}'",
                     topic.as_str()
@@ -137,7 +138,7 @@ impl<S: Service> iceoryx2_services_tunnel_backend::traits::Discovery for Discove
             } else if !live && discovered {
                 let service_hash = self.discovered.borrow()[topic];
                 fail!(from origin,
-                    when process_discovery(DiscoveryEvent::Removed(service_hash)),
+                    when process_discovery(DiscoveryUpdate::Removed(service_hash)),
                     with DiscoveryError::Processing,
                     "Failed to process discovery 'Removed' event for topic '{}'",
                     topic.as_str()
@@ -151,12 +152,13 @@ impl<S: Service> iceoryx2_services_tunnel_backend::traits::Discovery for Discove
     }
 }
 
-/// The [`StaticConfig`] synthesized for a discovered ROS topic.
-fn static_config<S: Service>(
+/// The [`ServiceDescription`] of the service bridging a discovered ROS
+/// topic. Settings are left unset; the tunnel applies local defaults.
+fn service_description<S: Service>(
     topic: &TopicName,
     type_name: &TypeName,
-) -> Result<StaticConfig, DiscoveryError> {
-    let origin = "discovery::static_config";
+) -> Result<ServiceDescription, DiscoveryError> {
+    let origin = "discovery::service_description";
 
     let service_name: ServiceName = fail!(from origin,
         when mapping::service_name(topic.as_str()).as_str().try_into(),
@@ -164,22 +166,29 @@ fn static_config<S: Service>(
         "Invalid service name derived from topic '{}'",
         topic.as_str()
     );
-    // TODO: Define configuration per-topic in configuration file; apply here.
-    let config = IceoryxConfig::global_config();
-    let payload = fail!(from origin,
-        when TypeDetail::__internal_new_from_parts(TypeVariant::Dynamic, type_name.as_str(), 1, 1),
-        with DiscoveryError::InvalidTypeName,
-        "Invalid payload type name '{}'",
-        type_name.as_str()
-    );
-    let user_header = RosHeader::type_detail();
 
-    Ok(
-        StaticConfig::__internal_new_publish_subscribe_with_details::<S::ServiceNameHasher>(
+    // TODO: Define configuration per-topic in configuration file; apply here.
+
+    // The payload is a dynamically-sized CDR stream; its type name carries
+    // the ROS 2 type name.
+    let payload = TypeDescription {
+        variant: TypeVariant::Dynamic,
+        type_name: type_name.as_str().to_string(),
+        size: 1,
+        alignment: 1,
+    };
+    let user_header = TypeDescription::from(&RosHeader::type_detail());
+
+    Ok(ServiceDescription {
+        service_hash: ServiceHash::new::<S::ServiceNameHasher>(
             &service_name,
-            config,
+            MessagingPattern::PublishSubscribe,
+        ),
+        name: service_name,
+        pattern: PatternDescription::PublishSubscribe(PublishSubscribeDescription {
             payload,
             user_header,
-        ),
-    )
+            settings: None,
+        }),
+    })
 }

--- a/integrations/ros2/tunnel-backend/src/discovery.rs
+++ b/integrations/ros2/tunnel-backend/src/discovery.rs
@@ -24,7 +24,8 @@ use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_log::fail;
 use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 use iceoryx2_services_tunnel_backend::types::service_description::{
-    PatternDescription, PublishSubscribeDescription, ServiceDescription, TypeDescription,
+    PatternDescription, PatternSettings, PublishSubscribeDescription, ServiceDescription,
+    TypeDescription,
 };
 
 use crate::config::TopicConfig;
@@ -188,7 +189,7 @@ fn service_description<S: Service>(
         pattern: PatternDescription::PublishSubscribe(PublishSubscribeDescription {
             payload,
             user_header,
-            settings: None,
+            settings: PatternSettings::UnknownApplyDefaults,
         }),
     })
 }

--- a/integrations/ros2/tunnel-backend/src/relays/event.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/event.rs
@@ -14,9 +14,9 @@ use std::sync::Arc;
 
 use iceoryx2::prelude::EventId;
 use iceoryx2::service::{Service, local_threadsafe};
-use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 use iceoryx2_log::warn;
 use iceoryx2_services_tunnel_backend::traits::{EventRelay, RelayBuilder};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 use iceoryx2_services_tunnel_backend::types::wake::WakeHandle;
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]

--- a/integrations/ros2/tunnel-backend/src/relays/event.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/event.rs
@@ -13,7 +13,8 @@
 use std::sync::Arc;
 
 use iceoryx2::prelude::EventId;
-use iceoryx2::service::{Service, local_threadsafe, static_config::StaticConfig};
+use iceoryx2::service::{Service, local_threadsafe};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 use iceoryx2_log::warn;
 use iceoryx2_services_tunnel_backend::traits::{EventRelay, RelayBuilder};
 use iceoryx2_services_tunnel_backend::types::wake::WakeHandle;
@@ -74,18 +75,18 @@ impl<S: Service> EventRelay<S> for Relay<S> {
 /// Builder for event [`Relay`]s.
 #[derive(Debug)]
 pub struct Builder<'config, S: Service> {
-    static_config: &'config StaticConfig,
+    description: &'config ServiceDescription,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     _phantom: core::marker::PhantomData<S>,
 }
 
 impl<'config, S: Service> Builder<'config, S> {
     pub fn new(
-        static_config: &'config StaticConfig,
+        description: &'config ServiceDescription,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Self {
         Self {
-            static_config,
+            description,
             wake,
             _phantom: core::marker::PhantomData,
         }
@@ -99,7 +100,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
     fn create(self) -> Result<Self::Relay, Self::CreationError> {
         warn!(
             "ROS 2 has no equivalent to iceoryx2 events; events of '{}' will not be tunneled",
-            self.static_config.name()
+            self.description.name
         );
         Ok(Relay {
             _phantom: core::marker::PhantomData,

--- a/integrations/ros2/tunnel-backend/src/relays/factory.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/factory.rs
@@ -13,7 +13,8 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use iceoryx2::service::{Service, local_threadsafe, static_config::StaticConfig};
+use iceoryx2::service::{Service, local_threadsafe};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 use iceoryx2_services_tunnel_backend::{traits::RelayFactory, types::wake::WakeHandle};
 
 use crate::rcl::RclNode;
@@ -62,7 +63,7 @@ impl<S: Service> RelayFactory<S> for Factory<'_, S> {
 
     fn publish_subscribe<'a>(
         &self,
-        static_config: &'a StaticConfig,
+        description: &'a ServiceDescription,
     ) -> Self::PublishSubscribeBuilder<'a>
     where
         Self: 'a,
@@ -70,15 +71,15 @@ impl<S: Service> RelayFactory<S> for Factory<'_, S> {
         publish_subscribe::Builder::new(
             Rc::clone(&self.node),
             self.type_registry,
-            static_config,
+            description,
             self.wake.clone(),
         )
     }
 
-    fn event<'a>(&self, static_config: &'a StaticConfig) -> Self::EventBuilder<'a>
+    fn event<'a>(&self, description: &'a ServiceDescription) -> Self::EventBuilder<'a>
     where
         Self: 'a,
     {
-        event::Builder::new(static_config, self.wake.clone())
+        event::Builder::new(description, self.wake.clone())
     }
 }

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -13,11 +13,14 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
-use iceoryx2::service::{Service, local_threadsafe, static_config::StaticConfig};
+use iceoryx2::service::{Service, local_threadsafe};
 use iceoryx2_log::fail;
 use iceoryx2_services_tunnel_backend::traits::{PublishSubscribeRelay, RelayBuilder};
 use iceoryx2_services_tunnel_backend::types::publish_subscribe::{
     LoanFn, Sample, SampleMut, SampleMutUninit,
+};
+use iceoryx2_services_tunnel_backend::types::service_description::{
+    PatternDescription, ServiceDescription, TypeDescription,
 };
 use iceoryx2_services_tunnel_backend::types::wake::WakeHandle;
 
@@ -32,7 +35,6 @@ use crate::{mapping, payload};
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum CreationError {
     InvalidServiceName,
-    InvalidTypeName,
     InvalidTopic,
     TypeSupport,
     Publisher,
@@ -149,7 +151,7 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
 pub struct Builder<'a, S: Service> {
     node: Rc<RclNode>,
     type_registry: &'a TypeSupportRegistry,
-    static_config: &'a StaticConfig,
+    description: &'a ServiceDescription,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     _phantom: core::marker::PhantomData<S>,
 }
@@ -158,13 +160,13 @@ impl<'a, S: Service> Builder<'a, S> {
     pub fn new(
         node: Rc<RclNode>,
         type_registry: &'a TypeSupportRegistry,
-        static_config: &'a StaticConfig,
+        description: &'a ServiceDescription,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Self {
         Self {
             node,
             type_registry,
-            static_config,
+            description,
             wake,
             _phantom: core::marker::PhantomData,
         }
@@ -179,23 +181,18 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
     fn create(self) -> Result<Self::Relay, Self::CreationError> {
         let origin = "publish_subscribe::Relay::create";
 
+        let PatternDescription::PublishSubscribe(pattern_description) = &self.description.pattern
+        else {
+            unreachable!("relay is only built for publish-subscribe descriptions")
+        };
+
         let topic = fail!(from origin,
-            when mapping::topic(self.static_config.name().as_str()).ok_or(CreationError::InvalidServiceName),
+            when mapping::topic(self.description.name.as_str()).ok_or(CreationError::InvalidServiceName),
             "Failed to map service name to a ROS 2 topic"
         );
 
         // The payload type name carries the ROS 2 type name.
-        let type_name = fail!(from origin,
-            when core::str::from_utf8(
-                self.static_config
-                    .publish_subscribe()
-                    .message_type_details()
-                    .payload
-                    .type_name(),
-            ),
-            with CreationError::InvalidTypeName,
-            "Failed to read the payload type name as UTF-8"
-        );
+        let type_name = pattern_description.payload.type_name.as_str();
 
         let type_support = fail!(from origin,
             when self.type_registry.load(type_name),
@@ -235,12 +232,8 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
         // Only services declaring the RosHeader user header receive the
         // remote origin; anything else (e.g. a header-less local service)
         // must not be written to.
-        let write_ros_header = self
-            .static_config
-            .publish_subscribe()
-            .message_type_details()
-            .user_header
-            == RosHeader::type_detail();
+        let write_ros_header =
+            pattern_description.user_header == TypeDescription::from(&RosHeader::type_detail());
 
         Ok(Relay {
             publisher,

--- a/integrations/zenoh/Cargo.lock
+++ b/integrations/zenoh/Cargo.lock
@@ -1671,7 +1671,7 @@ version = "0.9.999"
 dependencies = [
  "iceoryx2",
  "iceoryx2-bb-posix",
- "iceoryx2-services-common",
+ "serde",
 ]
 
 [[package]]

--- a/integrations/zenoh/Cargo.lock
+++ b/integrations/zenoh/Cargo.lock
@@ -1534,8 +1534,8 @@ dependencies = [
  "ron 0.11.0",
  "serde",
  "serde_json",
- "serde_yaml",
  "toml 0.9.12+spec-1.1.0",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -2054,6 +2054,12 @@ dependencies = [
  "clap",
  "escape8259",
 ]
+
+[[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4752,6 +4758,19 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/integrations/zenoh/tunnel-backend/src/discovery.rs
+++ b/integrations/zenoh/tunnel-backend/src/discovery.rs
@@ -12,10 +12,11 @@
 
 use std::collections::BTreeMap;
 
-use iceoryx2::service::{service_hash::ServiceHash, static_config::StaticConfig};
+use iceoryx2::service::service_hash::ServiceHash;
 use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_log::{error, fail, warn};
-use iceoryx2_services_common::{DiscoveryEvent, DiscoveryEventRef};
+use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 
 use zenoh::{
     Session, Wait,
@@ -121,14 +122,14 @@ impl iceoryx2_services_tunnel_backend::traits::Discovery for Discovery {
     type DiscoveryError = DiscoveryError;
     type AnnouncementError = AnnouncementError;
 
-    fn announce(&self, event: DiscoveryEventRef<'_>) -> Result<(), Self::AnnouncementError> {
-        match event {
-            DiscoveryEventRef::Added(static_config) => self.announce_added(static_config),
-            DiscoveryEventRef::Removed(service_hash) => self.announce_removed(service_hash),
+    fn announce(&self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
+        match update {
+            DiscoveryUpdateRef::Added(description) => self.announce_added(description),
+            DiscoveryUpdateRef::Removed(service_hash) => self.announce_removed(service_hash),
         }
     }
 
-    fn discover<E: core::error::Error, F: FnMut(DiscoveryEvent) -> Result<(), E>>(
+    fn discover<E: core::error::Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
         &self,
         mut process_discovery: F,
     ) -> Result<(), DiscoveryError> {
@@ -145,7 +146,7 @@ impl iceoryx2_services_tunnel_backend::traits::Discovery for Discovery {
 
             fail!(
                 from self,
-                when process_discovery(DiscoveryEvent::Removed(*service_hash)),
+                when process_discovery(DiscoveryUpdate::Removed(*service_hash)),
                 with DiscoveryError::DiscoveryProcessing,
                 "Failed to process Removed discovery event for {}", service_hash.as_str()
             );
@@ -156,11 +157,11 @@ impl iceoryx2_services_tunnel_backend::traits::Discovery for Discovery {
 
         // Adds a service to the tunnel. Called once the reply with the
         // service details of a discovered remote service has been received.
-        let on_service_details = |static_config: StaticConfig| {
-            let service_hash = *static_config.service_hash();
+        let on_service_details = |description: ServiceDescription| {
+            let service_hash = description.service_hash;
             fail!(
                 from self,
-                when process_discovery(DiscoveryEvent::Added(static_config)),
+                when process_discovery(DiscoveryUpdate::Added(description)),
                 with DiscoveryError::DiscoveryProcessing,
                 "Failed to process Added discovery event for {}", service_hash.as_str()
             );
@@ -178,8 +179,8 @@ impl Discovery {
     /// its details and a liveliness token at its key.
     ///
     /// No-op if the service has already been announced.
-    fn announce_added(&self, static_config: &StaticConfig) -> Result<(), AnnouncementError> {
-        let service_hash = *static_config.service_hash();
+    fn announce_added(&self, description: &ServiceDescription) -> Result<(), AnnouncementError> {
+        let service_hash = description.service_hash;
 
         if self.announced.borrow().contains_key(&service_hash) {
             return Ok(());
@@ -188,7 +189,7 @@ impl Discovery {
         let key = keys::service_details(&service_hash);
         let serialized = fail!(
             from self,
-            when serde_json::to_string(static_config),
+            when serde_json::to_string(description),
             with AnnouncementError::Serialization,
             "Failed to serialize service config"
         );
@@ -216,7 +217,7 @@ impl Discovery {
     }
 
     /// Declares a queryable that responds to remote peers' `get` requests for
-    /// a service's StaticConfig with the pre-serialised JSON payload.
+    /// a service's ServiceDescription with the pre-serialised JSON payload.
     fn declare_queryable(
         &self,
         key: &str,
@@ -299,7 +300,7 @@ impl Discovery {
         Ok(())
     }
 
-    /// Issues a Zenoh `get` for the service's StaticConfig and queues the
+    /// Issues a Zenoh `get` for the service's ServiceDescription and queues the
     /// reply handler under `pending`. Returns immediately; replies are
     /// processed by [`Discovery::process_service_details`] on subsequent calls.
     fn request_service_details(&self, service_hash: &ServiceHash) -> Result<(), DiscoveryError> {
@@ -318,7 +319,7 @@ impl Discovery {
     }
 
     /// Drains the cached handlers for replies received over the network and
-    /// dispatches each resolved [`StaticConfig`] to `on_service_details`.
+    /// dispatches each resolved [`ServiceDescription`] to `on_service_details`.
     /// Re-issues the query for any handler whose channel closed without a
     /// usable reply.
     fn process_service_details<OnServiceDetails>(
@@ -326,9 +327,9 @@ impl Discovery {
         mut on_service_details: OnServiceDetails,
     ) -> Result<(), DiscoveryError>
     where
-        OnServiceDetails: FnMut(StaticConfig) -> Result<(), DiscoveryError>,
+        OnServiceDetails: FnMut(ServiceDescription) -> Result<(), DiscoveryError>,
     {
-        let mut resolved: Vec<StaticConfig> = Vec::new();
+        let mut resolved: Vec<ServiceDescription> = Vec::new();
         let mut failed: Vec<ServiceHash> = Vec::new();
 
         // Check status of pending queries.
@@ -336,7 +337,7 @@ impl Discovery {
             let pending = self.pending.borrow();
             for (hash, handler) in pending.iter() {
                 match check_pending(hash, handler) {
-                    Ok(Some(static_config)) => resolved.push(static_config),
+                    Ok(Some(description)) => resolved.push(description),
                     Ok(None) => {}
                     Err(_) => failed.push(*hash),
                 }
@@ -346,8 +347,8 @@ impl Discovery {
         // Drop resolved entries from pending.
         {
             let mut pending = self.pending.borrow_mut();
-            for static_config in &resolved {
-                pending.remove(static_config.service_hash());
+            for description in &resolved {
+                pending.remove(&description.service_hash);
             }
         }
 
@@ -357,8 +358,8 @@ impl Discovery {
         }
 
         // Processed received service details.
-        for static_config in resolved {
-            on_service_details(static_config)?;
+        for description in resolved {
+            on_service_details(description)?;
         }
 
         Ok(())
@@ -371,7 +372,7 @@ struct Disconnected;
 fn check_pending(
     hash: &ServiceHash,
     handler: &FifoChannelHandler<Reply>,
-) -> Result<Option<StaticConfig>, Disconnected> {
+) -> Result<Option<ServiceDescription>, Disconnected> {
     loop {
         let Some(reply) = handler.try_recv().map_err(|_| Disconnected)? else {
             return Ok(None);
@@ -389,8 +390,8 @@ fn check_pending(
             }
         };
 
-        match serde_json::from_slice::<StaticConfig>(&sample.payload().to_bytes()) {
-            Ok(static_config) => return Ok(Some(static_config)),
+        match serde_json::from_slice::<ServiceDescription>(&sample.payload().to_bytes()) {
+            Ok(description) => return Ok(Some(description)),
             Err(e) => warn!(
                 "Skipping unparseable reply for service {}: {}",
                 hash.as_str(),

--- a/integrations/zenoh/tunnel-backend/src/relays/event.rs
+++ b/integrations/zenoh/tunnel-backend/src/relays/event.rs
@@ -15,9 +15,9 @@ use std::sync::Arc;
 use iceoryx2::prelude::EventId;
 use iceoryx2::service::Service;
 use iceoryx2::service::local_threadsafe;
-use iceoryx2::service::static_config::StaticConfig;
 use iceoryx2_log::{fail, trace};
 use iceoryx2_services_tunnel_backend::traits::{EventRelay, RelayBuilder};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 use iceoryx2_services_tunnel_backend::types::wake::WakeHandle;
 
 use zenoh::pubsub::{Publisher, Subscriber};
@@ -73,7 +73,7 @@ impl core::error::Error for ReceiveError {}
 #[derive(Debug)]
 pub struct Builder<'a, S: Service> {
     session: &'a Session,
-    static_config: &'a StaticConfig,
+    description: &'a ServiceDescription,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     _phantom: core::marker::PhantomData<S>,
 }
@@ -81,12 +81,12 @@ pub struct Builder<'a, S: Service> {
 impl<'a, S: Service> Builder<'a, S> {
     pub fn new(
         session: &'a Session,
-        static_config: &'a StaticConfig,
+        description: &'a ServiceDescription,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Builder<'a, S> {
         Builder {
             session,
-            static_config,
+            description,
             wake,
             _phantom: core::marker::PhantomData,
         }
@@ -99,7 +99,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
 
     fn create(self) -> Result<Self::Relay, Self::CreationError> {
         let origin = "event::Builder::create";
-        let key = keys::event(self.static_config.service_hash());
+        let key = keys::event(&self.description.service_hash);
 
         let notifier = fail!(
             from origin,
@@ -125,7 +125,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
         );
 
         Ok(Relay {
-            static_config: self.static_config.clone(),
+            description: self.description.clone(),
             notifier,
             listener,
             _phantom: core::marker::PhantomData,
@@ -135,7 +135,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
 
 #[derive(Debug)]
 pub struct Relay<S: Service> {
-    static_config: StaticConfig,
+    description: ServiceDescription,
     notifier: Publisher<'static>,
     listener: Subscriber<WakeAwareReceiver<Sample>>,
     _phantom: core::marker::PhantomData<S>,
@@ -149,8 +149,8 @@ impl<S: Service> EventRelay<S> for Relay<S> {
         trace!(
             from self,
             "Sending {}({})",
-            self.static_config.messaging_pattern(),
-            self.static_config.name()
+            self.description.pattern,
+            self.description.name
         );
 
         fail!(
@@ -176,8 +176,8 @@ impl<S: Service> EventRelay<S> for Relay<S> {
                 trace!(
                     from self,
                     "Ingesting {}({})",
-                    self.static_config.messaging_pattern(),
-                    self.static_config.name()
+                    self.description.pattern,
+                    self.description.name
                 );
                 let payload = sample.payload();
                 if payload.len() == std::mem::size_of::<usize>() {

--- a/integrations/zenoh/tunnel-backend/src/relays/factory.rs
+++ b/integrations/zenoh/tunnel-backend/src/relays/factory.rs
@@ -12,7 +12,8 @@
 
 use std::sync::Arc;
 
-use iceoryx2::service::{Service, local_threadsafe, static_config::StaticConfig};
+use iceoryx2::service::{Service, local_threadsafe};
+use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 use iceoryx2_services_tunnel_backend::{traits::RelayFactory, types::wake::WakeHandle};
 
 use zenoh::Session;
@@ -61,18 +62,21 @@ impl<S: Service> RelayFactory<S> for Factory<'_, S> {
 
     fn publish_subscribe<'config>(
         &self,
-        static_config: &'config StaticConfig,
+        description: &'config ServiceDescription,
     ) -> Self::PublishSubscribeBuilder<'config>
     where
         Self: 'config,
     {
-        publish_subscribe::Builder::new(self.session, static_config, self.wake.clone())
+        publish_subscribe::Builder::new(self.session, description, self.wake.clone())
     }
 
-    fn event<'config>(&self, static_config: &'config StaticConfig) -> Self::EventBuilder<'config>
+    fn event<'config>(
+        &self,
+        description: &'config ServiceDescription,
+    ) -> Self::EventBuilder<'config>
     where
         Self: 'config,
     {
-        event::Builder::new(self.session, static_config, self.wake.clone())
+        event::Builder::new(self.session, description, self.wake.clone())
     }
 }

--- a/integrations/zenoh/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/zenoh/tunnel-backend/src/relays/publish_subscribe.rs
@@ -15,12 +15,12 @@ use std::sync::Arc;
 use iceoryx2::service::{
     Service, local_threadsafe,
     marker::{CustomHeaderMarker, CustomPayloadMarker},
-    static_config::StaticConfig,
 };
 use iceoryx2_log::{fail, trace};
 use iceoryx2_services_tunnel_backend::{
     traits::{PublishSubscribeRelay, RelayBuilder},
     types::publish_subscribe::{LoanFn, SampleMut},
+    types::service_description::{PatternDescription, ServiceDescription},
     types::wake::WakeHandle,
 };
 
@@ -80,7 +80,7 @@ impl core::error::Error for ReceiveError {}
 #[derive(Debug)]
 pub struct Builder<'a, S: Service> {
     session: &'a Session,
-    static_config: &'a StaticConfig,
+    description: &'a ServiceDescription,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     _phantom: core::marker::PhantomData<S>,
 }
@@ -88,12 +88,12 @@ pub struct Builder<'a, S: Service> {
 impl<'a, S: Service> Builder<'a, S> {
     pub fn new(
         session: &'a Session,
-        static_config: &'a StaticConfig,
+        description: &'a ServiceDescription,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Builder<'a, S> {
         Builder {
             session,
-            static_config,
+            description,
             wake,
             _phantom: core::marker::PhantomData,
         }
@@ -106,7 +106,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
 
     fn create(self) -> Result<Self::Relay, Self::CreationError> {
         let origin = "publish_subscribe::Builder::create";
-        let key = keys::publish_subscribe(self.static_config.service_hash());
+        let key = keys::publish_subscribe(&self.description.service_hash);
 
         let publisher = fail!(
             from origin,
@@ -132,7 +132,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
         );
 
         Ok(Relay {
-            static_config: self.static_config.clone(),
+            description: self.description.clone(),
             publisher,
             subscriber,
             _phantom: core::marker::PhantomData,
@@ -142,7 +142,7 @@ impl<S: Service> RelayBuilder for Builder<'_, S> {
 
 #[derive(Debug)]
 pub struct Relay<S: Service> {
-    static_config: StaticConfig,
+    description: ServiceDescription,
     publisher: Publisher<'static>,
     subscriber: Subscriber<WakeAwareReceiver<Sample>>,
     _phantom: core::marker::PhantomData<S>,
@@ -159,8 +159,8 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
         trace!(
             from self,
             "Sending {}({})",
-            self.static_config.messaging_pattern(),
-            self.static_config.name()
+            self.description.pattern,
+            self.description.name
         );
 
         let user_header = sample.user_header();
@@ -170,7 +170,7 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
         writer.append(unsafe {
             core::slice::from_raw_parts(
                 user_header as *const CustomHeaderMarker as *const u8,
-                user_header_size(&self.static_config),
+                user_header_size(&self.description),
             )
             .into()
         });
@@ -203,13 +203,13 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
             trace!(
                 from self,
                 "Ingesting {}({})",
-                self.static_config.messaging_pattern(),
-                self.static_config.name()
+                self.description.pattern,
+                self.description.name
             );
 
             let bytes_received = zenoh_sample.payload().to_bytes();
 
-            let user_header_size = user_header_size(&self.static_config);
+            let user_header_size = user_header_size(&self.description);
             let user_header_received = &bytes_received[0..user_header_size];
             let payload_received = &bytes_received[user_header_size..];
 
@@ -252,10 +252,9 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
     }
 }
 
-fn user_header_size(static_config: &StaticConfig) -> usize {
-    static_config
-        .publish_subscribe()
-        .message_type_details()
-        .user_header
-        .size()
+fn user_header_size(description: &ServiceDescription) -> usize {
+    let PatternDescription::PublishSubscribe(description) = &description.pattern else {
+        unreachable!("relay is only built for publish-subscribe descriptions")
+    };
+    description.user_header.size
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Adds structs to describe communication endpoints sufficiently to create iceoryx2 services.

These structs are utilized (in upcoming PRs) to map between iceoryx2 services and backend communication endpoints. 

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [ ] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #1742 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
