### PR TITLE
[#1773] Add python language bindings for port name

### DIFF
--- a/iceoryx2-ffi/python/src/client.rs
+++ b/iceoryx2-ffi/python/src/client.rs
@@ -18,6 +18,7 @@ use crate::{
     backpressure_strategy::BackpressureStrategy,
     error::LoanError,
     parc::Parc,
+    port_name::PortName,
     request_mut_uninit::{RequestMutUninit, RequestMutUninitType},
     type_storage::TypeStorage,
     unique_client_id::UniqueClientId,
@@ -82,6 +83,17 @@ impl Client {
             ClientType::Ipc(Some(v)) => UniqueClientId(v.id()),
             ClientType::Local(Some(v)) => UniqueClientId(v.id()),
             _ => fatal_panic!(from "Client::id()", "Accessing a released client."),
+        }
+    }
+
+    #[getter]
+    /// Returns the `PortName` of the `Client`
+    pub fn name(&self) -> PortName {
+        match &self.value {
+            ClientType::Ipc(Some(v)) => PortName(*v.name()),
+            ClientType::Local(Some(v)) => PortName(*v.name()),
+            _ => fatal_panic!(from "Client::name()",
+                              "Accessing a released client."),
         }
     }
 

--- a/iceoryx2-ffi/python/src/lib.rs
+++ b/iceoryx2-ffi/python/src/lib.rs
@@ -59,6 +59,7 @@ pub mod port_factory_request_response;
 pub mod port_factory_server;
 pub mod port_factory_subscriber;
 pub mod port_factory_writer;
+pub mod port_name;
 pub mod publisher;
 pub mod reader;
 pub mod request_header;
@@ -175,6 +176,7 @@ fn _iceoryx2(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::port_factory_server::PortFactoryServer>()?;
     m.add_class::<crate::port_factory_subscriber::PortFactorySubscriber>()?;
     m.add_class::<crate::port_factory_writer::PortFactoryWriter>()?;
+    m.add_class::<crate::port_name::PortName>()?;
     m.add_class::<crate::publisher::Publisher>()?;
     m.add_class::<crate::reader::Reader>()?;
     m.add_class::<crate::request_header::RequestHeader>()?;

--- a/iceoryx2-ffi/python/src/listener.rs
+++ b/iceoryx2-ffi/python/src/listener.rs
@@ -17,7 +17,7 @@ use pyo3::prelude::*;
 
 use crate::{
     duration::Duration, error::ListenerWaitError, event_activation::EventActivation,
-    unique_listener_id::UniqueListenerId,
+    port_name::PortName, unique_listener_id::UniqueListenerId,
 };
 
 #[allow(clippy::large_enum_variant)] // used purely for python and there it will reside always in
@@ -115,6 +115,17 @@ impl Listener {
             ListenerType::Local(Some(v)) => UniqueListenerId(v.id()),
             _ => fatal_panic!(from "Listener::id()",
                     "Accessing a released listener."),
+        }
+    }
+
+    #[getter]
+    /// Returns the `PortName` of the `Listener`
+    pub fn name(&self) -> PortName {
+        match &self.0 {
+            ListenerType::Ipc(Some(v)) => PortName(*v.name()),
+            ListenerType::Local(Some(v)) => PortName(*v.name()),
+            _ => fatal_panic!(from "Listener::name()",
+                              "Accessing a released listener."),
         }
     }
 

--- a/iceoryx2-ffi/python/src/notifier.rs
+++ b/iceoryx2-ffi/python/src/notifier.rs
@@ -14,7 +14,7 @@ use iceoryx2_log::fatal_panic;
 use pyo3::prelude::*;
 
 use crate::{
-    duration::Duration, error::NotifierNotifyError, event_id::EventId,
+    duration::Duration, error::NotifierNotifyError, event_id::EventId, port_name::PortName,
     unique_notifier_id::UniqueNotifierId,
 };
 
@@ -38,6 +38,17 @@ impl Notifier {
             NotifierType::Local(Some(v)) => UniqueNotifierId(v.id()),
             _ => fatal_panic!(from "Notifier::id()",
                 "Accessing a released notifier."),
+        }
+    }
+
+    #[getter]
+    /// Returns the `PortName` of the `Server`
+    pub fn name(&self) -> PortName {
+        match &self.0 {
+            NotifierType::Ipc(Some(v)) => PortName(*v.name()),
+            NotifierType::Local(Some(v)) => PortName(*v.name()),
+            _ => fatal_panic!(from "Notifier::name()",
+                              "Accessing a released notifier."),
         }
     }
 

--- a/iceoryx2-ffi/python/src/notifier.rs
+++ b/iceoryx2-ffi/python/src/notifier.rs
@@ -42,7 +42,7 @@ impl Notifier {
     }
 
     #[getter]
-    /// Returns the `PortName` of the `Server`
+    /// Returns the `PortName` of the `Notifier`
     pub fn name(&self) -> PortName {
         match &self.0 {
             NotifierType::Ipc(Some(v)) => PortName(*v.name()),

--- a/iceoryx2-ffi/python/src/port_factory_client.rs
+++ b/iceoryx2-ffi/python/src/port_factory_client.rs
@@ -20,6 +20,7 @@ use crate::{
     client::{Client, ClientType},
     parc::Parc,
     port_factory_request_response::PortFactoryRequestResponseType,
+    port_name::PortName,
 };
 
 type IpcPortFactoryClient<'a> = iceoryx2::service::port_factory::client::PortFactoryClient<
@@ -176,6 +177,25 @@ impl PortFactoryClient {
             PortFactoryClientType::Local(v) => {
                 let this = unsafe { (*v.lock()).__internal_partial_clone() };
                 let this = this.backpressure_strategy(value.clone().into());
+                self.clone_local(this)
+            }
+        }
+    }
+
+    /// The `PortName` that shall be assigned to the `Client`. It does not
+    /// have to be unique. If no `PortName` is defined then the `Client`
+    /// does not have a name.
+    pub fn name(&mut self, value: &PortName) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactoryClientType::Ipc(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.name(&value.0);
+                self.clone_ipc(this)
+            }
+            PortFactoryClientType::Local(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.name(&value.0);
                 self.clone_local(this)
             }
         }

--- a/iceoryx2-ffi/python/src/port_factory_listener.rs
+++ b/iceoryx2-ffi/python/src/port_factory_listener.rs
@@ -19,17 +19,18 @@ use crate::{
     listener::{Listener, ListenerType},
     parc::Parc,
     port_factory_event::PortFactoryEventType,
+    port_name::PortName,
 };
+
+type IpcPortFactoryListener<'a> =
+    iceoryx2::service::port_factory::listener::PortFactoryListener<'static, crate::IpcService>;
+type LocalPortFactoryListener<'a> =
+    iceoryx2::service::port_factory::listener::PortFactoryListener<'static, crate::LocalService>;
 
 #[derive(Clone)]
 pub(crate) enum PortFactoryListenerType {
-    Ipc(iceoryx2::service::port_factory::listener::PortFactoryListener<'static, crate::IpcService>),
-    Local(
-        iceoryx2::service::port_factory::listener::PortFactoryListener<
-            'static,
-            crate::LocalService,
-        >,
-    ),
+    Ipc(IpcPortFactoryListener<'static>),
+    Local(LocalPortFactoryListener<'static>),
 }
 
 #[pyclass]
@@ -69,10 +70,43 @@ impl PortFactoryListener {
             },
         }
     }
+
+    fn clone_ipc(&self, value: IpcPortFactoryListener<'static>) -> Self {
+        Self {
+            factory: self.factory.clone(),
+            value: PortFactoryListenerType::Ipc(value),
+        }
+    }
+
+    fn clone_local(&self, value: LocalPortFactoryListener<'static>) -> Self {
+        Self {
+            factory: self.factory.clone(),
+            value: PortFactoryListenerType::Local(value),
+        }
+    }
 }
 
 #[pymethods]
 impl PortFactoryListener {
+    /// The `PortName` that shall be assigned to the `Listener`. It does not
+    /// have to be unique. If no `PortName` is defined then the `Listener`
+    /// does not have a name.
+    pub fn name(&mut self, value: &PortName) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactoryListenerType::Ipc(v) => {
+                let this = v.clone();
+                let this = this.name(&value.0);
+                self.clone_ipc(this)
+            }
+            PortFactoryListenerType::Local(v) => {
+                let this = v.clone();
+                let this = this.name(&value.0);
+                self.clone_local(this)
+            }
+        }
+    }
+
     /// Creates the `Listener` port or emits a `ListenerCreateError` on failure.
     pub fn create(&self) -> PyResult<Listener> {
         let _guard = self.factory.lock();

--- a/iceoryx2-ffi/python/src/port_factory_notifier.rs
+++ b/iceoryx2-ffi/python/src/port_factory_notifier.rs
@@ -18,17 +18,18 @@ use crate::{
     notifier::{Notifier, NotifierType},
     parc::Parc,
     port_factory_event::PortFactoryEventType,
+    port_name::PortName,
 };
+
+type IpcPortFactoryNotifier<'a> =
+    iceoryx2::service::port_factory::notifier::PortFactoryNotifier<'static, crate::IpcService>;
+type LocalPortFactoryNotifier<'a> =
+    iceoryx2::service::port_factory::notifier::PortFactoryNotifier<'static, crate::LocalService>;
 
 #[derive(Clone)]
 pub(crate) enum PortFactoryNotifierType {
-    Ipc(iceoryx2::service::port_factory::notifier::PortFactoryNotifier<'static, crate::IpcService>),
-    Local(
-        iceoryx2::service::port_factory::notifier::PortFactoryNotifier<
-            'static,
-            crate::LocalService,
-        >,
-    ),
+    Ipc(IpcPortFactoryNotifier<'static>),
+    Local(LocalPortFactoryNotifier<'static>),
 }
 
 #[pyclass]
@@ -68,10 +69,43 @@ impl PortFactoryNotifier {
             },
         }
     }
+
+    fn clone_ipc(&self, value: IpcPortFactoryNotifier<'static>) -> Self {
+        Self {
+            factory: self.factory.clone(),
+            value: PortFactoryNotifierType::Ipc(value),
+        }
+    }
+
+    fn clone_local(&self, value: LocalPortFactoryNotifier<'static>) -> Self {
+        Self {
+            factory: self.factory.clone(),
+            value: PortFactoryNotifierType::Local(value),
+        }
+    }
 }
 
 #[pymethods]
 impl PortFactoryNotifier {
+    /// The `PortName` that shall be assigned to the `Notifier`. It does not
+    /// have to be unique. If no `PortName` is defined then the `Notifier`
+    /// does not have a name.
+    pub fn name(&mut self, value: &PortName) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactoryNotifierType::Ipc(v) => {
+                let this = v.clone();
+                let this = this.name(&value.0);
+                self.clone_ipc(this)
+            }
+            PortFactoryNotifierType::Local(v) => {
+                let this = v.clone();
+                let this = this.name(&value.0);
+                self.clone_local(this)
+            }
+        }
+    }
+
     /// Creates a new `Notifier` port or emits a `NotifierCreateError` on failure.
     pub fn create(&self) -> PyResult<Notifier> {
         let _guard = self.factory.lock();

--- a/iceoryx2-ffi/python/src/port_factory_publisher.rs
+++ b/iceoryx2-ffi/python/src/port_factory_publisher.rs
@@ -19,6 +19,7 @@ use crate::{
     error::PublisherCreateError,
     parc::Parc,
     port_factory_publish_subscribe::PortFactoryPublishSubscribeType,
+    port_name::PortName,
     publisher::{Publisher, PublisherType},
     type_storage::TypeStorage,
 };
@@ -168,6 +169,25 @@ impl PortFactoryPublisher {
             PortFactoryPublisherType::Local(v) => {
                 let this = unsafe { (*v.lock()).__internal_partial_clone() };
                 let this = this.backpressure_strategy(value.clone().into());
+                self.clone_local(this)
+            }
+        }
+    }
+
+    /// The `PortName` that shall be assigned to the `Publisher`. It does not
+    /// have to be unique. If no `PortName` is defined then the `Publisher`
+    /// does not have a name.
+    pub fn name(&mut self, value: &PortName) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactoryPublisherType::Ipc(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.name(&value.0);
+                self.clone_ipc(this)
+            }
+            PortFactoryPublisherType::Local(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.name(&value.0);
                 self.clone_local(this)
             }
         }

--- a/iceoryx2-ffi/python/src/port_factory_reader.rs
+++ b/iceoryx2-ffi/python/src/port_factory_reader.rs
@@ -17,6 +17,7 @@ use pyo3::prelude::*;
 use crate::error::ReaderCreateError;
 use crate::parc::Parc;
 use crate::port_factory_blackboard::PortFactoryBlackboardType;
+use crate::port_name::PortName;
 use crate::reader::{Reader, ReaderType};
 use crate::type_storage::TypeStorage;
 
@@ -72,10 +73,45 @@ impl PortFactoryReader {
             key_type_storage,
         }
     }
+
+    fn clone_ipc(&self, value: IpcPortFactoryReader<'static>) -> Self {
+        Self {
+            factory: self.factory.clone(),
+            value: PortFactoryReaderType::Ipc(Parc::new(value)),
+            key_type_storage: self.key_type_storage.clone(),
+        }
+    }
+
+    fn clone_local(&self, value: LocalPortFactoryReader<'static>) -> Self {
+        Self {
+            factory: self.factory.clone(),
+            value: PortFactoryReaderType::Local(Parc::new(value)),
+            key_type_storage: self.key_type_storage.clone(),
+        }
+    }
 }
 
 #[pymethods]
 impl PortFactoryReader {
+    /// The `PortName` that shall be assigned to the `Reader`. It does not
+    /// have to be unique. If no `PortName` is defined then the `Reader`
+    /// does not have a name.
+    pub fn name(&mut self, value: &PortName) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactoryReaderType::Ipc(v) => {
+                let this = (*v.lock()).clone();
+                let this = this.name(&value.0);
+                self.clone_ipc(this)
+            }
+            PortFactoryReaderType::Local(v) => {
+                let this = (*v.lock()).clone();
+                let this = this.name(&value.0);
+                self.clone_local(this)
+            }
+        }
+    }
+
     /// Creates a new `Reader` or emits a `ReaderCreateError` on failure.
     pub fn create(&self) -> PyResult<Reader> {
         let _guard = self.factory.lock();

--- a/iceoryx2-ffi/python/src/port_factory_server.rs
+++ b/iceoryx2-ffi/python/src/port_factory_server.rs
@@ -19,6 +19,7 @@ use crate::{
     error::ServerCreateError,
     parc::Parc,
     port_factory_request_response::PortFactoryRequestResponseType,
+    port_name::PortName,
     server::{Server, ServerType},
     type_storage::TypeStorage,
 };
@@ -196,6 +197,25 @@ impl PortFactoryServer {
             PortFactoryServerType::Local(v) => {
                 let this = unsafe { (*v.lock()).__internal_partial_clone() };
                 let this = this.max_loaned_responses_per_request(value);
+                self.clone_local(this)
+            }
+        }
+    }
+
+    /// The `PortName` that shall be assigned to the `Server`. It does not
+    /// have to be unique. If no `PortName` is defined then the `Server`
+    /// does not have a name.
+    pub fn name(&mut self, value: &PortName) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactoryServerType::Ipc(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.name(&value.0);
+                self.clone_ipc(this)
+            }
+            PortFactoryServerType::Local(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.name(&value.0);
                 self.clone_local(this)
             }
         }

--- a/iceoryx2-ffi/python/src/port_factory_subscriber.rs
+++ b/iceoryx2-ffi/python/src/port_factory_subscriber.rs
@@ -17,6 +17,7 @@ use crate::{
     error::SubscriberCreateError,
     parc::Parc,
     port_factory_publish_subscribe::PortFactoryPublishSubscribeType,
+    port_name::PortName,
     subscriber::{Subscriber, SubscriberType},
     type_storage::TypeStorage,
 };
@@ -133,6 +134,25 @@ impl PortFactorySubscriber {
             PortFactorySubscriberType::Local(v) => {
                 let this = unsafe { (*v.lock()).__internal_partial_clone() };
                 let this = this.history_request(value);
+                self.clone_local(this)
+            }
+        }
+    }
+
+    /// The `PortName` that shall be assigned to the `Subscriber`. It does not
+    /// have to be unique. If no `PortName` is defined then the `Subscriber`
+    /// does not have a name.
+    pub fn name(&mut self, value: &PortName) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactorySubscriberType::Ipc(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.name(&value.0);
+                self.clone_ipc(this)
+            }
+            PortFactorySubscriberType::Local(v) => {
+                let this = unsafe { (*v.lock()).__internal_partial_clone() };
+                let this = this.name(&value.0);
                 self.clone_local(this)
             }
         }

--- a/iceoryx2-ffi/python/src/port_factory_writer.rs
+++ b/iceoryx2-ffi/python/src/port_factory_writer.rs
@@ -17,6 +17,7 @@ use pyo3::prelude::*;
 use crate::error::WriterCreateError;
 use crate::parc::Parc;
 use crate::port_factory_blackboard::PortFactoryBlackboardType;
+use crate::port_name::PortName;
 use crate::type_storage::TypeStorage;
 use crate::writer::{Writer, WriterType};
 
@@ -72,10 +73,45 @@ impl PortFactoryWriter {
             key_type_storage,
         }
     }
+
+    fn clone_ipc(&self, value: IpcPortFactoryWriter<'static>) -> Self {
+        Self {
+            factory: self.factory.clone(),
+            value: PortFactoryWriterType::Ipc(Parc::new(value)),
+            key_type_storage: self.key_type_storage.clone(),
+        }
+    }
+
+    fn clone_local(&self, value: LocalPortFactoryWriter<'static>) -> Self {
+        Self {
+            factory: self.factory.clone(),
+            value: PortFactoryWriterType::Local(Parc::new(value)),
+            key_type_storage: self.key_type_storage.clone(),
+        }
+    }
 }
 
 #[pymethods]
 impl PortFactoryWriter {
+    /// The `PortName` that shall be assigned to the `Writer`. It does not
+    /// have to be unique. If no `PortName` is defined then the `Writer`
+    /// does not have a name.
+    pub fn name(&mut self, value: &PortName) -> Self {
+        let _guard = self.factory.lock();
+        match &self.value {
+            PortFactoryWriterType::Ipc(v) => {
+                let this = (*v.lock()).clone();
+                let this = this.name(&value.0);
+                self.clone_ipc(this)
+            }
+            PortFactoryWriterType::Local(v) => {
+                let this = (*v.lock()).clone();
+                let this = this.name(&value.0);
+                self.clone_local(this)
+            }
+        }
+    }
+
     /// Creates a new `Writer` or returns a `WriterCreateError` on failure.
     pub fn create(&self) -> PyResult<Writer> {
         let _guard = self.factory.lock();

--- a/iceoryx2-ffi/python/src/port_name.rs
+++ b/iceoryx2-ffi/python/src/port_name.rs
@@ -15,7 +15,7 @@ use pyo3::prelude::*;
 
 #[pyclass(str = "{0:?}", eq)]
 #[derive(PartialEq)]
-/// Represent the name for a `Node`.
+/// Represent the name for a port.
 pub struct PortName(pub(crate) iceoryx2::prelude::PortName);
 
 #[pymethods]

--- a/iceoryx2-ffi/python/src/port_name.rs
+++ b/iceoryx2-ffi/python/src/port_name.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::error::SemanticStringError;
+use pyo3::prelude::*;
+
+#[pyclass(str = "{0:?}", eq)]
+#[derive(PartialEq)]
+/// Represent the name for a `Node`.
+pub struct PortName(pub(crate) iceoryx2::prelude::PortName);
+
+#[pymethods]
+impl PortName {
+    #[staticmethod]
+    /// Creates a new `PortName`.
+    /// If the provided name does not contain a valid `PortName` it will emit
+    /// `SemanticStringError`, otherwise the `PortName`.
+    pub fn new(name: &str) -> PyResult<Self> {
+        Ok(Self(iceoryx2::prelude::PortName::new(name).map_err(
+            |e| SemanticStringError::new_err(format!("{e:?}")),
+        )?))
+    }
+
+    #[staticmethod]
+    /// Returns the maximum length of a `PortName`
+    pub fn max_len() -> usize {
+        iceoryx2::prelude::PortName::max_len()
+    }
+
+    /// Converts the `PortName` into a `String`
+    pub fn as_str(&self) -> String {
+        self.0.as_str().to_string()
+    }
+}

--- a/iceoryx2-ffi/python/src/publisher.rs
+++ b/iceoryx2-ffi/python/src/publisher.rs
@@ -21,6 +21,7 @@ use crate::{
     backpressure_strategy::BackpressureStrategy,
     error::{ConnectionFailure, LoanError},
     parc::Parc,
+    port_name::PortName,
     sample_mut_uninit::{SampleMutUninit, SampleMutUninitType},
     type_storage::TypeStorage,
     unique_publisher_id::UniquePublisherId,
@@ -70,6 +71,17 @@ impl Publisher {
             PublisherType::Local(Some(v)) => UniquePublisherId(v.id()),
             _ => fatal_panic!(from "Publisher::id()",
                 "Accessing a deleted publisher."),
+        }
+    }
+
+    #[getter]
+    /// Returns the `PortName` of the `Publisher`
+    pub fn name(&self) -> PortName {
+        match &*self.value.lock() {
+            PublisherType::Ipc(Some(v)) => PortName(*v.name()),
+            PublisherType::Local(Some(v)) => PortName(*v.name()),
+            _ => fatal_panic!(from "Publisher::name()",
+                              "Accessing a deleted publisher."),
         }
     }
 

--- a/iceoryx2-ffi/python/src/reader.rs
+++ b/iceoryx2-ffi/python/src/reader.rs
@@ -17,6 +17,7 @@ use pyo3::prelude::*;
 use crate::entry_handle::{EntryHandle, EntryHandleType, InternalValueStorage};
 use crate::error::EntryHandleError;
 use crate::parc::Parc;
+use crate::port_name::PortName;
 use crate::type_detail::TypeDetail;
 use crate::type_storage::TypeStorage;
 use crate::unique_reader_id::UniqueReaderId;
@@ -48,6 +49,17 @@ impl Reader {
             ReaderType::Local(Some(v)) => UniqueReaderId(v.id()),
             _ => fatal_panic!(from "Reader::id()",
                     "Accessing a deleted reader."),
+        }
+    }
+
+    #[getter]
+    /// Returns the `PortName` of the `Reader`
+    pub fn name(&self) -> PortName {
+        match &*self.value.lock() {
+            ReaderType::Ipc(Some(v)) => PortName(*v.name()),
+            ReaderType::Local(Some(v)) => PortName(*v.name()),
+            _ => fatal_panic!(from "Reader::name()",
+                              "Accessing a released reader."),
         }
     }
 

--- a/iceoryx2-ffi/python/src/server.rs
+++ b/iceoryx2-ffi/python/src/server.rs
@@ -19,6 +19,7 @@ use crate::{
     backpressure_strategy::BackpressureStrategy,
     error::{ConnectionFailure, ReceiveError},
     parc::Parc,
+    port_name::PortName,
     type_storage::TypeStorage,
     unique_server_id::UniqueServerId,
 };
@@ -83,6 +84,17 @@ impl Server {
             ServerType::Local(Some(v)) => UniqueServerId(v.id()),
             _ => fatal_panic!(from "Server::id()",
                 "Accessing a released server."),
+        }
+    }
+
+    #[getter]
+    /// Returns the `PortName` of the `Server`
+    pub fn name(&self) -> PortName {
+        match &self.value {
+            ServerType::Ipc(Some(v)) => PortName(*v.name()),
+            ServerType::Local(Some(v)) => PortName(*v.name()),
+            _ => fatal_panic!(from "Server::name()",
+                              "Accessing a released server."),
         }
     }
 

--- a/iceoryx2-ffi/python/src/subscriber.rs
+++ b/iceoryx2-ffi/python/src/subscriber.rs
@@ -17,6 +17,7 @@ use pyo3::prelude::*;
 use crate::{
     error::{ConnectionFailure, ReceiveError},
     parc::Parc,
+    port_name::PortName,
     sample::{Sample, SampleType},
     type_storage::TypeStorage,
     unique_subscriber_id::UniqueSubscriberId,
@@ -61,6 +62,17 @@ impl Subscriber {
             SubscriberType::Local(Some(v)) => UniqueSubscriberId(v.id()),
             _ => fatal_panic!(from "Subscriber::id()",
                     "Accessing a released Subscriber."),
+        }
+    }
+
+    #[getter]
+    /// Returns the `PortName` of the `Subscriber`
+    pub fn name(&self) -> PortName {
+        match &*self.value.lock() {
+            SubscriberType::Ipc(Some(v)) => PortName(*v.name()),
+            SubscriberType::Local(Some(v)) => PortName(*v.name()),
+            _ => fatal_panic!(from "Subscriber::name()",
+                              "Accessing a released Subscriber."),
         }
     }
 

--- a/iceoryx2-ffi/python/src/writer.rs
+++ b/iceoryx2-ffi/python/src/writer.rs
@@ -17,6 +17,7 @@ use pyo3::prelude::*;
 use crate::entry_handle_mut::{EntryHandleMut, EntryHandleMutType};
 use crate::error::EntryHandleMutError;
 use crate::parc::Parc;
+use crate::port_name::PortName;
 use crate::type_detail::TypeDetail;
 use crate::type_storage::TypeStorage;
 use crate::unique_writer_id::UniqueWriterId;
@@ -49,6 +50,17 @@ impl Writer {
             WriterType::Local(Some(v)) => UniqueWriterId(v.id()),
             _ => fatal_panic!(from "Writer::id()",
                     "Accessing a deleted writer."),
+        }
+    }
+
+    #[getter]
+    /// Returns the `PortName` of the `Writer`
+    pub fn name(&self) -> PortName {
+        match &*self.value.lock() {
+            WriterType::Ipc(Some(v)) => PortName(*v.name()),
+            WriterType::Local(Some(v)) => PortName(*v.name()),
+            _ => fatal_panic!(from "WriterType::name()",
+                              "Accessing a released writer."),
         }
     }
 

--- a/iceoryx2-ffi/python/tests/port_name_tests.py
+++ b/iceoryx2-ffi/python/tests/port_name_tests.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache Software License 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+# which is available at https://opensource.org/licenses/MIT.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import iceoryx2 as iox2
+import pytest
+
+
+def test_port_name_can_be_constructed() -> None:
+    sut = iox2.PortName.new("hello world")
+    assert sut.as_str() == "hello world"
+
+
+def test_port_name_construction_fails_when_max_len_is_exceeded() -> None:
+    sut_value = "x" * (iox2.PortName.max_len() + 1)
+    with pytest.raises(iox2.SemanticStringError):
+        iox2.PortName.new(sut_value)

--- a/iceoryx2-ffi/python/tests/service_blackboard_tests.py
+++ b/iceoryx2-ffi/python/tests/service_blackboard_tests.py
@@ -977,3 +977,30 @@ def test_new_value_can_be_written_using_value_mut(
     new_value_3 = ctypes.c_uint16(4567)
     entry_handle_mut.update_with_copy(new_value_3)
     assert entry_handle.get().decode_as(ctypes.c_uint16).value == new_value_3.value
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_port_names_can_be_set(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    service_name = iox2.testing.generate_service_name()
+    key = ctypes.c_uint64(0)
+    value = ctypes.c_uint16(0)
+
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+    service = (
+        node.service_builder(service_name)
+        .blackboard_creator(ctypes.c_uint64)
+        .add(key, value)
+        .create()
+    )
+
+    reader_name = iox2.PortName.new("scheherazade")
+    writer_name = iox2.PortName.new("homer")
+
+    reader = service.reader_builder().name(reader_name).create()
+    writer = service.writer_builder().name(writer_name).create()
+
+    assert reader.name == reader_name
+    assert writer.name == writer_name

--- a/iceoryx2-ffi/python/tests/service_event_tests.py
+++ b/iceoryx2-ffi/python/tests/service_event_tests.py
@@ -158,3 +158,23 @@ def test_listener_blocking_wait_works(
     assert events[0].count == 1
     assert events[1].id == event_id_2
     assert events[1].count == 1
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_port_names_can_be_set(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+
+    service_name = iox2.testing.generate_service_name()
+    service = node.service_builder(service_name).event().create()
+
+    notifier_name = iox2.PortName.new("yell")
+    listener_name = iox2.PortName.new("wiretap")
+
+    notifier = service.notifier_builder().name(notifier_name).create()
+    listener = service.listener_builder().name(listener_name).create()
+
+    assert notifier.name == notifier_name
+    assert listener.name == listener_name

--- a/iceoryx2-ffi/python/tests/service_publish_subscribe_tests.py
+++ b/iceoryx2-ffi/python/tests/service_publish_subscribe_tests.py
@@ -439,3 +439,23 @@ def test_history_request_reduces_delivered_history(
         assert received_sample.payload().contents.data == 85 + i
 
     assert not subscriber.has_samples()
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_port_names_can_be_set(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+
+    service_name = iox2.testing.generate_service_name()
+    service = node.service_builder(service_name).publish_subscribe(Payload).create()
+
+    publisher_name = iox2.PortName.new("hypnotoad")
+    subscriber_name = iox2.PortName.new("brainslug")
+
+    publisher = service.publisher_builder().name(publisher_name).create()
+    subscriber = service.subscriber_builder().name(subscriber_name).create()
+
+    assert publisher.name == publisher_name
+    assert subscriber.name == subscriber_name

--- a/iceoryx2-ffi/python/tests/service_request_response_tests.py
+++ b/iceoryx2-ffi/python/tests/service_request_response_tests.py
@@ -607,3 +607,25 @@ def test_communication_works_when_client_sets_max_active_requests(
 
     response = pending_response.receive()
     assert response.payload().contents.data == 1
+
+
+@pytest.mark.parametrize("service_type", service_types)
+def test_port_names_can_be_set(
+    service_type: iox2.ServiceType,
+) -> None:
+    config = iox2.testing.generate_isolated_config()
+    node = iox2.NodeBuilder.new().config(config).create(service_type)
+
+    service_name = iox2.testing.generate_service_name()
+    service = (
+        node.service_builder(service_name).request_response(Payload, Payload).create()
+    )
+
+    client_name = iox2.PortName.new("bruce")
+    server_name = iox2.PortName.new("alfred")
+
+    client = service.client_builder().name(client_name).create()
+    server = service.server_builder().name(server_name).create()
+
+    assert client.name == client_name
+    assert server.name == server_name


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR adds the Python bindings for the port name. Quite some stuff was inspired by the code from `NodeName`.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1773

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
