### PR TITLE
[#1800] Fix missing namespace around CleanupState

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -45,6 +45,7 @@
 * [#1770](https://github.com/eclipse-iceoryx/iceoryx2/issues/1770) Fix logging in python module.
 * [#1777](https://github.com/eclipse-iceoryx/iceoryx2/issues/1777) Fix service root folder creation named concept of iceoryx2-cal fixing execution on Windows platform.
 * [#1786](https://github.com/eclipse-iceoryx/iceoryx2/issues/1786) Disable transport_compression feature in Zenoh.
+* [#1800](https://github.com/eclipse-iceoryx/iceoryx2/issues/1800) iceoryx2-cxx: CleanupState is defined in global namespace
 
 ### Refactoring
 
@@ -186,6 +187,16 @@
             // ...
         }
     }
+    ```
+
+1. In iceoryx2-cxx `CleanupState` was moved to the `iox2` namespace.
+
+    ```c++
+    // old
+    CleanupState cleanup = node.try_cleanup_dead_nodes();
+
+    // new
+    iox2::CleanupState cleanup = node.try_cleanup_dead_nodes();
     ```
 
 <!-- markdownlint-enable MD013 -->

--- a/iceoryx2-cxx/include/iox2/cleanup_state.hpp
+++ b/iceoryx2-cxx/include/iox2/cleanup_state.hpp
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 
+namespace iox2 {
 /// Returned by [`Node::try_cleanup_dead_nodes()`]. Contains the cleanup report of the call
 /// and contains the number of dead nodes that were successfully cleaned up and how many
 /// could not be cleaned up.
@@ -26,5 +27,6 @@ struct CleanupState {
     /// The number of failed dead node cleanups
     uint64_t failed_cleanups;
 };
+} // namespace iox2
 
 #endif


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
- I built with `-DBUILD_TESTING=ON` and tests still compiled successfully and also ran `cmake --build build --target RUN_TESTS` and that reported 100% pass rate (on Win 11 x64).

## Pre-Review Checklist for the PR Author

* [ ] Add sensible notes for the reviewer
* [X] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [X] Relevant issues are linked in the [References](#references) section
* [ ] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [ ] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

Closes #1800

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
