### PR TITLE
[#1807] Fix C FFI enum stringification

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -45,6 +45,7 @@
 * [#1786](https://github.com/eclipse-iceoryx/iceoryx2/issues/1786) Disable transport_compression feature in Zenoh.
 * [#1792](https://github.com/eclipse-iceoryx/iceoryx2/issues/1792) Set key eq comparison function in language bindings for blackboard opener.
 * [#1800](https://github.com/eclipse-iceoryx/iceoryx2/issues/1800) iceoryx2-cxx: CleanupState is defined in global namespace
+* [#1807](https://github.com/eclipse-iceoryx/iceoryx2/issues/1807) Fix generated C FFI strings for `UPPER_SNAKE_CASE` enum variants.
 
 ### Refactoring
 

--- a/iceoryx2-ffi/c/src/tests/node_builder_tests.rs
+++ b/iceoryx2-ffi/c/src/tests/node_builder_tests.rs
@@ -10,6 +10,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+mod node_creation_failure_string {
+    use crate::api::*;
+    use core::ffi::CStr;
+    use iceoryx2_bb_testing::assert_that;
+
+    #[test]
+    fn converts_upper_snake_case_to_words() {
+        unsafe {
+            let internal_error = CStr::from_ptr(iox2_node_creation_failure_string(
+                iox2_node_creation_failure_e::INTERNAL_ERROR,
+            ))
+            .to_str()
+            .unwrap();
+            assert_that!(internal_error, eq("internal error"));
+
+            let insufficient_permissions = CStr::from_ptr(iox2_node_creation_failure_string(
+                iox2_node_creation_failure_e::INSUFFICIENT_PERMISSIONS,
+            ))
+            .to_str()
+            .unwrap();
+            assert_that!(insufficient_permissions, eq("insufficient permissions"));
+        }
+    }
+}
+
 #[generic_tests::define]
 mod node_builder {
     use crate::api::*;

--- a/iceoryx2-ffi/ffi-macros/src/lib.rs
+++ b/iceoryx2-ffi/ffi-macros/src/lib.rs
@@ -280,16 +280,9 @@ pub fn string_literal_derive(input: TokenStream) -> TokenStream {
                     })
                     .unwrap_or_else(|| {
                         // No explicity `CStr` is provided.
-                        // Convert variant name from 'UpperCamelCase' to 'lowercase with spaces'.
-                        let enum_string = enum_name.to_string()
-                            .char_indices()
-                            .fold(String::new(), |mut acc, (i, c)| {
-                                if i > 0 && c.is_uppercase() {
-                                    acc.push(' ');
-                                }
-                                acc.push(c.to_ascii_lowercase());
-                                acc
-                            });
+                        // Convert variant name from 'UpperCamelCase' or 'UPPER_SNAKE_CASE'
+                        // to 'lowercase with spaces'.
+                        let enum_string = variant_name_to_string(&enum_name.to_string());
                         null_terminated(&enum_string)
                     });
 
@@ -320,4 +313,85 @@ pub fn string_literal_derive(input: TokenStream) -> TokenStream {
             #as_cstr_impl
         }
     })
+}
+
+fn variant_name_to_string(name: &str) -> String {
+    let chars = name.chars().collect::<Vec<_>>();
+    let mut result = String::with_capacity(name.len());
+
+    for (i, &c) in chars.iter().enumerate() {
+        if c == '_' {
+            // Treat underscores as word separators and collapse repeated underscores.
+            if !result.ends_with(' ') {
+                result.push(' ');
+            }
+            continue;
+        }
+
+        let prev = i.checked_sub(1).and_then(|prev| chars.get(prev)).copied();
+        let next = chars.get(i + 1).copied();
+        // Split before uppercase letters that start new CamelCase words.
+        let starts_camel_word = c.is_uppercase()
+            && i > 0
+            && prev != Some('_')
+            && (prev.is_some_and(|prev| prev.is_lowercase() || prev.is_ascii_digit())
+                || next.is_some_and(|next| next.is_lowercase()));
+
+        if starts_camel_word && !result.ends_with(' ') {
+            result.push(' ');
+        }
+        result.push(c.to_ascii_lowercase());
+    }
+
+    // Leading or trailing underscores may have produced outer spaces.
+    result.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::variant_name_to_string;
+
+    #[test]
+    fn variant_name_to_string_converts_upper_camel_case() {
+        assert_eq!(variant_name_to_string("VariantTwo"), "variant two");
+        assert_eq!(variant_name_to_string("InternalError"), "internal error");
+    }
+
+    #[test]
+    fn variant_name_to_string_converts_upper_snake_case() {
+        assert_eq!(variant_name_to_string("INTERNAL_ERROR"), "internal error");
+        assert_eq!(
+            variant_name_to_string("INSUFFICIENT_PERMISSIONS"),
+            "insufficient permissions"
+        );
+    }
+
+    #[test]
+    fn variant_name_to_string_keeps_acronyms_together() {
+        assert_eq!(variant_name_to_string("URLParseError"), "url parse error");
+        assert_eq!(variant_name_to_string("HTTP_REQUEST"), "http request");
+    }
+
+    #[test]
+    fn variant_name_to_string_trims_outer_separators() {
+        assert_eq!(
+            variant_name_to_string("__INTERNAL_ERROR__"),
+            "internal error"
+        );
+        assert_eq!(variant_name_to_string("__INTERNAL_ERROR"), "internal error");
+        assert_eq!(variant_name_to_string("INTERNAL_ERROR__"), "internal error");
+    }
+
+    #[test]
+    fn variant_name_to_string_collapses_repeated_separators() {
+        assert_eq!(variant_name_to_string("INTERNAL__ERROR"), "internal error");
+        assert_eq!(variant_name_to_string("__"), "");
+    }
+
+    #[test]
+    fn variant_name_to_string_handles_short_names() {
+        assert_eq!(variant_name_to_string("A"), "a");
+        assert_eq!(variant_name_to_string("AB"), "ab");
+        assert_eq!(variant_name_to_string("A_B"), "a b");
+    }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer

Fixes the generated C FFI string representation for `UPPER_SNAKE_CASE` enum
variants. Before this change, variants such as `INTERNAL_ERROR` were rendered as
`i n t e r n a l_ e r r o r`; they now render as `internal error`.

The change keeps the existing `UpperCamelCase` behavior and adds coverage for:

* `UpperCamelCase` conversion in the `CStrRepr` macro helper
* `UPPER_SNAKE_CASE` conversion in the `CStrRepr` macro helper
* acronym handling, e.g. `URLParseError`
* the exported C FFI path via `iox2_node_creation_failure_string(...)`

Tested with:

* `cargo test -p iceoryx2-ffi-macros`
* `cargo test -p iceoryx2-ffi-c node_creation_failure_string`

The local branch follows the documented format:
`iox2-1807-fix-c-ffi-enum-stringification`.

NB Codex-implemented (5.5 Extra High)

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1807

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->