### PR TITLE
[#1727] Add node_id() getter to C++ NodeState

### DIFF
--- a/iceoryx2-cxx/include/iox2/node_state.hpp
+++ b/iceoryx2-cxx/include/iox2/node_state.hpp
@@ -95,6 +95,9 @@ class NodeState {
     auto operator=(NodeState&&) -> NodeState& = default;
     ~NodeState() = default;
 
+    /// Returns the [`UniqueNodeId`] of the corresponding [`Node`].
+    auto node_id() const -> const UniqueNodeId&;
+
     /// If the [`Node`] is alive the provided callback is called with an [`AliveNodeView`]
     /// as argument.
     auto alive(const iox2::bb::StaticFunction<void(AliveNodeView<T>&)>& callback) -> NodeState&;

--- a/iceoryx2-cxx/src/node_state.cpp
+++ b/iceoryx2-cxx/src/node_state.cpp
@@ -111,6 +111,22 @@ NodeState<T>::NodeState(iox2_node_state_e node_state, const UniqueNodeId& node_i
 }
 
 template <ServiceType T>
+auto NodeState<T>::node_id() const -> const UniqueNodeId& {
+    switch (m_state.index()) {
+    case ALIVE_STATE:
+        return m_state.template get_at_index<ALIVE_STATE>()->id();
+    case DEAD_STATE:
+        return m_state.template get_at_index<DEAD_STATE>()->id();
+    case INACCESSIBLE_STATE:
+        return *m_state.template get_at_index<INACCESSIBLE_STATE>();
+    case UNDEFINED_STATE:
+        return *m_state.template get_at_index<UNDEFINED_STATE>();
+    default:
+        IOX2_UNREACHABLE();
+    }
+}
+
+template <ServiceType T>
 auto NodeState<T>::alive(const iox2::bb::StaticFunction<void(AliveNodeView<T>&)>& callback) -> NodeState& {
     if (m_state.index() == ALIVE_STATE) {
         callback(*m_state.template get_at_index<ALIVE_STATE>());

--- a/iceoryx2-cxx/tests/src/node_state_tests.cpp
+++ b/iceoryx2-cxx/tests/src/node_state_tests.cpp
@@ -37,6 +37,7 @@ TYPED_TEST(NodeStateTest, alive_node_works) {
     bool has_invalid_state = false;
     Node<SERVICE_TYPE>::list(node.config(), [&](auto state) -> auto {
         state.alive([&](auto& view) -> auto {
+            EXPECT_EQ(state.node_id(), node_id);
             alive_node_found = view.details()->name().to_string() == node_name.to_string();
         });
         state.dead([&](auto& view) -> auto {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The Rust NodeState enum provides a node_id() method that returns the node UniqueNodeId across all four variants. The C++ binding was missing this getter, forcing callers to use the callback-based visitor methods just to extract the ID.

This adds a const node_id() getter that returns const UniqueNodeId& regardless of state, matching the existing AliveNodeView::id() and DeadNodeView::id() patterns.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #1727

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->