### PR TITLE
[#1797] Reclaim disconnected client connections

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -45,6 +45,7 @@
 * [#1777](https://github.com/eclipse-iceoryx/iceoryx2/issues/1777) Fix service root folder creation named concept of iceoryx2-cal fixing execution on Windows platform.
 * [#1786](https://github.com/eclipse-iceoryx/iceoryx2/issues/1786) Disable transport_compression feature in Zenoh.
 * [#1792](https://github.com/eclipse-iceoryx/iceoryx2/issues/1792) Set key eq comparison function in language bindings for blackboard opener.
+* [#1797](https://github.com/eclipse-iceoryx/iceoryx2/issues/1797) Reclaim disconnected request-response client connections when fire-and-forget requests are disabled.
 * [#1800](https://github.com/eclipse-iceoryx/iceoryx2/issues/1800) iceoryx2-cxx: CleanupState is defined in global namespace
 * [#1807](https://github.com/eclipse-iceoryx/iceoryx2/issues/1807) Fix generated C FFI strings for `UPPER_SNAKE_CASE` enum variants.
 * [#1810](https://github.com/eclipse-iceoryx/iceoryx2/issues/1810) Make mgmt segment globally accessible

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -1728,4 +1728,39 @@ pub mod service_request_response {
         assert_that!(response, is_some);
         assert_that!(*response.unwrap(), eq 1);
     }
+
+    #[conformance_test]
+    pub fn reconnecting_clients_do_not_exhaust_server_connection_storage_when_fire_and_forget_is_disabled<
+        S: Service,
+    >() {
+        const MAX_CLIENTS: usize = 2;
+        const EXPIRED_CONNECTION_BUFFER: usize = 4;
+        const ITERATIONS: usize = 3 * (MAX_CLIENTS + EXPIRED_CONNECTION_BUFFER);
+
+        let mut test = Test::<S>::new();
+        test.config_mut()
+            .defaults
+            .request_response
+            .server_expired_connection_buffer = EXPIRED_CONNECTION_BUFFER;
+        let node = test.create_node();
+        let service_name = generate_service_name();
+
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<usize, usize>()
+            .enable_fire_and_forget_requests(false)
+            .max_clients(MAX_CLIENTS)
+            .create()
+            .unwrap();
+
+        let server = service.server_builder().create().unwrap();
+
+        for n in 0..ITERATIONS {
+            let client = service.client_builder().create().unwrap();
+            let _pending_response = client.send_copy(n).unwrap();
+            while let Some(active_request) = server.receive().unwrap() {
+                drop(active_request);
+            }
+        }
+    }
 }

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -547,10 +547,10 @@ impl<
             service_state: service.clone(),
             buffer_size: static_config.max_response_buffer_size,
             tagger: CyclicTagger::new(),
-            to_be_removed_connections: Some(UnsafeCell::new(
+            to_be_removed_connections: UnsafeCell::new(
                 PolymorphicVec::new(HeapAllocator::global(), number_of_to_be_removed_connections)
                     .expect("Heap allocator provides memory."),
-            )),
+            ),
             degradation_handler: client_factory.response_degradation_handler,
             message_type_details: static_config.response_message_type_details,
             receiver_max_borrowed_samples: static_config

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -143,7 +143,7 @@ pub(crate) struct Receiver<Service: service::Service, Resource: ServiceResource>
     pub(crate) buffer_size: usize,
     pub(crate) tagger: CyclicTagger,
     pub(crate) to_be_removed_connections:
-        Option<UnsafeCell<PolymorphicVec<'static, SlotMapKey, HeapAllocator>>>,
+        UnsafeCell<PolymorphicVec<'static, SlotMapKey, HeapAllocator>>,
     pub(crate) degradation_handler: DegradationHandler<'static>,
     pub(crate) message_type_details: MessageTypeDetails,
     pub(crate) receiver_max_borrowed_samples: usize,
@@ -258,71 +258,69 @@ impl<Service: service::Service, Resource: ServiceResource> Receiver<Service, Res
     }
 
     pub(crate) fn prepare_connection_removal(&self, index: usize) {
-        if let Some(to_be_removed_connections) = &self.to_be_removed_connections {
-            let key = unsafe { *self.connections[index].get() };
-            let key = match key {
-                None => return,
-                Some(key) => key,
-            };
+        let key = unsafe { *self.connections[index].get() };
+        let key = match key {
+            None => return,
+            Some(key) => key,
+        };
 
-            let connection_storage = unsafe { &mut *self.connection_storage.get() };
+        let connection_storage = unsafe { &mut *self.connection_storage.get() };
 
-            if let Some(connection) = connection_storage.get_mut(key) {
-                let receiver = &connection.receiver;
-                let (connection_has_data, connection_has_borrows) =
-                    Self::receiver_channels_have_data_or_borrows(receiver);
+        if let Some(connection) = connection_storage.get_mut(key) {
+            let receiver = &connection.receiver;
+            let (connection_has_data, connection_has_borrows) =
+                Self::receiver_channels_have_data_or_borrows(receiver);
 
-                let keep_connection = connection_has_data | connection_has_borrows;
-                if keep_connection {
-                    let to_be_removed_connections =
-                        unsafe { &mut *to_be_removed_connections.get() };
-                    if to_be_removed_connections.push(key).is_err() {
-                        let msg_begin = "Expired connection buffer exceeded.";
-                        let msg_disconnect_with_data =
-                            "A sender disconnected with undelivered data that will be discarded.";
-                        let msg_disconnet_with_borrows = "A sender disconnected with data that is still borrowed. This will lead to segmentation faults when the data is accessed later on.";
-                        let msg_end =
-                            "Increase the expired connection buffer to mitigate the problem.";
+            let keep_connection = connection_has_data | connection_has_borrows;
+            if keep_connection {
+                let to_be_removed_connections =
+                    unsafe { &mut *self.to_be_removed_connections.get() };
+                if to_be_removed_connections.push(key).is_err() {
+                    let msg_begin = "Expired connection buffer exceeded.";
+                    let msg_disconnect_with_data =
+                        "A sender disconnected with undelivered data that will be discarded.";
+                    let msg_disconnet_with_borrows = "A sender disconnected with data that is still borrowed. This will lead to segmentation faults when the data is accessed later on.";
+                    let msg_end =
+                        "Increase the expired connection buffer to mitigate the problem.";
 
-                        // push failed! let's see if there is something that can be removed
-                        let index_and_key_to_remove =
-                            Self::find_connection_without_data_and_borrows(
-                                connection_storage,
-                                to_be_removed_connections,
-                            );
+                    // push failed! let's see if there is something that can be removed
+                    let index_and_key_to_remove =
+                        Self::find_connection_without_data_and_borrows(
+                            connection_storage,
+                            to_be_removed_connections,
+                        );
+
+                    if let Some((index, key)) = index_and_key_to_remove {
+                        // we found a connection without data and borrows which can be removed from the container
+                        to_be_removed_connections.remove(index);
+                        connection_storage.remove(key);
+                    } else if connection_has_borrows {
+                        // we did not find a connection that can safely be removed to create some space for the connection with borrows;
+                        // removing a connection with borrows might lead to segfaults -> try to remove a connection without borrows
+                        let index_and_key_to_remove = Self::find_connection_without_borrows(
+                            connection_storage,
+                            to_be_removed_connections,
+                        );
 
                         if let Some((index, key)) = index_and_key_to_remove {
-                            // we found a connection without data and borrows which can be removed from the container
+                            // we found a connection without borrows which can be removed from the container
+                            warn!(from self, "{} {} {}", msg_begin, msg_disconnect_with_data, msg_end);
                             to_be_removed_connections.remove(index);
-                            connection_storage.remove(key);
-                        } else if connection_has_borrows {
-                            // we did not find a connection that can safely be removed to create some space for the connection with borrows;
-                            // removing a connection with borrows might lead to segfaults -> try to remove a connection without borrows
-                            let index_and_key_to_remove = Self::find_connection_without_borrows(
-                                connection_storage,
-                                to_be_removed_connections,
-                            );
-
-                            if let Some((index, key)) = index_and_key_to_remove {
-                                // we found a connection without borrows which can be removed from the container
-                                warn!(from self, "{} {} {}", msg_begin, msg_disconnect_with_data, msg_end);
-                                to_be_removed_connections.remove(index);
-                                connection_storage.remove(key);
-                            }
-                        }
-
-                        if to_be_removed_connections.push(key).is_err() {
-                            if connection_has_borrows {
-                                fatal_panic!(from self, "This should never happen! {} {} {}", msg_begin, msg_disconnet_with_borrows, msg_end);
-                            } else {
-                                warn!(from self, "{} {} {}", msg_begin, msg_disconnect_with_data, msg_end);
-                            }
                             connection_storage.remove(key);
                         }
                     }
-                } else {
-                    connection_storage.remove(key);
+
+                    if to_be_removed_connections.push(key).is_err() {
+                        if connection_has_borrows {
+                            fatal_panic!(from self, "This should never happen! {} {} {}", msg_begin, msg_disconnet_with_borrows, msg_end);
+                        } else {
+                            warn!(from self, "{} {} {}", msg_begin, msg_disconnect_with_data, msg_end);
+                        }
+                        connection_storage.remove(key);
+                    }
                 }
+            } else {
+                connection_storage.remove(key);
             }
         }
     }
@@ -479,62 +477,60 @@ impl<Service: service::Service, Resource: ServiceResource> Receiver<Service, Res
         channel_id: ChannelId,
     ) -> Result<Option<(ChunkDetails, Chunk)>, ReceiveError> {
         let mut ret_val = None;
-        if let Some(to_be_removed_connections) = &self.to_be_removed_connections {
-            let to_be_removed_connections = unsafe { &mut *to_be_removed_connections.get() };
+        let to_be_removed_connections = unsafe { &mut *self.to_be_removed_connections.get() };
 
-            if !to_be_removed_connections.is_empty() {
-                let connection_storage = unsafe { &mut *self.connection_storage.get() };
+        if !to_be_removed_connections.is_empty() {
+            let connection_storage = unsafe { &mut *self.connection_storage.get() };
 
-                let mut indices_to_skip = 0;
-                // loop through all 'to_be_removed_connections' break the for-loop if a connection needs to be removed;
-                // then continue the for-loop but skip the previously looped indices
-                loop {
-                    let mut index_and_key = None;
-                    for (n, connection_key) in to_be_removed_connections
-                        .iter()
-                        .skip(indices_to_skip)
-                        .enumerate()
-                    {
-                        let connection = match connection_storage.get(*connection_key) {
-                            Some(connection) => connection,
-                            None => {
-                                index_and_key = Some((n, *connection_key));
-                                break;
-                            }
-                        };
-                        let receiver = &connection.receiver;
-
-                        if receiver.borrow_count(channel_id) == receiver.max_borrowed_samples() {
-                            continue;
-                        }
-
-                        if let Some((details, absolute_address)) =
-                            self.receive_from_connection(connection, *connection_key, channel_id)?
-                        {
-                            ret_val = Some((details, absolute_address));
+            let mut indices_to_skip = 0;
+            // loop through all 'to_be_removed_connections' break the for-loop if a connection needs to be removed;
+            // then continue the for-loop but skip the previously looped indices
+            loop {
+                let mut index_and_key = None;
+                for (n, connection_key) in to_be_removed_connections
+                    .iter()
+                    .skip(indices_to_skip)
+                    .enumerate()
+                {
+                    let connection = match connection_storage.get(*connection_key) {
+                        Some(connection) => connection,
+                        None => {
+                            index_and_key = Some((n, *connection_key));
                             break;
-                        } else {
-                            let (_has_data, has_borrows) =
-                                Self::receiver_channels_have_data_or_borrows(receiver);
-
-                            if !has_borrows {
-                                index_and_key = Some((n, *connection_key));
-                                break;
-                            }
                         }
-                    }
-                    // there is a connection which has neither data nor borrows nor is it present in the 'connection_storage'
-                    if let Some((index, key)) = index_and_key {
-                        to_be_removed_connections.remove(index);
-                        connection_storage.remove(key);
-                        indices_to_skip = index;
+                    };
+                    let receiver = &connection.receiver;
 
+                    if receiver.borrow_count(channel_id) == receiver.max_borrowed_samples() {
                         continue;
                     }
 
-                    // at this point we either were able to receive a sample or iterated through all connections
-                    break;
+                    if let Some((details, absolute_address)) =
+                        self.receive_from_connection(connection, *connection_key, channel_id)?
+                    {
+                        ret_val = Some((details, absolute_address));
+                        break;
+                    } else {
+                        let (_has_data, has_borrows) =
+                            Self::receiver_channels_have_data_or_borrows(receiver);
+
+                        if !has_borrows {
+                            index_and_key = Some((n, *connection_key));
+                            break;
+                        }
+                    }
                 }
+                // there is a connection which has neither data nor borrows nor is it present in the 'connection_storage'
+                if let Some((index, key)) = index_and_key {
+                    to_be_removed_connections.remove(index);
+                    connection_storage.remove(key);
+                    indices_to_skip = index;
+
+                    continue;
+                }
+
+                // at this point we either were able to receive a sample or iterated through all connections
+                break;
             }
         }
 

--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -280,15 +280,13 @@ impl<Service: service::Service, Resource: ServiceResource> Receiver<Service, Res
                     let msg_disconnect_with_data =
                         "A sender disconnected with undelivered data that will be discarded.";
                     let msg_disconnet_with_borrows = "A sender disconnected with data that is still borrowed. This will lead to segmentation faults when the data is accessed later on.";
-                    let msg_end =
-                        "Increase the expired connection buffer to mitigate the problem.";
+                    let msg_end = "Increase the expired connection buffer to mitigate the problem.";
 
                     // push failed! let's see if there is something that can be removed
-                    let index_and_key_to_remove =
-                        Self::find_connection_without_data_and_borrows(
-                            connection_storage,
-                            to_be_removed_connections,
-                        );
+                    let index_and_key_to_remove = Self::find_connection_without_data_and_borrows(
+                        connection_storage,
+                        to_be_removed_connections,
+                    );
 
                     if let Some((index, key)) = index_and_key_to_remove {
                         // we found a connection without data and borrows which can be removed from the container

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -385,17 +385,13 @@ impl<
             enable_safe_overflow: static_config.enable_safe_overflow_for_requests,
             buffer_size: static_config.max_active_requests_per_client,
             tagger: CyclicTagger::new(),
-            to_be_removed_connections: if static_config.enable_fire_and_forget_requests {
-                Some(UnsafeCell::new(
-                    PolymorphicVec::new(
-                        HeapAllocator::global(),
-                        number_of_to_be_removed_connections,
-                    )
-                    .expect("Heap allocator provides memory."),
-                ))
-            } else {
-                None
-            },
+            to_be_removed_connections: Some(UnsafeCell::new(
+                PolymorphicVec::new(
+                    HeapAllocator::global(),
+                    number_of_to_be_removed_connections,
+                )
+                .expect("Heap allocator provides memory."),
+            )),
             degradation_handler: server_factory.request_degradation_handler,
             number_of_channels: 1,
             connection_storage: UnsafeCell::new(SlotMap::new(number_of_connections)),

--- a/iceoryx2/src/port/server.rs
+++ b/iceoryx2/src/port/server.rs
@@ -385,13 +385,10 @@ impl<
             enable_safe_overflow: static_config.enable_safe_overflow_for_requests,
             buffer_size: static_config.max_active_requests_per_client,
             tagger: CyclicTagger::new(),
-            to_be_removed_connections: Some(UnsafeCell::new(
-                PolymorphicVec::new(
-                    HeapAllocator::global(),
-                    number_of_to_be_removed_connections,
-                )
-                .expect("Heap allocator provides memory."),
-            )),
+            to_be_removed_connections: UnsafeCell::new(
+                PolymorphicVec::new(HeapAllocator::global(), number_of_to_be_removed_connections)
+                    .expect("Heap allocator provides memory."),
+            ),
             degradation_handler: server_factory.request_degradation_handler,
             number_of_channels: 1,
             connection_storage: UnsafeCell::new(SlotMap::new(number_of_connections)),

--- a/iceoryx2/src/port/subscriber.rs
+++ b/iceoryx2/src/port/subscriber.rs
@@ -297,13 +297,13 @@ impl<
                 enable_safe_overflow: static_config.enable_safe_overflow,
                 buffer_size,
                 tagger: CyclicTagger::new(),
-                to_be_removed_connections: Some(UnsafeCell::new(
+                to_be_removed_connections: UnsafeCell::new(
                     PolymorphicVec::new(
                         HeapAllocator::global(),
                         number_of_to_be_removed_connections,
                     )
                     .expect("Heap allocator provides memory."),
-                )),
+                ),
                 degradation_handler: config.degradation_handler,
                 number_of_channels: 1,
                 connection_storage: UnsafeCell::new(SlotMap::new(number_of_connections)),


### PR DESCRIPTION
## Notes for Reviewer

When fire-and-forget requests are disabled, the server does not allocate
`Receiver::to_be_removed_connections`. Since disconnected connections are
reclaimed through this buffer, every disconnected client permanently consumes
a connection storage slot.

After enough client reconnects, the connection storage reaches its capacity
and the server terminates with `Internal connection storage capacity exceeded`.

This change:

* Allocates the server's deferred connection-removal buffer regardless of
  whether fire-and-forget requests are enabled.
* Reuses the existing borrow-aware removal path, ensuring connections with
  outstanding `ActiveRequest`s remain deferred until they can be removed safely.
* Adds a conformance test that reconnects more clients than the combined
  `max_clients` and expired connection buffer capacity.
* Updates the unreleased bugfix notes.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft
* [x] Relevant issues are linked in the References section
* [x] Branch follows the naming format
* [x] Commit messages follow the project guideline
    * [x] Commit messages have the issue ID
* [x] Tests follow the best practice for testing
* [x] Changelog updated in the unreleased section

## PR Reviewer Reminders

* Commits are properly organized and messages follow the guideline
* Unit tests have been written for the corrected behavior
* PR title describes the changes

## References

Closes #1797