### PR TITLE
[#1834] Implement MaybeTorn wrapper

### DIFF
--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -44,7 +44,7 @@
 //! let new_value = Foo { bar: 4, baz: 6 };
 //! unsafe {
 //!     wrapper.write(new_value);
-//!     let read_value = wrapper.read().assume_init();
+//!     let read_value = wrapper.read().assume_consistent();
 //!     assert_eq!(read_value.bar, new_value.bar);
 //!     assert_eq!(read_value.baz, new_value.baz);
 //! }
@@ -81,7 +81,7 @@
 //!         .expect("RelocatableByteAtomic initialized.");
 //!
 //!     wrapper.write(new_value);
-//!     let read_value = wrapper.read().assume_init();
+//!     let read_value = wrapper.read().assume_consistent();
 //!     assert_eq!(read_value.bar, new_value.bar);
 //!     assert_eq!(read_value.baz, new_value.baz);
 //! }
@@ -97,6 +97,35 @@ use iceoryx2_bb_elementary_traits::allocator::{AllocationError, BaseAllocator};
 use iceoryx2_bb_elementary_traits::{atomic_copy::AtomicCopy, zero_copy_send::ZeroCopySend};
 use iceoryx2_log::fail;
 use iceoryx2_log::fatal_panic;
+
+/// A wrapper representing a value that has been copied byte-wise atomically, but might has
+/// been subject to torn-writes/torn-reads. Use [`MaybeTorn`] in conjunction with
+/// synchronization primitives (like a sequence lock) to verify that the data is consistent
+/// before use.
+#[repr(transparent)]
+pub struct MaybeTorn<T> {
+    inner: MaybeUninit<T>,
+}
+
+impl<T> MaybeTorn<T> {
+    /// Creates a new [`MaybeTorn<T>`] from the passed [`MaybeUninit<T>`].
+    pub fn new(inner: MaybeUninit<T>) -> Self {
+        Self { inner }
+    }
+
+    /// Extracts the value from the [`MaybeTorn`] container.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that the underlying memory does not contain a torn state,
+    /// otherwise `T` may be "logically" invalid. In the context of [`FixedSizeByteAtomic::read()`],
+    /// this means that the caller must have verified via synchronization primitives that no
+    /// concurrent writes occured during the read operation. If called on a torn value, using the
+    /// resulting `T` may lead to undefined behavior.
+    pub unsafe fn assume_consistent(self) -> T {
+        unsafe { self.inner.assume_init() }
+    }
+}
 
 /// Failures caused by [`FixedSizeByteAtomic::new()`].
 #[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
@@ -192,13 +221,13 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
         size_of::<T>()
     }
 
-    /// Copies the stored value byte-wise into a [`MaybeUninit<T>`].
+    /// Copies the stored value byte-wise into a [`MaybeTorn<T>`].
     ///
     /// # Safety
     ///
     /// * When the value is concurrently written to, torn-reads are possible. The user must take
     ///   care of the data integrity.
-    pub unsafe fn read(&self) -> MaybeUninit<T> {
+    pub unsafe fn read(&self) -> MaybeTorn<T> {
         self.verify_init("read()");
         unsafe { read_impl(self.data_ptr.as_ptr()) }
     }
@@ -259,13 +288,13 @@ impl<T: AtomicCopy, const SIZE: usize> FixedSizeByteAtomic<T, SIZE> {
         })
     }
 
-    /// Copies the stored value byte-wise into a [`MaybeUninit<T>`].
+    /// Copies the stored value byte-wise into a [`MaybeTorn<T>`].
     ///
     /// # Safety
     ///
     /// * When the value is concurrently written to, torn-reads are possible. The user must take care
     ///   of the data integrity.
-    pub unsafe fn read(&self) -> MaybeUninit<T> {
+    pub unsafe fn read(&self) -> MaybeTorn<T> {
         unsafe { read_impl(self.data.as_ptr()) }
     }
 
@@ -280,7 +309,7 @@ impl<T: AtomicCopy, const SIZE: usize> FixedSizeByteAtomic<T, SIZE> {
     }
 }
 
-unsafe fn read_impl<T: AtomicCopy>(src_data_ptr: *const AtomicU8) -> MaybeUninit<T> {
+unsafe fn read_impl<T: AtomicCopy>(src_data_ptr: *const AtomicU8) -> MaybeTorn<T> {
     let mut data: MaybeUninit<T> = MaybeUninit::uninit();
     let dest_data_ptr = data.as_mut_ptr() as *mut u8;
     for i in 0..size_of::<T>() {
@@ -288,7 +317,7 @@ unsafe fn read_impl<T: AtomicCopy>(src_data_ptr: *const AtomicU8) -> MaybeUninit
             *dest_data_ptr.add(i) = (*src_data_ptr.add(i)).load(Ordering::Relaxed);
         }
     }
-    data
+    MaybeTorn::new(data)
 }
 
 unsafe fn write_impl<T: AtomicCopy>(dest_data_ptr: *const AtomicU8, value: T) {

--- a/iceoryx2-bb/container/tests-common/src/byte_atomic_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/byte_atomic_tests.rs
@@ -10,6 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 
 use iceoryx2_bb_container::byte_atomic::*;
@@ -51,7 +52,7 @@ pub fn new_creates_byte_atomic_containing_passed_value() {
     const SIZE: usize = size_of::<u64>();
     let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(value);
     assert_that!(fixed_size_sut, is_ok);
-    let read_value = unsafe { fixed_size_sut.unwrap().read().assume_init() };
+    let read_value = unsafe { fixed_size_sut.unwrap().read().assume_consistent() };
     assert_that!(read_value, eq value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<u64>::const_memory_size();
@@ -62,7 +63,7 @@ pub fn new_creates_byte_atomic_containing_passed_value() {
         relocatable_sut
             .init(&allocator, value)
             .expect("RelocatableByteAtomic initialized.");
-        assert_that!(relocatable_sut.read().assume_init(), eq value);
+        assert_that!(relocatable_sut.read().assume_consistent(), eq value);
     }
 }
 
@@ -78,7 +79,7 @@ pub fn new_creates_fixed_size_byte_atomic_containing_passed_complex_value() {
     const SIZE: usize = size_of::<ComplexType>();
     let fixed_size_sut = FixedSizeByteAtomic::<ComplexType, SIZE>::new(value);
     assert_that!(fixed_size_sut, is_ok);
-    let read_value = unsafe { fixed_size_sut.unwrap().read().assume_init() };
+    let read_value = unsafe { fixed_size_sut.unwrap().read().assume_consistent() };
     assert_that!(read_value, eq value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<ComplexType>::const_memory_size();
@@ -89,7 +90,7 @@ pub fn new_creates_fixed_size_byte_atomic_containing_passed_complex_value() {
         relocatable_sut
             .init(&allocator, value)
             .expect("RelocatableByteAtomic initialized.");
-        let read_value = relocatable_sut.read().assume_init();
+        let read_value = relocatable_sut.read().assume_consistent();
         assert_that!(read_value, eq value);
     }
 }
@@ -102,7 +103,7 @@ pub fn byte_atomic_contains_passed_value_after_write() {
     let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(0).unwrap();
     unsafe {
         fixed_size_sut.write(new_value);
-        assert_that!(fixed_size_sut.read().assume_init(), eq new_value);
+        assert_that!(fixed_size_sut.read().assume_consistent(), eq new_value);
     }
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<u64>::const_memory_size();
@@ -114,7 +115,7 @@ pub fn byte_atomic_contains_passed_value_after_write() {
             .init(&allocator, 0)
             .expect("RelocatableByteAtomic initialized.");
         relocatable_sut.write(new_value);
-        assert_that!(relocatable_sut.read().assume_init(), eq new_value);
+        assert_that!(relocatable_sut.read().assume_consistent(), eq new_value);
     }
 }
 
@@ -137,7 +138,7 @@ pub fn byte_atomic_contains_passed_complex_value_after_write() {
     let fixed_size_sut = FixedSizeByteAtomic::<ComplexType, SIZE>::new(init_value).unwrap();
     unsafe {
         fixed_size_sut.write(new_value);
-        let read_value = fixed_size_sut.read().assume_init();
+        let read_value = fixed_size_sut.read().assume_consistent();
         assert_that!(read_value, eq new_value);
     }
 
@@ -150,7 +151,7 @@ pub fn byte_atomic_contains_passed_complex_value_after_write() {
             .init(&allocator, init_value)
             .expect("RelocatableByteAtomic initialized.");
         relocatable_sut.write(new_value);
-        let read_value = relocatable_sut.read().assume_init();
+        let read_value = relocatable_sut.read().assume_consistent();
         assert_that!(read_value, eq new_value);
     }
 }
@@ -192,10 +193,10 @@ pub fn concurrent_read_without_write_always_returns_correct_data() {
                     for _ in 0..REPETITIONS {
                         unsafe {
                             let read_value_fixed_size = fixed_size_sut.read();
-                            assert_that!(read_value_fixed_size.assume_init(), eq value);
+                            assert_that!(read_value_fixed_size.assume_consistent(), eq value);
 
                             let read_value_relocatable = relocatable_sut.read();
-                            assert_that!(read_value_relocatable.assume_init(), eq value);
+                            assert_that!(read_value_relocatable.assume_consistent(), eq value);
                         }
                     }
                 })
@@ -252,8 +253,8 @@ pub fn concurrent_write_does_not_trigger_ub() {
         let read_value_fixed_size = fixed_size_sut.read();
         let read_value_relocatable = relocatable_sut.read();
         // safe because the value is a u64
-        assert_that!(read_value_fixed_size.assume_init(), eq value);
-        assert_that!(read_value_relocatable.assume_init(), eq value);
+        assert_that!(read_value_fixed_size.assume_consistent(), eq value);
+        assert_that!(read_value_relocatable.assume_consistent(), eq value);
     }
 }
 
@@ -341,4 +342,14 @@ pub fn panic_is_called_in_debug_mode_if_relocatable_byte_atomic_is_not_initializ
         let sut = RelocatableByteAtomic::<u8>::new_uninit();
         sut.write(9);
     }
+}
+
+#[test]
+pub fn maybe_torn_contains_correct_value() {
+    let mut inner = MaybeUninit::<StaticString<10>>::uninit();
+    let data = StaticString::try_from("whoosh").unwrap();
+    inner.write(data);
+
+    let sut = MaybeTorn::new(inner);
+    assert_that!(unsafe { sut.assume_consistent() }, eq data);
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR introduces a wrapper that shall alert the user of `ByteAtomic::read()` that the returned value may be logically invalid because of possible torn-reads.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1834 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
