### PR TITLE
[#1837] Use logical AND instead of bitwise AND

### DIFF
--- a/iceoryx2/src/port/details/receiver.rs
+++ b/iceoryx2/src/port/details/receiver.rs
@@ -385,7 +385,7 @@ impl<Service: service::Service, Resource: ServiceResource> Receiver<Service, Res
             let channel_id = ChannelId::new(id);
             has_data |= receiver.has_data(channel_id);
             has_borrows |= receiver.borrow_count(channel_id) > 0;
-            if has_data & has_borrows {
+            if has_data && has_borrows {
                 break;
             }
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

There is one place in `receiver.rs` where a bitwise AND was used instead of a logical AND. This PR changes it to a logical AND. The behavior remains the same but it is a bit more efficient due to the short-circuiting if the first boolean is already `false`.

The change is not relevant enough to be added to the release notes.

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1837 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
