### PR TITLE
[#1841] Remove unsafe from read and write method in ByteAtomic

### DIFF
--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -219,28 +219,18 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
         size_of::<T>()
     }
 
-    /// Copies the stored value byte-wise into a [`MaybeTorn<T>`].
-    ///
-    /// # Safety
-    ///
-    /// * When the value is concurrently written to, torn-reads are possible. The user must take
-    ///   care of the data integrity.
-    pub unsafe fn read(&self) -> MaybeTorn<T> {
+    /// Copies the stored value byte-wise into a [`MaybeTorn<T>`]. Torn reads are possible when
+    /// the value is concurrently written to. The user must take care of the data integrity.
+    pub fn read(&self) -> MaybeTorn<T> {
         self.verify_init("read()");
-        unsafe { read_impl(self.data_ptr.as_ptr()) }
+        read_impl(self.data_ptr.as_ptr())
     }
 
-    /// Stores the passed value byte-wise atomically.
-    ///
-    /// # Safety
-    ///
-    /// * When used concurrently, torn-writes and torn-reads are possible. The user must take
-    ///   care of the data integrity.
-    pub unsafe fn write(&self, value: T) {
+    /// Stores the passed value byte-wise atomically. When used concurrently, torn writes and
+    /// torn reads are possible. The user must take care of the data integrity.
+    pub fn write(&self, value: T) {
         self.verify_init("write()");
-        unsafe {
-            write_impl(self.data_ptr.as_ptr(), value);
-        }
+        write_impl(self.data_ptr.as_ptr(), value);
     }
 }
 
@@ -286,28 +276,20 @@ impl<T: AtomicCopy, const SIZE: usize> FixedSizeByteAtomic<T, SIZE> {
         })
     }
 
-    /// Copies the stored value byte-wise into a [`MaybeTorn<T>`].
-    ///
-    /// # Safety
-    ///
-    /// * When the value is concurrently written to, torn-reads are possible. The user must take care
-    ///   of the data integrity.
-    pub unsafe fn read(&self) -> MaybeTorn<T> {
-        unsafe { read_impl(self.data.as_ptr()) }
+    /// Copies the stored value byte-wise into a [`MaybeTorn<T>`]. Torn reads are possible when
+    /// the value is concurrently written to. The user must take care of the data integrity.
+    pub fn read(&self) -> MaybeTorn<T> {
+        read_impl(self.data.as_ptr())
     }
 
-    /// Stores the passed value byte-wise atomically.
-    ///
-    /// # Safety
-    ///
-    /// * When used concurrently, torn-writes and torn-reads are possible. The user must take care
-    ///   of the data integrity.
-    pub unsafe fn write(&self, value: T) {
-        unsafe { write_impl(self.data.as_ptr(), value) };
+    /// Stores the passed value byte-wise atomically. When used concurrently, torn writes and
+    /// torn reads are possible. The user must take care of the data integrity.
+    pub fn write(&self, value: T) {
+        write_impl(self.data.as_ptr(), value);
     }
 }
 
-unsafe fn read_impl<T: AtomicCopy>(src_data_ptr: *const AtomicU8) -> MaybeTorn<T> {
+fn read_impl<T: AtomicCopy>(src_data_ptr: *const AtomicU8) -> MaybeTorn<T> {
     let mut data: MaybeUninit<T> = MaybeUninit::uninit();
     let dest_data_ptr = data.as_mut_ptr() as *mut u8;
     for i in 0..size_of::<T>() {
@@ -318,7 +300,7 @@ unsafe fn read_impl<T: AtomicCopy>(src_data_ptr: *const AtomicU8) -> MaybeTorn<T
     MaybeTorn::new(data)
 }
 
-unsafe fn write_impl<T: AtomicCopy>(dest_data_ptr: *const AtomicU8, value: T) {
+fn write_impl<T: AtomicCopy>(dest_data_ptr: *const AtomicU8, value: T) {
     let value_ptr = (&value as *const T) as *const u8;
     value.for_each_field(0, &mut |offset, size| {
         for i in offset..offset + size {

--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -39,7 +39,7 @@
 //! }
 //!
 //! const SIZE: usize = size_of::<Foo>();
-//! let wrapper = FixedSizeByteAtomic::<Foo, SIZE>::new(Foo { bar: 0, baz: 0 }).unwrap();
+//! let wrapper = FixedSizeByteAtomic::<Foo, SIZE>::new(Foo { bar: 0, baz: 0 });
 //!
 //! let new_value = Foo { bar: 4, baz: 6 };
 //! unsafe {
@@ -125,13 +125,6 @@ impl<T> MaybeTorn<T> {
     }
 }
 
-/// Failures caused by [`FixedSizeByteAtomic::new()`].
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq)]
-pub enum ByteAtomicError {
-    /// The size of the passed value and SIZE do not match.
-    SizesDoNotMatch,
-}
-
 /// A runtime fixed-size, shared-memory compatible [`RelocatableByteAtomic`].
 pub struct RelocatableByteAtomic<T: AtomicCopy> {
     data_ptr: RelocatablePointer<AtomicU8>,
@@ -199,7 +192,7 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
             }
         }
 
-        let value_ptr = (&value as *const T) as *const u8;
+        let value_ptr = (&raw const value).cast::<u8>();
         value.for_each_field(0, &mut |offset, size| {
             for i in offset..offset + size {
                 unsafe {
@@ -234,6 +227,20 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
     }
 }
 
+// TODO #1644: Used to check at compile-time that T and SIZE of FixedSizeByteAtomic are
+// equal. Can be removed once size_of::<T>() can be directly used in the struct definition.
+const fn static_assert_size_of<T, const SIZE: usize>() {
+    let () = AssertSizeOf::<T, SIZE>::OK;
+}
+
+struct AssertSizeOf<T, const SIZE: usize> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T, const SIZE: usize> AssertSizeOf<T, SIZE> {
+    const OK: () = assert!(size_of::<T>() == SIZE, "T must have size defined by SIZE");
+}
+
 /// A compile-time fixed-size, shared-memory compatible [`FixedSizeByteAtomic`].
 #[repr(C)]
 pub struct FixedSizeByteAtomic<T: AtomicCopy, const SIZE: usize> {
@@ -247,19 +254,15 @@ unsafe impl<T: AtomicCopy + ZeroCopySend, const SIZE: usize> ZeroCopySend
 }
 
 impl<T: AtomicCopy, const SIZE: usize> FixedSizeByteAtomic<T, SIZE> {
-    /// Creates a new [`FixedSizeByteAtomic`] that contains the passed value. It fails when
-    /// the size of the value and `SIZE` do not match.
-    pub fn new(value: T) -> Result<Self, ByteAtomicError> {
+    /// Creates a new [`FixedSizeByteAtomic`] that contains the passed value.
+    pub fn new(value: T) -> Self {
         // TODO #1644: The following check and the SIZE parameter can be removed once size_of::<T>()
         // can be directly used in the struct definition. Consider then to remove the
         // RelocatableByteAtomic implementation as well; maybe add a placement_new() to the
         // FixedSizeByteAtomic.
-        if size_of::<T>() != SIZE {
-            fail!(from "ByteAtomic::new()", with ByteAtomicError::SizesDoNotMatch,
-                "size_of::<T>() and SIZE must be equal.");
-        }
+        static_assert_size_of::<T, SIZE>();
 
-        let value_ptr = (&value as *const T) as *const u8;
+        let value_ptr = (&raw const value).cast::<u8>();
 
         // The passed value may contain padding bytes. Reading these padding bytes
         // would lead to undefined behavior. Therefore, we first set all bytes to zero and
@@ -270,10 +273,10 @@ impl<T: AtomicCopy, const SIZE: usize> FixedSizeByteAtomic<T, SIZE> {
                 *byte = unsafe { *value_ptr.add(i) };
             }
         });
-        Ok(Self {
+        Self {
             data: bytes.map(AtomicU8::new),
             _inner_type: PhantomData,
-        })
+        }
     }
 
     /// Copies the stored value byte-wise into a [`MaybeTorn<T>`]. Torn reads are possible when
@@ -301,7 +304,7 @@ fn read_impl<T: AtomicCopy>(src_data_ptr: *const AtomicU8) -> MaybeTorn<T> {
 }
 
 fn write_impl<T: AtomicCopy>(dest_data_ptr: *const AtomicU8, value: T) {
-    let value_ptr = (&value as *const T) as *const u8;
+    let value_ptr = (&raw const value).cast::<u8>();
     value.for_each_field(0, &mut |offset, size| {
         for i in offset..offset + size {
             unsafe {

--- a/iceoryx2-bb/container/tests-common/src/byte_atomic_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/byte_atomic_tests.rs
@@ -85,14 +85,14 @@ pub fn new_creates_fixed_size_byte_atomic_containing_passed_complex_value() {
     const MEM_SIZE: usize = RelocatableByteAtomic::<ComplexType>::const_memory_size();
     let memory = [0u8; MEM_SIZE];
     let allocator = BumpAllocator::new(NonNull::<u8>::from_ref(&memory[0]), memory.len());
+    let mut relocatable_sut = unsafe { RelocatableByteAtomic::new_uninit() };
     unsafe {
-        let mut relocatable_sut = RelocatableByteAtomic::new_uninit();
         relocatable_sut
             .init(&allocator, value)
             .expect("RelocatableByteAtomic initialized.");
-        let read_value = relocatable_sut.read().assume_consistent();
-        assert_that!(read_value, eq value);
     }
+    let read_value = relocatable_sut.read();
+    assert_that!(unsafe { read_value.assume_consistent() }, eq value);
 }
 
 #[test]
@@ -101,22 +101,20 @@ pub fn byte_atomic_contains_passed_value_after_write() {
 
     const SIZE: usize = size_of::<u64>();
     let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(0).unwrap();
-    unsafe {
-        fixed_size_sut.write(new_value);
-        assert_that!(fixed_size_sut.read().assume_consistent(), eq new_value);
-    }
+    fixed_size_sut.write(new_value);
+    assert_that!(unsafe { fixed_size_sut.read().assume_consistent() }, eq new_value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<u64>::const_memory_size();
     let memory = [0u8; MEM_SIZE];
     let allocator = BumpAllocator::new(NonNull::<u8>::from_ref(&memory[0]), memory.len());
+    let mut relocatable_sut = unsafe { RelocatableByteAtomic::new_uninit() };
     unsafe {
-        let mut relocatable_sut = RelocatableByteAtomic::new_uninit();
         relocatable_sut
             .init(&allocator, 0)
             .expect("RelocatableByteAtomic initialized.");
-        relocatable_sut.write(new_value);
-        assert_that!(relocatable_sut.read().assume_consistent(), eq new_value);
     }
+    relocatable_sut.write(new_value);
+    assert_that!(unsafe { relocatable_sut.read().assume_consistent() }, eq new_value);
 }
 
 #[test]
@@ -136,24 +134,22 @@ pub fn byte_atomic_contains_passed_complex_value_after_write() {
 
     const SIZE: usize = size_of::<ComplexType>();
     let fixed_size_sut = FixedSizeByteAtomic::<ComplexType, SIZE>::new(init_value).unwrap();
-    unsafe {
-        fixed_size_sut.write(new_value);
-        let read_value = fixed_size_sut.read().assume_consistent();
-        assert_that!(read_value, eq new_value);
-    }
+    fixed_size_sut.write(new_value);
+    let read_value = unsafe { fixed_size_sut.read().assume_consistent() };
+    assert_that!(read_value, eq new_value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<ComplexType>::const_memory_size();
     let memory = [0u8; MEM_SIZE];
     let allocator = BumpAllocator::new(NonNull::<u8>::from_ref(&memory[0]), memory.len());
+    let mut relocatable_sut = unsafe { RelocatableByteAtomic::new_uninit() };
     unsafe {
-        let mut relocatable_sut = RelocatableByteAtomic::new_uninit();
         relocatable_sut
             .init(&allocator, init_value)
             .expect("RelocatableByteAtomic initialized.");
-        relocatable_sut.write(new_value);
-        let read_value = relocatable_sut.read().assume_consistent();
-        assert_that!(read_value, eq new_value);
     }
+    relocatable_sut.write(new_value);
+    let read_value = relocatable_sut.read();
+    assert_that!(unsafe { read_value.assume_consistent() }, eq new_value);
 }
 
 // TODO #1601: The following tests should be run with Miri but using
@@ -182,8 +178,8 @@ pub fn concurrent_read_without_write_always_returns_correct_data() {
         relocatable_sut
             .init(&allocator, value)
             .expect("RelocatableByteAtomic initialized.");
-        relocatable_sut.write(value);
     }
+    relocatable_sut.write(value);
 
     thread_scope(|s| {
         for _ in 0..number_of_threads {
@@ -191,13 +187,11 @@ pub fn concurrent_read_without_write_always_returns_correct_data() {
                 .spawn(|| {
                     barrier.wait();
                     for _ in 0..REPETITIONS {
-                        unsafe {
-                            let read_value_fixed_size = fixed_size_sut.read();
-                            assert_that!(read_value_fixed_size.assume_consistent(), eq value);
+                        let read_value_fixed_size = fixed_size_sut.read();
+                        assert_that!(unsafe { read_value_fixed_size.assume_consistent() }, eq value);
 
-                            let read_value_relocatable = relocatable_sut.read();
-                            assert_that!(read_value_relocatable.assume_consistent(), eq value);
-                        }
+                        let read_value_relocatable = relocatable_sut.read();
+                        assert_that!(unsafe { read_value_relocatable.assume_consistent() }, eq value);
                     }
                 })
                 .expect("failed to spawn thread");
@@ -228,8 +222,8 @@ pub fn concurrent_write_does_not_trigger_ub() {
         relocatable_sut
             .init(&allocator, value)
             .expect("RelocatableByteAtomic initialized.");
-        relocatable_sut.write(value);
     }
+    relocatable_sut.write(value);
 
     thread_scope(|s| {
         for _ in 0..number_of_threads {
@@ -237,10 +231,8 @@ pub fn concurrent_write_does_not_trigger_ub() {
                 .spawn(|| {
                     barrier.wait();
                     for _ in 0..REPETITIONS {
-                        unsafe {
-                            fixed_size_sut.write(value);
-                            relocatable_sut.write(value);
-                        }
+                        fixed_size_sut.write(value);
+                        relocatable_sut.write(value);
                     }
                 })
                 .expect("failed to spawn thread");
@@ -249,9 +241,9 @@ pub fn concurrent_write_does_not_trigger_ub() {
     })
     .expect("failed to create scoped thread");
 
+    let read_value_fixed_size = fixed_size_sut.read();
+    let read_value_relocatable = relocatable_sut.read();
     unsafe {
-        let read_value_fixed_size = fixed_size_sut.read();
-        let read_value_relocatable = relocatable_sut.read();
         // safe because the value is a u64
         assert_that!(read_value_fixed_size.assume_consistent(), eq value);
         assert_that!(read_value_relocatable.assume_consistent(), eq value);
@@ -279,8 +271,8 @@ pub fn concurrent_read_and_write_does_not_trigger_ub() {
         relocatable_sut
             .init(&allocator, value)
             .expect("RelocatableByteAtomic initialized.");
-        relocatable_sut.write(value);
     }
+    relocatable_sut.write(value);
 
     thread_scope(|s| {
         for _ in 0..number_of_threads / 2 {
@@ -288,13 +280,11 @@ pub fn concurrent_read_and_write_does_not_trigger_ub() {
                 .spawn(|| {
                     barrier.wait();
                     for _ in 0..REPETITIONS {
-                        unsafe {
-                            let read_value_fixed_size = fixed_size_sut.read();
-                            let read_value_relocatable = relocatable_sut.read();
-                            // dummy assert to prevent the read operation from being optimized away
-                            assert_that!(core::mem::size_of_val(&read_value_fixed_size), eq SIZE);
-                            assert_that!(core::mem::size_of_val(&read_value_relocatable), eq SIZE);
-                        }
+                        let read_value_fixed_size = fixed_size_sut.read();
+                        let read_value_relocatable = relocatable_sut.read();
+                        // dummy assert to prevent the read operation from being optimized away
+                        assert_that!(core::mem::size_of_val(&read_value_fixed_size), eq SIZE);
+                        assert_that!(core::mem::size_of_val(&read_value_relocatable), eq SIZE);
                     }
                 })
                 .expect("failed to spawn thread");
@@ -305,10 +295,8 @@ pub fn concurrent_read_and_write_does_not_trigger_ub() {
                 .spawn(|| {
                     barrier.wait();
                     for _ in 0..REPETITIONS {
-                        unsafe {
-                            fixed_size_sut.write(value);
-                            relocatable_sut.write(value);
-                        }
+                        fixed_size_sut.write(value);
+                        relocatable_sut.write(value);
                     }
                 })
                 .expect("failed to spawn thread");
@@ -338,10 +326,8 @@ pub fn double_init_call_causes_panic() {
 #[cfg(debug_assertions)]
 #[should_panic]
 pub fn panic_is_called_in_debug_mode_if_relocatable_byte_atomic_is_not_initialized() {
-    unsafe {
-        let sut = RelocatableByteAtomic::<u8>::new_uninit();
-        sut.write(9);
-    }
+    let sut = unsafe { RelocatableByteAtomic::<u8>::new_uninit() };
+    sut.write(9);
 }
 
 #[test]

--- a/iceoryx2-bb/container/tests-common/src/byte_atomic_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/byte_atomic_tests.rs
@@ -37,22 +37,12 @@ struct ComplexType {
 }
 
 #[test]
-pub fn fixed_size_byte_atomic_cannot_be_created_when_sizes_do_not_match() {
-    const SIZE: usize = size_of::<u64>();
-    let value: u8 = 0;
-    let sut = FixedSizeByteAtomic::<u8, SIZE>::new(value);
-    assert_that!(sut, is_err);
-    assert_that!(sut.err().unwrap(), eq ByteAtomicError::SizesDoNotMatch);
-}
-
-#[test]
 pub fn new_creates_byte_atomic_containing_passed_value() {
     let value = 963;
 
     const SIZE: usize = size_of::<u64>();
     let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(value);
-    assert_that!(fixed_size_sut, is_ok);
-    let read_value = unsafe { fixed_size_sut.unwrap().read().assume_consistent() };
+    let read_value = unsafe { fixed_size_sut.read().assume_consistent() };
     assert_that!(read_value, eq value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<u64>::const_memory_size();
@@ -78,8 +68,7 @@ pub fn new_creates_fixed_size_byte_atomic_containing_passed_complex_value() {
 
     const SIZE: usize = size_of::<ComplexType>();
     let fixed_size_sut = FixedSizeByteAtomic::<ComplexType, SIZE>::new(value);
-    assert_that!(fixed_size_sut, is_ok);
-    let read_value = unsafe { fixed_size_sut.unwrap().read().assume_consistent() };
+    let read_value = unsafe { fixed_size_sut.read().assume_consistent() };
     assert_that!(read_value, eq value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<ComplexType>::const_memory_size();
@@ -100,7 +89,7 @@ pub fn byte_atomic_contains_passed_value_after_write() {
     let new_value: u64 = 752389;
 
     const SIZE: usize = size_of::<u64>();
-    let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(0).unwrap();
+    let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(0);
     fixed_size_sut.write(new_value);
     assert_that!(unsafe { fixed_size_sut.read().assume_consistent() }, eq new_value);
 
@@ -133,7 +122,7 @@ pub fn byte_atomic_contains_passed_complex_value_after_write() {
     };
 
     const SIZE: usize = size_of::<ComplexType>();
-    let fixed_size_sut = FixedSizeByteAtomic::<ComplexType, SIZE>::new(init_value).unwrap();
+    let fixed_size_sut = FixedSizeByteAtomic::<ComplexType, SIZE>::new(init_value);
     fixed_size_sut.write(new_value);
     let read_value = unsafe { fixed_size_sut.read().assume_consistent() };
     assert_that!(read_value, eq new_value);
@@ -168,7 +157,7 @@ pub fn concurrent_read_without_write_always_returns_correct_data() {
         .unwrap();
 
     const SIZE: usize = size_of::<u64>();
-    let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(value).unwrap();
+    let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<u64>::const_memory_size();
     let memory = [0u8; MEM_SIZE];
@@ -212,7 +201,7 @@ pub fn concurrent_write_does_not_trigger_ub() {
         .unwrap();
 
     const SIZE: usize = size_of::<u64>();
-    let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(value).unwrap();
+    let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<u64>::const_memory_size();
     let memory = [0u8; MEM_SIZE];
@@ -261,7 +250,7 @@ pub fn concurrent_read_and_write_does_not_trigger_ub() {
         .unwrap();
 
     const SIZE: usize = size_of::<u64>();
-    let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(value).unwrap();
+    let fixed_size_sut = FixedSizeByteAtomic::<u64, SIZE>::new(value);
 
     const MEM_SIZE: usize = RelocatableByteAtomic::<u64>::const_memory_size();
     let memory = [0u8; MEM_SIZE];


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
See title.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1841 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
