### PR TITLE
[#1844] [#1845] Fix 'semantic_string' macro for rust-analyzer and reduce imports

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -49,6 +49,7 @@
 * [#1800](https://github.com/eclipse-iceoryx/iceoryx2/issues/1800) iceoryx2-cxx: CleanupState is defined in global namespace
 * [#1807](https://github.com/eclipse-iceoryx/iceoryx2/issues/1807) Fix generated C FFI strings for `UPPER_SNAKE_CASE` enum variants.
 * [#1810](https://github.com/eclipse-iceoryx/iceoryx2/issues/1810) Make mgmt segment globally accessible
+* [#1844](https://github.com/eclipse-iceoryx/iceoryx2/issues/1844) Fix `semantic_string` macro for `rust-analyzer` auto-completion
 
 ### Refactoring
 

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -61,6 +61,7 @@
 * [#996](https://github.com/eclipse-iceoryx/iceoryx2/issues/996) Move BumpAllocator from iceoryx2-bb-memory into iceoryx2-bb-elementary
 * [#1613](https://github.com/eclipse-iceoryx/iceoryx2/issues/1613) Remove `NonNullCompat` after moving to Rust 1.89
 * [#1776](https://github.com/eclipse-iceoryx/iceoryx2/issues/1776) Rename AtomicCopy::__for_each_field() to for_each_field()
+* [#1845](https://github.com/eclipse-iceoryx/iceoryx2/issues/1845) Reduce imports for usage of the `semantic_string` macro
 
 ### Workflow
 

--- a/iceoryx2-bb/container/src/semantic_string.rs
+++ b/iceoryx2-bb/container/src/semantic_string.rs
@@ -24,7 +24,6 @@
 //! use iceoryx2_bb_derive_macros::ZeroCopySend;
 //! use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 //!
-//! use core::hash::{Hash, Hasher};
 //! use iceoryx2_bb_container::semantic_string;
 //!
 //! const GROUP_NAME_LENGTH: usize = 31;
@@ -509,23 +508,23 @@ macro_rules! semantic_string {
             }
         }
 
-        impl Hash for $string_name {
-            fn hash<H: Hasher>(&self, state: &mut H) {
+        impl core::hash::Hash for $string_name {
+            fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
                 self.normalize().as_bytes().hash(state)
             }
         }
 
-        impl From<$string_name> for String {
-            fn from(value: $string_name) -> String {
+        impl From<$string_name> for alloc::string::String {
+            fn from(value: $string_name) -> alloc::string::String {
                 // SAFETY: It is ensured that the semantic string contains only valid utf-8 strings
-                unsafe { String::from_utf8_unchecked(value.as_bytes().to_vec()) }
+                unsafe { alloc::string::String::from_utf8_unchecked(value.as_bytes().to_vec()) }
             }
         }
 
-        impl From<&$string_name> for String {
-            fn from(value: &$string_name) -> String {
+        impl From<&$string_name> for alloc::string::String {
+            fn from(value: &$string_name) -> alloc::string::String {
                 // SAFETY: It is ensured that the semantic string contains only valid utf-8 strings
-                unsafe { String::from_utf8_unchecked(value.as_bytes().to_vec()) }
+                unsafe { alloc::string::String::from_utf8_unchecked(value.as_bytes().to_vec()) }
             }
         }
 

--- a/iceoryx2-bb/container/src/semantic_string.rs
+++ b/iceoryx2-bb/container/src/semantic_string.rs
@@ -389,20 +389,22 @@ pub trait SemanticString<const CAPACITY: usize>:
 /// [`mod@crate::semantic_string`].
 #[macro_export(local_inner_macros)]
 macro_rules! semantic_string {
-    {$(#[$documentation:meta])*
-     /// Name of the struct
-     name: $string_name:ident,
-     /// Capacity of the underlying StaticString
-     capacity: $capacity:expr,
-     /// Callable that gets a [`&[u8]`] as input and shall return true when the slice contains
-     /// invalid content.
-     invalid_content: $invalid_content:expr,
-     /// Callable that gets a [`&[u8]`] as input and shall return true when the slice contains
-     /// invalid characters.
-     invalid_characters: $invalid_characters:expr,
-     /// Normalizes the content. Required when the same semantical content has multiple
-     /// representations like paths for instance (`/tmp` == `/tmp/`)
-     normalize: $normalize:expr} => {
+    {
+        $(#[$documentation:meta])*
+        // Name of the struct
+        name: $string_name:ident,
+        // Capacity of the underlying StaticString
+        capacity: $capacity:expr,
+        // Callable that gets a [`&[u8]`] as input and shall return true when the slice contains
+        // invalid content.
+        invalid_content: $invalid_content:expr,
+        // Callable that gets a [`&[u8]`] as input and shall return true when the slice contains
+        // invalid characters.
+        invalid_characters: $invalid_characters:expr,
+        // Normalizes the content. Required when the same semantical content has multiple
+        // representations like paths for instance (`/tmp` == `/tmp/`)
+        normalize: $normalize:expr
+    } => {
         $(#[$documentation])*
         #[repr(C)]
         #[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord, ZeroCopySend)]

--- a/iceoryx2-bb/container/src/semantic_string.rs
+++ b/iceoryx2-bb/container/src/semantic_string.rs
@@ -413,11 +413,11 @@ macro_rules! semantic_string {
         }
 
         // BEGIN: serde
-        pub(crate) mod VisitorType {
+        pub(crate) mod semantic_string_visitor_type {
             pub(crate) struct $string_name;
         }
 
-        impl<'de> serde::de::Visitor<'de> for VisitorType::$string_name {
+        impl<'de> serde::de::Visitor<'de> for semantic_string_visitor_type::$string_name {
             type Value = $string_name;
 
             fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -440,7 +440,7 @@ macro_rules! semantic_string {
             where
                 D: serde::Deserializer<'de>,
             {
-                deserializer.deserialize_str(VisitorType::$string_name)
+                deserializer.deserialize_str(semantic_string_visitor_type::$string_name)
             }
         }
 
@@ -465,13 +465,15 @@ macro_rules! semantic_string {
 
             unsafe fn new_unchecked(bytes: &[u8]) -> Self {
                 Self {
-                    value: iceoryx2_bb_container::string::StaticString::from_bytes_unchecked(bytes),
+                    value: unsafe { iceoryx2_bb_container::string::StaticString::from_bytes_unchecked(bytes) },
                 }
             }
 
             unsafe fn insert_bytes_unchecked(&mut self, idx: usize, bytes: &[u8]) {
                 use iceoryx2_bb_container::string::String;
-                self.value.insert_bytes_unchecked(idx, bytes);
+                unsafe {
+                    self.value.insert_bytes_unchecked(idx, bytes);
+                }
             }
         }
 
@@ -486,7 +488,7 @@ macro_rules! semantic_string {
             pub const unsafe fn new_unchecked_const(value: &[u8]) -> $string_name {
                 core::debug_assert!(value.len() <= $capacity);
                 $string_name {
-                    value: iceoryx2_bb_container::string::StaticString::from_bytes_unchecked(value),
+                    value: unsafe { iceoryx2_bb_container::string::StaticString::from_bytes_unchecked(value) },
                 }
             }
 
@@ -495,6 +497,7 @@ macro_rules! semantic_string {
                 $capacity
             }
 
+            /// Returns a slice to the underlying bytes
             pub const fn as_bytes_const(&self) -> &[u8] {
                 self.value.as_bytes_const()
             }
@@ -631,6 +634,5 @@ macro_rules! semantic_string {
                 $invalid_characters(string)
             }
         }
-
-    };
+    }
 }

--- a/iceoryx2-bb/system-types/src/base64url.rs
+++ b/iceoryx2-bb/system-types/src/base64url.rs
@@ -12,10 +12,6 @@
 
 pub use iceoryx2_bb_container::semantic_string::SemanticString;
 
-use core::hash::{Hash, Hasher};
-
-use alloc::string::String;
-
 use iceoryx2_bb_container::semantic_string;
 use iceoryx2_bb_derive_macros::ZeroCopySend;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;

--- a/iceoryx2-bb/system-types/src/file_path.rs
+++ b/iceoryx2-bb/system-types/src/file_path.rs
@@ -31,10 +31,6 @@
 
 pub use iceoryx2_bb_container::semantic_string::SemanticString;
 
-use core::hash::{Hash, Hasher};
-
-use alloc::string::String;
-
 use iceoryx2_bb_container::semantic_string;
 use iceoryx2_bb_container::semantic_string::SemanticStringError;
 use iceoryx2_bb_derive_macros::ZeroCopySend;

--- a/iceoryx2-bb/system-types/src/group_name.rs
+++ b/iceoryx2-bb/system-types/src/group_name.rs
@@ -29,10 +29,6 @@
 
 pub use iceoryx2_bb_container::semantic_string::SemanticString;
 
-use core::hash::{Hash, Hasher};
-
-use alloc::string::String;
-
 use iceoryx2_bb_container::semantic_string;
 use iceoryx2_bb_derive_macros::ZeroCopySend;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;

--- a/iceoryx2-bb/system-types/src/path.rs
+++ b/iceoryx2-bb/system-types/src/path.rs
@@ -31,10 +31,7 @@
 
 pub use iceoryx2_bb_container::semantic_string::SemanticString;
 
-use core::hash::{Hash, Hasher};
-
 use alloc::format;
-use alloc::string::String;
 use alloc::vec::Vec;
 
 use iceoryx2_bb_container::semantic_string;

--- a/iceoryx2-bb/system-types/src/user_name.rs
+++ b/iceoryx2-bb/system-types/src/user_name.rs
@@ -30,10 +30,6 @@
 
 pub use iceoryx2_bb_container::semantic_string::SemanticString;
 
-use core::hash::{Hash, Hasher};
-
-use alloc::string::String;
-
 use iceoryx2_bb_container::semantic_string;
 use iceoryx2_bb_derive_macros::ZeroCopySend;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;

--- a/iceoryx2/src/service/attribute.rs
+++ b/iceoryx2/src/service/attribute.rs
@@ -109,12 +109,6 @@ use serde::{Deserialize, Serialize};
 use crate::constants::MAX_ATTRIBUTES;
 
 mod key {
-
-    use core::hash::Hash;
-    use core::hash::Hasher;
-
-    use alloc::string::String;
-
     use iceoryx2_bb_container::semantic_string;
     use iceoryx2_bb_container::semantic_string::SemanticString;
     use iceoryx2_bb_derive_macros::ZeroCopySend;
@@ -144,12 +138,6 @@ pub type AttributeKey = key::FixedString;
 
 /// Module containing the value type used for service attributes.
 mod value {
-
-    use core::hash::Hash;
-    use core::hash::Hasher;
-
-    use alloc::string::String;
-
     use iceoryx2_bb_container::semantic_string;
     use iceoryx2_bb_container::semantic_string::SemanticString;
     use iceoryx2_bb_derive_macros::ZeroCopySend;


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The docstring in the `semantic_string` macro caused parsing errors in the rust-analyer, which broke the auto-completion for types generated by the macro.

Additionally, some warnings were fixed and the number of required imports when using the `semantic_string` macro was reduced.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1844
Closes #1845

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
