### PR TITLE
[#1742] Add translator implementation for ROS 2

### DIFF
--- a/iceoryx2-services/tunnel-backend/src/traits/backend.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/backend.rs
@@ -74,7 +74,9 @@ pub trait Backend<S: Service>: Sized {
     type Mapping: Mapping;
 
     /// Payload translation strategy applied by this backend.
-    type Translator: Translator;
+    type Translator: Translator<
+        EndpointDescription = <Self::Mapping as Mapping>::EndpointDescription,
+    >;
 
     /// Error type that can occur during backend creation
     type CreationError: Error;

--- a/iceoryx2-services/tunnel-backend/src/traits/mod.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/mod.rs
@@ -14,6 +14,7 @@ mod backend;
 mod discovery;
 mod mapping;
 mod relay;
+mod resizable_buffer;
 mod translator;
 
 pub mod testing;
@@ -22,4 +23,5 @@ pub use backend::*;
 pub use discovery::*;
 pub use mapping::*;
 pub use relay::*;
+pub use resizable_buffer::*;
 pub use translator::*;

--- a/iceoryx2-services/tunnel-backend/src/traits/resizable_buffer.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/resizable_buffer.rs
@@ -10,6 +10,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+/// The requested capacity exceeds what the buffer can provide.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ResizeError {
+    /// The capacity the buffer can actually provide.
+    pub available: usize,
+}
+
+impl core::fmt::Display for ResizeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "ResizeError {{ available: {} }}", self.available)
+    }
+}
+
+impl core::error::Error for ResizeError {}
+
 /// Resizable destination for translated bytes.
 ///
 /// The backing storage could be scratch memory, shared memory or anything
@@ -17,14 +32,16 @@
 pub trait ResizableBuffer {
     /// Ensures at least `min_capacity` writable bytes and returns the whole
     /// writable region.
-    fn resize(&mut self, min_capacity: usize) -> &mut [u8];
+    ///
+    /// Fails when the buffer cannot grow to `min_capacity`.
+    fn resize(&mut self, min_capacity: usize) -> Result<&mut [u8], ResizeError>;
 }
 
 impl ResizableBuffer for alloc::vec::Vec<u8> {
-    fn resize(&mut self, min_capacity: usize) -> &mut [u8] {
+    fn resize(&mut self, min_capacity: usize) -> Result<&mut [u8], ResizeError> {
         if self.len() < min_capacity {
             self.resize(min_capacity, 0);
         }
-        self
+        Ok(self)
     }
 }

--- a/iceoryx2-services/tunnel-backend/src/traits/resizable_buffer.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/resizable_buffer.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+/// Resizable destination for translated bytes.
+///
+/// The backing storage could be scratch memory, shared memory or anything
+/// else. It is owned by the caller.
+///
+/// Resizing preserves already-written bytes but may relocate them: regions
+/// returned by earlier [`resize`](ResizableBuffer::resize) calls are
+/// invalidated (realloc semantics).
+pub trait ResizableBuffer {
+    /// Ensures at least `min_capacity` writable bytes and returns the whole
+    /// writable region.
+    fn resize(&mut self, min_capacity: usize) -> &mut [u8];
+}
+
+impl ResizableBuffer for alloc::vec::Vec<u8> {
+    fn resize(&mut self, min_capacity: usize) -> &mut [u8] {
+        if self.len() < min_capacity {
+            self.resize(min_capacity, 0);
+        }
+        self
+    }
+}

--- a/iceoryx2-services/tunnel-backend/src/traits/resizable_buffer.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/resizable_buffer.rs
@@ -14,10 +14,6 @@
 ///
 /// The backing storage could be scratch memory, shared memory or anything
 /// else. It is owned by the caller.
-///
-/// Resizing preserves already-written bytes but may relocate them: regions
-/// returned by earlier [`resize`](ResizableBuffer::resize) calls are
-/// invalidated (realloc semantics).
 pub trait ResizableBuffer {
     /// Ensures at least `min_capacity` writable bytes and returns the whole
     /// writable region.

--- a/iceoryx2-services/tunnel-backend/src/traits/translator.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/translator.rs
@@ -20,68 +20,80 @@ use crate::types::service_description::ServiceDescription;
 
 /// Strategy for translating payload bytes between the wire format and the
 /// iceoryx2 payload.
-///
-/// [`Default`] must never resolve to silently wrong behavior: a strategy
-/// whose default cannot translate must fail [`Translator::resolve`] rather
-/// than fall back to [`TranslationMode::Passthrough`].
 pub trait Translator: Default + Debug + Send + 'static {
-    /// Error type returned by the strategy's methods.
+    /// Error type returned by the translator's methods.
     type Error: Error;
 
-    /// The backend-side description of a tunneled service's endpoints.
-    /// Must match the [`Mapping::EndpointDescription`](crate::traits::Mapping::EndpointDescription)
-    /// of the backend the strategy is instantiated for.
+    /// Type describing the remote endpoints to translate to/from.
     type EndpointDescription;
 
-    /// Decides, once at relay creation, how payloads of the described
-    /// service cross the backend. An error aborts relay creation.
-    fn resolve(
+    /// The transcoder used to translate the bytes.
+    type Transcoder: Transcoder<Error = Self::Error> + Debug;
+
+    /// Creates a [`Translation`] instance for the specified iceoryx2 service
+    /// and remote endpoint pair.
+    fn create(
         &self,
         service: &ServiceDescription,
         endpoint: &Self::EndpointDescription,
-    ) -> Result<TranslationMode, Self::Error>;
+    ) -> Result<Translation<Self::Transcoder>, Self::Error>;
+}
+
+/// The logic to convert payload bytes between wire format and shared memory
+/// format.
+pub trait Transcoder {
+    /// Error type returned by the transcoder's methods.
+    type Error: Error;
 
     /// Translates an iceoryx2 payload into its wire representation, written
-    /// into `wire`. Returns the number of bytes written.
+    /// into `wire`.
+    ///
+    /// Returns the number of bytes written.
     fn to_wire(
         &self,
-        service: &ServiceDescription,
-        endpoint: &Self::EndpointDescription,
         payload: &[u8],
         wire: &mut impl ResizableBuffer,
     ) -> Result<usize, Self::Error>;
 
-    /// Translates a wire payload into its iceoryx2 representation, written
-    /// into `payload`. Returns the number of bytes written.
+    /// Translates a wire payload into its shared memory representation,
+    /// written into `payload`.
+    ///
+    /// Returns the number of bytes written.
+    #[allow(clippy::wrong_self_convention)]
     fn from_wire(
         &self,
-        service: &ServiceDescription,
-        endpoint: &Self::EndpointDescription,
         wire: &[u8],
         payload: &mut impl ResizableBuffer,
     ) -> Result<usize, Self::Error>;
 }
 
-// TODO: Consider if supporting both passthrough and translation modes
-//       in one translator is really needed...
-/// How a service's payloads cross the backend.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub enum TranslationMode {
-    /// Payload bytes cross unmodified.
+/// An instantiation of the [`Translator`] for a specific service/endpoint
+/// pair.
+#[derive(Debug)]
+pub enum Translation<T> {
+    /// Payload bytes cross unmodified. Bytes are moved directly to the
+    /// destination with no intermediate buffering or transcoding.
     Passthrough,
-    /// Payloads are transcoded via [`Translator::to_wire`] and
-    /// [`Translator::from_wire`].
-    Translate {
-        /// Layout of the iceoryx2-side payload. Applied when the tunnel
-        /// creates the local service for a remotely discovered one, where
-        /// only the translator knows the native layout.
-        native_layout: Layout,
+    /// Payload bytes are translated into the target representation by `transcoder`
+    /// in an intermediate buffer before being written to the destination.
+    Transcode {
+        /// Layout of the payload in shared memory.
+        payload_layout: PayloadLayout,
+        /// Transcoder converting the payload bytes in both directions.
+        transcoder: T,
     },
 }
 
-/// The identity [`Translator`]: resolves every service to
-/// [`TranslationMode::Passthrough`], so payloads cross unmodified in both
-/// directions.
+/// Layout of the payload in shared memory.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PayloadLayout {
+    /// A single value of a static size.
+    FixedSize(Layout),
+    /// A slice of elements whose length varies per message.
+    Dynamic { element: Layout },
+}
+
+/// The identity [`Translator`]: payloads cross unmodified in both directions.
 pub struct Passthrough<E> {
     _endpoint: PhantomData<fn() -> E>,
 }
@@ -117,140 +129,38 @@ impl<E> Copy for Passthrough<E> {}
 impl<E: 'static> Translator for Passthrough<E> {
     type Error = core::convert::Infallible;
     type EndpointDescription = E;
+    type Transcoder = Never;
 
-    fn resolve(
+    fn create(
         &self,
         _service: &ServiceDescription,
         _endpoint: &Self::EndpointDescription,
-    ) -> Result<TranslationMode, Self::Error> {
-        Ok(TranslationMode::Passthrough)
+    ) -> Result<Translation<Self::Transcoder>, Self::Error> {
+        Ok(Translation::Passthrough)
     }
+}
+
+/// A [`Transcoder`] that cannot be instantiated for [`Translator`]s that
+/// should never do any transcoding.
+#[derive(Debug)]
+pub enum Never {}
+
+impl Transcoder for Never {
+    type Error = core::convert::Infallible;
 
     fn to_wire(
         &self,
-        _service: &ServiceDescription,
-        _endpoint: &Self::EndpointDescription,
         _payload: &[u8],
         _wire: &mut impl ResizableBuffer,
     ) -> Result<usize, Self::Error> {
-        unreachable!("Passthrough resolves every service to TranslationMode::Passthrough")
+        match *self {}
     }
 
     fn from_wire(
         &self,
-        _service: &ServiceDescription,
-        _endpoint: &Self::EndpointDescription,
         _wire: &[u8],
         _payload: &mut impl ResizableBuffer,
     ) -> Result<usize, Self::Error> {
-        unreachable!("Passthrough resolves every service to TranslationMode::Passthrough")
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use alloc::string::String;
-    use alloc::vec;
-    use alloc::vec::Vec;
-
-    use iceoryx2::service::local::Service;
-    use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
-    use iceoryx2_bb_testing::assert_that;
-
-    use crate::types::service_description::{
-        PatternDescription, PortSettings, PublishSubscribeDescription, TypeDescription,
-    };
-
-    fn service_description() -> ServiceDescription {
-        ServiceDescription::new::<Service>(
-            "translator-tests".try_into().expect("valid service name"),
-            PatternDescription::PublishSubscribe(PublishSubscribeDescription {
-                user_header: TypeDescription::from(&TypeDetail::new::<()>(TypeVariant::FixedSize)),
-                payload: TypeDescription::from(&TypeDetail::new::<u64>(TypeVariant::FixedSize)),
-                settings: PortSettings::LocalDefaults,
-            }),
-        )
-    }
-
-    /// Wire format: every payload byte appears twice.
-    #[derive(Debug, Default)]
-    struct DuplicatingTranslator;
-
-    impl Translator for DuplicatingTranslator {
-        type Error = core::convert::Infallible;
-        type EndpointDescription = String;
-
-        fn resolve(
-            &self,
-            _service: &ServiceDescription,
-            _endpoint: &String,
-        ) -> Result<TranslationMode, Self::Error> {
-            Ok(TranslationMode::Translate {
-                native_layout: Layout::new::<u8>(),
-            })
-        }
-
-        fn to_wire(
-            &self,
-            _service: &ServiceDescription,
-            _endpoint: &String,
-            payload: &[u8],
-            wire: &mut impl ResizableBuffer,
-        ) -> Result<usize, Self::Error> {
-            let region = wire.resize(payload.len() * 2);
-            for (index, byte) in payload.iter().enumerate() {
-                region[index * 2] = *byte;
-                region[index * 2 + 1] = *byte;
-            }
-            Ok(payload.len() * 2)
-        }
-
-        fn from_wire(
-            &self,
-            _service: &ServiceDescription,
-            _endpoint: &String,
-            wire: &[u8],
-            payload: &mut impl ResizableBuffer,
-        ) -> Result<usize, Self::Error> {
-            let region = payload.resize(wire.len() / 2);
-            for (index, byte) in region.iter_mut().enumerate().take(wire.len() / 2) {
-                *byte = wire[index * 2];
-            }
-            Ok(wire.len() / 2)
-        }
-    }
-
-    #[test]
-    fn passthrough_resolves_every_service_to_passthrough() {
-        let translator = Passthrough::<String>::new();
-
-        let mode = translator
-            .resolve(&service_description(), &String::from("endpoint"))
-            .expect("passthrough resolution is infallible");
-
-        assert_that!(mode, eq TranslationMode::Passthrough);
-    }
-
-    #[test]
-    fn translated_payload_round_trips_through_translation_buffers() {
-        const PAYLOAD: [u8; 4] = [1, 2, 3, 4];
-
-        let translator = DuplicatingTranslator;
-        let service = service_description();
-        let endpoint = String::from("endpoint");
-
-        let mut wire = Vec::<u8>::new();
-        let wire_len = translator
-            .to_wire(&service, &endpoint, &PAYLOAD, &mut wire)
-            .expect("translation to the wire is infallible");
-        assert_that!(wire[..wire_len], eq vec![1, 1, 2, 2, 3, 3, 4, 4]);
-
-        let mut payload = Vec::<u8>::new();
-        let payload_len = translator
-            .from_wire(&service, &endpoint, &wire[..wire_len], &mut payload)
-            .expect("translation from the wire is infallible");
-        assert_that!(payload[..payload_len], eq PAYLOAD);
+        match *self {}
     }
 }

--- a/iceoryx2-services/tunnel-backend/src/traits/translator.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/translator.rs
@@ -10,14 +10,247 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use core::alloc::Layout;
+use core::error::Error;
 use core::fmt::Debug;
+use core::marker::PhantomData;
+
+use crate::traits::ResizableBuffer;
+use crate::types::service_description::ServiceDescription;
 
 /// Strategy for translating payload bytes between the wire format and the
 /// iceoryx2 payload.
-pub trait Translator: Default + Debug + Send + 'static {}
+///
+/// [`Default`] must never resolve to silently wrong behavior: a strategy
+/// whose default cannot translate must fail [`Translator::resolve`] rather
+/// than fall back to [`TranslationMode::Passthrough`].
+pub trait Translator: Default + Debug + Send + 'static {
+    /// Error type returned by the strategy's methods.
+    type Error: Error;
 
-/// The identity [`Translator`]: payloads cross unmodified in both directions.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Passthrough;
+    /// The backend-side description of a tunneled service's endpoints.
+    /// Must match the [`Mapping::EndpointDescription`](crate::traits::Mapping::EndpointDescription)
+    /// of the backend the strategy is instantiated for.
+    type EndpointDescription;
 
-impl Translator for Passthrough {}
+    /// Decides, once at relay creation, how payloads of the described
+    /// service cross the backend. An error aborts relay creation.
+    fn resolve(
+        &self,
+        service: &ServiceDescription,
+        endpoint: &Self::EndpointDescription,
+    ) -> Result<TranslationMode, Self::Error>;
+
+    /// Translates an iceoryx2 payload into its wire representation, written
+    /// into `wire`. Returns the number of bytes written.
+    fn to_wire(
+        &self,
+        service: &ServiceDescription,
+        endpoint: &Self::EndpointDescription,
+        payload: &[u8],
+        wire: &mut impl ResizableBuffer,
+    ) -> Result<usize, Self::Error>;
+
+    /// Translates a wire payload into its iceoryx2 representation, written
+    /// into `payload`. Returns the number of bytes written.
+    fn from_wire(
+        &self,
+        service: &ServiceDescription,
+        endpoint: &Self::EndpointDescription,
+        wire: &[u8],
+        payload: &mut impl ResizableBuffer,
+    ) -> Result<usize, Self::Error>;
+}
+
+// TODO: Consider if supporting both passthrough and translation modes
+//       in one translator is really needed...
+/// How a service's payloads cross the backend.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum TranslationMode {
+    /// Payload bytes cross unmodified.
+    Passthrough,
+    /// Payloads are transcoded via [`Translator::to_wire`] and
+    /// [`Translator::from_wire`].
+    Translate {
+        /// Layout of the iceoryx2-side payload. Applied when the tunnel
+        /// creates the local service for a remotely discovered one, where
+        /// only the translator knows the native layout.
+        native_layout: Layout,
+    },
+}
+
+/// The identity [`Translator`]: resolves every service to
+/// [`TranslationMode::Passthrough`], so payloads cross unmodified in both
+/// directions.
+pub struct Passthrough<E> {
+    _endpoint: PhantomData<fn() -> E>,
+}
+
+impl<E> Passthrough<E> {
+    pub fn new() -> Self {
+        Self {
+            _endpoint: PhantomData,
+        }
+    }
+}
+
+impl<E> Default for Passthrough<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E> Debug for Passthrough<E> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Passthrough")
+    }
+}
+
+impl<E> Clone for Passthrough<E> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<E> Copy for Passthrough<E> {}
+
+impl<E: 'static> Translator for Passthrough<E> {
+    type Error = core::convert::Infallible;
+    type EndpointDescription = E;
+
+    fn resolve(
+        &self,
+        _service: &ServiceDescription,
+        _endpoint: &Self::EndpointDescription,
+    ) -> Result<TranslationMode, Self::Error> {
+        Ok(TranslationMode::Passthrough)
+    }
+
+    fn to_wire(
+        &self,
+        _service: &ServiceDescription,
+        _endpoint: &Self::EndpointDescription,
+        _payload: &[u8],
+        _wire: &mut impl ResizableBuffer,
+    ) -> Result<usize, Self::Error> {
+        unreachable!("Passthrough resolves every service to TranslationMode::Passthrough")
+    }
+
+    fn from_wire(
+        &self,
+        _service: &ServiceDescription,
+        _endpoint: &Self::EndpointDescription,
+        _wire: &[u8],
+        _payload: &mut impl ResizableBuffer,
+    ) -> Result<usize, Self::Error> {
+        unreachable!("Passthrough resolves every service to TranslationMode::Passthrough")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use iceoryx2::service::local::Service;
+    use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
+    use iceoryx2_bb_testing::assert_that;
+
+    use crate::types::service_description::{
+        PatternDescription, PortSettings, PublishSubscribeDescription, TypeDescription,
+    };
+
+    fn service_description() -> ServiceDescription {
+        ServiceDescription::new::<Service>(
+            "translator-tests".try_into().expect("valid service name"),
+            PatternDescription::PublishSubscribe(PublishSubscribeDescription {
+                user_header: TypeDescription::from(&TypeDetail::new::<()>(TypeVariant::FixedSize)),
+                payload: TypeDescription::from(&TypeDetail::new::<u64>(TypeVariant::FixedSize)),
+                settings: PortSettings::LocalDefaults,
+            }),
+        )
+    }
+
+    /// Wire format: every payload byte appears twice.
+    #[derive(Debug, Default)]
+    struct DuplicatingTranslator;
+
+    impl Translator for DuplicatingTranslator {
+        type Error = core::convert::Infallible;
+        type EndpointDescription = String;
+
+        fn resolve(
+            &self,
+            _service: &ServiceDescription,
+            _endpoint: &String,
+        ) -> Result<TranslationMode, Self::Error> {
+            Ok(TranslationMode::Translate {
+                native_layout: Layout::new::<u8>(),
+            })
+        }
+
+        fn to_wire(
+            &self,
+            _service: &ServiceDescription,
+            _endpoint: &String,
+            payload: &[u8],
+            wire: &mut impl ResizableBuffer,
+        ) -> Result<usize, Self::Error> {
+            let region = wire.resize(payload.len() * 2);
+            for (index, byte) in payload.iter().enumerate() {
+                region[index * 2] = *byte;
+                region[index * 2 + 1] = *byte;
+            }
+            Ok(payload.len() * 2)
+        }
+
+        fn from_wire(
+            &self,
+            _service: &ServiceDescription,
+            _endpoint: &String,
+            wire: &[u8],
+            payload: &mut impl ResizableBuffer,
+        ) -> Result<usize, Self::Error> {
+            let region = payload.resize(wire.len() / 2);
+            for (index, byte) in region.iter_mut().enumerate().take(wire.len() / 2) {
+                *byte = wire[index * 2];
+            }
+            Ok(wire.len() / 2)
+        }
+    }
+
+    #[test]
+    fn passthrough_resolves_every_service_to_passthrough() {
+        let translator = Passthrough::<String>::new();
+
+        let mode = translator
+            .resolve(&service_description(), &String::from("endpoint"))
+            .expect("passthrough resolution is infallible");
+
+        assert_that!(mode, eq TranslationMode::Passthrough);
+    }
+
+    #[test]
+    fn translated_payload_round_trips_through_translation_buffers() {
+        const PAYLOAD: [u8; 4] = [1, 2, 3, 4];
+
+        let translator = DuplicatingTranslator;
+        let service = service_description();
+        let endpoint = String::from("endpoint");
+
+        let mut wire = Vec::<u8>::new();
+        let wire_len = translator
+            .to_wire(&service, &endpoint, &PAYLOAD, &mut wire)
+            .expect("translation to the wire is infallible");
+        assert_that!(wire[..wire_len], eq vec![1, 1, 2, 2, 3, 3, 4, 4]);
+
+        let mut payload = Vec::<u8>::new();
+        let payload_len = translator
+            .from_wire(&service, &endpoint, &wire[..wire_len], &mut payload)
+            .expect("translation from the wire is infallible");
+        assert_that!(payload[..payload_len], eq PAYLOAD);
+    }
+}

--- a/iceoryx2-services/tunnel-backend/src/traits/translator.rs
+++ b/iceoryx2-services/tunnel-backend/src/traits/translator.rs
@@ -94,11 +94,11 @@ pub enum PayloadLayout {
 }
 
 /// The identity [`Translator`]: payloads cross unmodified in both directions.
-pub struct Passthrough<E> {
-    _endpoint: PhantomData<fn() -> E>,
+pub struct Passthrough<EndpointDescription> {
+    _endpoint: PhantomData<fn() -> EndpointDescription>,
 }
 
-impl<E> Passthrough<E> {
+impl<EndpointDescription> Passthrough<EndpointDescription> {
     pub fn new() -> Self {
         Self {
             _endpoint: PhantomData,
@@ -106,13 +106,13 @@ impl<E> Passthrough<E> {
     }
 }
 
-impl<E> Default for Passthrough<E> {
+impl<EndpointDescription> Default for Passthrough<EndpointDescription> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<E> Debug for Passthrough<E> {
+impl<EndpointDescription> Debug for Passthrough<EndpointDescription> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Passthrough")
     }
@@ -126,9 +126,9 @@ impl<E> Clone for Passthrough<E> {
 
 impl<E> Copy for Passthrough<E> {}
 
-impl<E: 'static> Translator for Passthrough<E> {
+impl<EndpointDescription: 'static> Translator for Passthrough<EndpointDescription> {
     type Error = core::convert::Infallible;
-    type EndpointDescription = E;
+    type EndpointDescription = EndpointDescription;
     type Transcoder = Never;
 
     fn create(

--- a/iceoryx2-services/tunnel-testing/src/backend/backend.rs
+++ b/iceoryx2-services/tunnel-testing/src/backend/backend.rs
@@ -43,7 +43,13 @@ impl core::fmt::Display for CreationError {
 impl core::error::Error for CreationError {}
 
 #[derive(Debug)]
-pub struct TestBackend<S: Service, M: Mapping = Identity, T: Translator = Passthrough> {
+pub struct TestBackend<
+    S: Service,
+    M: Mapping = Identity,
+    T: Translator<EndpointDescription = <M as Mapping>::EndpointDescription> = Passthrough<
+        <M as Mapping>::EndpointDescription,
+    >,
+> {
     session: Rc<Session>,
     discovery: Discovery,
     #[allow(dead_code)]
@@ -52,7 +58,9 @@ pub struct TestBackend<S: Service, M: Mapping = Identity, T: Translator = Passth
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<S: Service, M: Mapping, T: Translator> Backend<S> for TestBackend<S, M, T> {
+impl<S: Service, M: Mapping, T: Translator<EndpointDescription = M::EndpointDescription>> Backend<S>
+    for TestBackend<S, M, T>
+{
     type Config = Config;
     type Translator = T;
     type Mapping = M;
@@ -91,14 +99,23 @@ impl<S: Service, M: Mapping, T: Translator> Backend<S> for TestBackend<S, M, T> 
 
 /// Builder for [`TestBackend`].
 #[derive(Debug)]
-pub struct Builder<'config, S: Service, M: Mapping = Identity, T: Translator = Passthrough> {
+pub struct Builder<
+    'config,
+    S: Service,
+    M: Mapping = Identity,
+    T: Translator<EndpointDescription = <M as Mapping>::EndpointDescription> = Passthrough<
+        <M as Mapping>::EndpointDescription,
+    >,
+> {
     _config: &'config Config,
     translator: T,
     mapping: M,
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<'config, S: Service, M: Mapping, T: Translator> Builder<'config, S, M, T> {
+impl<'config, S: Service, M: Mapping, T: Translator<EndpointDescription = M::EndpointDescription>>
+    Builder<'config, S, M, T>
+{
     pub fn new(config: &'config Config) -> Self {
         Self {
             _config: config,
@@ -109,7 +126,9 @@ impl<'config, S: Service, M: Mapping, T: Translator> Builder<'config, S, M, T> {
     }
 }
 
-impl<S: Service, M: Mapping, T: Translator> BackendBuilder<S> for Builder<'_, S, M, T> {
+impl<S: Service, M: Mapping, T: Translator<EndpointDescription = M::EndpointDescription>>
+    BackendBuilder<S> for Builder<'_, S, M, T>
+{
     type Backend = TestBackend<S, M, T>;
     type CreationError = CreationError;
 

--- a/iceoryx2-services/tunnel/src/builder.rs
+++ b/iceoryx2-services/tunnel/src/builder.rs
@@ -94,9 +94,8 @@ where
         self
     }
 
-    /// Sets the payload translation strategy applied by the backend. Defaults
-    /// to [`Passthrough`](iceoryx2_services_tunnel_backend::traits::Passthrough)
-    /// when not set.
+    /// Sets the payload translation strategy applied by the backend. Falls
+    /// back to the strategy's default when not set.
     pub fn translator(mut self, translator: <B as Backend<S>>::Translator) -> Self {
         self.translator = Some(translator);
         self

--- a/integrations/ros2/tunnel-backend/src/backend.rs
+++ b/integrations/ros2/tunnel-backend/src/backend.rs
@@ -48,7 +48,7 @@ impl core::error::Error for CreationError {}
 pub struct Ros2Backend<
     S: Service,
     M: Mapping<EndpointDescription = TopicDescription> = PrefixMapping,
-    T: Translator = Passthrough,
+    T: Translator<EndpointDescription = TopicDescription> = Passthrough<TopicDescription>,
 > {
     node: Rc<RclNode>,
     /// Typesupport for all configured topics, loaded on initialization.
@@ -61,8 +61,11 @@ pub struct Ros2Backend<
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>, T: Translator> Backend<S>
-    for Ros2Backend<S, M, T>
+impl<
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> Backend<S> for Ros2Backend<S, M, T>
 {
     type Config = Config;
     type Translator = T;
@@ -112,7 +115,7 @@ pub struct Builder<
     'a,
     S: Service,
     M: Mapping<EndpointDescription = TopicDescription> = PrefixMapping,
-    T: Translator = Passthrough,
+    T: Translator<EndpointDescription = TopicDescription> = Passthrough<TopicDescription>,
 > {
     config: &'a Config,
     mapping: M,
@@ -121,8 +124,12 @@ pub struct Builder<
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<'a, S: Service, M: Mapping<EndpointDescription = TopicDescription>, T: Translator>
-    Builder<'a, S, M, T>
+impl<
+    'a,
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> Builder<'a, S, M, T>
 {
     pub fn new(config: &'a Config) -> Self {
         Self {
@@ -135,8 +142,11 @@ impl<'a, S: Service, M: Mapping<EndpointDescription = TopicDescription>, T: Tran
     }
 }
 
-impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>, T: Translator>
-    BackendBuilder<S> for Builder<'_, S, M, T>
+impl<
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> BackendBuilder<S> for Builder<'_, S, M, T>
 {
     type Backend = Ros2Backend<S, M, T>;
     type CreationError = CreationError;
@@ -187,8 +197,11 @@ impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>, T: Translat
     }
 }
 
-impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>, T: Translator>
-    ReactiveBackendBuilder<S> for Builder<'_, S, M, T>
+impl<
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> ReactiveBackendBuilder<S> for Builder<'_, S, M, T>
 {
     type WakeService = local_threadsafe::Service;
 

--- a/integrations/ros2/tunnel-backend/src/backend.rs
+++ b/integrations/ros2/tunnel-backend/src/backend.rs
@@ -27,7 +27,7 @@ use crate::{
     discovery::Discovery,
     rcl::{RclNode, RclNodeBuilder},
     relays::{Factory, event, publish_subscribe},
-    typesupport::TypeSupportRegistry,
+    typesupport,
 };
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -51,8 +51,6 @@ pub struct Ros2Backend<
     T: Translator<EndpointDescription = TopicDescription> = Passthrough<TopicDescription>,
 > {
     node: Rc<RclNode>,
-    /// Typesupport for all configured topics, loaded on initialization.
-    type_registry: TypeSupportRegistry,
     discovery: Discovery<S, M, T>,
     mapping: Rc<M>,
     translator: Rc<T>,
@@ -93,7 +91,6 @@ impl<
     fn relay_builder(&self) -> Self::RelayFactory<'_> {
         Factory::new(
             Rc::clone(&self.node),
-            &self.type_registry,
             &self.mapping,
             Rc::clone(&self.translator),
             self.wake.clone(),
@@ -172,11 +169,10 @@ impl<
 
         // Load all typesupport libraries for configured topics during
         // initialization.
-        let type_registry = TypeSupportRegistry::default();
         for topic in &self.config.topics {
             let type_name = topic.type_name.as_str();
             fail!(from origin,
-                when type_registry.load(type_name),
+                when typesupport::load(type_name),
                 with CreationError::TypeSupport,
                 "Failed to load typesupport for configured topic '{}'", type_name
             );
@@ -193,7 +189,6 @@ impl<
 
         Ok(Ros2Backend {
             node,
-            type_registry,
             discovery,
             mapping,
             translator,

--- a/integrations/ros2/tunnel-backend/src/backend.rs
+++ b/integrations/ros2/tunnel-backend/src/backend.rs
@@ -53,10 +53,9 @@ pub struct Ros2Backend<
     node: Rc<RclNode>,
     /// Typesupport for all configured topics, loaded on initialization.
     type_registry: TypeSupportRegistry,
-    discovery: Discovery<S, M>,
+    discovery: Discovery<S, M, T>,
     mapping: Rc<M>,
-    #[allow(dead_code)]
-    translator: T,
+    translator: Rc<T>,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     _phantom: core::marker::PhantomData<S>,
 }
@@ -77,13 +76,13 @@ impl<
     where
         Self::Config: 'a;
 
-    type Discovery = Discovery<S, M>;
+    type Discovery = Discovery<S, M, T>;
 
-    type PublishSubscribeRelay = publish_subscribe::Relay<S>;
+    type PublishSubscribeRelay = publish_subscribe::Relay<S, T>;
     type EventRelay = event::Relay<S>;
 
     type RelayFactory<'b>
-        = Factory<'b, S, M>
+        = Factory<'b, S, M, T>
     where
         Self: 'b;
 
@@ -96,6 +95,7 @@ impl<
             Rc::clone(&self.node),
             &self.type_registry,
             &self.mapping,
+            Rc::clone(&self.translator),
             self.wake.clone(),
         )
     }
@@ -183,14 +183,20 @@ impl<
         }
 
         let mapping = Rc::new(self.mapping);
-        let discovery = Discovery::new(Rc::clone(&node), &self.config.topics, Rc::clone(&mapping));
+        let translator = Rc::new(self.translator);
+        let discovery = Discovery::new(
+            Rc::clone(&node),
+            &self.config.topics,
+            Rc::clone(&mapping),
+            Rc::clone(&translator),
+        );
 
         Ok(Ros2Backend {
             node,
             type_registry,
             discovery,
             mapping,
-            translator: self.translator,
+            translator,
             wake: self.wake.map(Arc::new),
             _phantom: core::marker::PhantomData,
         })

--- a/integrations/ros2/tunnel-backend/src/discovery.rs
+++ b/integrations/ros2/tunnel-backend/src/discovery.rs
@@ -20,7 +20,9 @@ use iceoryx2::service::service_hash::ServiceHash;
 use iceoryx2::service::static_config::message_type_details::TypeVariant;
 use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_log::fail;
-use iceoryx2_services_tunnel_backend::traits::{Mapping, TranslationMode, Translator};
+use iceoryx2_services_tunnel_backend::traits::{
+    Mapping, PayloadLayout, Translation, Translator,
+};
 use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 use iceoryx2_services_tunnel_backend::types::service_description::PatternDescription;
 
@@ -159,21 +161,30 @@ impl<
             return Ok(());
         };
 
-        // Translated topics carry the native payload layout, which only the
+        // Translated topics carry the payload layout, which only the
         // translator knows; the local service is created from it.
-        let mode = fail!(from origin,
-            when self.translator.resolve(&service_description, &topic_description),
+        let translation = fail!(from origin,
+            when self.translator.create(&service_description, &topic_description),
             with DiscoveryError::Translator,
-            "Translator failed to resolve topic '{}'",
+            "Translator failed to create translation for topic '{}'",
             topic.as_str()
         );
-        if let TranslationMode::Translate { native_layout } = mode
+        if let Translation::Transcode { payload_layout, .. } = translation
             && let PatternDescription::PublishSubscribe(pattern_description) =
                 &mut service_description.pattern
         {
-            pattern_description.payload.variant = TypeVariant::FixedSize;
-            pattern_description.payload.size = native_layout.size();
-            pattern_description.payload.alignment = native_layout.align();
+            match payload_layout {
+                PayloadLayout::FixedSize(layout) => {
+                    pattern_description.payload.variant = TypeVariant::FixedSize;
+                    pattern_description.payload.size = layout.size();
+                    pattern_description.payload.alignment = layout.align();
+                }
+                PayloadLayout::Dynamic { element } => {
+                    pattern_description.payload.variant = TypeVariant::Dynamic;
+                    pattern_description.payload.size = element.size();
+                    pattern_description.payload.alignment = element.align();
+                }
+            }
         }
 
         // Run discovery logic provided by the caller for the service discovered

--- a/integrations/ros2/tunnel-backend/src/discovery.rs
+++ b/integrations/ros2/tunnel-backend/src/discovery.rs
@@ -17,10 +17,12 @@ use core::error::Error;
 
 use iceoryx2::service::Service;
 use iceoryx2::service::service_hash::ServiceHash;
+use iceoryx2::service::static_config::message_type_details::TypeVariant;
 use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_log::fail;
-use iceoryx2_services_tunnel_backend::traits::Mapping;
+use iceoryx2_services_tunnel_backend::traits::{Mapping, TranslationMode, Translator};
 use iceoryx2_services_tunnel_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
+use iceoryx2_services_tunnel_backend::types::service_description::PatternDescription;
 
 use crate::config::{TopicConfig, TopicName, TypeName};
 use crate::mapping::TopicDescription;
@@ -30,6 +32,7 @@ use crate::rcl::RclNode;
 pub enum DiscoveryError {
     Graph,
     Processing,
+    Translator,
 }
 
 impl core::fmt::Display for DiscoveryError {
@@ -53,20 +56,35 @@ impl core::error::Error for AnnouncementError {}
 
 /// Reports liveness status of the configured topics in the ROS graph.
 #[derive(Debug)]
-pub struct Discovery<S: Service, M: Mapping<EndpointDescription = TopicDescription>> {
+pub struct Discovery<
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> {
     node: Rc<RclNode>,
     allowlist: HashMap<TopicName, TypeName>,
     mapping: Rc<M>,
+    translator: Rc<T>,
     /// Configured topics detected as live in the ROS graph, with the service
     /// hash they were reported under.
     discovered: RefCell<HashMap<TopicName, ServiceHash>>,
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> Discovery<S, M> {
+impl<
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> Discovery<S, M, T>
+{
     /// Creates a `Discovery` instance to track `topics` on the ROS graph
     /// via the provided `node`.
-    pub(crate) fn new(node: Rc<RclNode>, topics: &[TopicConfig], mapping: Rc<M>) -> Self {
+    pub(crate) fn new(
+        node: Rc<RclNode>,
+        topics: &[TopicConfig],
+        mapping: Rc<M>,
+        translator: Rc<T>,
+    ) -> Self {
         Self {
             node,
             allowlist: topics
@@ -74,6 +92,7 @@ impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> Discovery<S
                 .map(|topic| (topic.topic.clone(), topic.type_name.clone()))
                 .collect(),
             mapping,
+            translator,
             discovered: RefCell::new(HashMap::new()),
             _phantom: core::marker::PhantomData,
         }
@@ -136,9 +155,26 @@ impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> Discovery<S
         // These could be topics not following the conventions of the mapping (e.g. prefix)
         // or those explicitly not configured (e.g. static).
         let topic_description = self.topic_description(topic, type_name)?;
-        let Some(service_description) = self.mapping.local::<S>(&topic_description) else {
+        let Some(mut service_description) = self.mapping.local::<S>(&topic_description) else {
             return Ok(());
         };
+
+        // Translated topics carry the native payload layout, which only the
+        // translator knows; the local service is created from it.
+        let mode = fail!(from origin,
+            when self.translator.resolve(&service_description, &topic_description),
+            with DiscoveryError::Translator,
+            "Translator failed to resolve topic '{}'",
+            topic.as_str()
+        );
+        if let TranslationMode::Translate { native_layout } = mode
+            && let PatternDescription::PublishSubscribe(pattern_description) =
+                &mut service_description.pattern
+        {
+            pattern_description.payload.variant = TypeVariant::FixedSize;
+            pattern_description.payload.size = native_layout.size();
+            pattern_description.payload.alignment = native_layout.align();
+        }
 
         // Run discovery logic provided by the caller for the service discovered
         // as added.
@@ -186,8 +222,11 @@ impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> Discovery<S
     }
 }
 
-impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>>
-    iceoryx2_services_tunnel_backend::traits::Discovery for Discovery<S, M>
+impl<
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> iceoryx2_services_tunnel_backend::traits::Discovery for Discovery<S, M, T>
 {
     type DiscoveryError = DiscoveryError;
     type AnnouncementError = AnnouncementError;

--- a/integrations/ros2/tunnel-backend/src/lib.rs
+++ b/integrations/ros2/tunnel-backend/src/lib.rs
@@ -25,6 +25,8 @@ pub mod qos;
 pub mod relays;
 pub mod ros_header;
 pub mod testing;
+#[allow(unsafe_code)]
+pub mod translator;
 
 #[allow(unsafe_code)]
 pub(crate) mod payload;
@@ -37,6 +39,7 @@ pub use backend::*;
 pub use config::*;
 pub use mapping::{PrefixMapping, StaticMapping, TopicDescription};
 pub use qos::*;
+pub use translator::*;
 
 /// The name of the ROS 2 node representing the tunnel.
 #[allow(unsafe_code)]

--- a/integrations/ros2/tunnel-backend/src/payload.rs
+++ b/integrations/ros2/tunnel-backend/src/payload.rs
@@ -52,6 +52,26 @@ pub fn zeroed_bytes(payload: &mut [MaybeUninit<CustomPayloadMarker>]) -> &mut [u
     }
 }
 
+/// Copies `bytes` into an uninitialized untyped payload.
+pub fn copy_into_uninit(payload: &mut [MaybeUninit<CustomPayloadMarker>], bytes: &[u8]) {
+    assert!(
+        payload.len() == bytes.len(),
+        "payload length ({}) does not match the source length ({})",
+        payload.len(),
+        bytes.len()
+    );
+    // SAFETY: the marker is a single byte (asserted above), so length and
+    // alignment carry over; the region is initialized by the copy.
+    #[allow(unsafe_code)]
+    unsafe {
+        core::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            payload.as_mut_ptr().cast::<u8>(),
+            bytes.len(),
+        )
+    }
+}
+
 /// Writes `header` into an untyped user header location.
 ///
 /// The caller must ensure that the service's user-header type detail

--- a/integrations/ros2/tunnel-backend/src/payload.rs
+++ b/integrations/ros2/tunnel-backend/src/payload.rs
@@ -40,6 +40,18 @@ pub fn uninit_bytes_ptr(payload: &mut [MaybeUninit<CustomPayloadMarker>]) -> *mu
     payload.as_mut_ptr().cast()
 }
 
+/// Zero-initializes an uninitialized untyped payload and returns it as a
+/// writable byte slice.
+pub fn zeroed_bytes(payload: &mut [MaybeUninit<CustomPayloadMarker>]) -> &mut [u8] {
+    // SAFETY: the marker is a single byte (asserted above), so length and
+    // alignment carry over; the region is initialized by the zero-write.
+    #[allow(unsafe_code)]
+    unsafe {
+        core::ptr::write_bytes(payload.as_mut_ptr(), 0, payload.len());
+        core::slice::from_raw_parts_mut(payload.as_mut_ptr().cast::<u8>(), payload.len())
+    }
+}
+
 /// Writes `header` into an untyped user header location.
 ///
 /// The caller must ensure that the service's user-header type detail

--- a/integrations/ros2/tunnel-backend/src/qos.rs
+++ b/integrations/ros2/tunnel-backend/src/qos.rs
@@ -114,9 +114,7 @@ impl From<&QosProfile> for PublishSubscribeSettings {
             max_nodes: defaults.max_nodes,
             history_size: match profile.durability {
                 Durability::TransientLocal => depth,
-                Durability::SystemDefault | Durability::Volatile => {
-                    defaults.publisher_history_size
-                }
+                Durability::SystemDefault | Durability::Volatile => defaults.publisher_history_size,
             },
             subscriber_max_buffer_size: depth,
             subscriber_max_borrowed_samples: defaults.subscriber_max_borrowed_samples,

--- a/integrations/ros2/tunnel-backend/src/relays/factory.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/factory.rs
@@ -21,7 +21,6 @@ use iceoryx2_services_tunnel_backend::{traits::RelayFactory, types::wake::WakeHa
 use crate::mapping::TopicDescription;
 use crate::rcl::RclNode;
 use crate::relays::{event, publish_subscribe};
-use crate::typesupport::TypeSupportRegistry;
 
 /// Factory for creating relay builders.
 #[derive(Debug)]
@@ -32,7 +31,6 @@ pub struct Factory<
     T: Translator<EndpointDescription = TopicDescription>,
 > {
     node: Rc<RclNode>,
-    type_registry: &'a TypeSupportRegistry,
     mapping: &'a M,
     translator: Rc<T>,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
@@ -48,14 +46,12 @@ impl<
 {
     pub fn new(
         node: Rc<RclNode>,
-        type_registry: &'a TypeSupportRegistry,
         mapping: &'a M,
         translator: Rc<T>,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Self {
         Factory {
             node,
-            type_registry,
             mapping,
             translator,
             wake,
@@ -93,7 +89,6 @@ impl<
         publish_subscribe::Builder::new(
             description,
             Rc::clone(&self.node),
-            self.type_registry,
             self.mapping,
             Rc::clone(&self.translator),
             self.wake.clone(),

--- a/integrations/ros2/tunnel-backend/src/relays/factory.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/factory.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use iceoryx2::service::{Service, local_threadsafe};
-use iceoryx2_services_tunnel_backend::traits::Mapping;
+use iceoryx2_services_tunnel_backend::traits::{Mapping, Translator};
 use iceoryx2_services_tunnel_backend::types::service_description::ServiceDescription;
 use iceoryx2_services_tunnel_backend::{traits::RelayFactory, types::wake::WakeHandle};
 
@@ -25,39 +25,56 @@ use crate::typesupport::TypeSupportRegistry;
 
 /// Factory for creating relay builders.
 #[derive(Debug)]
-pub struct Factory<'a, S: Service, M: Mapping<EndpointDescription = TopicDescription>> {
+pub struct Factory<
+    'a,
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> {
     node: Rc<RclNode>,
     type_registry: &'a TypeSupportRegistry,
     mapping: &'a M,
+    translator: Rc<T>,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<'a, S: Service, M: Mapping<EndpointDescription = TopicDescription>> Factory<'a, S, M> {
+impl<
+    'a,
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> Factory<'a, S, M, T>
+{
     pub fn new(
         node: Rc<RclNode>,
         type_registry: &'a TypeSupportRegistry,
         mapping: &'a M,
+        translator: Rc<T>,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Self {
         Factory {
             node,
             type_registry,
             mapping,
+            translator,
             wake,
             _phantom: core::marker::PhantomData,
         }
     }
 }
 
-impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> RelayFactory<S>
-    for Factory<'_, S, M>
+impl<
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> RelayFactory<S> for Factory<'_, S, M, T>
 {
-    type PublishSubscribeRelay = publish_subscribe::Relay<S>;
+    type PublishSubscribeRelay = publish_subscribe::Relay<S, T>;
     type EventRelay = event::Relay<S>;
 
     type PublishSubscribeBuilder<'a>
-        = publish_subscribe::Builder<'a, S, M>
+        = publish_subscribe::Builder<'a, S, M, T>
     where
         Self: 'a;
 
@@ -78,6 +95,7 @@ impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> RelayFactor
             Rc::clone(&self.node),
             self.type_registry,
             self.mapping,
+            Rc::clone(&self.translator),
             self.wake.clone(),
         )
     }

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -13,9 +13,14 @@
 use std::rc::Rc;
 use std::sync::Arc;
 
+use core::alloc::Layout;
+
 use iceoryx2::service::{Service, local_threadsafe};
+use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_log::fail;
-use iceoryx2_services_tunnel_backend::traits::{Mapping, PublishSubscribeRelay, RelayBuilder};
+use iceoryx2_services_tunnel_backend::traits::{
+    Mapping, PublishSubscribeRelay, RelayBuilder, ResizableBuffer, TranslationMode, Translator,
+};
 use iceoryx2_services_tunnel_backend::types::publish_subscribe::{
     LoanFn, Sample, SampleMut, SampleMutUninit,
 };
@@ -36,6 +41,7 @@ use crate::typesupport::TypeSupportRegistry;
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum CreationError {
     Mapping,
+    Translator,
     TypeSupport,
     Publisher,
     Subscription,
@@ -52,6 +58,7 @@ impl core::error::Error for CreationError {}
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum SendError {
+    Translation,
     Publish,
 }
 
@@ -67,6 +74,7 @@ impl core::error::Error for SendError {}
 pub enum ReceiveError {
     Loan,
     Take,
+    Translation,
 }
 
 impl core::fmt::Display for ReceiveError {
@@ -77,30 +85,54 @@ impl core::fmt::Display for ReceiveError {
 
 impl core::error::Error for ReceiveError {}
 
+/// Translation state of a relayed service.
+#[derive(Debug)]
+struct Translation<T> {
+    translator: Rc<T>,
+    service: ServiceDescription,
+    endpoint: TopicDescription,
+    native_layout: Layout,
+    /// Reused wire-byte scratch; grows to the largest message seen.
+    scratch: RefCell<Vec<u8>>,
+}
+
+// TODO: Consider moving somewhere else?
+/// [`ResizableBuffer`] over a fixed-size loaned payload; refuses to resize
+/// past the loan.
+struct LoanBuffer<'a> {
+    bytes: &'a mut [u8],
+}
+
+impl ResizableBuffer for LoanBuffer<'_> {
+    fn resize(&mut self, min_capacity: usize) -> &mut [u8] {
+        assert!(
+            min_capacity <= self.bytes.len(),
+            "translated payload ({min_capacity} bytes) exceeds the loaned capacity ({} bytes)",
+            self.bytes.len()
+        );
+        self.bytes
+    }
+}
+
 /// Relays publish-subscribe payloads between iceoryx2 and a ROS 2 topic.
 #[derive(Debug)]
-pub struct Relay<S: Service> {
+pub struct Relay<S: Service, T: Translator<EndpointDescription = TopicDescription>> {
     publisher: RclPublisher,
     subscription: RclSubscription,
     /// Whether the service's user-header type is [`RosHeader`], i.e. the
     /// relay may write the remote origin into received samples.
     write_ros_header: bool,
+    translation: Option<Translation<T>>,
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
-    type SendError = SendError;
-    type ReceiveError = ReceiveError;
-
-    fn send(&self, sample: Sample<S>) -> Result<(), Self::SendError> {
+impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S, T> {
+    /// The direct path: publishes the payload bytes as they are.
+    fn send_passthrough(&self, payload: &[u8]) -> Result<(), SendError> {
         let origin = "publish_subscribe::Relay::send";
 
-        // TRANSLATION GOES HERE
-        // Instead of publishing the payload bytes directly:
-        //  1. Translate into intermediate buffer
-        //  2. Publish intermediate buffer
         fail!(from origin,
-            when self.publisher.publish(payload::as_bytes(sample.payload())),
+            when self.publisher.publish(payload),
             with SendError::Publish,
             "Failed to relay sample to ROS 2"
         );
@@ -108,16 +140,42 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
         Ok(())
     }
 
-    fn receive<LoanError>(
+    /// The buffered path: translates the payload into the scratch, then
+    /// publishes the wire bytes.
+    fn send_translated(
+        &self,
+        translation: &Translation<T>,
+        payload: &[u8],
+    ) -> Result<(), SendError> {
+        let origin = "publish_subscribe::Relay::send";
+
+        let mut scratch = translation.scratch.borrow_mut();
+        let written = fail!(from origin,
+            when translation.translator.to_wire(
+                &translation.service,
+                &translation.endpoint,
+                payload,
+                &mut *scratch
+            ),
+            with SendError::Translation,
+            "Failed to translate payload to the wire"
+        );
+        fail!(from origin,
+            when self.publisher.publish(&scratch[..written]),
+            with SendError::Publish,
+            "Failed to relay translated sample to ROS 2"
+        );
+
+        Ok(())
+    }
+
+    /// The direct path: takes the wire bytes straight into a loaned payload.
+    fn receive_passthrough<LoanError>(
         &self,
         loan: &mut LoanFn<'_, S, LoanError>,
-    ) -> Result<Option<SampleMut<S>>, Self::ReceiveError> {
+    ) -> Result<Option<SampleMut<S>>, ReceiveError> {
         let mut loaned: Option<SampleMutUninit<S>> = None;
 
-        // TRANSLATION GOES HERE
-        // Instead of taking directly into an iceoryx2 buffer:
-        //  1. Take into an intermediate buffer
-        //  2. Translate from intermediate buffer into iceoryx2 buffer
         let result = self.subscription.take_into(|size| match loan(size) {
             Ok(mut sample) => {
                 let buffer = payload::uninit_bytes_ptr(sample.payload_mut());
@@ -153,31 +211,133 @@ impl<S: Service> PublishSubscribeRelay<S> for Relay<S> {
             Err(TakeError::Take) => Err(ReceiveError::Take),
         }
     }
+
+    /// The buffered path: takes the wire bytes into the scratch, then
+    /// translates them into a loaned payload of the native layout.
+    fn receive_translated<LoanError>(
+        &self,
+        translation: &Translation<T>,
+        loan: &mut LoanFn<'_, S, LoanError>,
+    ) -> Result<Option<SampleMut<S>>, ReceiveError> {
+        let origin = "publish_subscribe::Relay::receive";
+
+        // The scratch is rcl's take destination here, the translator
+        // reads it and writes the translation into the loan.
+        let mut scratch = translation.scratch.borrow_mut();
+        let result = self.subscription.take_into(|size| {
+            if scratch.len() < size {
+                scratch.resize(size, 0);
+            }
+            Some(scratch.as_mut_ptr())
+        });
+
+        match result {
+            Ok(Some((size, message_info))) => {
+                let mut sample = match loan(translation.native_layout.size()) {
+                    Ok(sample) => sample,
+                    Err(_) => return Err(ReceiveError::Loan),
+                };
+
+                let mut destination = LoanBuffer {
+                    bytes: payload::zeroed_bytes(sample.payload_mut()),
+                };
+                let written = fail!(from origin,
+                    when translation.translator.from_wire(
+                        &translation.service,
+                        &translation.endpoint,
+                        &scratch[..size],
+                        &mut destination
+                    ),
+                    with ReceiveError::Translation,
+                    "Failed to translate received payload from the wire"
+                );
+                if written != translation.native_layout.size() {
+                    fail!(from origin,
+                        with ReceiveError::Translation,
+                        "Translated payload ({} bytes) does not fill the native layout ({} bytes)",
+                        written,
+                        translation.native_layout.size()
+                    );
+                }
+
+                if self.write_ros_header {
+                    payload::write_user_header(
+                        sample.user_header_mut(),
+                        RosHeader::from(message_info),
+                    );
+                }
+
+                Ok(Some(payload::assume_init(sample)))
+            }
+            Ok(None) => Ok(None),
+            Err(TakeError::LoanDeclined) => Err(ReceiveError::Loan),
+            Err(TakeError::Take) => Err(ReceiveError::Take),
+        }
+    }
+}
+
+impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> PublishSubscribeRelay<S>
+    for Relay<S, T>
+{
+    type SendError = SendError;
+    type ReceiveError = ReceiveError;
+
+    fn send(&self, sample: Sample<S>) -> Result<(), Self::SendError> {
+        let payload = payload::as_bytes(sample.payload());
+        match &self.translation {
+            None => self.send_passthrough(payload),
+            Some(translation) => self.send_translated(translation, payload),
+        }
+    }
+
+    fn receive<LoanError>(
+        &self,
+        loan: &mut LoanFn<'_, S, LoanError>,
+    ) -> Result<Option<SampleMut<S>>, Self::ReceiveError> {
+        match &self.translation {
+            None => self.receive_passthrough(loan),
+            Some(translation) => self.receive_translated(translation, loan),
+        }
+    }
 }
 
 /// Builder for publish-subscribe [`Relay`]s.
 #[derive(Debug)]
-pub struct Builder<'a, S: Service, M: Mapping<EndpointDescription = TopicDescription>> {
+pub struct Builder<
+    'a,
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> {
     node: Rc<RclNode>,
     type_registry: &'a TypeSupportRegistry,
     mapping: &'a M,
+    translator: Rc<T>,
     description: &'a ServiceDescription,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<'a, S: Service, M: Mapping<EndpointDescription = TopicDescription>> Builder<'a, S, M> {
+impl<
+    'a,
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> Builder<'a, S, M, T>
+{
     pub fn new(
         description: &'a ServiceDescription,
         node: Rc<RclNode>,
         type_registry: &'a TypeSupportRegistry,
         mapping: &'a M,
+        translator: Rc<T>,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Self {
         Self {
             node,
             type_registry,
             mapping,
+            translator,
             description,
             wake,
             _phantom: core::marker::PhantomData,
@@ -185,11 +345,14 @@ impl<'a, S: Service, M: Mapping<EndpointDescription = TopicDescription>> Builder
     }
 }
 
-impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> RelayBuilder
-    for Builder<'_, S, M>
+impl<
+    S: Service,
+    M: Mapping<EndpointDescription = TopicDescription>,
+    T: Translator<EndpointDescription = TopicDescription>,
+> RelayBuilder for Builder<'_, S, M, T>
 {
     type CreationError = CreationError;
-    type Relay = Relay<S>;
+    type Relay = Relay<S, T>;
 
     // Endpoint creation simultaneously announces over the DDS SEDP.
     fn create(self) -> Result<Self::Relay, Self::CreationError> {
@@ -206,6 +369,13 @@ impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> RelayBuilde
                 self.description.name
             );
         };
+
+        let mode = fail!(from origin,
+            when self.translator.resolve(self.description, &topic_description),
+            with CreationError::Translator,
+            "Translator failed to resolve service '{}'",
+            self.description.name
+        );
 
         let type_name = topic_description.type_name.as_str();
         let type_support = fail!(from origin,
@@ -250,10 +420,22 @@ impl<S: Service, M: Mapping<EndpointDescription = TopicDescription>> RelayBuilde
         let write_ros_header =
             pattern_description.user_header == TypeDescription::from(&RosHeader::type_detail());
 
+        let translation = match mode {
+            TranslationMode::Passthrough => None,
+            TranslationMode::Translate { native_layout } => Some(Translation {
+                translator: Rc::clone(&self.translator),
+                service: self.description.clone(),
+                endpoint: topic_description.clone(),
+                native_layout,
+                scratch: RefCell::new(Vec::new()),
+            }),
+        };
+
         Ok(Relay {
             publisher,
             subscription,
             write_ros_header,
+            translation,
             _phantom: core::marker::PhantomData,
         })
     }

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -86,32 +86,23 @@ impl core::fmt::Display for ReceiveError {
 
 impl core::error::Error for ReceiveError {}
 
-/// The path a relayed service's payloads take across the boundary.
-#[derive(Debug)]
-enum PayloadPath<C> {
-    /// Bytes cross unmodified, on the relay's zero-copy path.
-    Passthrough,
-    /// Bytes are translated through `transcoder`, reusing scratch buffers.
-    Transcode {
-        transcoder: C,
-        payload_layout: PayloadLayout,
-        /// Reused wire-byte scratch; grows to the largest message seen.
-        wire_scratch: RefCell<Vec<u8>>,
-        /// Reused payload-byte scratch for dynamic layouts, where the loan
-        /// can only be sized after translation; grows to the largest message
-        /// seen.
-        payload_scratch: RefCell<Vec<u8>>,
-    },
+/// Reused byte buffers for the transcoding paths.
+#[derive(Debug, Default)]
+struct Scratch {
+    /// Reused wire-byte scratch buffer.
+    wire: RefCell<Vec<u8>>,
+    /// Reused payload-byte scratch for dynamic layouts where the loan can
+    /// only be sized after transcoding.
+    payload: RefCell<Vec<u8>>,
 }
 
 // TODO: Consider moving somewhere else?
-/// [`ResizableBuffer`] over a fixed-size loaned payload; refuses to resize
-/// past the loan.
-struct LoanBuffer<'a> {
+/// [`ResizableBuffer`] over a fixed-size loaned payload.
+struct LoanedBuffer<'a> {
     bytes: &'a mut [u8],
 }
 
-impl ResizableBuffer for LoanBuffer<'_> {
+impl ResizableBuffer for LoanedBuffer<'_> {
     fn resize(&mut self, min_capacity: usize) -> &mut [u8] {
         assert!(
             min_capacity <= self.bytes.len(),
@@ -130,12 +121,13 @@ pub struct Relay<S: Service, T: Translator<EndpointDescription = TopicDescriptio
     /// Whether the service's user-header type is [`RosHeader`], i.e. the
     /// relay may write the remote origin into received samples.
     write_ros_header: bool,
-    payload_path: PayloadPath<T::Transcoder>,
+    translation: Translation<T::Transcoder>,
+    scratch: Scratch,
     _phantom: core::marker::PhantomData<S>,
 }
 
 impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S, T> {
-    /// The direct path: publishes the payload bytes as they are.
+    /// Propagate bytes without any modification.
     fn send_passthrough(&self, payload: &[u8]) -> Result<(), SendError> {
         let origin = "publish_subscribe::Relay::send";
 
@@ -148,17 +140,11 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
         Ok(())
     }
 
-    /// The buffered path: translates the payload into the scratch, then
-    /// publishes the wire bytes.
-    fn send_translated(
-        &self,
-        transcoder: &T::Transcoder,
-        wire_scratch: &RefCell<Vec<u8>>,
-        payload: &[u8],
-    ) -> Result<(), SendError> {
+    /// Transcode bytes into intermediate scratch buffer then propagate.
+    fn send_translated(&self, transcoder: &T::Transcoder, payload: &[u8]) -> Result<(), SendError> {
         let origin = "publish_subscribe::Relay::send";
 
-        let mut wire_scratch = wire_scratch.borrow_mut();
+        let mut wire_scratch = self.scratch.wire.borrow_mut();
         let written = fail!(from origin,
             when transcoder.to_wire(payload, &mut *wire_scratch),
             with SendError::Translation,
@@ -173,7 +159,7 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
         Ok(())
     }
 
-    /// The direct path: takes the wire bytes straight into a loaned payload.
+    /// Ingest bytes without modification into loaned payload.
     fn receive_passthrough<LoanError>(
         &self,
         loan: &mut LoanFn<'_, S, LoanError>,
@@ -216,39 +202,31 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
         }
     }
 
-    /// The buffered path: takes the wire bytes into the wire scratch, then
-    /// translates them into a loaned payload of the resolved layout.
+    /// Receive bytes into intermediate scratch buffer then transcode into
+    /// shared memory loan.
     fn receive_translated<LoanError>(
         &self,
         transcoder: &T::Transcoder,
         payload_layout: PayloadLayout,
-        wire_scratch: &RefCell<Vec<u8>>,
-        payload_scratch: &RefCell<Vec<u8>>,
         loan: &mut LoanFn<'_, S, LoanError>,
     ) -> Result<Option<SampleMut<S>>, ReceiveError> {
-        // The wire scratch is rcl's take destination here, the transcoder reads
-        // it and writes the translation towards the loan.
-        let mut wire_scratch = wire_scratch.borrow_mut();
+        let mut wire_bytes = self.scratch.wire.borrow_mut();
         let result = self.subscription.take_into(|size| {
-            if wire_scratch.len() < size {
-                wire_scratch.resize(size, 0);
+            if wire_bytes.len() < size {
+                wire_bytes.resize(size, 0);
             }
-            Some(wire_scratch.as_mut_ptr())
+            Some(wire_bytes.as_mut_ptr())
         });
 
         match result {
             Ok(Some((size, message_info))) => {
                 let mut sample = match payload_layout {
                     PayloadLayout::FixedSize(layout) => {
-                        self.translate_into_loan(transcoder, &wire_scratch[..size], layout, loan)?
+                        self.translate_fixed_size(transcoder, &wire_bytes[..size], layout, loan)?
                     }
-                    PayloadLayout::Dynamic { element } => self.translate_via_scratch(
-                        transcoder,
-                        payload_scratch,
-                        &wire_scratch[..size],
-                        element,
-                        loan,
-                    )?,
+                    PayloadLayout::Dynamic { element } => {
+                        self.translate_dynamic_size(transcoder, &wire_bytes[..size], element, loan)?
+                    }
                 };
 
                 if self.write_ros_header {
@@ -266,12 +244,11 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
         }
     }
 
-    /// Translates wire bytes directly into a loaned payload of the fixed
-    /// layout, which the transcoder must fill exactly.
-    fn translate_into_loan<LoanError>(
+    /// Transcodes wire bytes directly into a loaned payload.
+    fn translate_fixed_size<LoanError>(
         &self,
         transcoder: &T::Transcoder,
-        wire: &[u8],
+        wire_bytes: &[u8],
         layout: Layout,
         loan: &mut LoanFn<'_, S, LoanError>,
     ) -> Result<SampleMutUninit<S>, ReceiveError> {
@@ -282,11 +259,11 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
             Err(_) => return Err(ReceiveError::Loan),
         };
 
-        let mut loan_buffer = LoanBuffer {
+        let mut loan_buffer = LoanedBuffer {
             bytes: payload::zeroed_bytes(sample.payload_mut()),
         };
         let written = fail!(from origin,
-            when transcoder.from_wire(wire, &mut loan_buffer),
+            when transcoder.from_wire(wire_bytes, &mut loan_buffer),
             with ReceiveError::Translation,
             "Failed to translate received payload from the wire"
         );
@@ -302,21 +279,20 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
         Ok(sample)
     }
 
-    /// Translates wire bytes into the payload scratch, then loans a payload
-    /// sized to the translated length and copies the translation into it.
-    fn translate_via_scratch<LoanError>(
+    /// Transcodes dynamically-sized wire bytes into intermediate scratch
+    /// buffer, then loans a payload of appropriate size to translate to.
+    fn translate_dynamic_size<LoanError>(
         &self,
         transcoder: &T::Transcoder,
-        payload_scratch: &RefCell<Vec<u8>>,
-        wire: &[u8],
+        wire_bytes: &[u8],
         element: Layout,
         loan: &mut LoanFn<'_, S, LoanError>,
     ) -> Result<SampleMutUninit<S>, ReceiveError> {
         let origin = "publish_subscribe::Relay::receive";
 
-        let mut payload_scratch = payload_scratch.borrow_mut();
+        let mut payload_bytes = self.scratch.payload.borrow_mut();
         let written = fail!(from origin,
-            when transcoder.from_wire(wire, &mut *payload_scratch),
+            when transcoder.from_wire(wire_bytes, &mut *payload_bytes),
             with ReceiveError::Translation,
             "Failed to translate received payload from the wire"
         );
@@ -333,7 +309,7 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
             Ok(sample) => sample,
             Err(_) => return Err(ReceiveError::Loan),
         };
-        payload::copy_into_uninit(sample.payload_mut(), &payload_scratch[..written]);
+        payload::copy_into_uninit(sample.payload_mut(), &payload_bytes[..written]);
 
         Ok(sample)
     }
@@ -347,11 +323,9 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> PublishS
 
     fn send(&self, sample: Sample<S>) -> Result<(), Self::SendError> {
         let payload = payload::as_bytes(sample.payload());
-        match &self.payload_path {
-            PayloadPath::Passthrough => self.send_passthrough(payload),
-            PayloadPath::Transcode {
-                transcoder, wire_scratch, ..
-            } => self.send_translated(transcoder, wire_scratch, payload),
+        match &self.translation {
+            Translation::Passthrough => self.send_passthrough(payload),
+            Translation::Transcode { transcoder, .. } => self.send_translated(transcoder, payload),
         }
     }
 
@@ -359,20 +333,12 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> PublishS
         &self,
         loan: &mut LoanFn<'_, S, LoanError>,
     ) -> Result<Option<SampleMut<S>>, Self::ReceiveError> {
-        match &self.payload_path {
-            PayloadPath::Passthrough => self.receive_passthrough(loan),
-            PayloadPath::Transcode {
+        match &self.translation {
+            Translation::Passthrough => self.receive_passthrough(loan),
+            Translation::Transcode {
                 transcoder,
                 payload_layout,
-                wire_scratch,
-                payload_scratch,
-            } => self.receive_translated(
-                transcoder,
-                *payload_layout,
-                wire_scratch,
-                payload_scratch,
-                loan,
-            ),
+            } => self.receive_translated(transcoder, *payload_layout, loan),
         }
     }
 }
@@ -497,34 +463,24 @@ impl<
         let write_ros_header =
             pattern_description.user_header == TypeDescription::from(&RosHeader::type_detail());
 
-        let payload_path = match translation {
-            Translation::Passthrough => PayloadPath::Passthrough,
-            Translation::Transcode {
-                payload_layout,
-                transcoder,
-            } => {
-                if let PayloadLayout::Dynamic { element } = payload_layout
-                    && element.size() == 0
-                {
-                    fail!(from origin, with CreationError::Translator,
-                        "Translator produced a dynamic payload with a zero-sized element for service '{}'",
-                        self.service_description.name
-                    );
-                }
-                PayloadPath::Transcode {
-                    transcoder,
-                    payload_layout,
-                    wire_scratch: RefCell::new(Vec::new()),
-                    payload_scratch: RefCell::new(Vec::new()),
-                }
-            }
-        };
+        if let Translation::Transcode {
+            payload_layout: PayloadLayout::Dynamic { element },
+            ..
+        } = &translation
+            && element.size() == 0
+        {
+            fail!(from origin, with CreationError::Translator,
+                "Translator produced a dynamic payload with a zero-sized element for service '{}'",
+                self.service_description.name
+            );
+        }
 
         Ok(Relay {
             publisher,
             subscription,
             write_ros_header,
-            payload_path,
+            translation,
+            scratch: Scratch::default(),
             _phantom: core::marker::PhantomData,
         })
     }

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -129,7 +129,7 @@ pub struct Relay<S: Service, T: Translator<EndpointDescription = TopicDescriptio
 impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S, T> {
     /// Propagate bytes without any modification.
     fn send_passthrough(&self, payload: &[u8]) -> Result<(), SendError> {
-        let origin = "publish_subscribe::Relay::send";
+        let origin = "publish_subscribe::Relay::send_passthrough";
 
         fail!(from origin,
             when self.publisher.publish(payload),
@@ -142,7 +142,7 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
 
     /// Transcode bytes into intermediate scratch buffer then propagate.
     fn send_translated(&self, transcoder: &T::Transcoder, payload: &[u8]) -> Result<(), SendError> {
-        let origin = "publish_subscribe::Relay::send";
+        let origin = "publish_subscribe::Relay::send_translated";
 
         let mut wire_scratch = self.scratch.wire.borrow_mut();
         let written = fail!(from origin,
@@ -252,7 +252,7 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
         layout: Layout,
         loan: &mut LoanFn<'_, S, LoanError>,
     ) -> Result<SampleMutUninit<S>, ReceiveError> {
-        let origin = "publish_subscribe::Relay::receive";
+        let origin = "publish_subscribe::Relay::translate_fixed_size";
 
         let mut sample = match loan(layout.size()) {
             Ok(sample) => sample,
@@ -288,7 +288,7 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
         element: Layout,
         loan: &mut LoanFn<'_, S, LoanError>,
     ) -> Result<SampleMutUninit<S>, ReceiveError> {
-        let origin = "publish_subscribe::Relay::receive";
+        let origin = "publish_subscribe::Relay::translate_dynamic_size";
 
         let mut payload_bytes = self.scratch.payload.borrow_mut();
         let written = fail!(from origin,

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -19,8 +19,8 @@ use iceoryx2::service::{Service, local_threadsafe};
 use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_log::fail;
 use iceoryx2_services_tunnel_backend::traits::{
-    Mapping, PayloadLayout, PublishSubscribeRelay, RelayBuilder, ResizableBuffer, Transcoder,
-    Translation, Translator,
+    Mapping, PayloadLayout, PublishSubscribeRelay, RelayBuilder, ResizableBuffer, ResizeError,
+    Transcoder, Translation, Translator,
 };
 use iceoryx2_services_tunnel_backend::types::publish_subscribe::{
     LoanFn, Sample, SampleMut, SampleMutUninit,
@@ -103,13 +103,13 @@ struct LoanedBuffer<'a> {
 }
 
 impl ResizableBuffer for LoanedBuffer<'_> {
-    fn resize(&mut self, min_capacity: usize) -> &mut [u8] {
-        assert!(
-            min_capacity <= self.bytes.len(),
-            "translated payload ({min_capacity} bytes) exceeds the loaned capacity ({} bytes)",
-            self.bytes.len()
-        );
-        self.bytes
+    fn resize(&mut self, min_capacity: usize) -> Result<&mut [u8], ResizeError> {
+        if min_capacity > self.bytes.len() {
+            return Err(ResizeError {
+                available: self.bytes.len(),
+            });
+        }
+        Ok(self.bytes)
     }
 }
 

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -37,7 +37,7 @@ use crate::rcl::{
     subscription::TakeError,
 };
 use crate::ros_header::RosHeader;
-use crate::typesupport::TypeSupportRegistry;
+use crate::typesupport;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum CreationError {
@@ -352,7 +352,6 @@ pub struct Builder<
     T: Translator<EndpointDescription = TopicDescription>,
 > {
     node: Rc<RclNode>,
-    type_registry: &'a TypeSupportRegistry,
     mapping: &'a M,
     translator: Rc<T>,
     service_description: &'a ServiceDescription,
@@ -370,14 +369,12 @@ impl<
     pub fn new(
         service_description: &'a ServiceDescription,
         node: Rc<RclNode>,
-        type_registry: &'a TypeSupportRegistry,
         mapping: &'a M,
         translator: Rc<T>,
         wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     ) -> Self {
         Self {
             node,
-            type_registry,
             mapping,
             translator,
             service_description,
@@ -422,7 +419,7 @@ impl<
 
         let type_name = topic_description.type_name.as_str();
         let type_support = fail!(from origin,
-            when self.type_registry.load(type_name),
+            when typesupport::load(type_name),
             with CreationError::TypeSupport,
             "Failed to load typesupport for '{}'",
             type_name

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -19,7 +19,8 @@ use iceoryx2::service::{Service, local_threadsafe};
 use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_log::fail;
 use iceoryx2_services_tunnel_backend::traits::{
-    Mapping, PublishSubscribeRelay, RelayBuilder, ResizableBuffer, TranslationMode, Translator,
+    Mapping, PayloadLayout, PublishSubscribeRelay, RelayBuilder, ResizableBuffer, Transcoder,
+    Translation, Translator,
 };
 use iceoryx2_services_tunnel_backend::types::publish_subscribe::{
     LoanFn, Sample, SampleMut, SampleMutUninit,
@@ -85,15 +86,22 @@ impl core::fmt::Display for ReceiveError {
 
 impl core::error::Error for ReceiveError {}
 
-/// Translation state of a relayed service.
+/// The path a relayed service's payloads take across the boundary.
 #[derive(Debug)]
-struct Translation<T> {
-    translator: Rc<T>,
-    service: ServiceDescription,
-    endpoint: TopicDescription,
-    native_layout: Layout,
-    /// Reused wire-byte scratch; grows to the largest message seen.
-    scratch: RefCell<Vec<u8>>,
+enum PayloadPath<C> {
+    /// Bytes cross unmodified, on the relay's zero-copy path.
+    Passthrough,
+    /// Bytes are translated through `transcoder`, reusing scratch buffers.
+    Transcode {
+        transcoder: C,
+        payload_layout: PayloadLayout,
+        /// Reused wire-byte scratch; grows to the largest message seen.
+        wire_scratch: RefCell<Vec<u8>>,
+        /// Reused payload-byte scratch for dynamic layouts, where the loan
+        /// can only be sized after translation; grows to the largest message
+        /// seen.
+        payload_scratch: RefCell<Vec<u8>>,
+    },
 }
 
 // TODO: Consider moving somewhere else?
@@ -122,7 +130,7 @@ pub struct Relay<S: Service, T: Translator<EndpointDescription = TopicDescriptio
     /// Whether the service's user-header type is [`RosHeader`], i.e. the
     /// relay may write the remote origin into received samples.
     write_ros_header: bool,
-    translation: Option<Translation<T>>,
+    payload_path: PayloadPath<T::Transcoder>,
     _phantom: core::marker::PhantomData<S>,
 }
 
@@ -144,24 +152,20 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
     /// publishes the wire bytes.
     fn send_translated(
         &self,
-        translation: &Translation<T>,
+        transcoder: &T::Transcoder,
+        wire_scratch: &RefCell<Vec<u8>>,
         payload: &[u8],
     ) -> Result<(), SendError> {
         let origin = "publish_subscribe::Relay::send";
 
-        let mut scratch = translation.scratch.borrow_mut();
+        let mut wire_scratch = wire_scratch.borrow_mut();
         let written = fail!(from origin,
-            when translation.translator.to_wire(
-                &translation.service,
-                &translation.endpoint,
-                payload,
-                &mut *scratch
-            ),
+            when transcoder.to_wire(payload, &mut *wire_scratch),
             with SendError::Translation,
             "Failed to translate payload to the wire"
         );
         fail!(from origin,
-            when self.publisher.publish(&scratch[..written]),
+            when self.publisher.publish(&wire_scratch[..written]),
             with SendError::Publish,
             "Failed to relay translated sample to ROS 2"
         );
@@ -212,53 +216,40 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
         }
     }
 
-    /// The buffered path: takes the wire bytes into the scratch, then
-    /// translates them into a loaned payload of the native layout.
+    /// The buffered path: takes the wire bytes into the wire scratch, then
+    /// translates them into a loaned payload of the resolved layout.
     fn receive_translated<LoanError>(
         &self,
-        translation: &Translation<T>,
+        transcoder: &T::Transcoder,
+        payload_layout: PayloadLayout,
+        wire_scratch: &RefCell<Vec<u8>>,
+        payload_scratch: &RefCell<Vec<u8>>,
         loan: &mut LoanFn<'_, S, LoanError>,
     ) -> Result<Option<SampleMut<S>>, ReceiveError> {
-        let origin = "publish_subscribe::Relay::receive";
-
-        // The scratch is rcl's take destination here, the translator
-        // reads it and writes the translation into the loan.
-        let mut scratch = translation.scratch.borrow_mut();
+        // The wire scratch is rcl's take destination here, the transcoder reads
+        // it and writes the translation towards the loan.
+        let mut wire_scratch = wire_scratch.borrow_mut();
         let result = self.subscription.take_into(|size| {
-            if scratch.len() < size {
-                scratch.resize(size, 0);
+            if wire_scratch.len() < size {
+                wire_scratch.resize(size, 0);
             }
-            Some(scratch.as_mut_ptr())
+            Some(wire_scratch.as_mut_ptr())
         });
 
         match result {
             Ok(Some((size, message_info))) => {
-                let mut sample = match loan(translation.native_layout.size()) {
-                    Ok(sample) => sample,
-                    Err(_) => return Err(ReceiveError::Loan),
+                let mut sample = match payload_layout {
+                    PayloadLayout::FixedSize(layout) => {
+                        self.translate_into_loan(transcoder, &wire_scratch[..size], layout, loan)?
+                    }
+                    PayloadLayout::Dynamic { element } => self.translate_via_scratch(
+                        transcoder,
+                        payload_scratch,
+                        &wire_scratch[..size],
+                        element,
+                        loan,
+                    )?,
                 };
-
-                let mut destination = LoanBuffer {
-                    bytes: payload::zeroed_bytes(sample.payload_mut()),
-                };
-                let written = fail!(from origin,
-                    when translation.translator.from_wire(
-                        &translation.service,
-                        &translation.endpoint,
-                        &scratch[..size],
-                        &mut destination
-                    ),
-                    with ReceiveError::Translation,
-                    "Failed to translate received payload from the wire"
-                );
-                if written != translation.native_layout.size() {
-                    fail!(from origin,
-                        with ReceiveError::Translation,
-                        "Translated payload ({} bytes) does not fill the native layout ({} bytes)",
-                        written,
-                        translation.native_layout.size()
-                    );
-                }
 
                 if self.write_ros_header {
                     payload::write_user_header(
@@ -274,6 +265,78 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
             Err(TakeError::Take) => Err(ReceiveError::Take),
         }
     }
+
+    /// Translates wire bytes directly into a loaned payload of the fixed
+    /// layout, which the transcoder must fill exactly.
+    fn translate_into_loan<LoanError>(
+        &self,
+        transcoder: &T::Transcoder,
+        wire: &[u8],
+        layout: Layout,
+        loan: &mut LoanFn<'_, S, LoanError>,
+    ) -> Result<SampleMutUninit<S>, ReceiveError> {
+        let origin = "publish_subscribe::Relay::receive";
+
+        let mut sample = match loan(layout.size()) {
+            Ok(sample) => sample,
+            Err(_) => return Err(ReceiveError::Loan),
+        };
+
+        let mut loan_buffer = LoanBuffer {
+            bytes: payload::zeroed_bytes(sample.payload_mut()),
+        };
+        let written = fail!(from origin,
+            when transcoder.from_wire(wire, &mut loan_buffer),
+            with ReceiveError::Translation,
+            "Failed to translate received payload from the wire"
+        );
+        if written != layout.size() {
+            fail!(from origin,
+                with ReceiveError::Translation,
+                "Translated payload ({} bytes) does not fill the fixed payload layout ({} bytes)",
+                written,
+                layout.size()
+            );
+        }
+
+        Ok(sample)
+    }
+
+    /// Translates wire bytes into the payload scratch, then loans a payload
+    /// sized to the translated length and copies the translation into it.
+    fn translate_via_scratch<LoanError>(
+        &self,
+        transcoder: &T::Transcoder,
+        payload_scratch: &RefCell<Vec<u8>>,
+        wire: &[u8],
+        element: Layout,
+        loan: &mut LoanFn<'_, S, LoanError>,
+    ) -> Result<SampleMutUninit<S>, ReceiveError> {
+        let origin = "publish_subscribe::Relay::receive";
+
+        let mut payload_scratch = payload_scratch.borrow_mut();
+        let written = fail!(from origin,
+            when transcoder.from_wire(wire, &mut *payload_scratch),
+            with ReceiveError::Translation,
+            "Failed to translate received payload from the wire"
+        );
+        if !written.is_multiple_of(element.size()) {
+            fail!(from origin,
+                with ReceiveError::Translation,
+                "Translated payload ({} bytes) is not a whole number of {}-byte elements",
+                written,
+                element.size()
+            );
+        }
+
+        let mut sample = match loan(written) {
+            Ok(sample) => sample,
+            Err(_) => return Err(ReceiveError::Loan),
+        };
+        payload::copy_into_uninit(sample.payload_mut(), &payload_scratch[..written]);
+
+        Ok(sample)
+    }
 }
 
 impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> PublishSubscribeRelay<S>
@@ -284,9 +347,11 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> PublishS
 
     fn send(&self, sample: Sample<S>) -> Result<(), Self::SendError> {
         let payload = payload::as_bytes(sample.payload());
-        match &self.translation {
-            None => self.send_passthrough(payload),
-            Some(translation) => self.send_translated(translation, payload),
+        match &self.payload_path {
+            PayloadPath::Passthrough => self.send_passthrough(payload),
+            PayloadPath::Transcode {
+                transcoder, wire_scratch, ..
+            } => self.send_translated(transcoder, wire_scratch, payload),
         }
     }
 
@@ -294,9 +359,20 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> PublishS
         &self,
         loan: &mut LoanFn<'_, S, LoanError>,
     ) -> Result<Option<SampleMut<S>>, Self::ReceiveError> {
-        match &self.translation {
-            None => self.receive_passthrough(loan),
-            Some(translation) => self.receive_translated(translation, loan),
+        match &self.payload_path {
+            PayloadPath::Passthrough => self.receive_passthrough(loan),
+            PayloadPath::Transcode {
+                transcoder,
+                payload_layout,
+                wire_scratch,
+                payload_scratch,
+            } => self.receive_translated(
+                transcoder,
+                *payload_layout,
+                wire_scratch,
+                payload_scratch,
+                loan,
+            ),
         }
     }
 }
@@ -313,7 +389,7 @@ pub struct Builder<
     type_registry: &'a TypeSupportRegistry,
     mapping: &'a M,
     translator: Rc<T>,
-    description: &'a ServiceDescription,
+    service_description: &'a ServiceDescription,
     wake: Option<Arc<WakeHandle<local_threadsafe::Service>>>,
     _phantom: core::marker::PhantomData<S>,
 }
@@ -326,7 +402,7 @@ impl<
 > Builder<'a, S, M, T>
 {
     pub fn new(
-        description: &'a ServiceDescription,
+        service_description: &'a ServiceDescription,
         node: Rc<RclNode>,
         type_registry: &'a TypeSupportRegistry,
         mapping: &'a M,
@@ -338,7 +414,7 @@ impl<
             type_registry,
             mapping,
             translator,
-            description,
+            service_description,
             wake,
             _phantom: core::marker::PhantomData,
         }
@@ -358,23 +434,24 @@ impl<
     fn create(self) -> Result<Self::Relay, Self::CreationError> {
         let origin = "publish_subscribe::Relay::create";
 
-        let PatternDescription::PublishSubscribe(pattern_description) = &self.description.pattern
+        let PatternDescription::PublishSubscribe(pattern_description) =
+            &self.service_description.pattern
         else {
             unreachable!("relay is only built for publish-subscribe descriptions")
         };
 
-        let Some(topic_description) = self.mapping.remote(self.description) else {
+        let Some(topic_description) = self.mapping.remote(self.service_description) else {
             fail!(from origin, with CreationError::Mapping,
                 "Mapping does not map service '{}' to a ROS 2 topic",
-                self.description.name
+                self.service_description.name
             );
         };
 
-        let mode = fail!(from origin,
-            when self.translator.resolve(self.description, &topic_description),
+        let translation = fail!(from origin,
+            when self.translator.create(self.service_description, &topic_description),
             with CreationError::Translator,
-            "Translator failed to resolve service '{}'",
-            self.description.name
+            "Translator failed to create translation for service '{}'",
+            self.service_description.name
         );
 
         let type_name = topic_description.type_name.as_str();
@@ -420,22 +497,34 @@ impl<
         let write_ros_header =
             pattern_description.user_header == TypeDescription::from(&RosHeader::type_detail());
 
-        let translation = match mode {
-            TranslationMode::Passthrough => None,
-            TranslationMode::Translate { native_layout } => Some(Translation {
-                translator: Rc::clone(&self.translator),
-                service: self.description.clone(),
-                endpoint: topic_description.clone(),
-                native_layout,
-                scratch: RefCell::new(Vec::new()),
-            }),
+        let payload_path = match translation {
+            Translation::Passthrough => PayloadPath::Passthrough,
+            Translation::Transcode {
+                payload_layout,
+                transcoder,
+            } => {
+                if let PayloadLayout::Dynamic { element } = payload_layout
+                    && element.size() == 0
+                {
+                    fail!(from origin, with CreationError::Translator,
+                        "Translator produced a dynamic payload with a zero-sized element for service '{}'",
+                        self.service_description.name
+                    );
+                }
+                PayloadPath::Transcode {
+                    transcoder,
+                    payload_layout,
+                    wire_scratch: RefCell::new(Vec::new()),
+                    payload_scratch: RefCell::new(Vec::new()),
+                }
+            }
         };
 
         Ok(Relay {
             publisher,
             subscription,
             write_ros_header,
-            translation,
+            payload_path,
             _phantom: core::marker::PhantomData,
         })
     }

--- a/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
+++ b/integrations/ros2/tunnel-backend/src/relays/publish_subscribe.rs
@@ -254,9 +254,8 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
     ) -> Result<SampleMutUninit<S>, ReceiveError> {
         let origin = "publish_subscribe::Relay::translate_fixed_size";
 
-        let mut sample = match loan(layout.size()) {
-            Ok(sample) => sample,
-            Err(_) => return Err(ReceiveError::Loan),
+        let Ok(mut sample) = loan(layout.size()) else {
+            return Err(ReceiveError::Loan);
         };
 
         let mut loan_buffer = LoanedBuffer {
@@ -305,10 +304,10 @@ impl<S: Service, T: Translator<EndpointDescription = TopicDescription>> Relay<S,
             );
         }
 
-        let mut sample = match loan(written) {
-            Ok(sample) => sample,
-            Err(_) => return Err(ReceiveError::Loan),
+        let Ok(mut sample) = loan(written) else {
+            return Err(ReceiveError::Loan);
         };
+
         payload::copy_into_uninit(sample.payload_mut(), &payload_bytes[..written]);
 
         Ok(sample)

--- a/integrations/ros2/tunnel-backend/src/testing.rs
+++ b/integrations/ros2/tunnel-backend/src/testing.rs
@@ -16,10 +16,13 @@
 use std::rc::Rc;
 
 use crate::qos::QosProfile;
-use crate::rcl::{NodeName, RclNode, RclNodeBuilder, RclPublisherBuilder, TopicName};
+use crate::rcl::{
+    NodeName, RclNode, RclNodeBuilder, RclPublisherBuilder, RclSubscriptionBuilder, TopicName,
+};
 use crate::typesupport::TypeSupportRegistry;
 
 pub use crate::rcl::publisher::RclPublisher;
+pub use crate::rcl::subscription::RclSubscription;
 
 /// A separate ROS 2 peer for observing and validating changes to
 /// ROS 2 graph.
@@ -51,6 +54,18 @@ impl TestPeer {
         RclPublisherBuilder::new(Rc::clone(&self.node), &topic, type_support)
             .create()
             .expect("failed to create the test peer publisher")
+    }
+
+    /// Creates a subscription on `topic` with default QoS.
+    pub fn create_subscription(&self, topic: &str, type_name: &str) -> RclSubscription {
+        let topic = TopicName::new(topic).expect("valid topic name");
+        let type_support = self
+            .types
+            .load(type_name)
+            .expect("failed to load typesupport");
+        RclSubscriptionBuilder::new(Rc::clone(&self.node), &topic, type_support)
+            .create()
+            .expect("failed to create the test peer subscription")
     }
 
     /// The QoS profiles of the publishers on `topic`.
@@ -86,3 +101,20 @@ impl TestPeer {
 pub struct Testing;
 
 impl iceoryx2_services_tunnel_backend::traits::testing::Testing for Testing {}
+
+/// Takes the next message on `subscription` as its serialized bytes, or
+/// [`None`] when the queue is empty.
+pub fn take_serialized(subscription: &RclSubscription) -> Option<Vec<u8>> {
+    let mut buffer = Vec::new();
+    let taken = subscription
+        .take_into(|size| {
+            buffer.resize(size, 0);
+            Some(buffer.as_mut_ptr())
+        })
+        .expect("failed to take from the test peer subscription");
+
+    taken.map(|(size, _message_info)| {
+        buffer.truncate(size);
+        buffer
+    })
+}

--- a/integrations/ros2/tunnel-backend/src/testing.rs
+++ b/integrations/ros2/tunnel-backend/src/testing.rs
@@ -19,7 +19,7 @@ use crate::qos::QosProfile;
 use crate::rcl::{
     NodeName, RclNode, RclNodeBuilder, RclPublisherBuilder, RclSubscriptionBuilder, TopicName,
 };
-use crate::typesupport::TypeSupportRegistry;
+use crate::typesupport;
 
 pub use crate::rcl::publisher::RclPublisher;
 pub use crate::rcl::subscription::RclSubscription;
@@ -29,7 +29,6 @@ pub use crate::rcl::subscription::RclSubscription;
 #[derive(Debug)]
 pub struct TestPeer {
     node: Rc<RclNode>,
-    types: TypeSupportRegistry,
 }
 
 impl TestPeer {
@@ -40,17 +39,13 @@ impl TestPeer {
             .expect("failed to create the test peer node");
         Self {
             node: Rc::new(node),
-            types: TypeSupportRegistry::default(),
         }
     }
 
     /// Creates a publisher on `topic` with default QoS.
     pub fn create_publisher(&self, topic: &str, type_name: &str) -> RclPublisher {
         let topic = TopicName::new(topic).expect("valid topic name");
-        let type_support = self
-            .types
-            .load(type_name)
-            .expect("failed to load typesupport");
+        let type_support = typesupport::load(type_name).expect("failed to load typesupport");
         RclPublisherBuilder::new(Rc::clone(&self.node), &topic, type_support)
             .create()
             .expect("failed to create the test peer publisher")
@@ -59,10 +54,7 @@ impl TestPeer {
     /// Creates a subscription on `topic` with default QoS.
     pub fn create_subscription(&self, topic: &str, type_name: &str) -> RclSubscription {
         let topic = TopicName::new(topic).expect("valid topic name");
-        let type_support = self
-            .types
-            .load(type_name)
-            .expect("failed to load typesupport");
+        let type_support = typesupport::load(type_name).expect("failed to load typesupport");
         RclSubscriptionBuilder::new(Rc::clone(&self.node), &topic, type_support)
             .create()
             .expect("failed to create the test peer subscription")

--- a/integrations/ros2/tunnel-backend/src/translator/introspection_translator.rs
+++ b/integrations/ros2/tunnel-backend/src/translator/introspection_translator.rs
@@ -54,9 +54,9 @@ const MESSAGE: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_MESS
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum TranslationError {
     /// The introspection library of the type's package failed to load.
-    Introspection,
+    FailedToLoadIntrospectionLibrary,
     /// The typesupport library of the type's package failed to load.
-    TypeSupport,
+    FailedToLoadTypeSupportLibrary,
     /// The type has pointer-backed (strings, sequences) or
     /// platform-defined (long double) members and cannot be translated.
     UnsupportedType,
@@ -107,7 +107,7 @@ impl Translator for IntrospectionTranslator {
 
         let introspection = fail!(from origin,
             when typesupport::load_introspection(type_name),
-            with TranslationError::Introspection,
+            with TranslationError::FailedToLoadIntrospectionLibrary,
             "Failed to load introspection for type '{}'",
             type_name
         );
@@ -146,7 +146,7 @@ impl Translator for IntrospectionTranslator {
 
         let type_support = fail!(from origin,
             when typesupport::load(type_name),
-            with TranslationError::TypeSupport,
+            with TranslationError::FailedToLoadTypeSupportLibrary,
             "Failed to load typesupport for type '{}'",
             type_name
         );

--- a/integrations/ros2/tunnel-backend/src/translator/introspection_translator.rs
+++ b/integrations/ros2/tunnel-backend/src/translator/introspection_translator.rs
@@ -13,6 +13,8 @@
 //! Translation between rosidl C structs and their CDR wire representation,
 //! driven by the type's introspection data loaded at runtime.
 
+use std::rc::Rc;
+
 use core::alloc::Layout;
 use core::ffi::c_void;
 
@@ -102,7 +104,7 @@ impl Translator for IntrospectionTranslator {
         let type_name = topic_description.type_name.as_str();
 
         let introspection = fail!(from origin,
-            when typesupport::load_typesupport_introspection(type_name),
+            when typesupport::load_introspection(type_name),
             with TranslationError::Introspection,
             "Failed to load introspection for type '{}'",
             type_name
@@ -141,7 +143,7 @@ impl Translator for IntrospectionTranslator {
         }
 
         let type_support = fail!(from origin,
-            when typesupport::load_typesupport(type_name),
+            when typesupport::load(type_name),
             with TranslationError::TypeSupport,
             "Failed to load typesupport for type '{}'",
             type_name
@@ -167,7 +169,7 @@ pub struct CdrTranscoder {
     /// ROS 2 type name, for diagnostics.
     type_name: String,
     /// Typesupport handle driving `rmw_serialize`/`rmw_deserialize`.
-    type_support: TypeSupport,
+    type_support: Rc<TypeSupport>,
     /// Layout of the type's rosidl C struct.
     layout: Layout,
 }

--- a/integrations/ros2/tunnel-backend/src/translator/introspection_translator.rs
+++ b/integrations/ros2/tunnel-backend/src/translator/introspection_translator.rs
@@ -1,0 +1,368 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Translation between rosidl C structs and their CDR wire representation,
+//! driven by the type's introspection data loaded at runtime.
+
+use core::alloc::Layout;
+use core::ffi::c_void;
+
+use iceoryx2::service::static_config::message_type_details::TypeVariant;
+use iceoryx2_log::fail;
+use iceoryx2_services_tunnel_backend::traits::{
+    PayloadLayout, ResizableBuffer, Transcoder, Translation, Translator,
+};
+use iceoryx2_services_tunnel_backend::types::service_description::{
+    PatternDescription, ServiceDescription,
+};
+use r2r_rcl::{
+    RMW_RET_OK, rcutils_allocator_t, rcutils_get_default_allocator, rmw_deserialize, rmw_serialize,
+    rmw_serialized_message_t, rosidl_typesupport_introspection_c__MessageMembers as MessageMembers,
+    rosidl_typesupport_introspection_c_field_types as FieldType,
+};
+
+use crate::mapping::TopicDescription;
+use crate::typesupport::{self, TypeSupport};
+
+const FLOAT: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_FLOAT as u8;
+const DOUBLE: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_DOUBLE as u8;
+const CHAR: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_CHAR as u8;
+const WCHAR: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_WCHAR as u8;
+const BOOLEAN: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_BOOLEAN as u8;
+const OCTET: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_OCTET as u8;
+const UINT8: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_UINT8 as u8;
+const INT8: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_INT8 as u8;
+const UINT16: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_UINT16 as u8;
+const INT16: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_INT16 as u8;
+const UINT32: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_UINT32 as u8;
+const INT32: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_INT32 as u8;
+const UINT64: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_UINT64 as u8;
+const INT64: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_INT64 as u8;
+const MESSAGE: u8 = FieldType::rosidl_typesupport_introspection_c__ROS_TYPE_MESSAGE as u8;
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum TranslationError {
+    /// The introspection library of the type's package failed to load.
+    Introspection,
+    /// The typesupport library of the type's package failed to load.
+    TypeSupport,
+    /// The type has pointer-backed (strings, sequences) or
+    /// platform-defined (long double) members and cannot be translated.
+    UnsupportedType,
+    /// The service's declared fixed-size payload contradicts the layout
+    /// introspected from the ROS 2 type.
+    LayoutMismatch,
+    /// The payload size does not match the resolved layout.
+    UnexpectedPayloadSize,
+    /// Failed to serialize the payload.
+    Serialize,
+    /// Failed to deserialize the wire bytes.
+    Deserialize,
+}
+
+impl core::fmt::Display for TranslationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "TranslationError::{self:?}")
+    }
+}
+
+impl core::error::Error for TranslationError {}
+
+/// A [`Translator`] for fixed-size ROS 2 message types.
+///
+/// The payload in shared memory is the type's rosidl C struct, which is
+/// converted to and from CDR using the typesupport (de)serializer when
+/// crossing wire boundaries.
+///
+/// Types introspected to have dynamically sized members (strings, sequences)
+/// are rejected.
+#[derive(Debug, Default)]
+pub struct IntrospectionTranslator;
+
+impl Translator for IntrospectionTranslator {
+    type Error = TranslationError;
+    type EndpointDescription = TopicDescription;
+    type Transcoder = CdrTranscoder;
+
+    fn create(
+        &self,
+        service_description: &ServiceDescription,
+        topic_description: &TopicDescription,
+    ) -> Result<Translation<Self::Transcoder>, Self::Error> {
+        let origin = "IntrospectionTranslator::create";
+        let type_name = topic_description.type_name.as_str();
+
+        let introspection = fail!(from origin,
+            when typesupport::load_typesupport_introspection(type_name),
+            with TranslationError::Introspection,
+            "Failed to load introspection for type '{}'",
+            type_name
+        );
+
+        let members = unsafe { (*introspection.handle()).data }.cast::<MessageMembers>();
+        let layout = match unsafe { introspected_layout(members) } {
+            IntrospectedLayout::FixedSize(layout) => layout,
+            IntrospectedLayout::Unsupported => {
+                fail!(from origin,
+                    with TranslationError::UnsupportedType,
+                    "ROS 2 type '{}' has dynamically sized or platform-defined members and cannot be translated",
+                    type_name
+                );
+            }
+        };
+
+        // The type-name contract requires that a fixed-size local payload
+        // claiming this ROS 2 type has the type's introspected layout.
+        if let PatternDescription::PublishSubscribe(pattern_description) =
+            &service_description.pattern
+            && pattern_description.payload.variant == TypeVariant::FixedSize
+            && (pattern_description.payload.size != layout.size()
+                || pattern_description.payload.alignment != layout.align())
+        {
+            fail!(from origin,
+                with TranslationError::LayoutMismatch,
+                "Payload of service '{}' ({} bytes, align {}) does not match ROS 2 type '{}' ({} bytes, align {})",
+                service_description.name,
+                pattern_description.payload.size,
+                pattern_description.payload.alignment,
+                type_name,
+                layout.size(),
+                layout.align()
+            );
+        }
+
+        let type_support = fail!(from origin,
+            when typesupport::load_typesupport(type_name),
+            with TranslationError::TypeSupport,
+            "Failed to load typesupport for type '{}'",
+            type_name
+        );
+
+        Ok(Translation::Transcode {
+            payload_layout: PayloadLayout::FixedSize(layout),
+            transcoder: CdrTranscoder {
+                type_name: type_name.to_string(),
+                type_support,
+                layout,
+            },
+        })
+    }
+}
+
+/// The [`Transcoder`] for a resolved fixed-size ROS 2 message type.
+///
+/// Transcodes the type's rosidl C struct to and from its CDR wire
+/// representation using the typesupports (de)serializer function pointers.
+#[derive(Debug)]
+pub struct CdrTranscoder {
+    /// ROS 2 type name, for diagnostics.
+    type_name: String,
+    /// Typesupport handle driving `rmw_serialize`/`rmw_deserialize`.
+    type_support: TypeSupport,
+    /// Layout of the type's rosidl C struct.
+    layout: Layout,
+}
+
+impl Transcoder for CdrTranscoder {
+    type Error = TranslationError;
+
+    fn to_wire(
+        &self,
+        payload: &[u8],
+        wire: &mut impl ResizableBuffer,
+    ) -> Result<usize, Self::Error> {
+        let origin = "CdrTranscoder::to_wire";
+
+        if payload.len() != self.layout.size() {
+            fail!(from origin,
+                with TranslationError::UnexpectedPayloadSize,
+                "Payload ({} bytes) does not match the resolved layout ({} bytes)",
+                payload.len(),
+                self.layout.size()
+            );
+        }
+        debug_assert!(
+            (payload.as_ptr() as usize).is_multiple_of(self.layout.align()),
+            "the payload must be aligned to the resolved layout"
+        );
+
+        let mut serialized = rmw_serialized_message_t {
+            buffer: core::ptr::null_mut(),
+            buffer_length: 0,
+            buffer_capacity: 0,
+            allocator: buffer_allocator(wire),
+        };
+        let ret = unsafe {
+            rmw_serialize(
+                payload.as_ptr().cast::<c_void>(),
+                self.type_support.handle(),
+                &mut serialized,
+            )
+        };
+        if ret != RMW_RET_OK as i32 {
+            fail!(from origin,
+                with TranslationError::Serialize,
+                "Middleware failed to serialize payload of type '{}'",
+                self.type_name
+            );
+        }
+
+        Ok(serialized.buffer_length)
+    }
+
+    fn from_wire(
+        &self,
+        wire: &[u8],
+        payload: &mut impl ResizableBuffer,
+    ) -> Result<usize, Self::Error> {
+        let origin = "CdrTranscoder::from_wire";
+
+        let destination = payload.resize(self.layout.size());
+        debug_assert!(
+            (destination.as_ptr() as usize).is_multiple_of(self.layout.align()),
+            "the payload buffer must be aligned to the resolved layout"
+        );
+
+        let serialized = rmw_serialized_message_t {
+            buffer: wire.as_ptr().cast_mut(),
+            buffer_length: wire.len(),
+            buffer_capacity: wire.len(),
+            allocator: unsafe { rcutils_get_default_allocator() },
+        };
+        let ret = unsafe {
+            rmw_deserialize(
+                &serialized,
+                self.type_support.handle(),
+                destination.as_mut_ptr().cast::<c_void>(),
+            )
+        };
+        if ret != RMW_RET_OK as i32 {
+            fail!(from origin,
+                with TranslationError::Deserialize,
+                "Middleware failed to deserialize wire bytes of type '{}'",
+                self.type_name
+            );
+        }
+
+        Ok(self.layout.size())
+    }
+}
+
+/// The outcome of introspecting a message type's C struct layout.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum IntrospectedLayout {
+    /// Every member is stored inline.
+    FixedSize(Layout),
+    /// A member is pointer-backed (strings, sequences) or has a
+    /// platform-defined layout (long double) therefore not translatable.
+    Unsupported,
+}
+
+/// Computes the layout of the rosidl C struct described by `members`.
+///
+/// # Safety
+///
+/// `members` must point to a valid introspection member table whose
+/// library stays loaded for the duration of the call.
+unsafe fn introspected_layout(members: *const MessageMembers) -> IntrospectedLayout {
+    let table = unsafe { &*members };
+
+    let mut alignment = 1;
+    for index in 0..table.member_count_ as usize {
+        let member = unsafe { &*table.members_.add(index) };
+
+        if member.is_array_ && (member.array_size_ == 0 || member.is_upper_bound_) {
+            return IntrospectedLayout::Unsupported;
+        }
+
+        let member_alignment = if member.type_id_ == MESSAGE {
+            let nested = unsafe { (*member.members_).data }.cast::<MessageMembers>();
+            match unsafe { introspected_layout(nested) } {
+                IntrospectedLayout::FixedSize(layout) => layout.align(),
+                IntrospectedLayout::Unsupported => return IntrospectedLayout::Unsupported,
+            }
+        } else {
+            match basic_member_alignment(member.type_id_) {
+                Some(member_alignment) => member_alignment,
+                None => return IntrospectedLayout::Unsupported,
+            }
+        };
+        alignment = alignment.max(member_alignment);
+    }
+
+    IntrospectedLayout::FixedSize(
+        Layout::from_size_align(table.size_of_, alignment)
+            .expect("introspected size and alignment form a valid layout"),
+    )
+}
+
+/// Alignment of a basic (non-message) member type inside the rosidl C
+/// struct.
+///
+/// `None` for dynamically sized (strings) or unsupported (long
+/// double, with platform-defined alignment) member types.
+fn basic_member_alignment(type_id: u8) -> Option<usize> {
+    match type_id {
+        BOOLEAN | OCTET | CHAR | UINT8 | INT8 => Some(1),
+        WCHAR | UINT16 | INT16 => Some(2),
+        FLOAT | UINT32 | INT32 => Some(4),
+        DOUBLE | UINT64 | INT64 => Some(8),
+        _ => None,
+    }
+}
+
+/// An `rcutils` allocator over a [`ResizableBuffer`], letting the
+/// middleware serialize directly into it. The buffer stays owned by the
+/// caller; deallocation is a no-op.
+fn buffer_allocator<B: ResizableBuffer>(buffer: &mut B) -> rcutils_allocator_t {
+    unsafe extern "C" fn allocate<B: ResizableBuffer>(
+        size: usize,
+        state: *mut c_void,
+    ) -> *mut c_void {
+        let buffer = unsafe { &mut *(state as *mut B) };
+        buffer.resize(size).as_mut_ptr().cast::<c_void>()
+    }
+
+    unsafe extern "C" fn reallocate<B: ResizableBuffer>(
+        _pointer: *mut c_void,
+        size: usize,
+        state: *mut c_void,
+    ) -> *mut c_void {
+        // Resizing preserves written bytes (realloc semantics), regardless
+        // of the pointer handed back.
+        unsafe { allocate::<B>(size, state) }
+    }
+
+    unsafe extern "C" fn deallocate(_pointer: *mut c_void, _state: *mut c_void) {}
+
+    unsafe extern "C" fn zero_allocate<B: ResizableBuffer>(
+        number_of_elements: usize,
+        size_of_element: usize,
+        state: *mut c_void,
+    ) -> *mut c_void {
+        let Some(size) = number_of_elements.checked_mul(size_of_element) else {
+            return core::ptr::null_mut();
+        };
+        let buffer = unsafe { &mut *(state as *mut B) };
+        let region = &mut buffer.resize(size)[..size];
+        region.fill(0);
+        region.as_mut_ptr().cast::<c_void>()
+    }
+
+    rcutils_allocator_t {
+        allocate: Some(allocate::<B>),
+        deallocate: Some(deallocate),
+        reallocate: Some(reallocate::<B>),
+        zero_allocate: Some(zero_allocate::<B>),
+        state: (buffer as *mut B).cast::<c_void>(),
+    }
+}

--- a/integrations/ros2/tunnel-backend/src/translator/introspection_translator.rs
+++ b/integrations/ros2/tunnel-backend/src/translator/introspection_translator.rs
@@ -65,6 +65,8 @@ pub enum TranslationError {
     LayoutMismatch,
     /// The payload size does not match the resolved layout.
     UnexpectedPayloadSize,
+    /// The destination buffer cannot hold the translated bytes.
+    InsufficientCapacity,
     /// Failed to serialize the payload.
     Serialize,
     /// Failed to deserialize the wire bytes.
@@ -228,7 +230,13 @@ impl Transcoder for CdrTranscoder {
     ) -> Result<usize, Self::Error> {
         let origin = "CdrTranscoder::from_wire";
 
-        let destination = payload.resize(self.layout.size());
+        let destination = fail!(from origin,
+            when payload.resize(self.layout.size()),
+            with TranslationError::InsufficientCapacity,
+            "Payload buffer cannot hold the deserialized type '{}' ({} bytes)",
+            self.type_name,
+            self.layout.size()
+        );
         debug_assert!(
             (destination.as_ptr() as usize).is_multiple_of(self.layout.align()),
             "the payload buffer must be aligned to the resolved layout"
@@ -324,14 +332,18 @@ fn basic_member_alignment(type_id: u8) -> Option<usize> {
 
 /// An `rcutils` allocator over a [`ResizableBuffer`], letting the
 /// middleware serialize directly into it. The buffer stays owned by the
-/// caller; deallocation is a no-op.
+/// caller; deallocation is a no-op. A buffer that cannot provide the
+/// requested capacity surfaces as a null allocation.
 fn buffer_allocator<B: ResizableBuffer>(buffer: &mut B) -> rcutils_allocator_t {
     unsafe extern "C" fn allocate<B: ResizableBuffer>(
         size: usize,
         state: *mut c_void,
     ) -> *mut c_void {
         let buffer = unsafe { &mut *(state as *mut B) };
-        buffer.resize(size).as_mut_ptr().cast::<c_void>()
+        match buffer.resize(size) {
+            Ok(region) => region.as_mut_ptr().cast::<c_void>(),
+            Err(_) => core::ptr::null_mut(),
+        }
     }
 
     unsafe extern "C" fn reallocate<B: ResizableBuffer>(
@@ -355,7 +367,10 @@ fn buffer_allocator<B: ResizableBuffer>(buffer: &mut B) -> rcutils_allocator_t {
             return core::ptr::null_mut();
         };
         let buffer = unsafe { &mut *(state as *mut B) };
-        let region = &mut buffer.resize(size)[..size];
+        let Ok(region) = buffer.resize(size) else {
+            return core::ptr::null_mut();
+        };
+        let region = &mut region[..size];
         region.fill(0);
         region.as_mut_ptr().cast::<c_void>()
     }

--- a/integrations/ros2/tunnel-backend/src/translator/mod.rs
+++ b/integrations/ros2/tunnel-backend/src/translator/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+mod introspection_translator;
+
+pub use introspection_translator::*;

--- a/integrations/ros2/tunnel-backend/src/typesupport.rs
+++ b/integrations/ros2/tunnel-backend/src/typesupport.rs
@@ -42,19 +42,20 @@ impl core::error::Error for LoadError {}
 /// A resolved ROS 2 *typesupport* handle.
 ///
 /// In ROS 2 a "typesupport" is the per-message-type descriptor that rcl and
-/// the underlying middleware (DDS) need in order to work with a type: its
-/// fully-qualified name, a type hash used to match endpoints, and the function
-/// table to (de)serialize it. The `rosidl` code generator emits one for every
-/// `.msg` definition.
+/// the underlying middleware (DDS) need in order to work with a type. It
+/// comes in flavors sharing one handle type, where the regular flavor carries
+/// the function table to (de)serialize the type and the introspection flavor
+/// its member table. The `rosidl` code generator emits both for every `.msg`
+/// definition.
 ///
 /// The tunnel must handle whatever message types the user bridges, known only
 /// by *name* (a string from config or graph discovery) at runtime, never at
 /// compile time. ROS ships each package's typesupport as a compiled shared
-/// object (`lib<pkg>__rosidl_typesupport_c.so`) exporting a C getter function
-/// per type, so the only way to obtain the handle for a given name is to
-/// `dlopen` that library and resolve the getter symbol at runtime. Without
-/// the handle, rcl cannot create a publisher or subscription that DDS peers
-/// will match.
+/// object per flavor (`lib<pkg>__rosidl_typesupport_c.so`, ...) exporting a
+/// C getter function per type, so the only way to obtain the handle for a
+/// given name is to `dlopen` that library and resolve the getter symbol at
+/// runtime. Without the handle, rcl cannot create a publisher or
+/// subscription that DDS peers will match.
 ///
 /// The handle points into the loaded library's memory, so the `Library` is
 /// kept alive here. The typesupport is shared: the registry cache and every
@@ -72,6 +73,10 @@ impl TypeSupport {
     }
 }
 
+// SAFETY: the handle points at immutable static data inside the loaded
+// library, which `_library` keeps alive.
+unsafe impl Send for TypeSupport {}
+
 /// Resolves and caches typesupport handles. Entries are never evicted; the
 /// registry must outlive all endpoints created from its handles.
 #[derive(Debug, Default)]
@@ -85,7 +90,7 @@ impl TypeSupportRegistry {
             return Ok(Rc::clone(type_support));
         }
 
-        let type_support = Rc::new(load_typesupport_library(type_name)?);
+        let type_support = Rc::new(load_typesupport(type_name)?);
         self.entries
             .borrow_mut()
             .insert(type_name.to_string(), Rc::clone(&type_support));
@@ -94,9 +99,22 @@ impl TypeSupportRegistry {
     }
 }
 
-/// Loads the typesupport library of the type's package and looks up the
-/// type's handle in it.
-fn load_typesupport_library(type_name: &str) -> Result<TypeSupport, LoadError> {
+const TYPESUPPORT: &str = "rosidl_typesupport_c";
+const TYPESUPPORT_INTROSPECTION: &str = "rosidl_typesupport_introspection_c";
+
+/// Loads the regular typesupport handle of `type_name`.
+pub(crate) fn load_typesupport(type_name: &str) -> Result<TypeSupport, LoadError> {
+    load_typesupport_handle(type_name, TYPESUPPORT)
+}
+
+/// Loads the introspection typesupport handle of `type_name`.
+pub(crate) fn load_typesupport_introspection(type_name: &str) -> Result<TypeSupport, LoadError> {
+    load_typesupport_handle(type_name, TYPESUPPORT_INTROSPECTION)
+}
+
+/// Loads the `flavor` typesupport library of the type's package and retrieves
+/// the handle pointer.
+fn load_typesupport_handle(type_name: &str, flavor: &str) -> Result<TypeSupport, LoadError> {
     let origin = "TypeSupportRegistry::load";
 
     let (package, message) = fail!(
@@ -105,9 +123,9 @@ fn load_typesupport_library(type_name: &str) -> Result<TypeSupport, LoadError> {
         "Invalid ROS 2 type name '{}'",
         type_name
     );
-    let library_name = format!("lib{package}__rosidl_typesupport_c.so");
+    let library_name = format!("lib{package}__{flavor}.so");
     let symbol_name =
-        format!("rosidl_typesupport_c__get_message_type_support_handle__{package}__msg__{message}");
+        format!("{flavor}__get_message_type_support_handle__{package}__msg__{message}");
 
     // Load the typesupport library, found via the sourced environment's
     // LD_LIBRARY_PATH.

--- a/integrations/ros2/tunnel-backend/src/typesupport.rs
+++ b/integrations/ros2/tunnel-backend/src/typesupport.rs
@@ -42,25 +42,26 @@ impl core::error::Error for LoadError {}
 /// A resolved ROS 2 *typesupport* handle.
 ///
 /// In ROS 2 a "typesupport" is the per-message-type descriptor that rcl and
-/// the underlying middleware (DDS) need in order to work with a type. It
-/// comes in flavors sharing one handle type, where the regular flavor carries
-/// the function table to (de)serialize the type and the introspection flavor
-/// its member table. The `rosidl` code generator emits both for every `.msg`
-/// definition.
+/// the underlying middleware (DDS) need in order to work with a type. The
+/// `rosidl` code generator emits two of them for every `.msg` definition.
+/// The regular typesupport carries the function table to (de)serialize the
+/// type and the introspection typesupport a description of its fields and
+/// the layout of its generated C struct. Both are described by the same C
+/// handle type, so `TypeSupport` represents either.
 ///
 /// The tunnel must handle whatever message types the user bridges, known only
 /// by *name* (a string from config or graph discovery) at runtime, never at
-/// compile time. ROS ships each package's typesupport as a compiled shared
-/// object per flavor (`lib<pkg>__rosidl_typesupport_c.so`, ...) exporting a
+/// compile time. ROS ships each package's typesupports as one compiled shared
+/// object each (`lib<pkg>__rosidl_typesupport_c.so`, ...) exporting a
 /// C getter function per type, so the only way to obtain the handle for a
 /// given name is to `dlopen` that library and resolve the getter symbol at
 /// runtime. Without the handle, rcl cannot create a publisher or
 /// subscription that DDS peers will match.
 ///
 /// The handle points into the loaded library's memory, so the `Library` is
-/// kept alive here. The typesupport is shared: the registry cache and every
-/// endpoint using it hold a share of one `Rc<TypeSupport>`, keeping the
-/// library loaded as long as any share is alive.
+/// kept alive here. Resolved handles are cached and handed out as shares of
+/// one `Rc<TypeSupport>`, keeping each library loaded for as long as any
+/// share survives.
 #[derive(Debug)]
 pub struct TypeSupport {
     handle: *const rosidl_message_type_support_t,
@@ -73,49 +74,24 @@ impl TypeSupport {
     }
 }
 
-// SAFETY: the handle points at immutable static data inside the loaded
-// library, which `_library` keeps alive.
-unsafe impl Send for TypeSupport {}
+thread_local! {
+    /// Cached typesupport handles resolved so far.
+    static TYPESUPPORT: RefCell<HashMap<String, Rc<TypeSupport>>> =
+        RefCell::new(HashMap::new());
 
-/// Resolves and caches typesupport handles. Entries are never evicted; the
-/// registry must outlive all endpoints created from its handles.
-#[derive(Debug, Default)]
-pub struct TypeSupportRegistry {
-    entries: RefCell<HashMap<String, Rc<TypeSupport>>>,
+    /// Cached introspection typesupport handles resolved so far.
+    static INTROSPECTION: RefCell<HashMap<String, Rc<TypeSupport>>> =
+        RefCell::new(HashMap::new());
 }
 
-impl TypeSupportRegistry {
-    pub fn load(&self, type_name: &str) -> Result<Rc<TypeSupport>, LoadError> {
-        if let Some(type_support) = self.entries.borrow().get(type_name) {
-            return Ok(Rc::clone(type_support));
-        }
+/// Returns the typesupport handle of `type_name`, driving rcl endpoint
+/// creation and `rmw_serialize`/`rmw_deserialize`.
+pub(crate) fn load(type_name: &str) -> Result<Rc<TypeSupport>, LoadError> {
+    let origin = "typesupport::load";
 
-        let type_support = Rc::new(load_typesupport(type_name)?);
-        self.entries
-            .borrow_mut()
-            .insert(type_name.to_string(), Rc::clone(&type_support));
-
-        Ok(type_support)
+    if let Some(type_support) = TYPESUPPORT.with(|cache| cache.borrow().get(type_name).cloned()) {
+        return Ok(type_support);
     }
-}
-
-const TYPESUPPORT: &str = "rosidl_typesupport_c";
-const TYPESUPPORT_INTROSPECTION: &str = "rosidl_typesupport_introspection_c";
-
-/// Loads the regular typesupport handle of `type_name`.
-pub(crate) fn load_typesupport(type_name: &str) -> Result<TypeSupport, LoadError> {
-    load_typesupport_handle(type_name, TYPESUPPORT)
-}
-
-/// Loads the introspection typesupport handle of `type_name`.
-pub(crate) fn load_typesupport_introspection(type_name: &str) -> Result<TypeSupport, LoadError> {
-    load_typesupport_handle(type_name, TYPESUPPORT_INTROSPECTION)
-}
-
-/// Loads the `flavor` typesupport library of the type's package and retrieves
-/// the handle pointer.
-fn load_typesupport_handle(type_name: &str, flavor: &str) -> Result<TypeSupport, LoadError> {
-    let origin = "TypeSupportRegistry::load";
 
     let (package, message) = fail!(
         from origin,
@@ -123,17 +99,69 @@ fn load_typesupport_handle(type_name: &str, flavor: &str) -> Result<TypeSupport,
         "Invalid ROS 2 type name '{}'",
         type_name
     );
-    let library_name = format!("lib{package}__{flavor}.so");
-    let symbol_name =
-        format!("{flavor}__get_message_type_support_handle__{package}__msg__{message}");
+    let type_support = Rc::new(load_handle(
+        type_name,
+        format!("lib{package}__rosidl_typesupport_c.so"),
+        format!("rosidl_typesupport_c__get_message_type_support_handle__{package}__msg__{message}"),
+    )?);
+
+    TYPESUPPORT.with(|cache| {
+        cache
+            .borrow_mut()
+            .insert(type_name.to_string(), Rc::clone(&type_support));
+    });
+
+    Ok(type_support)
+}
+
+/// Returns the introspection typesupport handle of `type_name`, describing
+/// the members of the type's C struct.
+pub(crate) fn load_introspection(type_name: &str) -> Result<Rc<TypeSupport>, LoadError> {
+    let origin = "typesupport::load_introspection";
+
+    if let Some(type_support) = INTROSPECTION.with(|cache| cache.borrow().get(type_name).cloned()) {
+        return Ok(type_support);
+    }
+
+    let (package, message) = fail!(
+        from origin,
+        when split_type_name(type_name),
+        "Invalid ROS 2 type name '{}'",
+        type_name
+    );
+    let type_support = Rc::new(load_handle(
+        type_name,
+        format!("lib{package}__rosidl_typesupport_introspection_c.so"),
+        format!(
+            "rosidl_typesupport_introspection_c__get_message_type_support_handle__{package}__msg__{message}"
+        ),
+    )?);
+
+    INTROSPECTION.with(|cache| {
+        cache
+            .borrow_mut()
+            .insert(type_name.to_string(), Rc::clone(&type_support));
+    });
+
+    Ok(type_support)
+}
+
+/// Loads `library_name` and retrieves the handle pointer that `symbol_name`
+/// returns.
+fn load_handle(
+    type_name: &str,
+    library_name: String,
+    symbol_name: String,
+) -> Result<TypeSupport, LoadError> {
+    let origin = "typesupport::load_handle";
 
     // Load the typesupport library, found via the sourced environment's
     // LD_LIBRARY_PATH.
     let library = fail!(from origin,
         when unsafe { Library::new(&library_name) },
         with LoadError::LibraryNotFound { library: library_name },
-        "Failed to load typesupport library for package '{}'",
-        package
+        "Failed to load typesupport library for type '{}'",
+        type_name
     );
 
     // Get the typesupport handle from the loaded library.
@@ -145,7 +173,7 @@ fn load_typesupport_handle(type_name: &str, flavor: &str) -> Result<TypeSupport,
             when unsafe { library.get(symbol_name.as_bytes()) },
             with LoadError::SymbolNotFound { symbol: symbol_name },
             "Failed to resolve typesupport symbol for type '{}'",
-            message
+            type_name
         );
         unsafe { get_handle() }
     };

--- a/integrations/ros2/tunnel-backend/tests/common/mod.rs
+++ b/integrations/ros2/tunnel-backend/tests/common/mod.rs
@@ -17,11 +17,6 @@ use iceoryx2::prelude::*;
 pub const DISCOVERY_RETRY_PERIOD: Duration = Duration::from_millis(50);
 pub const DISCOVERY_RETRY_ATTEMPTS: usize = 200;
 
-#[derive(Debug, ZeroCopySend)]
-#[type_name("std_msgs/msg/String")]
-#[repr(C)]
-pub struct RosString(u8);
-
 pub fn service_name(name: &str) -> ServiceName {
     name.try_into().expect("valid service name")
 }

--- a/integrations/ros2/tunnel-backend/tests/introspection_translator_tests.rs
+++ b/integrations/ros2/tunnel-backend/tests/introspection_translator_tests.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use core::alloc::Layout;
+
+use iceoryx2::service::local::Service;
+use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
+use iceoryx2_bb_testing::assert_that;
+use iceoryx2_integrations_ros2_tunnel_backend::{
+    IntrospectionTranslator, QosProfile, TopicDescription, TopicName, TranslationError, TypeName,
+};
+use iceoryx2_services_tunnel_backend::traits::{
+    PayloadLayout, Transcoder, Translation, Translator,
+};
+use iceoryx2_services_tunnel_backend::types::service_description::{
+    PatternDescription, PortSettings, PublishSubscribeDescription, ServiceDescription,
+    TypeDescription,
+};
+
+const TWIST_TYPE_NAME: &str = "geometry_msgs/msg/Twist";
+
+fn service_description(payload: TypeDetail) -> ServiceDescription {
+    ServiceDescription::new::<Service>(
+        "translator-tests".try_into().expect("valid service name"),
+        PatternDescription::PublishSubscribe(PublishSubscribeDescription {
+            user_header: TypeDescription::from(&TypeDetail::new::<()>(TypeVariant::FixedSize)),
+            payload: TypeDescription::from(&payload),
+            settings: PortSettings::LocalDefaults,
+        }),
+    )
+}
+
+fn topic_description(type_name: &str) -> TopicDescription {
+    TopicDescription {
+        topic: TopicName::new("/translator_tests").expect("valid topic name"),
+        type_name: TypeName::new(type_name).expect("valid type name"),
+        qos: QosProfile::default(),
+    }
+}
+
+#[test]
+fn create_succeeds_for_fixed_size_types() {
+    let translator = IntrospectionTranslator;
+
+    let translation = translator
+        .create(
+            &service_description(TypeDetail::new::<u8>(TypeVariant::Dynamic)),
+            &topic_description(TWIST_TYPE_NAME),
+        )
+        .expect("fixed-size types resolve");
+
+    let Translation::Transcode { payload_layout, .. } = translation else {
+        panic!("fixed-size types resolve to translation");
+    };
+    assert_that!(
+        payload_layout,
+        eq PayloadLayout::FixedSize(Layout::from_size_align(48, 8).expect("valid layout"))
+    );
+}
+
+#[test]
+fn create_fails_for_dynamically_sized_types() {
+    let translator = IntrospectionTranslator;
+
+    let result = translator.create(
+        &service_description(TypeDetail::new::<u8>(TypeVariant::Dynamic)),
+        &topic_description("std_msgs/msg/String"),
+    );
+
+    assert_that!(matches!(result, Err(TranslationError::UnsupportedType)), eq true);
+}
+
+#[test]
+fn create_accepts_layout_compatible_fixed_size_payloads() {
+    let translator = IntrospectionTranslator;
+
+    let result = translator.create(
+        &service_description(TypeDetail::new::<[f64; 6]>(TypeVariant::FixedSize)),
+        &topic_description(TWIST_TYPE_NAME),
+    );
+
+    assert_that!(result, is_ok);
+}
+
+#[test]
+fn create_fails_on_layout_incompatible_fixed_size_payloads() {
+    let translator = IntrospectionTranslator;
+
+    let result = translator.create(
+        &service_description(TypeDetail::new::<u64>(TypeVariant::FixedSize)),
+        &topic_description(TWIST_TYPE_NAME),
+    );
+
+    assert_that!(matches!(result, Err(TranslationError::LayoutMismatch)), eq true);
+}
+
+#[test]
+fn twist_round_trips_through_the_wire() {
+    let translator = IntrospectionTranslator;
+    let service = service_description(TypeDetail::new::<[f64; 6]>(TypeVariant::FixedSize));
+    let endpoint = topic_description(TWIST_TYPE_NAME);
+
+    let Translation::Transcode { transcoder, .. } = translator
+        .create(&service, &endpoint)
+        .expect("twist resolves")
+    else {
+        panic!("twist resolves to translation");
+    };
+
+    // Twist is six little-endian f64s, both natively and as CDR.
+    let payload: Vec<u8> = (1..=6)
+        .flat_map(|value| (value as f64).to_le_bytes())
+        .collect();
+
+    let mut wire = Vec::<u8>::new();
+    let written = transcoder
+        .to_wire(&payload, &mut wire)
+        .expect("serialization succeeds");
+
+    // Encapsulation header (4 bytes) + body.
+    assert_that!(written, eq 4 + payload.len());
+    assert_that!(&wire[4..written], eq & payload[..]);
+
+    let mut roundtrip = Vec::<u8>::new();
+    let read = transcoder
+        .from_wire(&wire[..written], &mut roundtrip)
+        .expect("deserialization succeeds");
+    assert_that!(read, eq payload.len());
+    assert_that!(&roundtrip[..read], eq & payload[..]);
+}

--- a/integrations/ros2/tunnel-backend/tests/introspection_translator_tunnel_tests.rs
+++ b/integrations/ros2/tunnel-backend/tests/introspection_translator_tunnel_tests.rs
@@ -1,0 +1,222 @@
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache Software License 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0, or the MIT license
+// which is available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+mod common;
+
+use common::{DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_PERIOD, service_name};
+
+use iceoryx2::prelude::*;
+use iceoryx2::service::Service as _;
+use iceoryx2::service::local::Service;
+use iceoryx2::service::static_config::message_type_details::TypeVariant;
+use iceoryx2::testing::generate_isolated_config;
+use iceoryx2_bb_testing::assert_that;
+use iceoryx2_integrations_ros2_tunnel_backend::Config as BackendConfig;
+use iceoryx2_integrations_ros2_tunnel_backend::mapping::static_mapping::{
+    Config, Entry, IceoryxSettings, RosSettings,
+};
+use iceoryx2_integrations_ros2_tunnel_backend::ros_header::RosHeader;
+use iceoryx2_integrations_ros2_tunnel_backend::testing::{TestPeer, Testing, take_serialized};
+use iceoryx2_integrations_ros2_tunnel_backend::{
+    IntrospectionTranslator, QosProfile, Ros2Backend, StaticMapping, TopicName, TypeName,
+};
+use iceoryx2_services_tunnel::Tunnel;
+use iceoryx2_services_tunnel_backend::traits::testing::Testing as _;
+use iceoryx2_services_tunnel_backend::types::service_description::PortSettings;
+
+const TWIST_TYPE_NAME: &str = "geometry_msgs/msg/Twist";
+
+/// Native mirror of `geometry_msgs/msg/Twist`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, ZeroCopySend)]
+#[type_name("geometry_msgs/msg/Twist")]
+#[repr(C)]
+struct Twist {
+    linear: [f64; 3],
+    angular: [f64; 3],
+}
+
+impl Twist {
+    fn test_value() -> Self {
+        Self {
+            linear: [1.0, 2.0, 3.0],
+            angular: [-1.0, -2.0, -3.0],
+        }
+    }
+
+    /// The CDR wire encoding of this twist: an encapsulation header followed
+    /// by the six little-endian doubles in declaration order.
+    #[allow(clippy::wrong_self_convention)]
+    fn to_cdr(&self) -> Vec<u8> {
+        /// 4-byte CDR encapsulation header (CDR_LE) preceding every wire message.
+        const CDR_HEADER: [u8; 4] = [0x00, 0x01, 0x00, 0x00];
+        let mut wire = CDR_HEADER.to_vec();
+        for value in self.linear.iter().chain(&self.angular) {
+            wire.extend_from_slice(&value.to_le_bytes());
+        }
+        wire
+    }
+}
+
+fn twist_mapping(topic: &str, service: &str) -> StaticMapping {
+    StaticMapping::new(Config {
+        entries: vec![Entry {
+            iceoryx2: IceoryxSettings {
+                service_name: service_name(service),
+                payload_type: TWIST_TYPE_NAME.to_string(),
+                settings: PortSettings::LocalDefaults,
+            },
+            ros2: RosSettings {
+                topic: TopicName::new(topic).expect("valid topic name"),
+                type_name: TypeName::new(TWIST_TYPE_NAME).expect("valid type name"),
+                qos: QosProfile::default(),
+            },
+        }],
+    })
+    .expect("valid mapping config")
+}
+
+#[test]
+fn translates_inbound_messages_into_fixed_size_payloads() {
+    let pid = std::process::id();
+    let topic = format!("/introspection_translator_tunnel_tests/inbound_{pid}");
+    let service = format!("IntrospectionInbound_{pid}");
+
+    let iceoryx_config = generate_isolated_config();
+    let mapping = twist_mapping(&topic, &service);
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, StaticMapping, IntrospectionTranslator>>::new()
+            .iceoryx_config(iceoryx_config.clone())
+            .backend_config(BackendConfig {
+                topics: mapping.topics(),
+            })
+            .mapping(mapping)
+            .polled()
+            .create()
+            .expect("failed to create tunnel");
+
+    let rcl_peer = TestPeer::create();
+    let rcl_publisher = rcl_peer.create_publisher(&topic, TWIST_TYPE_NAME);
+
+    let name = service_name(&service);
+    Testing::retry(
+        || {
+            tunnel.discover().expect("tunnel discovery failed");
+            Service::details(&name, &iceoryx_config, MessagingPattern::PublishSubscribe)
+                .expect("failed to query service details")
+                .is_some()
+                .then_some(())
+                .ok_or("local service not yet created")
+        },
+        DISCOVERY_RETRY_PERIOD,
+        Some(DISCOVERY_RETRY_ATTEMPTS),
+    )
+    .expect("local service for the ROS 2 topic did not appear");
+
+    // The local service carries the translator's fixed native layout.
+    let details = Service::details(&name, &iceoryx_config, MessagingPattern::PublishSubscribe)
+        .expect("failed to query service details")
+        .expect("service exists");
+    let payload = &details
+        .static_details
+        .publish_subscribe()
+        .message_type_details()
+        .payload;
+    assert_that!(payload.variant(), eq TypeVariant::FixedSize);
+    assert_that!(payload.size(), eq core::mem::size_of::<Twist>());
+    assert_that!(payload.alignment(), eq core::mem::align_of::<Twist>());
+
+    let iceoryx_node = NodeBuilder::new()
+        .config(&iceoryx_config)
+        .create::<Service>()
+        .expect("failed to create node");
+    let iceoryx_service = iceoryx_node
+        .service_builder(&name)
+        .publish_subscribe::<Twist>()
+        .user_header::<RosHeader>()
+        .open()
+        .expect("failed to open the tunneled service");
+    let iceoryx_subscriber = iceoryx_service
+        .subscriber_builder()
+        .create()
+        .expect("failed to create subscriber");
+
+    let cdr_bytes = Twist::test_value().to_cdr();
+    Testing::retry(
+        || {
+            rcl_publisher
+                .publish(&cdr_bytes)
+                .expect("failed to publish");
+            tunnel.propagate().expect("tunnel propagation failed");
+            iceoryx_subscriber
+                .receive()
+                .expect("failed to receive")
+                .is_some_and(|sample| *sample.payload() == Twist::test_value())
+                .then_some(())
+                .ok_or("translated twist not yet received")
+        },
+        DISCOVERY_RETRY_PERIOD,
+        Some(DISCOVERY_RETRY_ATTEMPTS),
+    )
+    .expect("translated twist did not arrive natively");
+}
+
+#[test]
+fn translates_outbound_fixed_size_payloads_onto_the_wire() {
+    let pid = std::process::id();
+    let topic = format!("/introspection_translator_tunnel_tests/outbound_{pid}");
+    let service = format!("IntrospectionOutbound_{pid}");
+
+    let iceoryx_config = generate_isolated_config();
+    let iceoryx_node = NodeBuilder::new()
+        .config(&iceoryx_config)
+        .create::<Service>()
+        .expect("failed to create node");
+    let iceoryx_service = iceoryx_node
+        .service_builder(&service_name(&service))
+        .publish_subscribe::<Twist>()
+        .create()
+        .expect("failed to create service");
+    let iceoryx_publisher = iceoryx_service
+        .publisher_builder()
+        .create()
+        .expect("failed to create publisher");
+
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, StaticMapping, IntrospectionTranslator>>::new()
+            .iceoryx_config(iceoryx_config)
+            .backend_config(BackendConfig::default())
+            .mapping(twist_mapping(&topic, &service))
+            .polled()
+            .create()
+            .expect("failed to create tunnel");
+
+    let rcl_peer = TestPeer::create();
+    let rcl_subscription = rcl_peer.create_subscription(&topic, TWIST_TYPE_NAME);
+
+    let expected = Twist::test_value().to_cdr();
+    Testing::retry(
+        || {
+            iceoryx_publisher
+                .send_copy(Twist::test_value())
+                .expect("failed to send");
+            tunnel.discover().expect("tunnel discovery failed");
+            tunnel.propagate().expect("tunnel propagation failed");
+            take_serialized(&rcl_subscription)
+                .is_some_and(|bytes| bytes == expected)
+                .then_some(())
+                .ok_or("translated twist not yet on the wire")
+        },
+        DISCOVERY_RETRY_PERIOD,
+        Some(DISCOVERY_RETRY_ATTEMPTS),
+    )
+    .expect("translated twist did not arrive on the wire");
+}

--- a/integrations/ros2/tunnel-backend/tests/prefix_mapping_tunnel_tests.rs
+++ b/integrations/ros2/tunnel-backend/tests/prefix_mapping_tunnel_tests.rs
@@ -22,7 +22,9 @@ use iceoryx2::testing::generate_isolated_config;
 use iceoryx2_bb_testing::assert_that;
 use iceoryx2_integrations_ros2_tunnel_backend::ros_header::RosHeader;
 use iceoryx2_integrations_ros2_tunnel_backend::testing::{TestPeer, Testing};
-use iceoryx2_integrations_ros2_tunnel_backend::{Config, PrefixMapping, Ros2Backend, TopicConfig};
+use iceoryx2_integrations_ros2_tunnel_backend::{
+    Config, PrefixMapping, Ros2Backend, TopicConfig, TopicDescription,
+};
 use iceoryx2_services_tunnel::Tunnel;
 use iceoryx2_services_tunnel_backend::traits::Passthrough;
 use iceoryx2_services_tunnel_backend::traits::testing::Testing as _;
@@ -45,7 +47,9 @@ fn maps_iceoryx_services_onto_ros_topics() {
         .create()
         .unwrap();
 
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, PrefixMapping, Passthrough>>::new()
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, PrefixMapping, Passthrough<TopicDescription>>>::new(
+        )
         .iceoryx_config(config)
         .backend_config(Config::default())
         .polled()
@@ -92,7 +96,9 @@ fn does_not_map_unprefixed_services() {
         .create()
         .unwrap();
 
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, PrefixMapping, Passthrough>>::new()
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, PrefixMapping, Passthrough<TopicDescription>>>::new(
+        )
         .iceoryx_config(config)
         .backend_config(Config::default())
         .polled()
@@ -141,7 +147,9 @@ fn does_not_map_event_services() {
         .create()
         .unwrap();
 
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, PrefixMapping, Passthrough>>::new()
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, PrefixMapping, Passthrough<TopicDescription>>>::new(
+        )
         .iceoryx_config(config)
         .backend_config(Config::default())
         .polled()
@@ -174,16 +182,17 @@ fn maps_ros_topics_onto_iceoryx2_services() {
     );
 
     let config = generate_isolated_config();
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, PrefixMapping, Passthrough>>::new()
-        .iceoryx_config(config.clone())
-        .backend_config(Config {
-            topics: vec![
-                TopicConfig::new(&topic, "std_msgs/msg/String").expect("valid topic config"),
-            ],
-        })
-        .polled()
-        .create()
-        .unwrap();
+    let mut tunnel = Tunnel::<
+        Service,
+        Ros2Backend<Service, PrefixMapping, Passthrough<TopicDescription>>,
+    >::new()
+    .iceoryx_config(config.clone())
+    .backend_config(Config {
+        topics: vec![TopicConfig::new(&topic, "std_msgs/msg/String").expect("valid topic config")],
+    })
+    .polled()
+    .create()
+    .unwrap();
 
     let peer = TestPeer::create();
     let _publisher = peer.create_publisher(&topic, "std_msgs/msg/String");

--- a/integrations/ros2/tunnel-backend/tests/prefix_mapping_tunnel_tests.rs
+++ b/integrations/ros2/tunnel-backend/tests/prefix_mapping_tunnel_tests.rs
@@ -12,7 +12,7 @@
 
 mod common;
 
-use common::{DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_PERIOD, RosString, service_name};
+use common::{DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_PERIOD, service_name};
 
 use iceoryx2::prelude::*;
 use iceoryx2::service::Service as _;
@@ -28,6 +28,11 @@ use iceoryx2_integrations_ros2_tunnel_backend::{
 use iceoryx2_services_tunnel::Tunnel;
 use iceoryx2_services_tunnel_backend::traits::Passthrough;
 use iceoryx2_services_tunnel_backend::traits::testing::Testing as _;
+
+#[derive(Debug, ZeroCopySend)]
+#[type_name("std_msgs/msg/String")]
+#[repr(C)]
+struct RosString(u8);
 
 #[test]
 fn maps_iceoryx_services_onto_ros_topics() {

--- a/integrations/ros2/tunnel-backend/tests/static_mapping_tunnel_tests.rs
+++ b/integrations/ros2/tunnel-backend/tests/static_mapping_tunnel_tests.rs
@@ -14,7 +14,7 @@ mod common;
 
 use core::time::Duration;
 
-use common::{DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_PERIOD, RosString, service_name};
+use common::{DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_PERIOD, service_name};
 
 use iceoryx2::prelude::*;
 use iceoryx2::service::Service as _;
@@ -38,6 +38,11 @@ use iceoryx2_services_tunnel_backend::traits::testing::Testing as _;
 use iceoryx2_services_tunnel_backend::types::service_description::{
     PortSettings, PublishSubscribeSettings,
 };
+
+#[derive(Debug, ZeroCopySend)]
+#[type_name("std_msgs/msg/String")]
+#[repr(C)]
+struct RosString(u8);
 
 #[test]
 fn maps_iceoryx_services_onto_ros_topics() {

--- a/integrations/ros2/tunnel-backend/tests/static_mapping_tunnel_tests.rs
+++ b/integrations/ros2/tunnel-backend/tests/static_mapping_tunnel_tests.rs
@@ -29,7 +29,8 @@ use iceoryx2_integrations_ros2_tunnel_backend::mapping::static_mapping::{
 use iceoryx2_integrations_ros2_tunnel_backend::ros_header::RosHeader;
 use iceoryx2_integrations_ros2_tunnel_backend::testing::{TestPeer, Testing};
 use iceoryx2_integrations_ros2_tunnel_backend::{
-    Durability, QosProfile, Reliability, Ros2Backend, StaticMapping, TopicName, TypeName,
+    Durability, QosProfile, Reliability, Ros2Backend, StaticMapping, TopicDescription, TopicName,
+    TypeName,
 };
 use iceoryx2_services_tunnel::Tunnel;
 use iceoryx2_services_tunnel_backend::traits::Passthrough;
@@ -72,7 +73,9 @@ fn maps_iceoryx_services_onto_ros_topics() {
     })
     .expect("valid mapping config");
 
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough>>::new()
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough<TopicDescription>>>::new(
+        )
         .iceoryx_config(iceoryx_config)
         .backend_config(BackendConfig::default())
         .mapping(mapping)
@@ -136,7 +139,9 @@ fn does_not_map_iceoryx_services_without_an_entry() {
     })
     .expect("valid mapping config");
 
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough>>::new()
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough<TopicDescription>>>::new(
+        )
         .iceoryx_config(iceoryx_config)
         .backend_config(BackendConfig::default())
         .mapping(mapping)
@@ -185,7 +190,9 @@ fn maps_ros_topics_onto_iceoryx_services() {
     .expect("valid mapping config");
 
     let iceoryx_config = generate_isolated_config();
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough>>::new()
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough<TopicDescription>>>::new(
+        )
         .iceoryx_config(iceoryx_config.clone())
         .backend_config(BackendConfig {
             topics: mapping.topics(),
@@ -271,7 +278,9 @@ fn applies_specified_qos_to_ros_endpoints() {
     })
     .expect("valid mapping config");
 
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough>>::new()
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough<TopicDescription>>>::new(
+        )
         .iceoryx_config(iceoryx_config)
         .backend_config(BackendConfig::default())
         .mapping(mapping)
@@ -338,7 +347,9 @@ fn applies_specified_settings_to_iceoryx_services() {
     .expect("valid mapping config");
 
     let iceoryx_config = generate_isolated_config();
-    let mut tunnel = Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough>>::new()
+    let mut tunnel =
+        Tunnel::<Service, Ros2Backend<Service, StaticMapping, Passthrough<TopicDescription>>>::new(
+        )
         .iceoryx_config(iceoryx_config.clone())
         .backend_config(BackendConfig {
             topics: mapping.topics(),

--- a/integrations/zenoh/tunnel-backend/src/backend.rs
+++ b/integrations/zenoh/tunnel-backend/src/backend.rs
@@ -41,7 +41,13 @@ impl core::fmt::Display for CreationError {
 impl core::error::Error for CreationError {}
 
 #[derive(Debug)]
-pub struct ZenohBackend<S: Service, M: Mapping = Identity, T: Translator = Passthrough> {
+pub struct ZenohBackend<
+    S: Service,
+    M: Mapping = Identity,
+    T: Translator<EndpointDescription = <M as Mapping>::EndpointDescription> = Passthrough<
+        <M as Mapping>::EndpointDescription,
+    >,
+> {
     session: Session,
     discovery: Discovery,
     /// `Some` when constructed in reactive mode. Cloned into each relay's
@@ -53,7 +59,9 @@ pub struct ZenohBackend<S: Service, M: Mapping = Identity, T: Translator = Passt
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<S: Service, M: Mapping, T: Translator> Backend<S> for ZenohBackend<S, M, T> {
+impl<S: Service, M: Mapping, T: Translator<EndpointDescription = M::EndpointDescription>> Backend<S>
+    for ZenohBackend<S, M, T>
+{
     type Config = Config;
     type Mapping = M;
     type Translator = T;
@@ -91,7 +99,14 @@ impl<S: Service, M: Mapping, T: Translator> Backend<S> for ZenohBackend<S, M, T>
 
 /// Builder for [`ZenohBackend`].
 #[derive(Debug)]
-pub struct Builder<'config, S: Service, M: Mapping = Identity, T: Translator = Passthrough> {
+pub struct Builder<
+    'config,
+    S: Service,
+    M: Mapping = Identity,
+    T: Translator<EndpointDescription = <M as Mapping>::EndpointDescription> = Passthrough<
+        <M as Mapping>::EndpointDescription,
+    >,
+> {
     config: &'config Config,
     wake: Option<WakeHandle<local_threadsafe::Service>>,
     mapping: M,
@@ -99,7 +114,9 @@ pub struct Builder<'config, S: Service, M: Mapping = Identity, T: Translator = P
     _phantom: core::marker::PhantomData<S>,
 }
 
-impl<'config, S: Service, M: Mapping, T: Translator> Builder<'config, S, M, T> {
+impl<'config, S: Service, M: Mapping, T: Translator<EndpointDescription = M::EndpointDescription>>
+    Builder<'config, S, M, T>
+{
     pub fn new(config: &'config Config) -> Self {
         Self {
             config,
@@ -111,7 +128,9 @@ impl<'config, S: Service, M: Mapping, T: Translator> Builder<'config, S, M, T> {
     }
 }
 
-impl<S: Service, M: Mapping, T: Translator> BackendBuilder<S> for Builder<'_, S, M, T> {
+impl<S: Service, M: Mapping, T: Translator<EndpointDescription = M::EndpointDescription>>
+    BackendBuilder<S> for Builder<'_, S, M, T>
+{
     type Backend = ZenohBackend<S, M, T>;
     type CreationError = CreationError;
 
@@ -160,7 +179,9 @@ impl<S: Service, M: Mapping, T: Translator> BackendBuilder<S> for Builder<'_, S,
     }
 }
 
-impl<S: Service, M: Mapping, T: Translator> ReactiveBackendBuilder<S> for Builder<'_, S, M, T> {
+impl<S: Service, M: Mapping, T: Translator<EndpointDescription = M::EndpointDescription>>
+    ReactiveBackendBuilder<S> for Builder<'_, S, M, T>
+{
     type WakeService = local_threadsafe::Service;
 
     fn reactive(mut self, wake: WakeHandle<local_threadsafe::Service>) -> Self {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Adds a translator implementation for ROS 2:
* introspects the message type on initialization, rejects messages that are not shared-memory compatible
* (de)serializes payload bytes to/from CDR at ROS 2 boundary

To facilitate reviewing, this PR only includes the wiring of the Translator component into the ROS 2 backend.  
Examples and CLI are added in a subsequent PR.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [ ] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #1742 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
