### PR TITLE
[#1853] Improve error message in static asserts

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -62,6 +62,7 @@
 * [#1613](https://github.com/eclipse-iceoryx/iceoryx2/issues/1613) Remove `NonNullCompat` after moving to Rust 1.89
 * [#1776](https://github.com/eclipse-iceoryx/iceoryx2/issues/1776) Rename AtomicCopy::__for_each_field() to for_each_field()
 * [#1845](https://github.com/eclipse-iceoryx/iceoryx2/issues/1845) Reduce imports for usage of the `semantic_string` macro
+* [#1853](https://github.com/eclipse-iceoryx/iceoryx2/issues/1853) Improve error message in static asserts
 
 ### Workflow
 

--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -91,6 +91,7 @@ use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use iceoryx2_bb_concurrency::atomic::{AtomicBool, AtomicU8, Ordering};
 use iceoryx2_bb_elementary::relocatable_pointer::{Pointer, RelocatablePointer};
+use iceoryx2_bb_elementary::static_assert::static_assert_size_of;
 use iceoryx2_bb_elementary_traits::allocator::{Allocate, AllocationError};
 use iceoryx2_bb_elementary_traits::{atomic_copy::AtomicCopy, zero_copy_send::ZeroCopySend};
 use iceoryx2_log::fail;
@@ -225,20 +226,6 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
         self.verify_init("write()");
         write_impl(self.data_ptr.as_ptr(), value);
     }
-}
-
-// TODO #1644: Used to check at compile-time that T and SIZE of FixedSizeByteAtomic are
-// equal. Can be removed once size_of::<T>() can be directly used in the struct definition.
-const fn static_assert_size_of<T, const SIZE: usize>() {
-    let () = AssertSizeOf::<T, SIZE>::OK;
-}
-
-struct AssertSizeOf<T, const SIZE: usize> {
-    _phantom: PhantomData<T>,
-}
-
-impl<T, const SIZE: usize> AssertSizeOf<T, SIZE> {
-    const OK: () = assert!(size_of::<T>() == SIZE, "T must have size defined by SIZE");
 }
 
 /// A compile-time fixed-size, shared-memory compatible [`FixedSizeByteAtomic`].

--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -91,7 +91,7 @@ use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use iceoryx2_bb_concurrency::atomic::{AtomicBool, AtomicU8, Ordering};
 use iceoryx2_bb_elementary::relocatable_pointer::{Pointer, RelocatablePointer};
-use iceoryx2_bb_elementary::static_assert::static_assert_size_of;
+use iceoryx2_bb_elementary::static_assert_size_of;
 use iceoryx2_bb_elementary_traits::allocator::{Allocate, AllocationError};
 use iceoryx2_bb_elementary_traits::{atomic_copy::AtomicCopy, zero_copy_send::ZeroCopySend};
 use iceoryx2_log::fail;
@@ -229,6 +229,24 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
 }
 
 /// A compile-time fixed-size, shared-memory compatible [`FixedSizeByteAtomic`].
+///
+/// # Examples
+///
+/// This does compile!
+///
+/// ```
+/// use iceoryx2_bb_container::byte_atomic::FixedSizeByteAtomic;
+///
+/// let _ = FixedSizeByteAtomic::<u64, 8>::new(0);
+/// ```
+///
+/// This does not compile!
+///
+/// ```compile_fail
+/// use iceoryx2_bb_container::byte_atomic::FixedSizeByteAtomic;
+///
+/// let _ = FixedSizeByteAtomic::<u64, 1>::new(0);
+/// ```
 #[repr(C)]
 pub struct FixedSizeByteAtomic<T: AtomicCopy, const SIZE: usize> {
     data: [AtomicU8; SIZE],
@@ -247,7 +265,7 @@ impl<T: AtomicCopy, const SIZE: usize> FixedSizeByteAtomic<T, SIZE> {
         // can be directly used in the struct definition. Consider then to remove the
         // RelocatableByteAtomic implementation as well; maybe add a placement_new() to the
         // FixedSizeByteAtomic.
-        static_assert_size_of::<T, SIZE>();
+        static_assert_size_of!(T, SIZE);
 
         let value_ptr = (&raw const value).cast::<u8>();
 

--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -232,7 +232,7 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
 ///
 /// # Examples
 ///
-/// This does compile!
+/// This does compile because the size parameter matches the size of the type.
 ///
 /// ```
 /// use iceoryx2_bb_container::byte_atomic::FixedSizeByteAtomic;
@@ -240,7 +240,7 @@ impl<T: AtomicCopy> RelocatableByteAtomic<T> {
 /// let _ = FixedSizeByteAtomic::<u64, 8>::new(0);
 /// ```
 ///
-/// This does not compile!
+/// This does not compile because the size parameter is smaller than the size of the type.
 ///
 /// ```compile_fail
 /// use iceoryx2_bb_container::byte_atomic::FixedSizeByteAtomic;

--- a/iceoryx2-bb/elementary/src/static_assert.rs
+++ b/iceoryx2-bb/elementary/src/static_assert.rs
@@ -17,15 +17,20 @@
 //! # Example
 //!
 //! ```
-//! use iceoryx2_bb_elementary::static_assert::*;
+//! use iceoryx2_bb_elementary::{
+//!     static_assert_eq, static_assert_ge, static_assert_gt, static_assert_le,
+//!     static_assert_lt, static_assert_size_of, static_assert_align_of,
+//! };
 //!
 //! use core::mem::{align_of, size_of};
 //!
-//! static_assert_eq::<{ size_of::<u64>() }, 8>();
-//! static_assert_ge::<{ size_of::<u64>() }, { size_of::<u32>() }>();
-//! static_assert_gt::<{ size_of::<u64>() }, { size_of::<u32>() }>();
-//! static_assert_le::<{ size_of::<u32>() }, { size_of::<u64>() }>();
-//! static_assert_lt::<{ size_of::<u32>() }, { size_of::<u64>() }>();
+//! static_assert_eq!(size_of::<u64>(), 8);
+//! static_assert_ge!(size_of::<u64>(), size_of::<u32>());
+//! static_assert_gt!(size_of::<u64>(), size_of::<u32>());
+//! static_assert_le!(size_of::<u32>(), size_of::<u64>());
+//! static_assert_lt!(size_of::<u32>(), size_of::<u64>());
+//! static_assert_size_of!(u32, 4);
+//! static_assert_align_of!(u32, 4);
 //! ```
 
 use core::marker::PhantomData;
@@ -37,21 +42,34 @@ use core::marker::PhantomData;
 /// This does compile!
 ///
 /// ```
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_eq;
 ///
-/// static_assert_eq::<1, 1>();
-///
+/// static_assert_eq!(1, 1);
 /// ```
 ///
 /// This does not compile!
 ///
 /// ```compile_fail
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_eq;
 ///
-/// static_assert_eq::<1, 2>();
-/// static_assert_eq::<2, 1>();
-///
+/// static_assert_eq!(1, 2);
 /// ```
+///
+/// ```compile_fail
+/// use iceoryx2_bb_elementary::static_assert_eq;
+///
+/// static_assert_eq!(2, 1);
+/// ```
+#[macro_export]
+macro_rules! static_assert_eq {
+    ($left:expr, $right:expr) => {
+        let _: () = const {
+            iceoryx2_bb_elementary::static_assert::static_assert_eq::<{ $left }, { $right }>()
+        };
+    };
+}
+
+/// Implementation detail! Use [`static_assert_eq!`] macro instead
 pub const fn static_assert_eq<const L: usize, const R: usize>() {
     let () = AssertEq::<L, R>::OK;
 }
@@ -69,21 +87,29 @@ impl<const L: usize, const R: usize> AssertEq<L, R> {
 /// This does compile!
 ///
 /// ```
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_ge;
 ///
-/// static_assert_ge::<1, 1>();
-/// static_assert_ge::<2, 1>();
-///
+/// static_assert_ge!(1, 1);
+/// static_assert_ge!(2, 1);
 /// ```
 ///
 /// This does not compile!
 ///
 /// ```compile_fail
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_ge;
 ///
-/// static_assert_ge::<1, 2>();
-///
+/// static_assert_ge!(1, 2);
 /// ```
+#[macro_export]
+macro_rules! static_assert_ge {
+    ($left:expr, $right:expr) => {
+        let _: () = const {
+            iceoryx2_bb_elementary::static_assert::static_assert_ge::<{ $left }, { $right }>()
+        };
+    };
+}
+
+/// Implementation detail! Use [`static_assert_ge!`] macro instead
 pub const fn static_assert_ge<const L: usize, const R: usize>() {
     let () = AssertGe::<L, R>::OK;
 }
@@ -101,21 +127,34 @@ impl<const L: usize, const R: usize> AssertGe<L, R> {
 /// This does compile!
 ///
 /// ```
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_gt;
 ///
-/// static_assert_gt::<2, 1>();
-///
+/// static_assert_gt!(2, 1);
 /// ```
 ///
 /// This does not compile!
 ///
 /// ```compile_fail
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_gt;
 ///
-/// static_assert_gt::<1, 1>();
-/// static_assert_gt::<1, 2>();
-///
+/// static_assert_gt!(1, 1);
 /// ```
+///
+/// ```compile_fail
+/// use iceoryx2_bb_elementary::static_assert_gt;
+///
+/// static_assert_gt!(1, 2);
+/// ```
+#[macro_export]
+macro_rules! static_assert_gt {
+    ($left:expr, $right:expr) => {
+        let _: () = const {
+            iceoryx2_bb_elementary::static_assert::static_assert_gt::<{ $left }, { $right }>()
+        };
+    };
+}
+
+/// Implementation detail! Use [`static_assert_gt!`] macro instead
 pub const fn static_assert_gt<const L: usize, const R: usize>() {
     let () = AssertGt::<L, R>::OK;
 }
@@ -133,21 +172,29 @@ impl<const L: usize, const R: usize> AssertGt<L, R> {
 /// This does compile!
 ///
 /// ```
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_le;
 ///
-/// static_assert_le::<1, 1>();
-/// static_assert_le::<1, 2>();
-///
+/// static_assert_le!(1, 1);
+/// static_assert_le!(1, 2);
 /// ```
 ///
 /// This does not compile!
 ///
 /// ```compile_fail
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_le;
 ///
-/// static_assert_le::<2, 1>();
-///
+/// static_assert_le!(2, 1);
 /// ```
+#[macro_export]
+macro_rules! static_assert_le {
+    ($left:expr, $right:expr) => {
+        let _: () = const {
+            iceoryx2_bb_elementary::static_assert::static_assert_le::<{ $left }, { $right }>()
+        };
+    };
+}
+
+/// Implementation detail! Use [`static_assert_le!`] macro instead
 pub const fn static_assert_le<const L: usize, const R: usize>() {
     let () = AssertLe::<L, R>::OK;
 }
@@ -165,21 +212,34 @@ impl<const L: usize, const R: usize> AssertLe<L, R> {
 /// This does compile!
 ///
 /// ```
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_lt;
 ///
-/// static_assert_lt::<1, 2>();
-///
+/// static_assert_lt!(1, 2);
 /// ```
 ///
 /// This does not compile!
 ///
 /// ```compile_fail
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_lt;
 ///
-/// static_assert_lt::<1, 1>();
-/// static_assert_lt::<2, 1>();
-///
+/// static_assert_lt!(1, 1);
 /// ```
+///
+/// ```compile_fail
+/// use iceoryx2_bb_elementary::static_assert_lt;
+///
+/// static_assert_lt!(2, 1);
+/// ```
+#[macro_export]
+macro_rules! static_assert_lt {
+    ($left:expr, $right:expr) => {
+        let _: () = const {
+            iceoryx2_bb_elementary::static_assert::static_assert_lt::<{ $left }, { $right }>()
+        };
+    };
+}
+
+/// Implementation detail! Use [`static_assert_lt!`] macro instead
 pub const fn static_assert_lt<const L: usize, const R: usize>() {
     let () = AssertLt::<L, R>::OK;
 }
@@ -197,20 +257,30 @@ impl<const L: usize, const R: usize> AssertLt<L, R> {
 /// This does compile!
 ///
 /// ```
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_size_of;
 ///
-/// static_assert_size_of::<u32, 4>();
+/// static_assert_size_of!(u32, 4);
 ///
 /// ```
 ///
 /// This does not compile!
 ///
 /// ```compile_fail
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_size_of;
 ///
-/// static_assert_size_of::<u8, 16>();
+/// static_assert_size_of!(u8, 16);
 ///
 /// ```
+#[macro_export]
+macro_rules! static_assert_size_of {
+    ($ty:ty, $value:expr) => {
+        let _: () = const {
+            iceoryx2_bb_elementary::static_assert::static_assert_size_of::<$ty, { $value }>()
+        };
+    };
+}
+
+/// Implementation detail! Use [`static_assert_size_of!`] macro instead
 pub const fn static_assert_size_of<T, const SIZE: usize>() {
     let () = AssertSizeOf::<T, SIZE>::OK;
 }
@@ -233,20 +303,30 @@ impl<T, const SIZE: usize> AssertSizeOf<T, SIZE> {
 /// This does compile!
 ///
 /// ```
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_align_of;
 ///
-/// static_assert_align_of::<u16, 2>();
+/// static_assert_align_of!(u16, 2);
 ///
 /// ```
 ///
 /// This does not compile!
 ///
 /// ```compile_fail
-/// use iceoryx2_bb_elementary::static_assert::*;
+/// use iceoryx2_bb_elementary::static_assert_align_of;
 ///
-/// static_assert_align_of::<u8, 32>();
+/// static_assert_align_of!(u8, 32);
 ///
 /// ```
+#[macro_export]
+macro_rules! static_assert_align_of {
+    ($ty:ty, $value:expr) => {
+        let _: () = const {
+            iceoryx2_bb_elementary::static_assert::static_assert_align_of::<$ty, { $value }>()
+        };
+    };
+}
+
+/// Implementation detail! Use [`static_assert_align_of!`] macro instead
 pub const fn static_assert_align_of<T, const ALIGNMENT: usize>() {
     let () = AssertAlignOf::<T, ALIGNMENT>::OK;
 }

--- a/iceoryx2-bb/elementary/src/static_assert.rs
+++ b/iceoryx2-bb/elementary/src/static_assert.rs
@@ -225,3 +225,39 @@ impl<T, const SIZE: usize> AssertSizeOf<T, SIZE> {
         "T must have size defined by SIZE"
     );
 }
+
+/// A compile time assert to check for the alignment of a type being equal to a value
+///
+/// # Examples
+///
+/// This does compile!
+///
+/// ```
+/// use iceoryx2_bb_elementary::static_assert::*;
+///
+/// static_assert_align_of::<u16, 2>();
+///
+/// ```
+///
+/// This does not compile!
+///
+/// ```compile_fail
+/// use iceoryx2_bb_elementary::static_assert::*;
+///
+/// static_assert_align_of::<u8, 32>();
+///
+/// ```
+pub const fn static_assert_align_of<T, const ALIGNMENT: usize>() {
+    let () = AssertAlignOf::<T, ALIGNMENT>::OK;
+}
+
+struct AssertAlignOf<T, const ALIGNMENT: usize> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T, const ALIGNMENT: usize> AssertAlignOf<T, ALIGNMENT> {
+    const OK: () = assert!(
+        core::mem::align_of::<T>() == ALIGNMENT,
+        "T must have alignment defined by ALIGNMENT"
+    );
+}

--- a/iceoryx2-bb/elementary/src/static_assert.rs
+++ b/iceoryx2-bb/elementary/src/static_assert.rs
@@ -252,6 +252,9 @@ impl<const L: usize, const R: usize> AssertLt<L, R> {
 
 /// A compile time assert to check for the size of a type being equal to a value
 ///
+/// Contrary to [`static_assert_eq!`], the [`static_assert_size_of!`](crate::static_assert_size_of) macro can easily
+/// be used with const generics, avoiding the `cannot perform const operation using 'T'` error.
+///
 /// # Examples
 ///
 /// This does compile!
@@ -259,8 +262,18 @@ impl<const L: usize, const R: usize> AssertLt<L, R> {
 /// ```
 /// use iceoryx2_bb_elementary::static_assert_size_of;
 ///
-/// static_assert_size_of!(u32, 4);
+/// pub struct Hypnotoad<T> {
+///     pub value: T,
+/// }
 ///
+/// impl<T: Default> Hypnotoad<T> {
+///     fn new() -> Self {
+///         static_assert_size_of!(T, 4);
+///         Self { value: T::default() }
+///     }
+/// }
+///
+/// let hypnotoad = Hypnotoad::<u32>::new();
 /// ```
 ///
 /// This does not compile!
@@ -268,8 +281,18 @@ impl<const L: usize, const R: usize> AssertLt<L, R> {
 /// ```compile_fail
 /// use iceoryx2_bb_elementary::static_assert_size_of;
 ///
-/// static_assert_size_of!(u8, 16);
+/// pub struct Hypnotoad<T> {
+///     pub value: T,
+/// }
 ///
+/// impl<T: Default> Hypnotoad<T> {
+///     fn new() -> Self {
+///         static_assert_size_of!(T, 1);
+///         Self { value: T::default() }
+///     }
+/// }
+///
+/// let hypnotoad = Hypnotoad::<u32>::new();
 /// ```
 #[macro_export]
 macro_rules! static_assert_size_of {
@@ -280,7 +303,7 @@ macro_rules! static_assert_size_of {
     };
 }
 
-/// Implementation detail! Use [`static_assert_size_of!`] macro instead
+/// Implementation detail! Use [`static_assert_size_of!`](crate::static_assert_size_of) macro instead
 pub const fn static_assert_size_of<T, const SIZE: usize>() {
     let () = AssertSizeOf::<T, SIZE>::OK;
 }
@@ -296,7 +319,10 @@ impl<T, const SIZE: usize> AssertSizeOf<T, SIZE> {
     );
 }
 
-/// A compile time assert to check for the alignment of a type being equal to a value
+/// A compile time assert to check for the alignment of a type being equal to a value.
+///
+/// Contrary to [`static_assert_eq!`], the [`static_assert_align_of!`](crate::static_assert_align_of) macro can easily
+/// be used with const generics, avoiding the `cannot perform const operation using 'T'` error.
 ///
 /// # Examples
 ///
@@ -305,8 +331,18 @@ impl<T, const SIZE: usize> AssertSizeOf<T, SIZE> {
 /// ```
 /// use iceoryx2_bb_elementary::static_assert_align_of;
 ///
-/// static_assert_align_of!(u16, 2);
+/// pub struct Hypnotoad<T> {
+///     pub value: T,
+/// }
 ///
+/// impl<T: Default> Hypnotoad<T> {
+///     fn new() -> Self {
+///         static_assert_align_of!(T, 4);
+///         Self { value: T::default() }
+///     }
+/// }
+///
+/// let hypnotoad = Hypnotoad::<u32>::new();
 /// ```
 ///
 /// This does not compile!
@@ -314,8 +350,18 @@ impl<T, const SIZE: usize> AssertSizeOf<T, SIZE> {
 /// ```compile_fail
 /// use iceoryx2_bb_elementary::static_assert_align_of;
 ///
-/// static_assert_align_of!(u8, 32);
+/// pub struct Hypnotoad<T> {
+///     pub value: T,
+/// }
 ///
+/// impl<T: Default> Hypnotoad<T> {
+///     fn new() -> Self {
+///         static_assert_align_of!(T, 1);
+///         Self { value: T::default() }
+///     }
+/// }
+///
+/// let hypnotoad = Hypnotoad::<u32>::new();
 /// ```
 #[macro_export]
 macro_rules! static_assert_align_of {
@@ -326,7 +372,7 @@ macro_rules! static_assert_align_of {
     };
 }
 
-/// Implementation detail! Use [`static_assert_align_of!`] macro instead
+/// Implementation detail! Use [`static_assert_align_of!`](crate::static_assert_align_of) macro instead
 pub const fn static_assert_align_of<T, const ALIGNMENT: usize>() {
     let () = AssertAlignOf::<T, ALIGNMENT>::OK;
 }

--- a/iceoryx2-bb/elementary/src/static_assert.rs
+++ b/iceoryx2-bb/elementary/src/static_assert.rs
@@ -28,6 +28,8 @@
 //! static_assert_lt::<{ size_of::<u32>() }, { size_of::<u64>() }>();
 //! ```
 
+use core::marker::PhantomData;
+
 /// A compile time assert to check for equal values
 ///
 /// # Examples
@@ -186,4 +188,40 @@ struct AssertLt<const L: usize, const R: usize>;
 
 impl<const L: usize, const R: usize> AssertLt<L, R> {
     const OK: () = assert!(L < R, "L must be less than R");
+}
+
+/// A compile time assert to check for the size of a type being equal to a value
+///
+/// # Examples
+///
+/// This does compile!
+///
+/// ```
+/// use iceoryx2_bb_elementary::static_assert::*;
+///
+/// static_assert_size_of::<u32, 4>();
+///
+/// ```
+///
+/// This does not compile!
+///
+/// ```compile_fail
+/// use iceoryx2_bb_elementary::static_assert::*;
+///
+/// static_assert_size_of::<u8, 16>();
+///
+/// ```
+pub const fn static_assert_size_of<T, const SIZE: usize>() {
+    let () = AssertSizeOf::<T, SIZE>::OK;
+}
+
+struct AssertSizeOf<T, const SIZE: usize> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T, const SIZE: usize> AssertSizeOf<T, SIZE> {
+    const OK: () = assert!(
+        core::mem::size_of::<T>() == SIZE,
+        "T must have size defined by SIZE"
+    );
 }

--- a/iceoryx2-bb/system-types/src/file_name.rs
+++ b/iceoryx2-bb/system-types/src/file_name.rs
@@ -37,7 +37,7 @@ use alloc::string::String;
 
 use iceoryx2_bb_container::semantic_string;
 use iceoryx2_bb_derive_macros::ZeroCopySend;
-use iceoryx2_bb_elementary::static_assert::{static_assert_ge, static_assert_le};
+use iceoryx2_bb_elementary::{static_assert_ge, static_assert_le};
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_pal_configuration::FILENAME_LENGTH;
 
@@ -101,8 +101,8 @@ impl<const CAPACITY: usize>
     for RestrictedFileName<CAPACITY>
 {
     unsafe fn new_empty() -> Self {
-        static_assert_le::<{ CAPACITY }, { FILENAME_LENGTH }>();
-        static_assert_ge::<{ CAPACITY }, 1>();
+        static_assert_le!(CAPACITY, FILENAME_LENGTH);
+        static_assert_ge!(CAPACITY, 1);
 
         Self {
             value: iceoryx2_bb_container::string::StaticString::new(),

--- a/iceoryx2-ffi/c/src/api/active_request.rs
+++ b/iceoryx2-ffi/c/src/api/active_request.rs
@@ -25,7 +25,6 @@ use super::{
 };
 use iceoryx2::active_request::ActiveRequest;
 use iceoryx2::prelude::*;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 // BEGIN types definition

--- a/iceoryx2-ffi/c/src/api/attribute_set.rs
+++ b/iceoryx2-ffi/c/src/api/attribute_set.rs
@@ -21,7 +21,6 @@ use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2::service::attribute::{Attribute, AttributeKey, AttributeSet};
 use iceoryx2_bb_container::semantic_string::SemanticString;
 use iceoryx2_bb_elementary::CallbackProgression;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 

--- a/iceoryx2-ffi/c/src/api/attribute_specifier.rs
+++ b/iceoryx2-ffi/c/src/api/attribute_specifier.rs
@@ -17,7 +17,6 @@ use crate::api::{AssertNonNullHandle, HandleToType, IOX2_OK, IntoCInt};
 use iceoryx2::prelude::*;
 use iceoryx2::service::attribute::{AttributeKey, AttributeValue};
 use iceoryx2_bb_container::semantic_string::SemanticString;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use core::ffi::c_int;

--- a/iceoryx2-ffi/c/src/api/attribute_verifier.rs
+++ b/iceoryx2-ffi/c/src/api/attribute_verifier.rs
@@ -17,7 +17,6 @@ use crate::api::{AssertNonNullHandle, HandleToType, IOX2_OK, IntoCInt};
 use iceoryx2::prelude::*;
 use iceoryx2::service::attribute::{AttributeKey, AttributeValue, AttributeVerificationError};
 use iceoryx2_bb_container::semantic_string::SemanticString;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use alloc::ffi::CString;

--- a/iceoryx2-ffi/c/src/api/client.rs
+++ b/iceoryx2-ffi/c/src/api/client.rs
@@ -17,7 +17,6 @@ use core::mem::ManuallyDrop;
 use iceoryx2::pending_response::PendingResponse;
 use iceoryx2::port::client::Client;
 use iceoryx2::prelude::*;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::IOX2_OK;

--- a/iceoryx2-ffi/c/src/api/config.rs
+++ b/iceoryx2-ffi/c/src/api/config.rs
@@ -18,7 +18,6 @@ use core::mem::ManuallyDrop;
 use core::time::Duration;
 use iceoryx2::config::{Config, ConfigCreationError};
 use iceoryx2_bb_container::semantic_string::*;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_bb_system_types::file_name::FileName;
 use iceoryx2_bb_system_types::file_path::FilePath;

--- a/iceoryx2-ffi/c/src/api/entry_handle.rs
+++ b/iceoryx2-ffi/c/src/api/entry_handle.rs
@@ -19,7 +19,6 @@ use crate::{
 use core::ffi::c_void;
 use core::mem::ManuallyDrop;
 use iceoryx2::port::reader::__InternalEntryHandle;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 // BEGIN types definition

--- a/iceoryx2-ffi/c/src/api/entry_handle_mut.rs
+++ b/iceoryx2-ffi/c/src/api/entry_handle_mut.rs
@@ -19,7 +19,6 @@ use crate::api::{
 use core::ffi::c_void;
 use core::mem::ManuallyDrop;
 use iceoryx2::port::writer::__InternalEntryHandleMut;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 // BEGIN types definition

--- a/iceoryx2-ffi/c/src/api/entry_value_uninit.rs
+++ b/iceoryx2-ffi/c/src/api/entry_value_uninit.rs
@@ -19,7 +19,6 @@ use crate::api::{
 use core::ffi::c_void;
 use core::mem::ManuallyDrop;
 use iceoryx2::port::writer::__InternalEntryValueUninit;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 // BEGIN types definition

--- a/iceoryx2-ffi/c/src/api/file_descriptor.rs
+++ b/iceoryx2-ffi/c/src/api/file_descriptor.rs
@@ -12,7 +12,6 @@
 
 #![allow(non_camel_case_types)]
 
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_posix::{
     file_descriptor::{FileDescriptor, FileDescriptorBased},
     file_descriptor_set::SynchronousMultiplexing,

--- a/iceoryx2-ffi/c/src/api/listener.rs
+++ b/iceoryx2-ffi/c/src/api/listener.rs
@@ -20,7 +20,6 @@ use crate::api::{
 use crate::iox2_file_descriptor_ptr;
 
 use iceoryx2::port::listener::Listener;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_bb_posix::file_descriptor::{FileDescriptor, FileDescriptorBased};
 use iceoryx2_cal::event::ListenerWaitError;

--- a/iceoryx2-ffi/c/src/api/node.rs
+++ b/iceoryx2-ffi/c/src/api/node.rs
@@ -26,7 +26,6 @@ use iceoryx2::node::{
 use iceoryx2::prelude::*;
 use iceoryx2::service::ServiceRemoveError;
 use iceoryx2_bb_container::semantic_string::SemanticString;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/node_builder.rs
+++ b/iceoryx2-ffi/c/src/api/node_builder.rs
@@ -19,7 +19,6 @@ use crate::api::{
 
 use iceoryx2::node::NodeCreationFailure;
 use iceoryx2::prelude::*;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/node_name.rs
+++ b/iceoryx2-ffi/c/src/api/node_name.rs
@@ -17,7 +17,6 @@ use crate::api::{
 };
 
 use iceoryx2::prelude::*;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use core::ffi::{c_char, c_int};

--- a/iceoryx2-ffi/c/src/api/notifier.rs
+++ b/iceoryx2-ffi/c/src/api/notifier.rs
@@ -18,7 +18,6 @@ use crate::api::{
 };
 
 use iceoryx2::port::notifier::{Notifier, NotifierNotifyError};
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/pending_response.rs
+++ b/iceoryx2-ffi/c/src/api/pending_response.rs
@@ -17,7 +17,6 @@
 use core::{ffi::c_int, ffi::c_void, mem::ManuallyDrop};
 
 use iceoryx2::pending_response::PendingResponse;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::{

--- a/iceoryx2-ffi/c/src/api/port_factory_blackboard.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_blackboard.rs
@@ -28,7 +28,7 @@ use core::mem::ManuallyDrop;
 use core::time::Duration;
 use iceoryx2::service::dynamic_config::blackboard::{ReaderDetails, WriterDetails};
 use iceoryx2::service::port_factory::blackboard::PortFactory;
-use iceoryx2_bb_elementary::{CallbackProgression, static_assert::*};
+use iceoryx2_bb_elementary::CallbackProgression;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 // BEGIN types definition

--- a/iceoryx2-ffi/c/src/api/port_factory_client_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_client_builder.rs
@@ -25,7 +25,6 @@ use crate::api::ClientUnion;
 use core::ffi::{c_char, c_int};
 use core::mem::ManuallyDrop;
 use iceoryx2::service::port_factory::client::{ClientCreateError, PortFactoryClient};
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::{CStrRepr, iceoryx2_ffi};
 

--- a/iceoryx2-ffi/c/src/api/port_factory_event.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_event.rs
@@ -23,7 +23,6 @@ use crate::{IOX2_OK, iox2_node_list_impl};
 
 use iceoryx2::service::dynamic_config::event::{ListenerDetails, NotifierDetails};
 use iceoryx2::service::port_factory::{PortFactory, event::PortFactory as PortFactoryEvent};
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use core::ffi::{c_char, c_int};

--- a/iceoryx2-ffi/c/src/api/port_factory_listener_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_listener_builder.rs
@@ -19,7 +19,6 @@ use crate::api::{
 
 use iceoryx2::port::listener::ListenerCreateError;
 use iceoryx2::service::port_factory::listener::PortFactoryListener;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/port_factory_notifier_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_notifier_builder.rs
@@ -19,7 +19,6 @@ use crate::api::{
 
 use iceoryx2::port::notifier::NotifierCreateError;
 use iceoryx2::service::port_factory::notifier::PortFactoryNotifier;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/port_factory_pub_sub.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_pub_sub.rs
@@ -29,7 +29,6 @@ use iceoryx2::service::{
     dynamic_config::publish_subscribe::PublisherDetails,
     port_factory::publish_subscribe::PortFactory,
 };
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use core::time::Duration;

--- a/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
@@ -23,7 +23,6 @@ use crate::api::{
 use iceoryx2::port::publisher::PublisherCreateError;
 use iceoryx2::prelude::*;
 use iceoryx2::service::port_factory::publisher::PortFactoryPublisher;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/port_factory_reader_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_reader_builder.rs
@@ -19,7 +19,6 @@ use crate::api::{
 
 use iceoryx2::port::reader::ReaderCreateError;
 use iceoryx2::service::port_factory::reader::PortFactoryReader;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::{CStrRepr, iceoryx2_ffi};
 

--- a/iceoryx2-ffi/c/src/api/port_factory_request_response.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_request_response.rs
@@ -21,7 +21,6 @@ use iceoryx2::service::dynamic_config::request_response::ServerDetails;
 use iceoryx2::service::{
     dynamic_config::request_response::ClientDetails, port_factory::request_response::PortFactory,
 };
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::{

--- a/iceoryx2-ffi/c/src/api/port_factory_server_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_server_builder.rs
@@ -27,7 +27,6 @@ use super::{
 };
 use core::ffi::{c_char, c_int};
 use iceoryx2::service::port_factory::server::{PortFactoryServer, ServerCreateError};
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::{CStrRepr, iceoryx2_ffi};
 

--- a/iceoryx2-ffi/c/src/api/port_factory_subscriber_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_subscriber_builder.rs
@@ -21,7 +21,6 @@ use crate::api::{
 
 use iceoryx2::port::subscriber::SubscriberCreateError;
 use iceoryx2::service::port_factory::subscriber::PortFactorySubscriber;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/port_factory_writer_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_writer_builder.rs
@@ -19,7 +19,6 @@ use crate::api::{
 
 use iceoryx2::port::writer::WriterCreateError;
 use iceoryx2::service::port_factory::writer::PortFactoryWriter;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/port_name.rs
+++ b/iceoryx2-ffi/c/src/api/port_name.rs
@@ -17,7 +17,6 @@ use crate::api::{
 };
 
 use iceoryx2::prelude::*;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use core::ffi::{c_char, c_int};

--- a/iceoryx2-ffi/c/src/api/publish_subscribe_header.rs
+++ b/iceoryx2-ffi/c/src/api/publish_subscribe_header.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::service::header::publish_subscribe::Header;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::{

--- a/iceoryx2-ffi/c/src/api/publisher.rs
+++ b/iceoryx2-ffi/c/src/api/publisher.rs
@@ -23,7 +23,6 @@ use iceoryx2::port::SendError;
 use iceoryx2::port::publisher::Publisher;
 use iceoryx2::port::update_connections::UpdateConnections;
 use iceoryx2::prelude::*;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/reader.rs
+++ b/iceoryx2-ffi/c/src/api/reader.rs
@@ -25,7 +25,6 @@ use crate::{
 use core::ffi::{c_char, c_int, c_void};
 use core::mem::ManuallyDrop;
 use iceoryx2::port::reader::{EntryHandleError, Reader};
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::{CStrRepr, iceoryx2_ffi};
 

--- a/iceoryx2-ffi/c/src/api/request_header.rs
+++ b/iceoryx2-ffi/c/src/api/request_header.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::service::header::request_response::RequestHeader;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::{

--- a/iceoryx2-ffi/c/src/api/request_mut.rs
+++ b/iceoryx2-ffi/c/src/api/request_mut.rs
@@ -22,7 +22,6 @@ use iceoryx2::port::LoanError;
 use iceoryx2::port::SendError;
 use iceoryx2::port::client::RequestSendError;
 use iceoryx2::request_mut_uninit::RequestMutUninit;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::{CStrRepr, iceoryx2_ffi};
 

--- a/iceoryx2-ffi/c/src/api/response.rs
+++ b/iceoryx2-ffi/c/src/api/response.rs
@@ -16,7 +16,6 @@
 
 use core::{ffi::c_void, mem::ManuallyDrop};
 use iceoryx2::response::Response;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use super::{

--- a/iceoryx2-ffi/c/src/api/response_header.rs
+++ b/iceoryx2-ffi/c/src/api/response_header.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::service::header::request_response::ResponseHeader;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::{

--- a/iceoryx2-ffi/c/src/api/response_mut.rs
+++ b/iceoryx2-ffi/c/src/api/response_mut.rs
@@ -15,7 +15,6 @@
 use core::{ffi::c_int, ffi::c_void, mem::ManuallyDrop};
 
 use iceoryx2::response_mut_uninit::ResponseMutUninit;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::{IOX2_OK, api::IntoCInt};

--- a/iceoryx2-ffi/c/src/api/sample.rs
+++ b/iceoryx2-ffi/c/src/api/sample.rs
@@ -18,7 +18,6 @@ use crate::api::{
 };
 
 use iceoryx2::sample::Sample;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use core::ffi::c_void;

--- a/iceoryx2-ffi/c/src/api/sample_mut.rs
+++ b/iceoryx2-ffi/c/src/api/sample_mut.rs
@@ -18,7 +18,6 @@ use crate::api::{
 };
 
 use iceoryx2::sample_mut_uninit::SampleMutUninit;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use core::ffi::{c_int, c_void};

--- a/iceoryx2-ffi/c/src/api/server.rs
+++ b/iceoryx2-ffi/c/src/api/server.rs
@@ -23,7 +23,6 @@ use super::{PayloadFfi, UserHeaderFfi};
 use core::ffi::c_int;
 use core::mem::ManuallyDrop;
 use iceoryx2::port::server::Server;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 // BEGIN types definition

--- a/iceoryx2-ffi/c/src/api/service_builder.rs
+++ b/iceoryx2-ffi/c/src/api/service_builder.rs
@@ -27,7 +27,6 @@ use iceoryx2::service::builder::{
     request_response::Builder as ServiceBuilderRequestResponse,
 };
 use iceoryx2::service::marker::{CustomHeaderMarker, CustomKeyMarker, CustomPayloadMarker};
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use core::mem::ManuallyDrop;

--- a/iceoryx2-ffi/c/src/api/service_name.rs
+++ b/iceoryx2-ffi/c/src/api/service_name.rs
@@ -19,7 +19,6 @@ use crate::c_size_t;
 
 use iceoryx2::prelude::*;
 use iceoryx2::service::service_name::ServiceNameError;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::{CStrRepr, iceoryx2_ffi};
 

--- a/iceoryx2-ffi/c/src/api/subscriber.rs
+++ b/iceoryx2-ffi/c/src/api/subscriber.rs
@@ -21,7 +21,6 @@ use crate::api::{
 use iceoryx2::port::ReceiveError;
 use iceoryx2::port::subscriber::Subscriber;
 use iceoryx2::port::update_connections::ConnectionFailure;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/unique_client_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_client_id.rs
@@ -15,7 +15,6 @@
 // BEGIN types definition
 
 use iceoryx2::identifiers::UniqueClientId;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use super::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/unique_listener_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_listener_id.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::identifiers::UniqueListenerId;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::api::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/unique_node_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_node_id.rs
@@ -15,7 +15,6 @@
 use crate::api::{AssertNonNullHandle, HandleToType};
 
 use iceoryx2::identifiers::UniqueNodeId;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 // BEGIN type definition

--- a/iceoryx2-ffi/c/src/api/unique_notifier_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_notifier_id.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::identifiers::UniqueNotifierId;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::api::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/unique_publisher_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_publisher_id.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::identifiers::UniquePublisherId;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::api::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/unique_reader_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_reader_id.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::identifiers::UniqueReaderId;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::api::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/unique_server_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_server_id.rs
@@ -15,7 +15,6 @@
 // BEGIN types definition
 
 use iceoryx2::identifiers::UniqueServerId;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use super::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/unique_subscriber_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_subscriber_id.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::identifiers::UniqueSubscriberId;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::api::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/unique_writer_id.rs
+++ b/iceoryx2-ffi/c/src/api/unique_writer_id.rs
@@ -13,7 +13,6 @@
 #![allow(non_camel_case_types)]
 
 use iceoryx2::identifiers::UniqueWriterId;
-use iceoryx2_bb_elementary::static_assert::static_assert_ge;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::api::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/waitset.rs
+++ b/iceoryx2-ffi/c/src/api/waitset.rs
@@ -25,7 +25,6 @@ use super::{AssertNonNullHandle, HandleToType, IntoCInt, iox2_signal_handling_mo
 use iceoryx2::waitset::{
     WaitSet, WaitSetAttachmentError, WaitSetCreateError, WaitSetRunError, WaitSetRunResult,
 };
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::CStrRepr;
 use iceoryx2_ffi_macros::iceoryx2_ffi;

--- a/iceoryx2-ffi/c/src/api/waitset_attachment_id.rs
+++ b/iceoryx2-ffi/c/src/api/waitset_attachment_id.rs
@@ -17,7 +17,6 @@ use core::{ffi::c_char, mem::ManuallyDrop};
 use alloc::format;
 
 use iceoryx2::prelude::WaitSetAttachmentId;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use crate::{c_size_t, iox2_service_type_e, iox2_waitset_guard_h_ref};

--- a/iceoryx2-ffi/c/src/api/waitset_builder.rs
+++ b/iceoryx2-ffi/c/src/api/waitset_builder.rs
@@ -20,7 +20,6 @@ use crate::{
 
 use super::{AssertNonNullHandle, HandleToType, iox2_signal_handling_mode_e};
 use iceoryx2::prelude::WaitSetBuilder;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 #[repr(C)]

--- a/iceoryx2-ffi/c/src/api/waitset_guard.rs
+++ b/iceoryx2-ffi/c/src/api/waitset_guard.rs
@@ -16,7 +16,6 @@ use core::mem::ManuallyDrop;
 
 use crate::iox2_service_type_e;
 use iceoryx2::waitset::WaitSetGuard;
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_ffi_macros::iceoryx2_ffi;
 
 use super::{AssertNonNullHandle, HandleToType};

--- a/iceoryx2-ffi/c/src/api/writer.rs
+++ b/iceoryx2-ffi/c/src/api/writer.rs
@@ -21,7 +21,6 @@ use crate::create_type_details;
 use core::ffi::{c_char, c_int, c_void};
 use core::mem::ManuallyDrop;
 use iceoryx2::port::writer::{EntryHandleMutError, Writer};
-use iceoryx2_bb_elementary::static_assert::*;
 use iceoryx2_bb_elementary_traits::AsCStr;
 use iceoryx2_ffi_macros::{CStrRepr, iceoryx2_ffi};
 

--- a/iceoryx2-ffi/ffi-macros/src/lib.rs
+++ b/iceoryx2-ffi/ffi-macros/src/lib.rs
@@ -96,14 +96,14 @@ pub fn iceoryx2_ffi(args: TokenStream, input: TokenStream) -> TokenStream {
     let expanded = quote! {
         impl #struct_storage_name {
             const fn assert_storage_layout() {
-                static_assert_ge::<
-                { ::core::mem::align_of::<#struct_storage_name>() },
-                { ::core::mem::align_of::<Option<#my_type>>() },
-                >();
-                static_assert_ge::<
-                { ::core::mem::size_of::<#struct_storage_name>() },
-                { ::core::mem::size_of::<Option<#my_type>>() },
-                >();
+                iceoryx2_bb_elementary::static_assert_ge!(
+                    ::core::mem::align_of::<#struct_storage_name>(),
+                    ::core::mem::align_of::<Option<#my_type>>()
+                );
+                iceoryx2_bb_elementary::static_assert_ge!(
+                    ::core::mem::size_of::<#struct_storage_name>(),
+                    ::core::mem::size_of::<Option<#my_type>>()
+                );
             }
 
             fn init(&mut self, value: #my_type) {

--- a/iceoryx2/src/service/resource/blackboard.rs
+++ b/iceoryx2/src/service/resource/blackboard.rs
@@ -33,7 +33,7 @@ use iceoryx2_bb_container::string::String;
 use iceoryx2_bb_container::vector::Vector;
 use iceoryx2_bb_container::{flatmap::RelocatableFlatMap, vector::RelocatableVec};
 use iceoryx2_bb_derive_macros::ZeroCopySend;
-use iceoryx2_bb_elementary::static_assert::static_assert_eq;
+use iceoryx2_bb_elementary::static_assert_align_of;
 use iceoryx2_bb_elementary_traits::{
     testing::abandonable::Abandonable, zero_copy_send::ZeroCopySend,
 };
@@ -64,19 +64,19 @@ pub struct KeyMemory<const CAPACITY: usize> {
 
 impl<const CAPACITY: usize> KeyMemory<CAPACITY> {
     pub fn try_from<T: Copy>(value: &T) -> Result<Self, KeyMemoryError> {
-        static_assert_eq::<{ align_of::<KeyMemory<1>>() }, MAX_BLACKBOARD_KEY_ALIGNMENT>();
+        static_assert_align_of!(KeyMemory<1>, MAX_BLACKBOARD_KEY_ALIGNMENT);
 
         let origin = "KeyMemory::try_from()";
         let msg = "Unable to create KeyMemory";
 
         // Replace if block with below compile-time assertion once available for generic parameters
-        // static_assert_le::<{ size_of::<T>() }, CAPACITY>();
+        // static_assert_size_of_le!(T, CAPACITY);
         if size_of::<T>() > CAPACITY {
             fail!(from origin, with KeyMemoryError::ValueTooLarge,
                 "{} since the passed value is too large. Its size must be <= {}.", msg, CAPACITY);
         }
         // Replace if block with below compile-time assertion once available for generic parameters
-        // static_assert_le::<{ align_of::<T>() }, MAX_BLACKBOARD_KEY_ALIGNMENT>();
+        // static_assert_align_of_le!(T, MAX_BLACKBOARD_KEY_ALIGNMENT);
         if align_of::<T>() > MAX_BLACKBOARD_KEY_ALIGNMENT {
             fail!(from origin, with KeyMemoryError::ValueAlignmentTooLarge,
                 "{} since the alignment of the passed value is too large. The alignment must be <= {}.",
@@ -94,7 +94,7 @@ impl<const CAPACITY: usize> KeyMemory<CAPACITY> {
     ///
     ///   * see Safety section of core::ptr::copy_nonoverlapping
     pub unsafe fn try_from_ptr(ptr: *const u8, key_layout: Layout) -> Result<Self, KeyMemoryError> {
-        static_assert_eq::<{ align_of::<KeyMemory<1>>() }, MAX_BLACKBOARD_KEY_ALIGNMENT>();
+        static_assert_align_of!(KeyMemory<1>, MAX_BLACKBOARD_KEY_ALIGNMENT);
 
         let origin = "KeyMemory::try_from_ptr()";
         let msg = "Unable to create KeyMemory";


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR improves the error message for the static asserts, especially the `static_assert_size_of` and also adds a `static_assert_align_of` to complete the layout asserts.

The newly introduced macros are used throughout the codebase.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1853 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
