### PR TITLE
[#1680] Add waitset test that blocks after a consumed event with multiple listeners

### DIFF
--- a/iceoryx2/conformance-tests/src/waitset.rs
+++ b/iceoryx2/conformance-tests/src/waitset.rs
@@ -308,6 +308,61 @@ pub mod waitset {
     }
 
     #[conformance_test]
+    pub fn wait_and_process_once_with_timeout_blocks_after_consumed_event_with_multiple_listeners<
+        S: Service,
+    >()
+    where
+        <S::Event as Event<RelocatableCountingBitSet>>::Listener: SynchronousMultiplexing,
+    {
+        let test = Test::<S>::new_with_custom_watchdog(Watchdog::new_with_timeout(TIMEOUT * 40));
+        let node = test.create_node();
+        let sut = WaitSetBuilder::new().create::<S>().unwrap();
+
+        let (listener_1, notifier_1) = create_event::<S>(&node);
+        let (listener_2, _notifier_2) = create_event::<S>(&node);
+
+        let guard_1 = sut.attach_notification(&listener_1).unwrap();
+        let _guard_2 = sut.attach_notification(&listener_2).unwrap();
+
+        notifier_1.notify().unwrap();
+
+        // the pending event is delivered and consumed here, therefore this call
+        // is allowed to return before the timeout has passed
+        let mut event_was_delivered = false;
+        sut.wait_and_process_once_with_timeout(
+            |attachment_id| {
+                if attachment_id.has_event_from(&guard_1) {
+                    listener_1.try_wait(|_| {}).unwrap();
+                    event_was_delivered = true;
+                }
+                CallbackProgression::Continue
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+
+        assert_that!(event_was_delivered, eq true);
+
+        // with the event consumed, every further call must block for the full
+        // timeout again instead of returning immediately
+        for _ in 0..3 {
+            let mut callback_called = false;
+            let start = Time::now().unwrap();
+            sut.wait_and_process_once_with_timeout(
+                |_| {
+                    callback_called = true;
+                    CallbackProgression::Continue
+                },
+                TIMEOUT,
+            )
+            .unwrap();
+
+            assert_that!(callback_called, eq false);
+            assert_that!(start.elapsed().unwrap(), time_at_least TIMEOUT);
+        }
+    }
+
+    #[conformance_test]
     pub fn wait_and_process_once_does_block_until_interval_when_user_timeout_is_larger<S: Service>()
     where
         <S::Event as Event<RelocatableCountingBitSet>>::Listener: SynchronousMultiplexing,


### PR DESCRIPTION
## Notes for Reviewer

@elBoberido this is the test you asked for in #1680.

The existing `wait_and_process_once_with_timeout_blocks_at_each_invocation` attaches a single listener and never fires an event, so it doesn't cover the reported scenario. This one attaches two listeners, fires one event, consumes it in the callback, and then checks that the following calls still block for the full timeout.

The bug itself is already gone, so this passes on current main. To make sure the test wasn't passing for the wrong reason, I removed the `try_wait` drain to recreate the old behaviour and confirmed all four service variants fail with:

```
assertion failed: expr: callback_called == false;  value: true == false
```

which is the reported symptom. Restored it afterwards and it's green again.

No changelog entry, since test-only changes don't appear to get one (e.g. `31d03b36e` for #1763). Happy to add one if you'd rather have it.

Checked with `cargo fmt` and `cargo test --workspace` on aarch64 macOS, 76 waitset tests pass.

Left this as `Relates to` rather than `Closes` since @gelanchez hasn't confirmed on Linux yet, so you may want to keep the issue open until then.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
* [x] Relevant issues are linked in the References section
* [x] Branch follows the naming format (`iox2-1680-waitset-blocks-after-event-with-multiple-listeners`)
* [x] Commits messages are according to commit message guidelines
    * [x] Commit messages have the issue ID (`[#1680]`)
* [x] Tests follow best practice for testing guidelines
* [~] Changelog updated in the unreleased section including API breaking changes - not applicable, test-only change, see notes

## References

Relates to #1680
