### PR TITLE
[#1788] Skip non-UTF-8 entries in Node::list() instead of panicking

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -44,6 +44,7 @@
 * [#1746](https://github.com/eclipse-iceoryx/iceoryx2/issues/1746) Disable `POSIX_SUPPORT_FILE_LOCK_FOR_SHARED_MEMORY` on FreeBSD and move CI job for FreeBSD to main pipeline
 * [#1777](https://github.com/eclipse-iceoryx/iceoryx2/issues/1777) Fix service root folder creation named concept of iceoryx2-cal fixing execution on Windows platform.
 * [#1786](https://github.com/eclipse-iceoryx/iceoryx2/issues/1786) Disable transport_compression feature in Zenoh.
+* [#1788](https://github.com/eclipse-iceoryx/iceoryx2/issues/1788) Skip non-UTF-8 entries in `Node::list()` instead of panicking.
 * [#1792](https://github.com/eclipse-iceoryx/iceoryx2/issues/1792) Set key eq comparison function in language bindings for blackboard opener.
 * [#1797](https://github.com/eclipse-iceoryx/iceoryx2/issues/1797) Reclaim disconnected request-response client connections when fire-and-forget requests are disabled.
 * [#1800](https://github.com/eclipse-iceoryx/iceoryx2/issues/1800) iceoryx2-cxx: CleanupState is defined in global namespace

--- a/iceoryx2/src/node/mod.rs
+++ b/iceoryx2/src/node/mod.rs
@@ -1167,10 +1167,12 @@ impl<Service: service::Service> Node<Service> {
         match Self::list_all_nodes(&monitoring_config) {
             Ok(node_list) => {
                 for node_name in node_list {
-                    let node_id = core::str::from_utf8(node_name.as_bytes()).unwrap();
+                    // not bad, just found a file that is not a node
+                    let Ok(node_id) = core::str::from_utf8(node_name.as_bytes()) else {
+                        continue;
+                    };
                     let node_id = match node_id.parse::<u128>() {
                         Ok(v) => UniqueNodeId(v.into()),
-                        // not bad, just found a file that is not a node
                         Err(_) => continue,
                     };
 


### PR DESCRIPTION
## Notes for Reviewer

Small hardening change. `Node::list()` had one remaining `unwrap` at `node/mod.rs:1170`:

```rust
let node_id = core::str::from_utf8(node_name.as_bytes()).unwrap();
```

The `parse::<u128>()` immediately below already skips entries that aren't nodes, so this just makes the UTF-8 check behave the same way.

Worth being upfront: I could not get this to panic on either platform tested. On Linux the directory-entry layer rejects the name before it reaches this line (per @dkroenke in #1788), and on macOS APFS refuses to create a non-UTF-8 filename at all, failing with `Illegal byte sequence (os error 92)`. So this is defence-in-depth rather than a fix for a live crash. Happy to drop it if you'd rather not carry the change.

No test added, for the same reason: I can't construct the triggering condition on macOS, so a test would have to be Linux-only or mock the directory listing. Let me know if you want one and how you'd prefer it scoped.

Checked with `cargo fmt`, `cargo clippy` and `cargo test --workspace` on aarch64 macOS. 376 node tests pass. The one clippy warning is in `iceoryx2-bb-posix` and is untouched by this change.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
* [x] Relevant issues are linked in the References section
* [x] Branch follows the naming format (`iox2-1788-harden-node-list-against-non-utf8-names`)
* [x] Commits messages are according to commit message guidelines
    * [x] Commit messages have the issue ID (`[#1788]`)
* [ ] Tests follow best practice for testing guidelines - no test added, see notes above
* [x] Changelog updated in the unreleased section including API breaking changes

## References

Relates to #1788
