### PR TITLE
[#1664] Use originating function name as log origin instead of Debug dump

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -60,6 +60,7 @@
 
 * [#996](https://github.com/eclipse-iceoryx/iceoryx2/issues/996) Move BumpAllocator from iceoryx2-bb-memory into iceoryx2-bb-elementary
 * [#1613](https://github.com/eclipse-iceoryx/iceoryx2/issues/1613) Remove `NonNullCompat` after moving to Rust 1.89
+* [#1664](https://github.com/eclipse-iceoryx/iceoryx2/issues/1664) Use the originating function name as log origin instead of a `Debug` dump of the whole builder
 * [#1776](https://github.com/eclipse-iceoryx/iceoryx2/issues/1776) Rename AtomicCopy::__for_each_field() to for_each_field()
 * [#1845](https://github.com/eclipse-iceoryx/iceoryx2/issues/1845) Reduce imports for usage of the `semantic_string` macro
 * [#1853](https://github.com/eclipse-iceoryx/iceoryx2/issues/1853) Improve error message in static asserts

--- a/iceoryx2-bb/linux/src/epoll.rs
+++ b/iceoryx2-bb/linux/src/epoll.rs
@@ -322,7 +322,7 @@ impl EpollBuilder {
             });
         }
 
-        let origin = format!("{self:?}");
+        let origin = "EpollBuilder::create()";
         let signal_fd = match SignalFdBuilder::new(self.signal_set)
             .set_close_on_exec(self.has_close_on_exec_flag)
             .create_non_blocking()

--- a/iceoryx2-bb/posix/src/read_write_mutex.rs
+++ b/iceoryx2-bb/posix/src/read_write_mutex.rs
@@ -55,8 +55,6 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use alloc::format;
-
 use iceoryx2_bb_concurrency::cell::UnsafeCell;
 use iceoryx2_bb_elementary::{enum_gen, scope_guard::ScopeGuardBuilder};
 use iceoryx2_log::{fail, fatal_panic, warn};
@@ -142,7 +140,7 @@ impl ReadWriteMutexBuilder {
         mtx: *mut posix::pthread_rwlock_t,
     ) -> Result<Capability, ReadWriteMutexCreationError> {
         let msg = "Failed to create mutex";
-        let origin = format!("{self:?}");
+        let origin = "ReadWriteMutexBuilder::initialize_rw_mutex()";
 
         let mut attributes = ScopeGuardBuilder::new(posix::pthread_rwlockattr_t::new_zeroed()).on_init(|attr| {
             handle_errno!(ReadWriteMutexCreationError, from self,

--- a/iceoryx2-cal/src/communication_channel/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/communication_channel/posix_shared_memory.rs
@@ -16,7 +16,6 @@
 //! It uses internally a [`DynamicStorage`] and [`SafelyOverflowingIndexQueue`].
 pub use crate::communication_channel::*;
 
-use alloc::format;
 use alloc::vec::Vec;
 use core::ptr::NonNull;
 use iceoryx2_bb_derive_macros::ZeroCopySend;
@@ -248,7 +247,7 @@ impl CommunicationChannelConnector<u64, Channel> for Connector {
 
     fn open_sender(self) -> Result<Sender, CommunicationChannelOpenError> {
         let msg = "Unable to open communication channel";
-        let origin = format!("{self:?}");
+        let origin = "posix_shared_memory::Connector::open_sender()";
         match self.try_open_sender() {
             Ok(s) => Ok(s),
             Err(CommunicationChannelOpenError::DoesNotExist) => {

--- a/iceoryx2-cal/src/communication_channel/process_local.rs
+++ b/iceoryx2-cal/src/communication_channel/process_local.rs
@@ -20,7 +20,6 @@ use core::fmt::Debug;
 use core::ptr::NonNull;
 
 use alloc::collections::BTreeMap;
-use alloc::format;
 use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -198,7 +197,7 @@ impl NamedConceptBuilder<Channel> for Connector {
 impl CommunicationChannelConnector<u64, Channel> for Connector {
     fn open_sender(self) -> Result<Duplex, CommunicationChannelOpenError> {
         let msg = "Failed to open sender";
-        let origin = format!("{self:?}");
+        let origin = "process_local::Connector::open_sender()";
         let name = self.name;
         match self.try_open_sender() {
             Err(CommunicationChannelOpenError::DoesNotExist) => {

--- a/iceoryx2-cal/src/communication_channel/unix_datagram.rs
+++ b/iceoryx2-cal/src/communication_channel/unix_datagram.rs
@@ -337,7 +337,7 @@ impl<T: Copy + Debug> NamedConceptBuilder<Channel<T>> for Connector<T> {
 impl<T: Copy + Debug> CommunicationChannelConnector<T, Channel<T>> for Connector<T> {
     fn open_sender(self) -> Result<Sender<T>, CommunicationChannelOpenError> {
         let msg = "Unable to create sender";
-        let origin = format!("{self:?}");
+        let origin = "unix_datagram::Connector::open_sender()";
 
         let full_name = self.config.path_for(&self.channel_name);
         let sender = UnixDatagramSenderBuilder::new(&full_name).create();

--- a/iceoryx2-cal/src/dynamic_storage/file.rs
+++ b/iceoryx2-cal/src/dynamic_storage/file.rs
@@ -399,7 +399,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
             supplementary_len,
         );
 
-        let origin = format!("{self:?}");
+        let origin = "dynamic_storage::file::Builder::init_impl()";
         if !self
             .initializer
             .call(unsafe { &mut (*value).data }, &mut allocator)

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -56,7 +56,6 @@ use core::ptr::NonNull;
 use core::time::Duration;
 use iceoryx2_bb_concurrency::atomic::Ordering;
 
-use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::vec;
@@ -350,7 +349,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
             supplementary_len,
         );
 
-        let origin = format!("{self:?}");
+        let origin = "dynamic_storage::posix_shared_memory::Builder::init_impl()";
         if !self
             .initializer
             .call(unsafe { &mut (*value).data }, &mut allocator)

--- a/iceoryx2-cal/src/dynamic_storage/process_local.rs
+++ b/iceoryx2-cal/src/dynamic_storage/process_local.rs
@@ -52,7 +52,6 @@ use core::ptr::NonNull;
 use iceoryx2_bb_concurrency::atomic::Ordering;
 
 use alloc::collections::BTreeMap;
-use alloc::format;
 use alloc::string::String;
 use alloc::string::ToString;
 use alloc::sync::Arc;
@@ -424,7 +423,7 @@ impl<T: Send + Sync + Debug + 'static + ZeroCopySend> Builder<'_, T> {
             self.supplementary_size,
         );
 
-        let origin = format!("{self:?}");
+        let origin = "dynamic_storage::process_local::Builder::create_impl()";
         if !self
             .initializer
             .call(unsafe { &mut *value }, &mut allocator)

--- a/iceoryx2-cal/src/reactor/epoll.rs
+++ b/iceoryx2-cal/src/reactor/epoll.rs
@@ -171,7 +171,7 @@ impl ReactorBuilder<Epoll> for EpollBuilder {
 
     fn create(self) -> Result<Epoll, ReactorCreateError> {
         let msg = "Unable to create epoll::Reactor";
-        let origin = format!("{self:?}");
+        let origin = "reactor::epoll::EpollBuilder::create()";
         match self.create() {
             Ok(v) => Ok(v),
             Err(EpollCreateError::InsufficientMemory)

--- a/iceoryx2-cal/src/resizable_shared_memory/dynamic.rs
+++ b/iceoryx2-cal/src/resizable_shared_memory/dynamic.rs
@@ -186,7 +186,7 @@ where
         self,
         access_mode: AccessMode,
     ) -> Result<DynamicView<Allocator, Shm>, SharedMemoryOpenError> {
-        let origin = format!("{self:?}");
+        let origin = "DynamicViewBuilder::open()";
         let msg = "Unable to open ResizableSharedMemoryView";
 
         let adjusted_name =
@@ -277,7 +277,7 @@ where
 
     fn create(mut self) -> Result<DynamicMemory<Allocator, Shm>, SharedMemoryCreateError> {
         let msg = "Unable to create ResizableSharedMemory";
-        let origin = format!("{self:?}");
+        let origin = "DynamicMemoryBuilder::create()";
 
         let hint = Allocator::initial_setup_hint(Layout::new::<u8>(), 1);
         let adjusted_name =

--- a/iceoryx2-userland/record-and-replay/src/record.rs
+++ b/iceoryx2-userland/record-and-replay/src/record.rs
@@ -263,7 +263,7 @@ impl<'a> RecordWriter<'a> {
     }
 
     pub(crate) fn write(self, record: RawRecord) -> Result<(), RecorderWriteError> {
-        let origin = format!("{self:?}");
+        let origin = "RecordWriter::write()";
         let mut write_to_file = |data| -> Result<(), RecorderWriteError> {
             match self.file.write(data) {
                 Ok(_) => Ok(()),

--- a/iceoryx2/src/service/builder/blackboard.rs
+++ b/iceoryx2/src/service/builder/blackboard.rs
@@ -19,7 +19,6 @@ use core::hash::Hash;
 use core::marker::PhantomData;
 
 use alloc::boxed::Box;
-use alloc::format;
 use alloc::vec::Vec;
 
 use crate::constants::MAX_BLACKBOARD_KEY_SIZE;
@@ -493,7 +492,7 @@ impl<
 
     /// Validates configuration and overrides the invalid setting with meaningful values.
     fn adjust_configuration_to_meaningful_values(&mut self) {
-        let origin = format!("{self:?}");
+        let origin = "blackboard::Builder::adjust_configuration_to_meaningful_values()";
         let settings = self.builder.config.base.service_config.blackboard_mut();
 
         if settings.max_readers == 0 {
@@ -529,7 +528,7 @@ impl<
         mut self,
         attributes: &AttributeSpecifier,
     ) -> Result<blackboard::PortFactory<ServiceType, KeyType>, BlackboardCreateError> {
-        let origin = format!("{self:?}");
+        let origin = "blackboard::Builder::create_impl()";
         let msg = "Unable to create blackboard service";
 
         self.adjust_configuration_to_meaningful_values();

--- a/iceoryx2/src/service/builder/event.rs
+++ b/iceoryx2/src/service/builder/event.rs
@@ -17,8 +17,6 @@
 pub use crate::port::event_id::EventId;
 use crate::service::resource::NoResource;
 
-use alloc::format;
-
 use iceoryx2_bb_container::relocatable_option::RelocatableOption;
 use iceoryx2_bb_posix::clock::Time;
 use iceoryx2_log::{fail, fatal_panic};
@@ -509,7 +507,7 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
         &self,
         attributes: &AttributeSpecifier,
     ) -> Result<event::PortFactory<ServiceType>, EventCreateError> {
-        let origin = format!("{self:?}");
+        let origin = "event::Builder::create_impl()";
         let msg = "Unable to create event service";
 
         let prepare_static_config = |service_config: &mut StaticConfig| {
@@ -554,7 +552,7 @@ impl<ServiceType: service::Service> Builder<ServiceType> {
     }
 
     fn adjust_attributes_to_meaningful_values(&mut self) {
-        let origin = format!("{self:?}");
+        let origin = "event::Builder::adjust_attributes_to_meaningful_values()";
         let settings = self.base.service_config.event_mut();
 
         if settings.max_notifiers == 0 {

--- a/iceoryx2/src/service/builder/mod.rs
+++ b/iceoryx2/src/service/builder/mod.rs
@@ -31,7 +31,6 @@ use core::hash::Hash;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
-use alloc::format;
 use alloc::string::String;
 use alloc::vec;
 
@@ -473,7 +472,7 @@ impl<ServiceType: service::Service> BuilderWithServiceType<ServiceType> {
         mut verify_service_configuration: F1,
         mut open_service_resource: F2,
     ) -> Result<service::ServiceState<ServiceType, R>, ErrorType> {
-        let origin = format!("{self:?}");
+        let origin = "BuilderWithServiceType::open()";
         let config = self.shared_node.config();
 
         if config.global.service.cleanup_dead_nodes_on_open {

--- a/iceoryx2/src/service/builder/publish_subscribe.rs
+++ b/iceoryx2/src/service/builder/publish_subscribe.rs
@@ -16,8 +16,6 @@
 //!
 use core::marker::PhantomData;
 
-use alloc::format;
-
 use iceoryx2_bb_elementary::alignment::Alignment;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_bb_flatbuffers::TypeName;
@@ -562,7 +560,7 @@ impl<
 
     /// Validates configuration and overrides the invalid setting with meaningful values.
     fn adjust_configuration_to_meaningful_values(&mut self) {
-        let origin = format!("{self:?}");
+        let origin = "publish_subscribe::Builder::adjust_configuration_to_meaningful_values()";
         let settings = self.base.service_config.publish_subscribe_mut();
 
         if settings.subscriber_max_borrowed_samples == 0 {

--- a/iceoryx2/src/service/builder/request_response.rs
+++ b/iceoryx2/src/service/builder/request_response.rs
@@ -13,8 +13,6 @@
 use core::fmt::Debug;
 use core::marker::PhantomData;
 
-use alloc::format;
-
 use iceoryx2_bb_elementary::alignment::Alignment;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_log::{fail, fatal_panic, warn};
@@ -596,7 +594,7 @@ impl<
     }
 
     fn adjust_configuration_to_meaningful_values(&mut self) {
-        let origin = format!("{self:?}");
+        let origin = "request_response::Builder::adjust_configuration_to_meaningful_values()";
         let settings = self.base.service_config.request_response_mut();
 
         if settings.max_response_buffer_size == 0 {

--- a/iceoryx2/src/service/port_factory/client.rs
+++ b/iceoryx2/src/service/port_factory/client.rs
@@ -38,7 +38,6 @@ use crate::{
     prelude::BackpressureStrategy,
     service,
 };
-use alloc::format;
 use core::fmt::Debug;
 use iceoryx2_bb_elementary::allocation_strategy::AllocationStrategy;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
@@ -302,7 +301,7 @@ impl<
         Client<Service, RequestPayload, RequestHeader, ResponsePayload, ResponseHeader>,
         ClientCreateError,
     > {
-        let origin = format!("{self:?}");
+        let origin = "PortFactoryClient::create()";
         Ok(fail!(from origin,
               when Client::new(self),
               "Failed to create new Client port."))

--- a/iceoryx2/src/service/port_factory/publisher.rs
+++ b/iceoryx2/src/service/port_factory/publisher.rs
@@ -63,7 +63,6 @@ use crate::{
     },
     service::{self, marker::Flatbuffer},
 };
-use alloc::format;
 use core::fmt::Debug;
 use iceoryx2_bb_elementary::allocation_strategy::AllocationStrategy;
 use iceoryx2_bb_elementary_traits::{iceoryx_send::IceoryxSend, zero_copy_send::ZeroCopySend};
@@ -244,7 +243,7 @@ impl<
 
     /// Creates a new [`Publisher`] or returns a [`PublisherCreateError`] on failure.
     pub fn create(self) -> Result<Publisher<Service, Payload, UserHeader>, PublisherCreateError> {
-        let origin = format!("{self:?}");
+        let origin = "PortFactoryPublisher::create()";
         Ok(fail!(from origin, when Publisher::new(self),
                 "Failed to create new Publisher port."))
     }

--- a/iceoryx2/src/service/port_factory/reader.rs
+++ b/iceoryx2/src/service/port_factory/reader.rs
@@ -32,8 +32,6 @@
 use core::fmt::Debug;
 use core::hash::Hash;
 
-use alloc::format;
-
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_log::fail;
 
@@ -83,7 +81,7 @@ impl<
 
     /// Creates a new [`Reader`] or returns a [`ReaderCreateError`] on failure.
     pub fn create(self) -> Result<Reader<Service, KeyType>, ReaderCreateError> {
-        let origin = format!("{self:?}");
+        let origin = "PortFactoryReader::create()";
         Ok(
             fail!(from origin, when Reader::new(self.factory.service.clone(), self.config.clone()),"Failed to create new Reader port."),
         )

--- a/iceoryx2/src/service/port_factory/server.rs
+++ b/iceoryx2/src/service/port_factory/server.rs
@@ -42,7 +42,6 @@ use crate::{
     prelude::BackpressureStrategy,
     service,
 };
-use alloc::format;
 use core::fmt::Debug;
 use iceoryx2_bb_elementary::allocation_strategy::AllocationStrategy;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
@@ -309,7 +308,7 @@ impl<
         Server<Service, RequestPayload, RequestHeader, ResponsePayload, ResponseHeader>,
         ServerCreateError,
     > {
-        let origin = format!("{self:?}");
+        let origin = "PortFactoryServer::create()";
         Ok(fail!(from origin,
               when Server::new(self),
               "Failed to create new Server port."))

--- a/iceoryx2/src/service/port_factory/subscriber.rs
+++ b/iceoryx2/src/service/port_factory/subscriber.rs
@@ -30,8 +30,6 @@
 
 use core::fmt::Debug;
 
-use alloc::format;
-
 use iceoryx2_bb_elementary_traits::{iceoryx_send::IceoryxSend, zero_copy_send::ZeroCopySend};
 use iceoryx2_log::fail;
 
@@ -143,7 +141,7 @@ impl<
     pub fn create(
         self,
     ) -> Result<Subscriber<Service, PayloadType, UserHeader>, SubscriberCreateError> {
-        let origin = format!("{self:?}");
+        let origin = "PortFactorySubscriber::create()";
         Ok(
             fail!(from origin, when Subscriber::new(self.factory.service.clone(), self.factory.service.static_config().publish_subscribe(), self.config),
                 "Failed to create new Subscriber port."),

--- a/iceoryx2/src/service/port_factory/writer.rs
+++ b/iceoryx2/src/service/port_factory/writer.rs
@@ -32,8 +32,6 @@
 use core::fmt::Debug;
 use core::hash::Hash;
 
-use alloc::format;
-
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
 use iceoryx2_log::fail;
 
@@ -83,7 +81,7 @@ impl<
 
     /// Creates a new [`Writer`] or returns a [`WriterCreateError`] on failure.
     pub fn create(self) -> Result<Writer<Service, KeyType>, WriterCreateError> {
-        let origin = format!("{self:?}");
+        let origin = "PortFactoryWriter::create()";
         Ok(
             fail!(from origin, when Writer::new(self.factory.service.clone(), self.config.clone()),"Failed to create new Writer port."),
         )

--- a/iceoryx2/src/service/static_config/mod.rs
+++ b/iceoryx2/src/service/static_config/mod.rs
@@ -30,8 +30,6 @@ pub mod messaging_pattern;
 
 pub mod blackboard;
 
-use alloc::format;
-
 use iceoryx2_bb_derive_macros::ZeroCopySend;
 use iceoryx2_bb_elementary::package_version::PackageVersion;
 use iceoryx2_bb_elementary_traits::zero_copy_send::ZeroCopySend;
@@ -179,7 +177,7 @@ impl StaticConfig {
     }
 
     pub(crate) fn request_response_mut(&mut self) -> &mut request_response::StaticConfig {
-        let origin = format!("{self:?}");
+        let origin = "StaticConfig::request_response_mut()";
         match &mut self.messaging_pattern {
             MessagingPattern::RequestResponse(v) => v,
             m => {
@@ -199,7 +197,7 @@ impl StaticConfig {
     }
 
     pub(crate) fn event_mut(&mut self) -> &mut event::StaticConfig {
-        let origin = format!("{self:?}");
+        let origin = "StaticConfig::event_mut()";
         match &mut self.messaging_pattern {
             MessagingPattern::Event(v) => v,
             m => {
@@ -219,7 +217,7 @@ impl StaticConfig {
     }
 
     pub(crate) fn publish_subscribe_mut(&mut self) -> &mut publish_subscribe::StaticConfig {
-        let origin = format!("{self:?}");
+        let origin = "StaticConfig::publish_subscribe_mut()";
         match &mut self.messaging_pattern {
             MessagingPattern::PublishSubscribe(v) => v,
             m => {
@@ -239,7 +237,7 @@ impl StaticConfig {
     }
 
     pub(crate) fn blackboard_mut(&mut self) -> &mut blackboard::StaticConfig {
-        let origin = format!("{self:?}");
+        let origin = "StaticConfig::blackboard_mut()";
         match &mut self.messaging_pattern {
             MessagingPattern::Blackboard(v) => v,
             m => {


### PR DESCRIPTION
## Notes for Reviewer

Follow up to the discussion in #1664, covering the "shorter origin" part only. PID and executable name are not in here, for the reasons in the issue comment.

29 call sites built their log origin with `format!("{self:?}")`, which dumps the whole builder. For a service builder warning that comes to 6493 characters, and the identifying parts sit far enough in that truncating in the logger doesn't help. `service_name` starts at char 280, the name itself at 352.

This replaces them with the name of the originating function, which is what the other 133 origin sites in the tree already do (`let origin = "Config::global_config()";` and so on). Before:

```
0 [W] "Builder { base: BuilderWithServiceType { service_config: StaticConfig { iceoryx2_version: PackageVersion { ... 6493 chars ... }"
| Setting the subscribers max borrowed samples to 0 is not supported. Adjust it to 1, the smallest supported value.
```

After:

```
0 [W] "publish_subscribe::Builder::adjust_configuration_to_meaningful_values()"
| Setting the subscribers max borrowed samples to 0 is not supported. Adjust it to 1, the smallest supported value.
```

Two things worth mentioning:

Most of these sites used `format!("{self:?}")` because `self` gets moved or mutably borrowed further down, so a `Debug` snapshot was the easy way to keep something to log. A `&'static str` sidesteps that, and drops an allocation from each of these paths, which is a small step towards #1450.

Removing the `format!` calls left 17 `use alloc::format;` imports unused, so those are gone too. I checked each file has no remaining `format!` usage rather than relying on the warning alone, in case any were feature gated.

No behaviour change beyond the log text. `cargo fmt`, `cargo clippy --workspace --all-targets` and `cargo test --workspace` are clean on aarch64 macOS. The one clippy warning in `iceoryx2-bb-posix` is present on main too.

Naming is the part I would most like input on. I used `Type::method()`, module qualified where the type name alone would be ambiguous, e.g. `posix_shared_memory::Connector::open_sender()`. Happy to change the scheme, it is a single line per site.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
* [x] Relevant issues are linked in the References section
* [x] Branch follows the naming format (`iox2-1664-replace-debug-dump-origins`)
* [x] Commits messages are according to commit message guidelines
    * [x] Commit messages have the issue ID (`[#1664]`)
* [ ] Tests follow best practice for testing guidelines - no new tests, log output only, see notes
* [x] Changelog updated in the unreleased section including API breaking changes

## References

Relates to #1664
