### PR TITLE
[#4] Fix typos in docs, comments and string literals

### DIFF
--- a/FAQ_ICEORYX_DEVS.md
+++ b/FAQ_ICEORYX_DEVS.md
@@ -25,7 +25,7 @@ Users can override the log level in the following ways:
 
 ## Tests marked with `#[should_panic]` attribute do not panic in release builds
 
-This usually happens when the panic is triggert via a `debug_assert` macro.
+This usually happens when the panic is triggered via a `debug_assert` macro.
 This macro is not active when the `-C debug-assertions` flag is not set, which
 is the case for release builds.
 To fix this problem, just add a `#[cfg(debug_assertions)]` to the test.

--- a/component-tests/cxx/src/test_containers.cpp
+++ b/component-tests/cxx/src/test_containers.cpp
@@ -117,7 +117,7 @@ auto check_metrics_for_vector(ContainerTestRequest const& req) -> bool {
     }
     if ((stats.storage_metrics.storage_alignment > std::numeric_limits<int32_t>::max())
         || (static_cast<int32_t>(stats.storage_metrics.storage_alignment) != req.container_alignment)) {
-        std::cout << "Storage alignmnent mismatch\n";
+        std::cout << "Storage alignment mismatch\n";
         return false;
     }
     if ((stats.storage_metrics.sizeof_bytes > std::numeric_limits<int32_t>::max())

--- a/config/README.md
+++ b/config/README.md
@@ -210,11 +210,11 @@ for the runtime configuration in TOML format as described above.
 
 The default settings are already tailored to the most common
 operating systems but it can happen that users may face a specific limitation
-(e.g. the `TEMP_DIRECTORY` is not writeable) on their specific platform.
+(e.g. the `TEMP_DIRECTORY` is not writable) on their specific platform.
 To provide the flexibility to easily handle such cases, it is possible to
 define a custom platform configuration to be used in the build.
 
-The first step is to create a file with custom configurtion
+The first step is to create a file with custom configuration
 at any location (e.g. `/my/funky/platform/platform_configuration.rs`).
 
 An example configuration may look like this, however be sure to check the

--- a/doc/development-setup/android.md
+++ b/doc/development-setup/android.md
@@ -93,7 +93,7 @@ sudo systemctl restart waydroid-container.service
 
 The `suspend` property prevents the Android session to activate the lock-screen.
 Without turning suspend off, the `adb` commands will fail a few minutes after
-the last interaction with `waydroid`. Alternatively, the option could als be set
+the last interaction with `waydroid`. Alternatively, the option could also be set
 via `adb` with:
 
 ```bash

--- a/doc/how-to-write-conformance-tests.md
+++ b/doc/how-to-write-conformance-tests.md
@@ -188,8 +188,8 @@ conformance test module:
 
 ```rs
 trait Foo {}
-struc Bar {}
-struc Baz {}
+struct Bar {}
+struct Baz {}
 
 impl Foo for Bar {}
 impl Foo for Baz {}

--- a/doc/user-documentation/bb-to-std-mapping.md
+++ b/doc/user-documentation/bb-to-std-mapping.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This document provides an overview of the iceoryx2 building blocks and their
-similiarities to Rust `std` types.
+similarities to Rust `std` types.
 
 ## Version
 

--- a/examples/cxx/health_monitoring/src/central_daemon.cpp
+++ b/examples/cxx/health_monitoring/src/central_daemon.cpp
@@ -55,7 +55,7 @@ auto main() -> int {
                                .notifier_created_event(iox2::bb::into<EventId>(PubSubEvent::PublisherConnected))
                                .notifier_dropped_event(iox2::bb::into<EventId>(PubSubEvent::PublisherDisconnected))
                                // This event is emitted when either the central daemon or a decentralized process
-                               // detects a dead node and cleaned up all of its stale resources succesfully.
+                               // detects a dead node and cleaned up all of its stale resources successfully.
                                .notifier_dead_event(iox2::bb::into<EventId>(PubSubEvent::ProcessDied))
                                .open_or_create()
                                .value();

--- a/examples/nostd/bare-metal/rust/publish-subscribe/README.md
+++ b/examples/nostd/bare-metal/rust/publish-subscribe/README.md
@@ -2,5 +2,5 @@
 
 This example illustrates the ability to use the publish-subscribe messaging
 pattern in a bare metal deployment. Samples are sent and received with the
-same publish-subscribe APIs used in more typical deployements to platforms
+same publish-subscribe APIs used in more typical deployments to platforms
 with an operating system.

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -9,7 +9,7 @@ Python bindings. e.g.
 pip install iceoryx2==0.9.999
 ```
 
-Be sure to switch to the matching release tag to ensure compatability:
+Be sure to switch to the matching release tag to ensure compatibility:
 
 ```console
 git checkout v0.9.999
@@ -42,7 +42,7 @@ poetry --project iceoryx2-ffi/python install
 
 ## Build
 
-Compile the iceoryx2 Python language bindings into the virutal
+Compile the iceoryx2 Python language bindings into the virtual
 environment by calling:
 
 ```sh

--- a/examples/rust/health_monitoring/central_daemon.rs
+++ b/examples/rust/health_monitoring/central_daemon.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), Box<dyn core::error::Error>> {
         .notifier_created_event(PubSubEvent::PublisherConnected.into())
         .notifier_dropped_event(PubSubEvent::PublisherDisconnected.into())
         // This event is emitted when either the central daemon or a decentralized process detects
-        // a dead node and cleaned up all of its stale resources succesfully.
+        // a dead node and cleaned up all of its stale resources successfully.
         .notifier_dead_event(PubSubEvent::ProcessDied.into())
         .open_or_create()?;
 

--- a/iceoryx2-bb/container/src/byte_atomic.rs
+++ b/iceoryx2-bb/container/src/byte_atomic.rs
@@ -119,7 +119,7 @@ impl<T> MaybeTorn<T> {
     /// The caller must guarantee that the underlying memory does not contain a torn state,
     /// otherwise `T` may be "logically" invalid. In the context of [`FixedSizeByteAtomic::read()`],
     /// this means that the caller must have verified via synchronization primitives that no
-    /// concurrent writes occured during the read operation. If called on a torn value, using the
+    /// concurrent writes occurred during the read operation. If called on a torn value, using the
     /// resulting `T` may lead to undefined behavior.
     pub unsafe fn assume_consistent(self) -> T {
         unsafe { self.inner.assume_init() }

--- a/iceoryx2-bb/container/src/semantic_string.rs
+++ b/iceoryx2-bb/container/src/semantic_string.rs
@@ -299,7 +299,7 @@ pub trait SemanticString<const CAPACITY: usize>:
         temp.remove_range(idx, len);
         if Self::is_invalid_content(temp.as_bytes()) {
             fail!(from self, with SemanticStringError::InvalidContent,
-                "Unable to remove range from {} with lenght {} since it would result in the illegal content \"{}\".",
+                "Unable to remove range from {} with length {} since it would result in the illegal content \"{}\".",
                     idx, len, temp);
         }
 

--- a/iceoryx2-bb/cxx/include/iox2/legacy/detail/convert.hpp
+++ b/iceoryx2-bb/cxx/include/iox2/legacy/detail/convert.hpp
@@ -60,7 +60,7 @@ class convert {
     static constexpr uint32_t FLOAT_SIGNALING_NAN_MASK { static_cast<uint32_t>(1) << static_cast<uint32_t>(22) };
     static constexpr uint64_t DOUBLE_SIGNALING_NAN_MASK { static_cast<uint64_t>(1) << static_cast<uint64_t>(51) };
 
-    /// @brief Converts every type which is either a pod (plain old data) type or is convertable
+    /// @brief Converts every type which is either a pod (plain old data) type or is convertible
     ///         to a string (this means that the operator std::string() is defined)
     /// @param Source type of the value which should be converted to a string
     /// @param[in] t value which should be converted to a string
@@ -69,7 +69,7 @@ class convert {
     static typename std::enable_if<!std::is_convertible<Source, std::string>::value, std::string>::type
     toString(const Source& t) noexcept;
 
-    /// @brief Converts every type which is either a pod (plain old data) type or is convertable
+    /// @brief Converts every type which is either a pod (plain old data) type or is convertible
     ///         to a string (this means that the operator std::string() is defined)
     /// @param Source type of the value which should be converted to a string
     /// @param[in] t value which should be converted to a string

--- a/iceoryx2-bb/elementary-traits/src/relocatable_container.rs
+++ b/iceoryx2-bb/elementary-traits/src/relocatable_container.rs
@@ -18,7 +18,7 @@ use crate::allocator::{Allocate, AllocationError};
 
 /// Describes a container which can shared between processes. Since the shared memory is often
 /// mapped at a different virtual memory position the underlying constructs must be relocatable in
-/// the sense that they should not rely on absolut memory positions.
+/// the sense that they should not rely on absolute memory positions.
 pub trait RelocatableContainer {
     /// Creates a new uninitialized RelocatableContainer. Before the container can be used the method
     /// [`RelocatableContainer::init()`] must be called.

--- a/iceoryx2-bb/elementary-traits/src/zeroable.rs
+++ b/iceoryx2-bb/elementary-traits/src/zeroable.rs
@@ -19,7 +19,7 @@
 /// 1. The user must ensure that an all-zero bit pattern is valid.
 ///
 pub unsafe trait Zeroable: core::marker::Sized {
-    /// Creates a new zerod value.
+    /// Creates a new zeroed value.
     fn new_zeroed() -> Self {
         unsafe { core::mem::zeroed() }
     }

--- a/iceoryx2-bb/elementary/src/cyclic_tagger.rs
+++ b/iceoryx2-bb/elementary/src/cyclic_tagger.rs
@@ -42,7 +42,7 @@
 //! // add a new thing
 //! my_things.push(MyThing { some_property: 456, tag: global_tagger.create_tag() });
 //!
-//! // remove all non-taged things
+//! // remove all non-tagged things
 //! my_things.retain(|thing| thing.was_tagged_by(&global_tagger));
 //! ```
 

--- a/iceoryx2-bb/elementary/src/relocatable_pointer.rs
+++ b/iceoryx2-bb/elementary/src/relocatable_pointer.rs
@@ -119,8 +119,8 @@ impl<T: Debug> RelocatablePointer<T> {
     }
 
     /// Initializes the [`RelocatablePointer`] by setting the distance to the memory destination
-    /// by providing an absolut pointer to it. The distance can be calculated from the
-    /// [`RelocatablePointer`] memory location and the absolut position of the destination.
+    /// by providing an absolute pointer to it. The distance can be calculated from the
+    /// [`RelocatablePointer`] memory location and the absolute position of the destination.
     /// **Important:** The pointer must point into the same shared memory object.
     ///
     /// # Safety

--- a/iceoryx2-bb/elementary/src/unique_id.rs
+++ b/iceoryx2-bb/elementary/src/unique_id.rs
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Contains two building blocks to generate unique ids. Useful for parallized unit test to
+//! Contains two building blocks to generate unique ids. Useful for parallelized unit test to
 //! generate names which point to OS resources or to enumerate constructs uniquely.
 //!
 //! # Examples

--- a/iceoryx2-bb/lock-free/src/mpmc/container.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/container.rs
@@ -191,7 +191,7 @@ impl<T: Copy + Debug> ContainerState<T> {
 /// A **threadsafe** and **lock-free** runtime fixed size container. The compile time fixed size
 /// container is called [`FixedSizeContainer`].
 ///
-/// **Restriction:** T is not allowed to implement [`Drop`], it must be trivially dropable!
+/// **Restriction:** T is not allowed to implement [`Drop`], it must be trivially droppable!
 #[repr(C)]
 #[derive(Debug)]
 pub struct Container<T: Copy + Debug> {
@@ -672,8 +672,8 @@ impl<T: Copy + Debug, const CAPACITY: usize> FixedSizeContainerData<T, CAPACITY>
 /// A **threadsafe** and **lock-free** compile time fixed size container. The runtime time fixed size
 /// container is called [`Container`].
 ///
-/// **Restriction:** T is not allowed to implement [`Drop`], it must be trivially dropable!
-// T is not allowed to implement Drop - must be trivially dropable
+/// **Restriction:** T is not allowed to implement [`Drop`], it must be trivially droppable!
+// T is not allowed to implement Drop - must be trivially droppable
 #[repr(C)]
 #[derive(Debug)]
 pub struct FixedSizeContainer<T: Copy + Debug, const CAPACITY: usize> {

--- a/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
+++ b/iceoryx2-bb/lock-free/src/mpmc/robust_unique_index_set.rs
@@ -509,7 +509,7 @@ impl RobustUniqueIndexSet {
             .borrowed_indices as usize
     }
 
-    /// This funtion returns the number of borrowed indices, meaning how many
+    /// This function returns the number of borrowed indices, meaning how many
     /// `cell`s != `OwnerId::EMPTY` combined with the generation counter at that
     /// time.
     fn borrowed_indices_and_generation_counter(&self) -> SetState {

--- a/iceoryx2-bb/lock-free/src/spsc/queue.rs
+++ b/iceoryx2-bb/lock-free/src/spsc/queue.rs
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A **threadsafe** **lock-free** single produce single consumer queue.
-//! **IMPORTANT** Can only be used with trivially copyable types which are also trivially dropable.
+//! **IMPORTANT** Can only be used with trivially copyable types which are also trivially droppable.
 //!
 //! # Example
 //!

--- a/iceoryx2-bb/posix/src/clock.rs
+++ b/iceoryx2-bb/posix/src/clock.rs
@@ -48,7 +48,7 @@ enum_gen! { NanosleepError
 
 enum_gen! {
 /// Use this more generic error enum when you do not require the fine grained error handling.
-/// Every error enum is convertable into this one and on a higher level this is convertable into
+/// Every error enum is convertible into this one and on a higher level this is convertible into
 /// [`crate::Error`].
     ClockError
   generalization:

--- a/iceoryx2-bb/posix/src/directory.rs
+++ b/iceoryx2-bb/posix/src/directory.rs
@@ -142,7 +142,7 @@ enum_gen! {
     /// The DirectoryError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward DirectoryError as more generic return value when a method
     /// returns a Directory***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     DirectoryError
   generalization:
     Create <= DirectoryCreateError,
@@ -152,7 +152,7 @@ enum_gen! {
 }
 
 /// Represents an entry of a [`Directory`]. It provides the name of the entry and [`Metadata`] to
-/// acquire additional informations about the entry.
+/// acquire additional information about the entry.
 ///
 /// # Example
 ///

--- a/iceoryx2-bb/posix/src/file.rs
+++ b/iceoryx2-bb/posix/src/file.rs
@@ -32,7 +32,7 @@
 //! file.read_to_vector(&mut content).expect("Failed to read file");
 //! file.write(content.as_slice()).expect("Failed to write file");
 //!
-//! if File::does_exist(&file_name).expect("Failed to check for existance") {
+//! if File::does_exist(&file_name).expect("Failed to check for existence") {
 //!   println!("Woohoo file exists");
 //! }
 //!
@@ -252,7 +252,7 @@ enum_gen! {
     /// The FileError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward FileError as more generic return value when a method
     /// returns a File***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     FileError
   generalization:
     Create <= FileCreationError,
@@ -543,7 +543,7 @@ impl File {
         {
             CreationMode::CreateExclusive => create_file(),
             CreationMode::PurgeAndCreate => {
-                if fail!(from config, when File::does_exist(&config.file_path), "{} since the file existance verification failed.", msg)
+                if fail!(from config, when File::does_exist(&config.file_path), "{} since the file existence verification failed.", msg)
                 {
                     fail!(from config, when File::remove(&config.file_path), "{} since the removal of the already existing file failed.", msg);
                 }
@@ -551,7 +551,7 @@ impl File {
                 create_file()
             }
             CreationMode::OpenOrCreate => {
-                match fail!(from config, when File::does_exist(&config.file_path), "{} since the file existance verification failed.", msg)
+                match fail!(from config, when File::does_exist(&config.file_path), "{} since the file existence verification failed.", msg)
                 {
                     true => Ok(FileDescriptor::new(unsafe {
                         posix::open(config.file_path.as_c_str(), config.access_mode.as_oflag())
@@ -993,7 +993,7 @@ impl File {
             Errno::ELOOP => (LoopInSymbolicLinks, "{} \"{}\" since a loop exists in the symbolic links.", msg, path),
             Errno::ENAMETOOLONG => (MaxSupportedPathLengthExceeded, "{} \"{}\" since it is longer than the maximum path name length.", msg, path),
             Errno::EROFS => (PartOfReadOnlyFileSystem, "{} \"{}\" since it is part of a read-only filesystem.", msg, path),
-            v => (UnknownError(v as i32), "{} \"{}\" since an unkown error occurred ({}).", msg, path, v)
+            v => (UnknownError(v as i32), "{} \"{}\" since an unknown error occurred ({}).", msg, path, v)
         );
     }
 

--- a/iceoryx2-bb/posix/src/memory_lock.rs
+++ b/iceoryx2-bb/posix/src/memory_lock.rs
@@ -41,7 +41,7 @@ enum_gen! {
     /// The MemoryLockError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward MemoryLockError as more generic return value when a method
     /// returns a MemoryLock***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     MemoryLockError
   generalization:
     LockFailed <= MemoryLockCreationError; MemoryLockAllError

--- a/iceoryx2-bb/posix/src/metadata.rs
+++ b/iceoryx2-bb/posix/src/metadata.rs
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! [`Metadata`] contains all informations like type, credentials, size, access times about every
+//! [`Metadata`] contains all information like type, credentials, size, access times about every
 //! structure which has a file handle representation. Every struct which implements the
 //! [`crate::file_descriptor::FileDescriptorManagement`] trait can emit a [`Metadata`].
 //! One struct is for instance [`crate::file::File`].
@@ -22,7 +22,7 @@ use crate::permission::{Permission, PermissionExt};
 use crate::user::Uid;
 use iceoryx2_pal_posix::*;
 
-/// Contains all informations like type, credentials, size, access times about every
+/// Contains all information like type, credentials, size, access times about every
 /// structure which has a file handle representation. Every struct which implements the
 /// [`crate::file_descriptor::FileDescriptorManagement`] trait can emit a [`Metadata`].
 /// One struct is for instance [`crate::file::File`].

--- a/iceoryx2-bb/posix/src/mutex.rs
+++ b/iceoryx2-bb/posix/src/mutex.rs
@@ -148,7 +148,7 @@ enum_gen! {
     /// The MutexError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward MutexError as more generic return value when a method
     /// returns a Mutex***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     MutexError
   entry:
     CreationFailed,

--- a/iceoryx2-bb/posix/src/process.rs
+++ b/iceoryx2-bb/posix/src/process.rs
@@ -97,7 +97,7 @@ enum_gen! {
     /// The ProcessError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward ProcessError as more generic return value when a method
     /// returns a Process***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     ProcessError
   generalization:
     FailedToSetSchedulerSettings <= ProcessSetSchedulerError,

--- a/iceoryx2-bb/posix/src/read_write_mutex.rs
+++ b/iceoryx2-bb/posix/src/read_write_mutex.rs
@@ -105,7 +105,7 @@ enum_gen! {
     /// The ReadWriteMutexError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward ReadWriteMutexError as more generic return value when a method
     /// returns a ReadWriteMutex***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     ReadWriteMutexError
   generalization:
     FailedToLock <= ReadWriteMutexWriteLockError; ReadWriteMutexReadLockError,

--- a/iceoryx2-bb/posix/src/semaphore.rs
+++ b/iceoryx2-bb/posix/src/semaphore.rs
@@ -106,7 +106,7 @@ enum_gen! {
     /// The SemaphoreError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward SemaphoreError as more generic return value when a method
     /// returns a Semaphore***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     SemaphoreError
   generalization:
     FailedToCreate <= NamedSemaphoreCreationError; UnnamedSemaphoreCreationError,

--- a/iceoryx2-bb/posix/src/signal.rs
+++ b/iceoryx2-bb/posix/src/signal.rs
@@ -248,7 +248,7 @@ enum_gen! {
     /// The SignalError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward SignalError as more generic return value when a method
     /// returns a Signal***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     SignalError
   generalization:
     FailedToRegister <= SignalRegisterError,

--- a/iceoryx2-bb/posix/src/thread.rs
+++ b/iceoryx2-bb/posix/src/thread.rs
@@ -260,7 +260,7 @@ enum_gen! {
     /// The ThreadError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward ThreadError as more generic return value when a method
     /// returns a Thread***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     ThreadError
   generalization:
     FailedToSpawn <= ThreadSpawnError,

--- a/iceoryx2-bb/posix/src/unix_datagram_socket.rs
+++ b/iceoryx2-bb/posix/src/unix_datagram_socket.rs
@@ -292,7 +292,7 @@ enum_gen! {
     /// The UnixDatagramError enum is a generalization when one doesn't require the fine-grained error
     /// handling enums. One can forward UnixDatagramError as more generic return value when a method
     /// returns a UnixDatagram***Error.
-    /// On a higher level it is again convertable to [`crate::Error`].
+    /// On a higher level it is again convertible to [`crate::Error`].
     UnixDatagramError
   generalization:
     CreationFailed <= UnixDatagramSenderCreationError; UnixDatagramReceiverCreationError,

--- a/iceoryx2-bb/system-types/src/file_name.rs
+++ b/iceoryx2-bb/system-types/src/file_name.rs
@@ -73,7 +73,7 @@ fn normalize(this: &FileName) -> FileName {
 }
 
 semantic_string! {
-  /// Represents a file name. The restriction are choosen in a way that it is platform independent.
+  /// Represents a file name. The restriction are chosen in a way that it is platform independent.
   /// This means characters/strings which would be legal on some platforms are forbidden as well.
   name: FileName,
   capacity: FILENAME_LENGTH,

--- a/iceoryx2-bb/system-types/src/file_path.rs
+++ b/iceoryx2-bb/system-types/src/file_path.rs
@@ -42,7 +42,7 @@ use crate::file_name::FileName;
 use crate::path::Path;
 
 semantic_string! {
-  /// Represents a file path. The restriction are choosen in a way that it is platform independent.
+  /// Represents a file path. The restriction are chosen in a way that it is platform independent.
   /// This means characters/strings which would be legal on some platforms are forbidden as well.
   name: FilePath,
   capacity: PATH_LENGTH,

--- a/iceoryx2-cal/src/dynamic_storage/mod.rs
+++ b/iceoryx2-cal/src/dynamic_storage/mod.rs
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Traits that provide modifyable memory which can be accessed by multiple processes
+//! Traits that provide modifiable memory which can be accessed by multiple processes
 //! identified by a name.
 //!
 //! A [`DynamicStorage`] has to fulfill the following contract:
@@ -151,7 +151,7 @@ pub trait DynamicStorageBuilder<'builder, T: Send + Sync + ZeroCopySend, D: Dyna
 
     /// The timeout defines how long the [`DynamicStorageBuilder`] should wait for
     /// [`DynamicStorageBuilder::create()`]
-    /// to finialize the initialization. This is required when the [`DynamicStorage`] is
+    /// to finalize the initialization. This is required when the [`DynamicStorage`] is
     /// created and initialized concurrently from another process.
     /// By default it is set to [`Duration::ZERO`] for no timeout.
     fn timeout(self, value: Duration) -> Self;
@@ -180,7 +180,7 @@ pub trait DynamicStorageBuilder<'builder, T: Send + Sync + ZeroCopySend, D: Dyna
 }
 
 /// Is being built by the [`DynamicStorageBuilder`]. The [`DynamicStorage`] trait shall provide
-/// inter-process access to a modifyable piece of memory identified by some name.
+/// inter-process access to a modifiable piece of memory identified by some name.
 pub trait DynamicStorage<T: Send + Sync + ZeroCopySend>:
     Sized + Debug + NamedConceptMgmt + NamedConcept + Send + Sync + Abandonable
 {
@@ -215,7 +215,7 @@ pub trait DynamicStorage<T: Send + Sync + ZeroCopySend>:
     /// # Safety
     ///
     /// * ensure that the contained type matches the semantic type_name given with `T`
-    /// * if `T` is some arbitary placeholder, then only use it to remove the concept or list it
+    /// * if `T` is some arbitrary placeholder, then only use it to remove the concept or list it
     ///   * DO NOT OPEN IT
     unsafe fn __internal_set_type_name_in_config(config: &mut Self::Configuration, type_name: &str);
 }

--- a/iceoryx2-cal/src/event/common.rs
+++ b/iceoryx2-cal/src/event/common.rs
@@ -706,7 +706,7 @@ impl<
             }
             Err(DynamicStorageCreateError::InitializationFailed) => {
                 fail!(from self, with ListenerCreateError::InternalFailure,
-                    "{msg} since the initialization of the underyling waiter failed.");
+                    "{msg} since the initialization of the underlying waiter failed.");
             }
             Err(DynamicStorageCreateError::InternalError) => {
                 fail!(from self, with ListenerCreateError::InternalFailure,

--- a/iceoryx2-cal/src/monitoring/mod.rs
+++ b/iceoryx2-cal/src/monitoring/mod.rs
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! Allows one process to monitor the state of another process. Can detect if the process is
-//! [`State::Alive`], [`State::Dead`] or the existance with [`State::DoesNotExist`]. To activate
+//! [`State::Alive`], [`State::Dead`] or the existence with [`State::DoesNotExist`]. To activate
 //! monitoring the process that shall be monitored must instantiate a [`MonitoringToken`]. As long
 //! as the [`MonitoringToken`] is in scope the [`MonitoringMonitor`] will detect the process as
 //! [`State::Alive`]. When the process crashes it will be detected as [`State::Dead`]. If the

--- a/iceoryx2-cal/src/resizable_shared_memory/dynamic.rs
+++ b/iceoryx2-cal/src/resizable_shared_memory/dynamic.rs
@@ -195,7 +195,7 @@ where
                                                         .config(&self.config.shm)
                                                         .has_ownership(false)
                                                         .open(access_mode),
-                                    "{msg} since the managment segment could not be opened.");
+                                    "{msg} since the management segment could not be opened.");
 
         let shared_memory_map = SlotMap::new(MAX_NUMBER_OF_REALLOCATIONS);
 
@@ -472,7 +472,7 @@ where
 
         let mgmt_name = Self::managment_segment_name(name);
         let mut shm_removed = fail!(from origin, when unsafe {Shm::remove_cfg(&mgmt_name, config)},
-            "{msg} since the underlying managment segment could not be removed.");
+            "{msg} since the underlying management segment could not be removed.");
 
         let raw_names = match Shm::list_cfg(config) {
             Ok(names) => names,
@@ -509,7 +509,7 @@ where
         let mgmt_name = Self::managment_segment_name(name);
         Ok(
             fail!(from origin, when Shm::does_exist_cfg(&mgmt_name, config),
-            "{msg} since the existance of the underlying managment segment could not be verified."),
+            "{msg} since the existence of the underlying management segment could not be verified."),
         )
     }
 
@@ -578,7 +578,7 @@ where
             let mut raw_segment_id = *name.as_string();
             raw_segment_id.remove_range(0, segment_id_start_pos);
 
-            // check nymber of digits
+            // check number of digits
             for byte in raw_segment_id.as_bytes() {
                 if !byte.is_ascii_digit() {
                     return None;

--- a/iceoryx2-cal/src/resizable_shared_memory/mod.rs
+++ b/iceoryx2-cal/src/resizable_shared_memory/mod.rs
@@ -119,7 +119,7 @@ pub trait ResizableSharedMemoryViewBuilder<
 {
     /// The timeout defines how long the
     /// [`SharedMemoryBuilder`](crate::shared_memory::SharedMemoryBuilder) should wait for
-    /// [`SharedMemoryBuilder::create()`](crate::shared_memory::SharedMemoryBuilder::create()) to finialize
+    /// [`SharedMemoryBuilder::create()`](crate::shared_memory::SharedMemoryBuilder::create()) to finalize
     /// the initialization. This is required when the [`SharedMemory`] is created and initialized
     /// concurrently from another process. By default it is set to [`Duration::ZERO`] for no
     /// timeout.
@@ -162,7 +162,7 @@ pub trait ResizableSharedMemoryView<Allocator: ShmAllocator, Shm: SharedMemory<A
     Debug + Send + Abandonable
 {
     /// Registers a received [`PointerOffset`] at the [`ResizableSharedMemoryView`] and returns the
-    /// absolut pointer to the data. If the segment of the received [`PointerOffset`] was not yet
+    /// absolute pointer to the data. If the segment of the received [`PointerOffset`] was not yet
     /// mapped into the processes space, it will be opened and mapped. If this fails a
     /// [`SharedMemoryOpenError`] is returned.
     ///

--- a/iceoryx2-cal/src/shared_memory/mod.rs
+++ b/iceoryx2-cal/src/shared_memory/mod.rs
@@ -161,7 +161,7 @@ pub trait SharedMemoryBuilder<Allocator: ShmAllocator, Shm: SharedMemory<Allocat
     fn size(self, value: usize) -> Self;
 
     /// The timeout defines how long the [`SharedMemoryBuilder`] should wait for
-    /// [`SharedMemoryBuilder::create()`] to finialize
+    /// [`SharedMemoryBuilder::create()`] to finalize
     /// the initialization. This is required when the [`SharedMemory`] is created and initialized
     /// concurrently from another process. By default it is set to [`Duration::ZERO`] for no
     /// timeout.

--- a/iceoryx2-cal/src/shm_allocator/pool_allocator.rs
+++ b/iceoryx2-cal/src/shm_allocator/pool_allocator.rs
@@ -46,8 +46,8 @@ impl ShmAllocatorConfig for Config {}
 #[repr(C)]
 pub struct PoolAllocator {
     allocator: iceoryx2_bb_memory::pool_allocator::PoolAllocator,
-    // is even with absolut base address relocatable since every process acquire and return
-    // the same relative offset which map then to the same absolut base address
+    // is even with absolute base address relocatable since every process acquire and return
+    // the same relative offset which map then to the same absolute base address
     // the allocator only manages a range of numbers
     base_address: usize,
     max_supported_alignment_by_memory: usize,
@@ -279,7 +279,7 @@ impl ShmAllocator for PoolAllocator {
 
         fail!(from self, when unsafe { self.allocator.init(mgmt_allocator)  },
             with ShmAllocatorInitError::AllocationFailed,
-            "{} since the allocation of the allocator managment memory failed.", msg);
+            "{} since the allocation of the allocator management memory failed.", msg);
 
         Ok(())
     }

--- a/iceoryx2-cal/src/static_storage/file.rs
+++ b/iceoryx2-cal/src/static_storage/file.rs
@@ -329,11 +329,11 @@ impl crate::named_concept::NamedConceptMgmt for Storage {
             Ok(file) => Ok(file),
             Err(FileAccessError::InsufficientPermissions) => {
                 fail!(from origin, with NamedConceptDoesExistError::InsufficientPermissions,
-                        "{} due to insufficient permissions to verify the existance of the underlying file.", msg);
+                        "{} due to insufficient permissions to verify the existence of the underlying file.", msg);
             }
             Err(e) => {
                 fail!(from origin, with NamedConceptDoesExistError::InternalError,
-                    "{} due to an unknown failure while determing the existance of the underlying file. [{e:?}]", msg);
+                    "{} due to an unknown failure while determing the existence of the underlying file. [{e:?}]", msg);
             }
         };
 
@@ -365,7 +365,7 @@ impl crate::named_concept::NamedConceptMgmt for Storage {
             }
 
             fail!(from origin, with NamedConceptDoesExistError::UnderlyingResourcesCorrupted,
-                "{} due to an internal failure ({:?}) while acquiring underlying file informations, is static storage in a corrupted state?",
+                "{} due to an internal failure ({:?}) while acquiring underlying file information, is static storage in a corrupted state?",
                 msg, metadata.err().unwrap());
         }
         let metadata = metadata.unwrap();

--- a/iceoryx2-cal/src/zero_copy_connection/common.rs
+++ b/iceoryx2-cal/src/zero_copy_connection/common.rs
@@ -904,7 +904,7 @@ pub mod details {
             // 10          1               3
             // 11          2               3
             //
-            // to map an index to a segment id, we need to substract from index the
+            // to map an index to a segment id, we need to subtract from index the
             // rounded down value of index which is rounded down to the greatest multiple
             // of number_of_segments.
             SegmentId::new((index - (index / number_of_segments) * number_of_segments) as u8)

--- a/iceoryx2-cxx/include/iox2/client_error.hpp
+++ b/iceoryx2-cxx/include/iox2/client_error.hpp
@@ -31,7 +31,7 @@ enum class ClientCreateError : uint8_t {
     FailedToDeployThreadsafetyPolicy,
     /// The tracking port tag, required for cleanup, could not be created.
     UnableToCreatePortTag,
-    /// When the [`Client`] requires more acitve requests than the
+    /// When the [`Client`] requires more active requests than the
     /// [`Service`] offers, the creation will fail.
     MaxActiveRequestsExceedsMaxSupportedActiveRequestsOfService,
 };

--- a/iceoryx2-cxx/include/iox2/config.hpp
+++ b/iceoryx2-cxx/include/iox2/config.hpp
@@ -240,7 +240,7 @@ class Event {
     auto notifier_dead_event() && -> bb::Optional<size_t>;
     /// Sets the event id value that is emitted if a notifier was identified as dead.
     void set_notifier_dead_event(bb::Optional<size_t> value) &&;
-    /// Defines the maximum allowed time between two consecutive notifications. If a notifiation
+    /// Defines the maximum allowed time between two consecutive notifications. If a notification
     /// is not sent after the defined time, every [`Listener`]
     /// that is attached to a [`WaitSet`] will be notified.
     auto deadline() && -> bb::Optional<iox2::bb::Duration>;

--- a/iceoryx2-cxx/include/iox2/port_factory_publish_subscribe.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_publish_subscribe.hpp
@@ -32,7 +32,7 @@
 
 namespace iox2 {
 /// The factory for [`MessagingPattern::PublishSubscribe`].
-/// It can acquire dynamic and static service informations and create
+/// It can acquire dynamic and static service information and create
 /// [`Publisher`] or [`Subscriber`] ports.
 template <ServiceType S, typename Payload, typename UserHeader>
 class PortFactoryPublishSubscribe {

--- a/iceoryx2-cxx/include/iox2/port_factory_request_response.hpp
+++ b/iceoryx2-cxx/include/iox2/port_factory_request_response.hpp
@@ -32,7 +32,7 @@
 
 namespace iox2 {
 /// The factory for [`MessagingPattern::RequestResponse`]. It can acquire
-/// dynamic and static service informations and create [`crate::port::client::Client`]
+/// dynamic and static service information and create [`crate::port::client::Client`]
 /// or [`crate::port::server::Server`] ports.
 template <ServiceType Service,
           typename RequestPayload,

--- a/iceoryx2-cxx/include/iox2/publisher.hpp
+++ b/iceoryx2-cxx/include/iox2/publisher.hpp
@@ -75,7 +75,7 @@ class Publisher {
 
     /// Loans/allocates a [`SampleMut`] from the underlying data segment of the [`Publisher`]
     /// and initialize it with the default value. This can be a performance hit and [`Publisher::loan_uninit`]
-    /// can be used to loan an uninitalized [`SampleMut`].
+    /// can be used to loan an uninitialized [`SampleMut`].
     ///
     /// On failure it returns [`LoanError`] describing the failure.
     template <typename T = Payload, typename = std::enable_if_t<!bb::IsSlice<T>::VALUE, void>>

--- a/iceoryx2-cxx/include/iox2/service_builder_blackboard_error.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_blackboard_error.hpp
@@ -22,7 +22,7 @@ enum class BlackboardOpenError : uint8_t {
     Interrupt,
     /// The [`Service`] could not be opened since it does not exist.
     DoesNotExist,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Service`] has the wrong key type.
     IncompatibleKeys,
@@ -65,7 +65,7 @@ enum class BlackboardCreateError : uint8_t {
     InternalFailure,
     /// The process has insufficient permissions to create the [`Service`].
     InsufficientPermissions,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Service`]s creation timeout has passed and it is still not initialized. Can be caused
     /// by a process that crashed during [`Service`] creation.

--- a/iceoryx2-cxx/include/iox2/service_builder_event_error.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_event_error.hpp
@@ -83,7 +83,7 @@ enum class EventCreateError : uint8_t {
     /// An interrupt signal was raised.
     Interrupt,
     /// Some underlying resources of the [`Service`] are either missing,
-    /// corrupted or unaccessible.
+    /// corrupted or inaccessible.
     ServiceInCorruptedState,
     /// Errors that indicate either an implementation issue or a wrongly
     /// configured system.
@@ -172,7 +172,7 @@ enum class EventOpenOrCreateError : uint8_t {
     /// An interrupt signal was raised.
     CreateInterrupt,
     /// Some underlying resources of the [`Service`] are either missing,
-    /// corrupted or unaccessible.
+    /// corrupted or inaccessible.
     CreateServiceInCorruptedState,
     /// Errors that indicate either an implementation issue or a wrongly
     /// configured system.

--- a/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe_error.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_publish_subscribe_error.hpp
@@ -54,7 +54,7 @@ enum class PublishSubscribeOpenError : uint8_t {
     /// The process has not enough permissions to open the [`Service`]
     InsufficientPermissions,
     /// Some underlying resources of the [`Service`] are either missing,
-    /// corrupted or unaccessible.
+    /// corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Service`]s creation timeout has passed and it is still not
     /// initialized. Can be caused
@@ -85,7 +85,7 @@ enum class PublishSubscribeCreateError : uint8_t {
     /// An interrupt signal was raised.
     Interrupt,
     /// Some underlying resources of the [`Service`] are either missing,
-    /// corrupted or unaccessible.
+    /// corrupted or inaccessible.
     ServiceInCorruptedState,
     /// Invalid [`Service`] configuration provided. The
     /// [`Subscriber`]s buffer size must be
@@ -154,7 +154,7 @@ enum class PublishSubscribeOpenOrCreateError : uint8_t {
     /// The process has not enough permissions to open the [`Service`]
     OpenInsufficientPermissions,
     /// Some underlying resources of the [`Service`] are either missing,
-    /// corrupted or unaccessible.
+    /// corrupted or inaccessible.
     OpenServiceInCorruptedState,
     /// The [`Service`]s creation timeout has passed and it is still not
     /// initialized. Can be caused
@@ -182,7 +182,7 @@ enum class PublishSubscribeOpenOrCreateError : uint8_t {
     /// An interrupt signal was raised.
     CreateInterrupt,
     /// Some underlying resources of the [`Service`] are either missing,
-    /// corrupted or unaccessible.
+    /// corrupted or inaccessible.
     CreateServiceInCorruptedState,
     /// Invalid [`Service`] configuration provided. The
     /// [`Subscriber`]s buffer size must be

--- a/iceoryx2-cxx/include/iox2/service_builder_request_response_error.hpp
+++ b/iceoryx2-cxx/include/iox2/service_builder_request_response_error.hpp
@@ -65,7 +65,7 @@ enum class RequestResponseOpenError : uint8_t {
     /// When the call creation call is repeated with a little delay the [`Service`] should be
     /// recreatable.
     IsMarkedForDestruction,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Node`] service tag could not be created. Required to track resources of dead nodes when cleaning them up.
     UnableToCreateServiceTag,
@@ -93,7 +93,7 @@ enum class RequestResponseCreateError : uint8_t {
     /// The [`Service`]s creation timeout has passed and it is still not initialized. Can be caused
     /// by a process that crashed during [`Service`] creation.
     HangsInCreation,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Node`] service tag could not be created. Required to track resources of dead nodes when cleaning them up.
     UnableToCreateServiceTag,
@@ -155,7 +155,7 @@ enum class RequestResponseOpenOrCreateError : uint8_t {
     /// When the call creation call is repeated with a little delay the [`Service`] should be
     /// recreatable.
     OpenIsMarkedForDestruction,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     OpenServiceInCorruptedState,
     /// The [`Node`] service tag could not be created. Required to track resources of dead nodes when cleaning them up.
     OpenUnableToCreateServiceTag,
@@ -180,7 +180,7 @@ enum class RequestResponseOpenOrCreateError : uint8_t {
     /// The [`Service`]s creation timeout has passed and it is still not initialized. Can be caused
     /// by a process that crashed during [`Service`] creation.
     CreateHangsInCreation,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     CreateServiceInCorruptedState,
     /// The [`Node`] service tag could not be created. Required to track resources of dead nodes when cleaning them up.
     CreateUnableToCreateServiceTag,

--- a/iceoryx2-ffi/c/src/api/active_request.rs
+++ b/iceoryx2-ffi/c/src/api/active_request.rs
@@ -160,7 +160,7 @@ pub unsafe extern "C" fn iox2_active_request_has_disconnect_hint(
     }
 }
 
-/// Returns true if the corresponding pending response is still connected anc can receive responses.
+/// Returns true if the corresponding pending response is still connected and can receive responses.
 ///
 /// # Arguments
 ///

--- a/iceoryx2-ffi/c/src/api/attribute_specifier.rs
+++ b/iceoryx2-ffi/c/src/api/attribute_specifier.rs
@@ -193,7 +193,7 @@ pub unsafe extern "C" fn iox2_attribute_specifier_define(
     }
 }
 
-/// Returnes a [`iox2_attribute_set_ptr`] to the underlying attribute set.
+/// Returns a [`iox2_attribute_set_ptr`] to the underlying attribute set.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/attribute_verifier.rs
+++ b/iceoryx2-ffi/c/src/api/attribute_verifier.rs
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn iox2_attribute_verifier_require_key(
     }
 }
 
-/// Returnes a [`iox2_attribute_set_ptr`] to the underlying attribute set.
+/// Returns a [`iox2_attribute_set_ptr`] to the underlying attribute set.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/node.rs
+++ b/iceoryx2-ffi/c/src/api/node.rs
@@ -662,7 +662,7 @@ pub unsafe extern "C" fn iox2_node_list(
     }
 }
 
-/// Removes the stale system resources of all dead nodess. The dead nodess are also
+/// Removes the stale system resources of all dead nodes. The dead nodes are also
 /// removed from all registered services.
 ///
 /// If a node cannot be cleaned up since the process has insufficient permissions or it

--- a/iceoryx2-ffi/c/src/api/port_factory_blackboard.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_blackboard.rs
@@ -564,7 +564,7 @@ pub unsafe extern "C" fn iox2_port_factory_blackboard_dynamic_config_number_of_r
 }
 
 /// Calls the callback repeatedly for every connected [`iox2_reader_h`](crate::iox2_reader_h)
-/// and provides all communcation details with a [`iox2_reader_details_ptr`].
+/// and provides all communication details with a [`iox2_reader_details_ptr`].
 ///
 /// # Safety
 ///
@@ -603,7 +603,7 @@ pub unsafe extern "C" fn iox2_port_factory_blackboard_dynamic_config_list_reader
 }
 
 /// Calls the callback repeatedly for every connected [`iox2_writer_h`](crate::iox2_writer_h)
-/// and provides all communcation details with a [`iox2_writer_details_ptr`].
+/// and provides all communication details with a [`iox2_writer_details_ptr`].
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/port_factory_event.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_event.rs
@@ -398,7 +398,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_listener_builder(
     }
 }
 
-/// Returnes the services attributes.
+/// Returns the services attributes.
 ///
 /// # Safety
 ///
@@ -563,7 +563,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_nodes(
 }
 
 /// Calls the callback repeatedly for every connected [`iox2_listener_h`](crate::iox2_listener_h)
-/// and provides all communcation details with a [`iox2_listener_details_ptr`].
+/// and provides all communication details with a [`iox2_listener_details_ptr`].
 ///
 /// # Safety
 ///
@@ -602,7 +602,7 @@ pub unsafe extern "C" fn iox2_port_factory_event_dynamic_config_list_listeners(
 }
 
 /// Calls the callback repeatedly for every connected [`iox2_notifier_h`](crate::iox2_notifier_h)
-/// and provides all communcation details with a [`iox2_notifier_details_ptr`].
+/// and provides all communication details with a [`iox2_notifier_details_ptr`].
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/port_factory_pub_sub.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_pub_sub.rs
@@ -267,7 +267,7 @@ pub unsafe extern "C" fn iox2_port_factory_pub_sub_subscriber_builder(
     }
 }
 
-/// Returnes the services attributes.
+/// Returns the services attributes.
 ///
 /// # Safety
 ///
@@ -580,7 +580,7 @@ pub unsafe extern "C" fn iox2_port_factory_pub_sub_dynamic_config_number_of_subs
 }
 
 /// Calls the callback repeatedly for every connected [`iox2_subscriber_h`](crate::iox2_subscriber_h)
-/// and provides all communcation details with a [`iox2_subscriber_details_ptr`].
+/// and provides all communication details with a [`iox2_subscriber_details_ptr`].
 ///
 /// # Safety
 ///
@@ -620,7 +620,7 @@ pub unsafe extern "C" fn iox2_port_factory_pub_sub_dynamic_config_list_subscribe
 }
 
 /// Calls the callback repeatedly for every connected [`iox2_publisher_h`](crate::iox2_publisher_h)
-/// and provides all communcation details with a [`iox2_publisher_details_ptr`].
+/// and provides all communication details with a [`iox2_publisher_details_ptr`].
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/port_factory_request_response.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_request_response.rs
@@ -591,7 +591,7 @@ pub unsafe extern "C" fn iox2_port_factory_request_response_service_hash(
 }
 
 /// Calls the callback repeatedly for every connected [`iox2_server_h`](crate::iox2_server_h)
-/// and provides all communcation details with a [`iox2_server_details_ptr`].
+/// and provides all communication details with a [`iox2_server_details_ptr`].
 ///
 /// # Safety
 ///
@@ -630,7 +630,7 @@ pub unsafe extern "C" fn iox2_port_factory_request_response_dynamic_config_list_
 }
 
 /// Calls the callback repeatedly with for every connected [`iox2_client_h`](crate::iox2_client_h)
-/// and provides all communcation details with a [`iox2_client_details_ptr`].
+/// and provides all communication details with a [`iox2_client_details_ptr`].
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/sample.rs
+++ b/iceoryx2-ffi/c/src/api/sample.rs
@@ -217,7 +217,7 @@ pub unsafe extern "C" fn iox2_sample_user_header(
 ///
 /// * `handle` obtained by [`iox2_subscriber_receive()`](crate::iox2_subscriber_receive())
 /// * `payload_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
-/// * `number_of_elements` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`] with
+/// * `number_of_elements` (optional) either a null pointer or a valid pointer pointing to a [`c_size_t`] with
 ///   the number of elements of the underlying type
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn iox2_sample_payload(

--- a/iceoryx2-ffi/c/src/api/sample_mut.rs
+++ b/iceoryx2-ffi/c/src/api/sample_mut.rs
@@ -246,7 +246,7 @@ pub unsafe extern "C" fn iox2_sample_mut_user_header_mut(
 ///
 /// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
 /// * `payload_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
-/// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
+/// * `payload_len` (optional) either a null pointer or a valid pointer pointing to a [`c_size_t`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn iox2_sample_mut_payload_mut(
     handle: iox2_sample_mut_h_ref,
@@ -281,7 +281,7 @@ pub unsafe extern "C" fn iox2_sample_mut_payload_mut(
 ///
 /// * `handle` obtained by [`iox2_publisher_loan_slice_uninit()`](crate::iox2_publisher_loan_slice_uninit())
 /// * `payload_ptr` a valid, non-null pointer pointing to a [`*const c_void`] pointer.
-/// * `payload_len` (optional) either a null poitner or a valid pointer pointing to a [`c_size_t`].
+/// * `payload_len` (optional) either a null pointer or a valid pointer pointing to a [`c_size_t`].
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn iox2_sample_mut_payload(
     handle: iox2_sample_mut_h_ref,

--- a/iceoryx2-ffi/c/src/api/server.rs
+++ b/iceoryx2-ffi/c/src/api/server.rs
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn iox2_server_has_requests(
     }
 }
 
-/// Returns the initial max slice len of the server. In the dynamic memory case, slice lenght might
+/// Returns the initial max slice len of the server. In the dynamic memory case, slice length might
 /// increase over time.
 ///
 /// # Safety

--- a/iceoryx2-ffi/ffi-macros/src/lib.rs
+++ b/iceoryx2-ffi/ffi-macros/src/lib.rs
@@ -279,7 +279,7 @@ pub fn string_literal_derive(input: TokenStream) -> TokenStream {
                         _ => None,
                     })
                     .unwrap_or_else(|| {
-                        // No explicity `CStr` is provided.
+                        // No explicitly `CStr` is provided.
                         // Convert variant name from 'UpperCamelCase' or 'UPPER_SNAKE_CASE'
                         // to 'lowercase with spaces'.
                         let enum_string = variant_name_to_string(&enum_name.to_string());

--- a/iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py
+++ b/iceoryx2-ffi/python/python-src/iceoryx2/publish_subscribe_extensions.py
@@ -47,7 +47,7 @@ def user_header(self: Any) -> Any:
 def publish_subscribe(
     self: ServiceBuilder, t: Type[T]
 ) -> ServiceBuilderPublishSubscribe:
-    """Returns the `ServiceBuilderPublishSusbcribe` to create a new publish-subscribe service. The payload ctype must be provided as argument."""
+    """Returns the `ServiceBuilderPublishSubscribe` to create a new publish-subscribe service. The payload ctype must be provided as argument."""
     if hasattr(t, "__name__"):
         type_name = getattr(t, "__name__")
     else:

--- a/iceoryx2-ffi/python/src/config.rs
+++ b/iceoryx2-ffi/python/src/config.rs
@@ -484,7 +484,7 @@ impl Event {
     }
 
     #[getter]
-    /// Defines the maximum allowed time between two consecutive notifications. If a notifiation
+    /// Defines the maximum allowed time between two consecutive notifications. If a notification
     /// is not sent after the defined time, every `Listener`
     /// that is attached to a `WaitSet` will be notified.
     pub fn deadline(&self) -> Duration {

--- a/iceoryx2-ffi/python/src/parc.rs
+++ b/iceoryx2-ffi/python/src/parc.rs
@@ -14,7 +14,7 @@ use core::fmt::Debug;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 /// Internal helper struct to handle the Python memory model where everything
-/// which is shared - even accross thread boundaries - is just a pointer to
+/// which is shared - even across thread boundaries - is just a pointer to
 /// some heap memory location. The `Arc<Mutex<T>>` ensures basic safety and this
 /// construct takes also care of the annoying `unwrap` inside the mutex. A mutex
 /// can fail when the thread died holding the mutex but in those cases a panic

--- a/iceoryx2-ffi/python/src/port_factory_blackboard.rs
+++ b/iceoryx2-ffi/python/src/port_factory_blackboard.rs
@@ -52,7 +52,7 @@ pub(crate) enum PortFactoryBlackboardType {
 
 #[pyclass]
 /// The factory for `MessagingPattern::Blackboard`. It can acquire dynamic and static service
-/// informations and create `Reader` or `Writer` ports.
+/// information and create `Reader` or `Writer` ports.
 pub struct PortFactoryBlackboard {
     pub(crate) value: Parc<PortFactoryBlackboardType>,
     key_type_storage: TypeStorage,

--- a/iceoryx2-ffi/python/src/port_factory_event.rs
+++ b/iceoryx2-ffi/python/src/port_factory_event.rs
@@ -35,7 +35,7 @@ pub(crate) enum PortFactoryEventType {
 
 #[pyclass]
 /// The factory for `MessagingPattern::Event`. It can acquire dynamic and static service
-/// informations and create `Notifier` or `Listener` ports.
+/// information and create `Notifier` or `Listener` ports.
 pub struct PortFactoryEvent(pub(crate) Parc<PortFactoryEventType>);
 
 #[pymethods]

--- a/iceoryx2-ffi/python/src/port_factory_notifier.rs
+++ b/iceoryx2-ffi/python/src/port_factory_notifier.rs
@@ -54,7 +54,7 @@ impl PortFactoryNotifier {
                     > = v;
                     // by converting the factory into a pointer we change the lifetime into 'static
                     // and with the factory reference hold by this object we ensure that it
-                    // lifes long enough
+                    // lives long enough
                     PortFactoryNotifierType::Ipc(unsafe { &*v }.notifier_builder())
                 }
                 PortFactoryEventType::Local(v) => {
@@ -63,7 +63,7 @@ impl PortFactoryNotifier {
                     > = v;
                     // by converting the factory into a pointer we change the lifetime into 'static
                     // and with the factory reference hold by this object we ensure that it
-                    // lifes long enough
+                    // lives long enough
                     PortFactoryNotifierType::Local(unsafe { &*v }.notifier_builder())
                 }
             },

--- a/iceoryx2-ffi/python/src/port_factory_publish_subscribe.rs
+++ b/iceoryx2-ffi/python/src/port_factory_publish_subscribe.rs
@@ -49,7 +49,7 @@ pub(crate) enum PortFactoryPublishSubscribeType {
 
 #[pyclass]
 /// The factory for `MessagingPattern::PublishSubscribe`. It can acquire dynamic and static service
-/// informations and create `Publisher` or `Subscriber` ports.
+/// information and create `Publisher` or `Subscriber` ports.
 pub struct PortFactoryPublishSubscribe {
     pub(crate) value: Parc<PortFactoryPublishSubscribeType>,
     payload_type_details: TypeStorage,

--- a/iceoryx2-ffi/python/src/port_factory_request_response.rs
+++ b/iceoryx2-ffi/python/src/port_factory_request_response.rs
@@ -54,7 +54,7 @@ pub(crate) enum PortFactoryRequestResponseType {
 
 #[pyclass]
 /// The factory for `MessagingPattern::RequestResponse`. It can acquire dynamic and static service
-/// informations and create `Client` or `Server` ports.
+/// information and create `Client` or `Server` ports.
 pub struct PortFactoryRequestResponse {
     pub(crate) value: Parc<PortFactoryRequestResponseType>,
     pub(crate) request_payload_type_details: TypeStorage,

--- a/iceoryx2-ffi/python/src/service_builder_blackboard.rs
+++ b/iceoryx2-ffi/python/src/service_builder_blackboard.rs
@@ -94,7 +94,7 @@ impl ServiceBuilderBlackboardCreator {
     }
 
     /// Defines the key type. To be able to connect to a `Service`, the `TypeDetail` must be
-    /// indentical in all participants since the communication is always strongly typed.
+    /// identical in all participants since the communication is always strongly typed.
     pub fn __set_key_type_details(&mut self, value: &TypeDetail) -> Self {
         match &mut *self.value.lock() {
             ServiceBuilderBlackboardCreatorType::Ipc(v) => {
@@ -324,7 +324,7 @@ impl ServiceBuilderBlackboardOpener {
     }
 
     /// Defines the key type. To be able to connect to a `Service`, the `TypeDetail` must be
-    /// indentical in all participants since the communication is always strongly typed.
+    /// identical in all participants since the communication is always strongly typed.
     pub fn __set_key_type_details(&mut self, value: &TypeDetail) -> Self {
         match &mut *self.value.lock() {
             ServiceBuilderBlackboardOpenerType::Ipc(v) => {

--- a/iceoryx2-log/log/src/fail.rs
+++ b/iceoryx2-log/log/src/fail.rs
@@ -45,7 +45,7 @@
 ///     }
 ///
 ///     fn evenMore(&self) -> Result<(), u64> {
-///         // forward error when it is compatible or convertable
+///         // forward error when it is compatible or convertible
 ///         fail!(from self, when self.doMore(), "doMore failed");
 ///         Ok(())
 ///     }

--- a/iceoryx2-log/log/src/lib.rs
+++ b/iceoryx2-log/log/src/lib.rs
@@ -18,7 +18,7 @@
 //! The Logging API for iceoryx2. It has 6 [`LogLevel`]s which can be set via
 //! [`set_log_level()`] and read via [`get_log_level()`].
 //!
-//! The API includes convinience macros to combine error/panic handling
+//! The API includes convenience macros to combine error/panic handling
 //! directly with a logger selected from the `iceoryx2_bb_loggers` crate.
 //! The [`fail!`] macro can return when the function which was called return an
 //! error containing result.
@@ -91,7 +91,7 @@
 //!     }
 //!
 //!     fn evenMore(&self) -> Result<(), u64> {
-//!         // forward error when it is compatible or convertable
+//!         // forward error when it is compatible or convertible
 //!         fail!(from self, when self.doMore(), "doMore failed");
 //!         Ok(())
 //!     }

--- a/iceoryx2-pal/concurrency-sync/src/spin_lock.rs
+++ b/iceoryx2-pal/concurrency-sync/src/spin_lock.rs
@@ -109,7 +109,7 @@ pub struct SpinLockGuard<'lk, T> {
     lock: &'lk SpinLock<T>,
 }
 
-// Sync implmentation needed because the unsafe Deref(Mut) implementation causes the SpinLockGuard
+// Sync implementation needed because the unsafe Deref(Mut) implementation causes the SpinLockGuard
 // to behave like &(mut) T
 // Send implementation not needed as the SpinLock implements Send, i.e. lock (&SpinLock<T>) is Send
 // only if T is Send

--- a/iceoryx2-pal/posix/src/linux/unistd.rs
+++ b/iceoryx2-pal/posix/src/linux/unistd.rs
@@ -74,7 +74,7 @@ pub unsafe fn gethostpid() -> pid_t {
         match pids.as_slice() {
             // in a PID namespace, the first value is the host PID
             [host_pid, _, ..] => *host_pid, // In a namespace, first value is host PID
-            // if there is no PID namespce, then we use the only PID listed
+            // if there is no PID namespace, then we use the only PID listed
             [only_pid] => *only_pid,
             // the NSpid: field is empty and we fall back to getpid
             [] => posix::getpid(),

--- a/iceoryx2-pal/posix/src/windows/errno.rs
+++ b/iceoryx2-pal/posix/src/windows/errno.rs
@@ -185,7 +185,7 @@ pub unsafe fn strerror(errnum: int) -> *const c_char {
         Errno::ENOENT => c"A required system-resource does not exist.".as_ptr() as *const c_char,
         Errno::ENOTSUP => c"The feature is not supported on this system.".as_ptr() as *const c_char,
         Errno::EBUSY => {
-            c"The resource is currently busy and unaccessable.".as_ptr() as *const c_char
+            c"The resource is currently busy and inaccessible.".as_ptr() as *const c_char
         }
         _ => c"Unknown error has occurred.".as_ptr() as *const c_char,
     }

--- a/iceoryx2-services/discovery/src/lib.rs
+++ b/iceoryx2-services/discovery/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! The `iceoryx2-services-discovery` crate provides discovery services for the components
 //! of an iceoryx2 system. These services enable other applications built on iceoryx2 to
-//! get informed of the presense of these components.
+//! get informed of the presence of these components.
 //!
 
 #![no_std]

--- a/iceoryx2-services/discovery/src/service_discovery/service.rs
+++ b/iceoryx2-services/discovery/src/service_discovery/service.rs
@@ -479,7 +479,7 @@ impl<S: ServiceType> Service<S> {
     /// Returns the service details of all the current services.
     ///
     /// This function is called within the spin function, so that
-    /// if any requests are recieved for the discovery states,
+    /// if any requests are received for the discovery states,
     /// it can be provided via the RequestResponse method.
     ///
     /// # Returns
@@ -489,7 +489,7 @@ impl<S: ServiceType> Service<S> {
     /// # Errors
     ///
     /// Returns a `ServerSpinError` if there was an error in Responsding,
-    /// Loaning or recieving Requests.
+    /// Loaning or receiving Requests.
     pub fn handle_discovery_requests(&mut self) -> Result<(), ServerSpinError> {
         let include_internal = self.discovery_config.include_internal;
         if let Some(server) = &mut self.server {

--- a/iceoryx2-services/tunnel/src/tunnel.rs
+++ b/iceoryx2-services/tunnel/src/tunnel.rs
@@ -173,7 +173,7 @@ impl<S: Service, B: for<'a> Backend<S> + Debug> Tunnel<S, B> {
         self.bridges.keys().cloned().collect()
     }
 
-    /// Updates the locally offerred services.
+    /// Updates the locally offered services.
     fn iceoryx_discovery(&mut self) -> Result<(), DiscoveryError> {
         match &self.discovery_strategy {
             LocalDiscoveryStrategy::Subscriber(_) => self.subscriber_discovery(),
@@ -181,7 +181,7 @@ impl<S: Service, B: for<'a> Backend<S> + Debug> Tunnel<S, B> {
         }
     }
 
-    /// Updates the remotely offerred services.
+    /// Updates the remotely offered services.
     fn backend_discovery(&mut self) -> Result<(), DiscoveryError> {
         let origin = format!("Tunnel({})::backend_discovery", self.node.id());
 

--- a/iceoryx2-userland/record-and-replay/src/lib.rs
+++ b/iceoryx2-userland/record-and-replay/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //! The individual types used by [`ServiceTypes`](crate::recorder::ServiceTypes) can be acquired
 //! from the [`StaticConfig`](iceoryx2::service::static_config::StaticConfig) of a
-//! [`Service`](iceoryx2::service::Service). For publish susbcribe one can call for instance
+//! [`Service`](iceoryx2::service::Service). For publish subscribe one can call for instance
 //! [`publish_subscribe::StaticConfig::message_type_details()`](iceoryx2::service::static_config::publish_subscribe::StaticConfig::message_type_details())
 //!
 //! ```
@@ -126,7 +126,7 @@ extern crate alloc;
 /// Free functions to convert bytes to a hex string and back.
 pub mod hex_conversion;
 
-/// Loads a meaninful subset.
+/// Loads a meaningful subset.
 pub mod prelude;
 
 /// Contains the [`Record`](crate::record::Record) and [`RawRecord`](crate::record::RawRecord)

--- a/iceoryx2-userland/record-and-replay/src/recorder.rs
+++ b/iceoryx2-userland/record-and-replay/src/recorder.rs
@@ -14,7 +14,7 @@
 //!
 //! The individual types used by [`ServiceTypes`](crate::recorder::ServiceTypes) can be acquired
 //! from the [`StaticConfig`](iceoryx2::service::static_config::StaticConfig) of a
-//! [`Service`](iceoryx2::service::Service). For publish susbcribe one can call for instance
+//! [`Service`](iceoryx2::service::Service). For publish subscribe one can call for instance
 //! [`publish_subscribe::StaticConfig::message_type_details()`](iceoryx2::service::static_config::publish_subscribe::StaticConfig::message_type_details())
 //!
 //! ```

--- a/iceoryx2/conformance-tests/src/service.rs
+++ b/iceoryx2/conformance-tests/src/service.rs
@@ -1043,7 +1043,7 @@ pub mod service {
     }
 
     #[cfg(not(target_os = "windows"))]
-    // disabled since the windows defender interfers and causes ERROR_ACCESS_DENIED failures on the platform when it locks file for scanning
+    // disabled since the windows defender interferes and causes ERROR_ACCESS_DENIED failures on the platform when it locks file for scanning
     #[conformance_test]
     pub fn concurrent_service_creation_and_listing_works<Sut: Service, Factory: SutFactory<Sut>>() {
         let test =

--- a/iceoryx2/src/config.rs
+++ b/iceoryx2/src/config.rs
@@ -380,7 +380,7 @@ pub struct Event {
     pub max_nodes: usize,
     /// The largest event id supported by the event service
     pub event_id_max_value: usize,
-    /// Defines the maximum allowed time between two consecutive notifications. If a notifiation
+    /// Defines the maximum allowed time between two consecutive notifications. If a notification
     /// is not sent after the defined time, every [`Listener`](crate::port::listener::Listener)
     /// that is attached to a [`WaitSet`](crate::waitset::WaitSet) will be notified.
     pub deadline: Option<Duration>,

--- a/iceoryx2/src/lib.rs
+++ b/iceoryx2/src/lib.rs
@@ -573,7 +573,7 @@ pub mod service;
 /// [`WaitSet`](crate::waitset::WaitSet) shall handle system signals.
 pub mod signal_handling_mode;
 
-/// Loads a meaninful subset to cover 90% of the iceoryx2 communication use cases.
+/// Loads a meaningful subset to cover 90% of the iceoryx2 communication use cases.
 pub mod prelude;
 
 #[doc(hidden)]

--- a/iceoryx2/src/node/mod.rs
+++ b/iceoryx2/src/node/mod.rs
@@ -310,7 +310,7 @@ enum NodeReadPortTagsFailure {
     InternalError,
 }
 
-/// Optional detailed informations that a [`Node`] can have. They can only be obtained when the
+/// Optional detailed information that a [`Node`] can have. They can only be obtained when the
 /// process has sufficient access permissions.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NodeDetails {
@@ -449,7 +449,7 @@ pub trait NodeView {
     fn details(&self) -> &Option<NodeDetails>;
 }
 
-/// All the informations of a [`Node`] that is alive.
+/// All the information of a [`Node`] that is alive.
 #[derive(Debug)]
 pub struct AliveNodeView<Service: service::Service> {
     id: UniqueNodeId,
@@ -477,7 +477,7 @@ impl<Service: service::Service> NodeView for AliveNodeView<Service> {
     }
 }
 
-/// All the informations and management operations belonging to a dead [`Node`].
+/// All the information and management operations belonging to a dead [`Node`].
 #[derive(Debug)]
 pub struct DeadNodeView<Service: service::Service>(AliveNodeView<Service>);
 
@@ -649,7 +649,7 @@ impl<Service: service::Service> DeadNodeView<Service> {
             Err(NodeReadServiceTagsFailure::InsufficientPermissions) => {
                 cleaner.abandon();
                 fail!(from self, with NodeCleanupFailure::InsufficientPermissions,
-                    "{} since the service tags could not be read due to insufficent permissions.", msg);
+                    "{} since the service tags could not be read due to insufficient permissions.", msg);
             }
             Err(NodeReadServiceTagsFailure::InternalError) => {
                 cleaner.abandon();
@@ -695,7 +695,7 @@ impl<Service: service::Service> DeadNodeView<Service> {
             Err(NodeReadPortTagsFailure::InsufficientPermissions) => {
                 cleaner.abandon();
                 fail!(from self, with NodeCleanupFailure::InsufficientPermissions,
-                    "{} since the port tags could not be read due to insufficent permissions.", msg);
+                    "{} since the port tags could not be read due to insufficient permissions.", msg);
             }
             Err(NodeReadPortTagsFailure::InternalError) => {
                 cleaner.abandon();

--- a/iceoryx2/src/port/details/sender.rs
+++ b/iceoryx2/src/port/details/sender.rs
@@ -202,7 +202,7 @@ impl<Service: service::Service, Resource: ServiceResource> Sender<Service, Resou
         unsafe { &(*self.connections[index].get()) }
     }
 
-    // only used internally as convinience function
+    // only used internally as convenience function
     #[allow(clippy::mut_from_ref)]
     fn get_mut(&self, index: usize) -> &mut Option<Connection<Service, Resource>> {
         #[deny(clippy::mut_from_ref)]

--- a/iceoryx2/src/port/writer.rs
+++ b/iceoryx2/src/port/writer.rs
@@ -481,7 +481,7 @@ impl<
     }
 }
 
-/// Wrapper around an uninitiaized entry value that can be used for a zero-copy update.
+/// Wrapper around an uninitialized entry value that can be used for a zero-copy update.
 pub struct EntryValueUninit<
     Service: service::Service,
     KeyType: Send + Sync + Eq + Clone + Debug + 'static + Hash + ZeroCopySend,
@@ -793,7 +793,7 @@ impl<Service: service::Service> __InternalEntryHandleMut<Service> {
     }
 }
 
-/// Wrapper around an uninitiaized entry value that can be used for a zero-copy update. Used
+/// Wrapper around an uninitialized entry value that can be used for a zero-copy update. Used
 /// for the language bindings where key and value type cannot be passed as generics.
 #[doc(hidden)]
 pub struct __InternalEntryValueUninit<Service: service::Service> {

--- a/iceoryx2/src/service/builder/blackboard.rs
+++ b/iceoryx2/src/service/builder/blackboard.rs
@@ -49,7 +49,7 @@ pub enum BlackboardOpenError {
     Interrupt,
     /// The [`Service`] could not be opened since it does not exist
     DoesNotExist,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Service`] has the wrong key type.
     IncompatibleKeys,
@@ -149,7 +149,7 @@ pub enum BlackboardCreateError {
     InternalFailure,
     /// The process has insufficient permissions to create the [`Service`].
     InsufficientPermissions,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Service`]s creation timeout has passed and it is still not initialized. Can be caused
     /// by a process that crashed during [`Service`] creation.

--- a/iceoryx2/src/service/builder/event.rs
+++ b/iceoryx2/src/service/builder/event.rs
@@ -169,7 +169,7 @@ impl From<EventOpenError> for ServiceOpenError {
 pub enum EventCreateError {
     /// An interrupt signal was received.
     Interrupt,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// Errors that indicate either an implementation issue or a wrongly configured system.
     InternalFailure,

--- a/iceoryx2/src/service/builder/mod.rs
+++ b/iceoryx2/src/service/builder/mod.rs
@@ -985,7 +985,7 @@ impl<ServiceType: service::Service> BuilderWithServiceType<ServiceType> {
                     }
                     Err(RegisterNodeResult::ExceedsMaxNumberOfNodes) => {
                         fail!(from self, with OpenDynamicStorageFailure::ExceedsMaxNumberOfNodes,
-                            "{} since it would exceed the maxium supported number of nodes.", msg);
+                            "{} since it would exceed the maximum supported number of nodes.", msg);
                     }
                 }
             },

--- a/iceoryx2/src/service/builder/publish_subscribe.rs
+++ b/iceoryx2/src/service/builder/publish_subscribe.rs
@@ -73,7 +73,7 @@ pub enum PublishSubscribeOpenError {
     IncompatibleOverflowBehavior,
     /// The process has not enough permissions to open the [`Service`]
     InsufficientPermissions,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Service`]s creation timeout has passed and it is still not initialized. Can be caused
     /// by a process that crashed during [`Service`] creation.
@@ -205,7 +205,7 @@ impl From<PublishSubscribeOpenError> for ServiceOpenError {
 pub enum PublishSubscribeCreateError {
     /// An interrupt signal was received.
     Interrupt,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// Invalid [`Service`] configuration provided. The
     /// [`Subscriber`](crate::port::subscriber::Subscriber)s buffer size must be at least the size

--- a/iceoryx2/src/service/builder/request_response.rs
+++ b/iceoryx2/src/service/builder/request_response.rs
@@ -84,7 +84,7 @@ pub enum RequestResponseOpenError {
     /// When the call creation call is repeated with a little delay the [`Service`] should be
     /// recreatable.
     IsMarkedForDestruction,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Node`](crate::node::Node) service tag could not be created. Required to track resources of dead nodes when cleaning them up.
     UnableToCreateServiceTag,
@@ -224,7 +224,7 @@ pub enum RequestResponseCreateError {
     /// The [`Service`]s creation timeout has passed and it is still not initialized. Can be caused
     /// by a process that crashed during [`Service`] creation.
     HangsInCreation,
-    /// Some underlying resources of the [`Service`] are either missing, corrupted or unaccessible.
+    /// Some underlying resources of the [`Service`] are either missing, corrupted or inaccessible.
     ServiceInCorruptedState,
     /// The [`Node`](crate::node::Node) service tag could not be created. Required to track resources of dead nodes when cleaning them up.
     UnableToCreateServiceTag,

--- a/iceoryx2/src/service/dynamic_config/blackboard.rs
+++ b/iceoryx2/src/service/dynamic_config/blackboard.rs
@@ -149,7 +149,7 @@ impl DynamicConfig {
             self.readers.recover(
                 node_id.owner_id(),
                 |registered_reader| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     registered_reader.node_id == *node_id
                         && port_cleanup_callback(UniquePortId::Reader(registered_reader.reader_id))
                             == PortCleanupAction::RemovePort
@@ -160,7 +160,7 @@ impl DynamicConfig {
             self.writers.recover(
                 node_id.owner_id(),
                 |registered_writer| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     registered_writer.node_id == *node_id
                         && port_cleanup_callback(UniquePortId::Writer(registered_writer.writer_id))
                             == PortCleanupAction::RemovePort

--- a/iceoryx2/src/service/dynamic_config/event.rs
+++ b/iceoryx2/src/service/dynamic_config/event.rs
@@ -157,7 +157,7 @@ impl DynamicConfig {
             self.listeners.recover(
                 node_id.owner_id(),
                 |registered_listener| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     registered_listener.node_id == *node_id
                         && port_cleanup_callback(UniquePortId::Listener(
                             registered_listener.listener_id,
@@ -169,7 +169,7 @@ impl DynamicConfig {
             self.notifiers.recover(
                 node_id.owner_id(),
                 |registered_notifier| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     registered_notifier.node_id == *node_id
                         && port_cleanup_callback(UniquePortId::Notifier(
                             registered_notifier.notifier_id,

--- a/iceoryx2/src/service/dynamic_config/mod.rs
+++ b/iceoryx2/src/service/dynamic_config/mod.rs
@@ -169,7 +169,7 @@ impl DynamicConfig {
             match self.nodes.recover(
                 node_id.owner_id(),
                 |entry_node_id| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     entry_node_id == *node_id
                 },
                 ReleaseMode::LockIfLastIndex,

--- a/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
+++ b/iceoryx2/src/service/dynamic_config/publish_subscribe.rs
@@ -136,7 +136,7 @@ impl DynamicConfig {
             self.publishers.recover(
                 node_id.owner_id(),
                 |registered_publisher| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     registered_publisher.node_id == *node_id
                         && port_cleanup_callback(UniquePortId::Publisher(
                             registered_publisher.publisher_id,
@@ -148,7 +148,7 @@ impl DynamicConfig {
             self.subscribers.recover(
                 node_id.owner_id(),
                 |registered_subscriber| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     registered_subscriber.node_id == *node_id
                         && port_cleanup_callback(UniquePortId::Subscriber(
                             registered_subscriber.subscriber_id,

--- a/iceoryx2/src/service/dynamic_config/request_response.rs
+++ b/iceoryx2/src/service/dynamic_config/request_response.rs
@@ -64,7 +64,7 @@ pub struct ServerDetails {
 pub struct ClientDetails {
     /// The [`UniqueClientId`] of the [`Client`](crate::port::client::Client).
     pub client_id: UniqueClientId,
-    /// The [`PortName`] of the [`Clinet`](crate::port::client::Client).
+    /// The [`PortName`] of the [`Client`](crate::port::client::Client).
     pub client_name: PortName,
     /// The [`UniqueNodeId`] of the [`Node`](crate::node::Node) under which the
     /// [`Client`](crate::port::client::Client) was created.
@@ -150,7 +150,7 @@ impl DynamicConfig {
             self.servers.recover(
                 node_id.owner_id(),
                 |registered_server| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     registered_server.node_id == *node_id
                         && port_cleanup_callback(UniquePortId::Server(registered_server.server_id))
                             == PortCleanupAction::RemovePort
@@ -161,7 +161,7 @@ impl DynamicConfig {
             self.clients.recover(
                 node_id.owner_id(),
                 |registered_client| {
-                    // additional comparision, since the node_id.owner_id() might be not enough
+                    // additional comparison, since the node_id.owner_id() might be not enough
                     registered_client.node_id == *node_id
                         && port_cleanup_callback(UniquePortId::Client(registered_client.client_id))
                             == PortCleanupAction::RemovePort

--- a/iceoryx2/src/service/mod.rs
+++ b/iceoryx2/src/service/mod.rs
@@ -443,7 +443,7 @@ pub struct ServiceDetails<S: Service> {
     /// The static configuration of the [`Service`] that never changes during the [`Service`]
     /// lifetime.
     pub static_details: StaticConfig,
-    /// The dynamic configuration of the [`Service`] that can conaints runtime informations.
+    /// The dynamic configuration of the [`Service`] that can conaints runtime information.
     pub dynamic_details: Option<ServiceDynamicDetails<S>>,
 }
 

--- a/iceoryx2/src/service/port_factory/blackboard.rs
+++ b/iceoryx2/src/service/port_factory/blackboard.rs
@@ -62,7 +62,7 @@ use iceoryx2_cal::dynamic_storage::DynamicStorage;
 
 /// The factory for
 /// [`MessagingPattern::Blackboard`](crate::service::messaging_pattern::MessagingPattern::Blackboard).
-/// It can acquire dynamic and static service informations and create
+/// It can acquire dynamic and static service information and create
 /// [`crate::port::reader::Reader`] or [`crate::port::writer::Writer`] ports.
 #[derive(Debug)]
 pub struct PortFactory<

--- a/iceoryx2/src/service/port_factory/event.rs
+++ b/iceoryx2/src/service/port_factory/event.rs
@@ -55,7 +55,7 @@ use iceoryx2_cal::dynamic_storage::DynamicStorage;
 
 /// The factory for
 /// [`MessagingPattern::Event`](crate::service::messaging_pattern::MessagingPattern::Event). It can
-/// acquire dynamic and static service informations and create [`crate::port::notifier::Notifier`]
+/// acquire dynamic and static service information and create [`crate::port::notifier::Notifier`]
 /// or [`crate::port::listener::Listener`] ports.
 #[derive(Debug)]
 pub struct PortFactory<Service: service::Service> {

--- a/iceoryx2/src/service/port_factory/publish_subscribe.rs
+++ b/iceoryx2/src/service/port_factory/publish_subscribe.rs
@@ -63,7 +63,7 @@ use iceoryx2_cal::dynamic_storage::DynamicStorage;
 
 /// The factory for
 /// [`MessagingPattern::PublishSubscribe`](crate::service::messaging_pattern::MessagingPattern::PublishSubscribe).
-/// It can acquire dynamic and static service informations and create
+/// It can acquire dynamic and static service information and create
 /// [`crate::port::publisher::Publisher`]
 /// or [`crate::port::subscriber::Subscriber`] ports.
 #[derive(Debug)]

--- a/iceoryx2/src/service/port_factory/request_response.rs
+++ b/iceoryx2/src/service/port_factory/request_response.rs
@@ -60,7 +60,7 @@ use iceoryx2_cal::dynamic_storage::DynamicStorage;
 
 /// The factory for
 /// [`MessagingPattern::RequestResponse`](crate::service::messaging_pattern::MessagingPattern::RequestResponse).
-/// It can acquire dynamic and static service informations and create
+/// It can acquire dynamic and static service information and create
 /// [`crate::port::client::Client`]
 /// or [`crate::port::server::Server`] ports.
 #[derive(Debug)]

--- a/iceoryx2/src/service/resource/blackboard.rs
+++ b/iceoryx2/src/service/resource/blackboard.rs
@@ -265,7 +265,7 @@ impl<ServiceType: service::Service> ServiceResource for BlackboardResources<Serv
             Ok(false) => Ok(()),
             Err(NamedConceptRemoveError::InsufficientPermissions) => {
                 fail!(from origin, with RemoveStaleResourcesError::InsufficientPermissions,
-                    "{msg} since the blackboard mgmt segment cannot be removed due to insufficient permisssions.");
+                    "{msg} since the blackboard mgmt segment cannot be removed due to insufficient permissions.");
             }
             Err(NamedConceptRemoveError::Interrupt) => {
                 fail!(from origin, with RemoveStaleResourcesError::InterruptedBySignal,

--- a/iceoryx2/src/service/resource/publish_subscribe.rs
+++ b/iceoryx2/src/service/resource/publish_subscribe.rs
@@ -201,7 +201,7 @@ impl<ServiceType: service::Service> ServiceResource for PublishSubscribeResource
                     }
                     Err(StaticStorageOpenError::InitializationNotYetFinalized) => {
                         fail!(from origin, with ServiceOpenError::HangsInCreation,
-                            "{msg} since the type defintion file is not yet initialized.");
+                            "{msg} since the type definition file is not yet initialized.");
                     }
                     Err(StaticStorageOpenError::DoesNotExist) => {
                         fail!(from origin, with ServiceOpenError::ServiceInCorruptedState,

--- a/integrations/zenoh/tunnel-backend/src/discovery.rs
+++ b/integrations/zenoh/tunnel-backend/src/discovery.rs
@@ -287,7 +287,7 @@ impl Discovery {
             let service_hash = match parse_service_hash(key) {
                 Some(h) => h,
                 None => {
-                    warn!("Skipping liveliness sample with unparseable key: {}", key);
+                    warn!("Skipping liveliness sample with unparsable key: {}", key);
                     continue;
                 }
             };
@@ -393,7 +393,7 @@ fn check_pending(
         match serde_json::from_slice::<ServiceDescription>(&sample.payload().to_bytes()) {
             Ok(description) => return Ok(Some(description)),
             Err(e) => warn!(
-                "Skipping unparseable reply for service {}: {}",
+                "Skipping unparsable reply for service {}: {}",
                 hash.as_str(),
                 e
             ),

--- a/internal/scripts/ci_test_spdx_license_header.sh
+++ b/internal/scripts/ci_test_spdx_license_header.sh
@@ -31,7 +31,7 @@ do
     # check that SPDX license identifier is used only once
     SPDX_LICENSE_IDENTIFIER_COUNT=$(echo $(grep "SPDX-License-Identifier: Apache-2.0 OR MIT" --count $FILE))
     if [[ "$SPDX_LICENSE_IDENTIFIER_COUNT" == "0" ]]; then
-        echo "The file '$FILE' has no valid SPDX license identifier with 'Aoache-2.0 OR MIT'."
+        echo "The file '$FILE' has no valid SPDX license identifier with 'Apache-2.0 OR MIT'."
         RET_VAL=1
     elif [[ "$SPDX_LICENSE_IDENTIFIER_COUNT" != "1" ]]; then
         if [[ "$FILE" != "./internal/scripts/ci_test_spdx_license_header.sh" \

--- a/internal/scripts/release/release_preparation.sh
+++ b/internal/scripts/release/release_preparation.sh
@@ -237,7 +237,7 @@ if [[ ${SELECTION} == ${YES} ]]; then
 
     echo -e "Did you check the release notes for dummy entries and cleaned it up?"
     show_default_selector
-    echo -e "Shall the changes be commited?"
+    echo -e "Shall the changes be committed?"
     show_default_selector
     if [[ ${SELECTION} == ${YES} ]]; then
         git add doc/release-notes/iceoryx2-v${ICEORYX2_RELEASE_VERSION}.md
@@ -300,7 +300,7 @@ if [[ ${SELECTION} == ${YES} ]]; then
     git add .
 
     echo -e ""
-    echo -e "Shall the changes be commited?"
+    echo -e "Shall the changes be committed?"
     show_default_selector
     if [[ ${SELECTION} == ${YES} ]]; then
         git commit -m"[#77] Update version number to v${ICEORYX2_RELEASE_VERSION}"

--- a/todo.md
+++ b/todo.md
@@ -189,7 +189,7 @@
         * Contains trait and all impls as pubs under same namespace
 * `DynamicStorage`
     * Restrict `T` to
-    <https://doc.rust-lang.org/std/intrinsics/fn.needs_drop.html> non dropable
+    <https://doc.rust-lang.org/std/intrinsics/fn.needs_drop.html> non droppable
 
 ## Advanced
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This PR fixes typos in docs, comments, and string literals. It should not change any behavior of the code. Similar to https://github.com/eclipse-iceoryx/iceoryx/pull/2539


Should not have any affect on code behavior.

`cargo fmt` and `clang-format` did not result in any changes.


## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] Tests follow the [best practice for testing][testing]
* [ ] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->
Relates to #4

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
