### PR TITLE
[#1152] Fix no_std build of the console logger on non-linux platforms

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -35,6 +35,7 @@
 
 * [#156](https://github.com/eclipse-iceoryx/iceoryx2/issues/156) Remove `fchmod`/`shm_open` macOS workarounds; route permissions through a trampoline state file.
 * [#588](https://github.com/eclipse-iceoryx/iceoryx2/issues/588) Replace deprecated `serde_yaml` dependency with `yaml_serde`.
+* [#1152](https://github.com/eclipse-iceoryx/iceoryx2/issues/1152) Fix `no_std` build of the console logger on platforms other than linux and nto.
 * [#1548](https://github.com/eclipse-iceoryx/iceoryx2/issues/1548) Fix Payload data lifetime tracking in python ffi by anchoring views to their owning Sample.
 * [#1673](https://github.com/eclipse-iceoryx/iceoryx2/issues/1673) Thread-stack-size is the same as process-stack-size on all platforms.
 * [#1695](https://github.com/eclipse-iceoryx/iceoryx2/issues/1695) Remove port_tag when stale resources of port are removed.

--- a/iceoryx2-bb/loggers/src/console.rs
+++ b/iceoryx2-bb/loggers/src/console.rs
@@ -70,6 +70,8 @@ fn duration_since_epoch() -> core::time::Duration {
         not(any(target_os = "linux", target_os = "nto",))
     ))]
     {
+        use core::time::Duration;
+
         Duration::from_secs(0)
     }
 }


### PR DESCRIPTION
## Notes for Reviewer

As discussed in #1152. The `unistd` part already looked done in `iceoryx2-pal-print/src/writer.rs`, so this only fixes the remaining `no_std` build break.

`duration_since_epoch()` in `console.rs` keeps `use core::time::Duration;` inside the linux/nto branch, but the fallback branch below it also uses `Duration`. So on any other target:

```
$ cargo build -p iceoryx2-bb-loggers --no-default-features --features console
error[E0433]: failed to resolve: use of undeclared type `Duration`
  --> iceoryx2-bb/loggers/src/console.rs:73:9
```

This adds the same import to that branch. Verified it fails on main and passes with the change, on aarch64 macOS. `std` builds are untouched, `cargo fmt` clean.

One thing you may want to pick up separately: the `no_std` CI job runs on ubuntu-latest, so it always takes the linux branch and can't see breakage in the fallback path. Adding a `no_std` build on a non-linux target, or a bare metal one, would catch this class of problem. Happy to open a separate issue for that if it's useful.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
* [x] Relevant issues are linked in the References section
* [x] Branch follows the naming format (`iox2-1152-fix-no-std-console-logger-build`)
* [x] Commits messages are according to commit message guidelines
    * [x] Commit messages have the issue ID (`[#1152]`)
* [ ] Tests follow best practice for testing guidelines - build fix, no test added, see notes
* [x] Changelog updated in the unreleased section including API breaking changes

## References

Relates to #1152
