### PR TITLE
[#1737] fix windows error output

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -41,6 +41,7 @@
 * [#1695](https://github.com/eclipse-iceoryx/iceoryx2/issues/1695) Remove port_tag when stale resources of port are removed.
 * [#1708](https://github.com/eclipse-iceoryx/iceoryx2/issues/1708) Remove `services` from tunnel conformance test crate to fix a linker error on macOS.
 * [#1718](https://github.com/eclipse-iceoryx/iceoryx2/issues/1718) Protect `ProcessState` from accidental file lock release.
+* [#1737](https://github.com/eclipse-iceoryx/iceoryx2/issues/1737) Fix error log output in Windows for languages with non UTF-8 characters.
 * [#1739](https://github.com/eclipse-iceoryx/iceoryx2/issues/1739) Make sure MSVC defines __cplusplus with accurate value
 * [#1746](https://github.com/eclipse-iceoryx/iceoryx2/issues/1746) Disable `POSIX_SUPPORT_FILE_LOCK_FOR_SHARED_MEMORY` on FreeBSD and move CI job for FreeBSD to main pipeline
 * [#1777](https://github.com/eclipse-iceoryx/iceoryx2/issues/1777) Fix service root folder creation named concept of iceoryx2-cal fixing execution on Windows platform.
@@ -183,13 +184,13 @@
         bar: u8,
         baz: u64,
     }
-    
+
     unsafe impl AtomicCopy for Foo {
         fn __for_each_field<F: FnMut(usize, usize)>(&self, base_offset: usize, callback: &mut F) {
             // ...
         }
     }
-    
+
     // new
     // ...
     unsafe impl AtomicCopy for Foo {

--- a/iceoryx2-pal/posix/src/windows/win32_call.rs
+++ b/iceoryx2-pal/posix/src/windows/win32_call.rs
@@ -112,21 +112,11 @@ macro_rules! win32call {
                 match last_error {
                     $($error => ()),*,
                     _ => {
-                        let mut buffer = [0u8; 1024];
-                        windows_sys::Win32::System::Diagnostics::Debug::FormatMessageA(
-                            windows_sys::Win32::System::Diagnostics::Debug::FORMAT_MESSAGE_FROM_SYSTEM |
-                            windows_sys::Win32::System::Diagnostics::Debug::FORMAT_MESSAGE_IGNORE_INSERTS,
-                            core::ptr::null::<void>(),
-                            last_error,
-                            0,
-                            buffer.as_mut_ptr(),
-                            buffer.len() as u32,
-                            core::ptr::null::<*const i8>()
-                        );
-                        std::eprintln!(
+                       let os_error = std::io::Error::from_raw_os_error(last_error as i32);
+                       std::eprintln!(
                             "< Win32 API error > {}:{} {} \n [ {} ] {}",
                             std::file!(), std::line!(), std::stringify!($call), last_error,
-                            core::str::from_utf8(&buffer).unwrap_or("non UTF-8 error messages are not supported")
+                            os_error
                         );
                     },
                 }
@@ -153,21 +143,11 @@ macro_rules! win32call {
                 match last_error {
                     $($error => ()),*,
                     _ => {
-                        let mut buffer = [0u8; 1024];
-                        windows_sys::Win32::System::Diagnostics::Debug::FormatMessageA(
-                            windows_sys::Win32::System::Diagnostics::Debug::FORMAT_MESSAGE_FROM_SYSTEM |
-                            windows_sys::Win32::System::Diagnostics::Debug::FORMAT_MESSAGE_IGNORE_INSERTS,
-                            core::ptr::null::<void>(),
-                            last_error as _,
-                            0,
-                            buffer.as_mut_ptr(),
-                            buffer.len() as u32,
-                            core::ptr::null::<*const i8>(),
-                        );
+                        let os_error = std::io::Error::from_raw_os_error(last_error as i32);
                         std::eprintln!(
                             "< Win32 WinSock2 API error > {}:{} {} \n [ {} ] {}",
                             std::file!(), std::line!(), std::stringify!($call), last_error,
-                            core::str::from_utf8(&buffer).unwrap_or("non UTF-8 error messages are not supported")
+                            os_error
                         );
                     },
                 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1737 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
