### PR TITLE
[#4] Fix Listener wait method docstrings in the python bindings

### DIFF
--- a/iceoryx2-ffi/python/src/listener.rs
+++ b/iceoryx2-ffi/python/src/listener.rs
@@ -44,8 +44,8 @@ impl Listener {
         }
     }
 
-    /// Non-blocking wait for new `EventId`s. Collects all `EventId`s that were received and
-    /// calls the provided callback is with the `EventId` as input argument.
+    /// Non-blocking wait for new events. Collects all `EventActivation`s that were received
+    /// and returns them.
     /// On error it emits `ListenerWaitError`.
     pub fn try_wait(&self) -> PyResult<Vec<EventActivation>> {
         let mut event_ids = vec![];
@@ -63,9 +63,9 @@ impl Listener {
         Ok(event_ids)
     }
 
-    /// Blocking wait for new `EventId`s until the provided timeout has passed. Unblocks as soon
-    /// as an `EventId` was received and then collects all `EventId`s that were received and
-    /// calls the provided callback is with the `EventId` as input argument.
+    /// Blocking wait for new events until the provided timeout has passed. Unblocks as soon
+    /// as an event was received and then collects all `EventActivation`s that were received
+    /// and returns them.
     /// On error it emits `ListenerWaitError`.
     pub fn timed_wait(&self, timeout: &Duration, py: Python<'_>) -> PyResult<Vec<EventActivation>> {
         py.detach(move || {
@@ -85,9 +85,9 @@ impl Listener {
         })
     }
 
-    /// Blocking wait for new `EventId`s. Unblocks as soon
-    /// as an `EventId` was received and then collects all `EventId`s that were received and
-    /// calls the provided callback is with the `EventId` as input argument.
+    /// Blocking wait for new events. Unblocks as soon
+    /// as an event was received and then collects all `EventActivation`s that were received
+    /// and returns them.
     /// On error it emits `ListenerWaitError`.
     pub fn blocking_wait(&self, py: Python<'_>) -> PyResult<Vec<EventActivation>> {
         py.detach(move || {


### PR DESCRIPTION
## Notes for Reviewer

@elfenpiff as offered in #1680. Filing under #4 rather than a new issue since it is a small documentation fix.

All three `Listener` wait methods in the python bindings documented a callback parameter that the python API does not have:

> Collects all `EventId`s that were received and calls the provided callback is with the `EventId` as input argument.

They take no callback and return the activations instead, so following the docs raises:

```python
>>> listener.try_wait(lambda event: None)
TypeError: Listener.try_wait() takes no arguments (1 given)
```

The text looks carried over from the Rust core, which does take a callback. Also corrected in the same sentence: the item type is `EventActivation` rather than `EventId`, and "calls the provided callback is with" was not grammatical.

Only the docs changed, no behaviour. Rebuilt the bindings with maturin and read the docstrings back from python to confirm they render correctly.

No changelog entry, following `b07c4c639` ("[#4] Fix typos in docs, comments and string literals") which did not add one. Happy to add one if you would rather have it.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
* [x] Relevant issues are linked in the References section
* [x] Branch follows the naming format (`iox2-4-fix-python-listener-wait-docstrings`)
* [x] Commits messages are according to commit message guidelines
    * [x] Commit messages have the issue ID (`[#4]`)
* [ ] Tests follow best practice for testing guidelines - documentation only, no test added
* [ ] Changelog updated in the unreleased section including API breaking changes - not applicable, see notes

## References

Relates to #4
Relates to #1680
