### PR TITLE
[#3] Speed up CI builds

### DIFF
--- a/.github/actions/cpu-count/action.yml
+++ b/.github/actions/cpu-count/action.yml
@@ -1,0 +1,17 @@
+name: CPU count
+description: Get the number of available CPU cores
+
+outputs:
+  count:
+    description: Number of available CPU cores
+    value: ${{ steps.cpu.outputs.count }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: cpu
+      shell: pwsh
+      run: |
+        $count = [System.Environment]::ProcessorCount
+        Write-Host "Available CPU cores: $count"
+        "count=$count" >> $env:GITHUB_OUTPUT

--- a/.github/actions/save-disk-space/action.yml
+++ b/.github/actions/save-disk-space/action.yml
@@ -51,5 +51,5 @@ runs:
         if: ${{ inputs.mode == 'cleanup-rust-build-files-from-cargo-target-folder' }}
         shell: bash
         run: |
-          rm -rf ${{ github.workspace }}/target/{debug,release}/{deps,incremental}
-          rm -rf ${{ github.workspace }}/target/*/{debug,release}/{deps,incremental} # Cleanup subfolders for target triples
+          rm -rf ${{ github.workspace }}/target/{debug,release,dev-fast-build,release-fast-build}/{deps,incremental}
+          rm -rf ${{ github.workspace }}/target/*/{debug,release}/{deps,incremental,dev-fast-build,release-fast-build} # Cleanup subfolders for target triples

--- a/.github/actions/set-build-flags/action.yml
+++ b/.github/actions/set-build-flags/action.yml
@@ -2,12 +2,12 @@ name: 'Set Build Flags'
 description: 'Sets flags for Cargo and CMake'
 inputs:
   profile:
-    description: "Build profile {debug;release}"
+    description: "Build profile {dev;dev-fast-build;release;release-fast-build}"
     required: true
 outputs:
-  cargo-build-mode:
-    description: "Cargo Build Mode"
-    value: ${{ steps.set-build-flags.outputs.cargo-build-mode}}
+  c-binding-artifacts-folder-name:
+    description: "The name of the folder with the C binding artifacts"
+    value: ${{ steps.set-build-flags.outputs.c-binding-artifacts-folder-name}}
   cmake-build-type:
     description: "CMake Build Type"
     value: ${{ steps.set-build-flags.outputs.cmake-build-type }}
@@ -21,24 +21,27 @@ runs:
         id: set-build-flags
         shell: bash
         run: |
-          CARGO_BUILD_MODE=""
+          C_BINDING_ARTIFACTS_FOLDER_NAME="${{ inputs.profile }}"
           CMAKE_BUILD_TYPE=""
           CMAKE_BUILD_CONFIG=""
-          if [[ ${{ inputs.profile }} == 'release' ]]; then
-            CARGO_BUILD_MODE="--release"
+
+          if [[ ${{ inputs.profile }} == dev ]]; then
+            C_BINDING_ARTIFACTS_FOLDER_NAME="debug"
+          fi
+
+          if [[ ${{ inputs.profile }} == release* ]]; then
             CMAKE_BUILD_TYPE="-DCMAKE_BUILD_TYPE=Release"
             CMAKE_BUILD_CONFIG="--config Release"
-            echo "cargo-build-mode=$(echo $CARGO_BUILD_MODE)" >> $GITHUB_OUTPUT
-            echo "cmake-build-type=$(echo $CMAKE_BUILD_TYPE)" >> $GITHUB_OUTPUT
-            echo "cmake-build-config=$(echo $CMAKE_BUILD_CONFIG)" >> $GITHUB_OUTPUT
           fi
-          if [[ ${{ inputs.profile }} == 'debug' ]]; then
-            CARGO_BUILD_MODE=""
+          if [[ ${{ inputs.profile }} == dev* ]]; then
             CMAKE_BUILD_TYPE="-DCMAKE_BUILD_TYPE=Debug"
             CMAKE_BUILD_CONFIG="--config Debug"
-            echo "cargo-build-mode=$(echo $CARGO_BUILD_MODE)" >> $GITHUB_OUTPUT
-            echo "cmake-build-type=$(echo $CMAKE_BUILD_TYPE)" >> $GITHUB_OUTPUT
-            echo "cmake-build-config=$(echo $CMAKE_BUILD_CONFIG)" >> $GITHUB_OUTPUT
           fi
-          echo "Cargo build mode: ${CARGO_BUILD_MODE}"
+
+          echo "c-binding-artifacts-folder-name=$(echo $C_BINDING_ARTIFACTS_FOLDER_NAME)" >> $GITHUB_OUTPUT
+          echo "cmake-build-type=$(echo $CMAKE_BUILD_TYPE)" >> $GITHUB_OUTPUT
+          echo "cmake-build-config=$(echo $CMAKE_BUILD_CONFIG)" >> $GITHUB_OUTPUT
+
+          echo "Cargo profile: ${{ inputs.profile }}"
           echo "CMake build type: ${CMAKE_BUILD_TYPE}"
+          echo "C binding artifacts folder name: ${C_BINDING_ARTIFACTS_FOLDER_NAME}"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -437,6 +437,31 @@ jobs:
       profile: "release-fast-build"
       workspace: zenoh
 
+  c-cxx-bindings-debug:
+    needs: [preflight-check]
+    if: ${{ needs.changes.outputs.source-code == 'true' }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [stable, 1.89.0]
+        include:
+          - toolchain: stable
+            os: ubuntu-24.04-arm
+    uses: ./.github/workflows/reuse_c_cxx_bindings.yml
+    with:
+      os: ${{ matrix.os }}
+      toolchain: ${{ matrix.toolchain }}
+      profile: "dev-fast-build"
+
+  c-cxx-bindings-release:
+    needs: [preflight-check]
+    if: ${{ needs.changes.outputs.source-code == 'true' }}
+    uses: ./.github/workflows/reuse_c_cxx_bindings.yml
+    with:
+      os: ubuntu-latest
+      toolchain: stable
+      profile: "release-fast-build"
+
   unstable:
     needs: [preflight-check, cargo-nextest]
     if: ${{ needs.changes.outputs.source-code == 'true' && github.ref != 'refs/heads/main' }}
@@ -619,6 +644,8 @@ jobs:
         Bazel,
         x86_32-debug,
         no_std,
+        c-cxx-bindings-debug,
+        c-cxx-bindings-release,
         cxx-vocabulary-types,
         python-bindings,
         end-to-end-tests,

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -175,8 +175,8 @@ jobs:
 
       - name: Run code examples in documentation
         run: |
-          just test sdk --doc
-          just test integrations-zenoh --doc
+          just test sdk --doc --profile dev-fast-build
+          just test integrations-zenoh --doc --profile dev-fast-build
 
       - name: Build documentation
         run: |
@@ -368,7 +368,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       toolchain: ${{ matrix.toolchain }}
-      profile: "debug"
+      profile: "dev-fast-build"
 
   sdk-stable-debug:
     needs: [preflight-check, cargo-nextest]
@@ -384,7 +384,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       toolchain: ${{ matrix.toolchain }}
-      profile: "debug"
+      profile: "dev-fast-build"
       workspace: sdk
 
   integrations-zenoh-stable-debug:
@@ -398,7 +398,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       toolchain: ${{ matrix.toolchain }}
-      profile: "debug"
+      profile: "dev-fast-build"
       workspace: zenoh
 
   integrations-ros2-stable-debug:
@@ -415,7 +415,7 @@ jobs:
       ros-distro: ${{ matrix.ros.distro }}
       rmw: ${{ matrix.ros.rmw }}
       toolchain: stable
-      profile: "debug"
+      profile: "dev-fast-build"
 
   sdk-stable-release:
     needs: [preflight-check, cargo-nextest]
@@ -424,7 +424,7 @@ jobs:
     with:
       os: ubuntu-latest
       toolchain: stable
-      profile: "release"
+      profile: "release-fast-build"
       workspace: sdk
 
   integrations-zenoh-stable-release:
@@ -434,7 +434,7 @@ jobs:
     with:
       os: ubuntu-latest
       toolchain: stable
-      profile: "release"
+      profile: "release-fast-build"
       workspace: zenoh
 
   unstable:
@@ -448,7 +448,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       toolchain: ${{ matrix.toolchain }}
-      profile: "debug"
+      profile: "dev-fast-build"
 
   freebsd:
     needs: [preflight-check]
@@ -458,7 +458,7 @@ jobs:
       matrix:
         freebsd_version: [ "15.0" ]
         toolchain: [ "stable" ]
-        mode: ["debug"]
+        mode: ["dev"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # version v7.0.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,10 +52,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain: [stable, 1.89.0]
-        profile: ["release", "debug"]
+        profile: ["release", "dev"]
         include:
           - toolchain: stable
-            profile: "debug"
+            profile: "dev"
             os: ubuntu-24.04-arm
         exclude:
           - os: ubuntu-latest # already tested in Pull-Requests and main branch
@@ -74,7 +74,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolchain: [stable, 1.89.0]
-        profile: ["release", "debug"]
+        profile: ["release", "dev"]
         exclude:
           - os: ubuntu-latest # already tested in Pull-Requests and main branch
             toolchain: stable
@@ -95,10 +95,10 @@ jobs:
           - { distro: jazzy, rmw: rmw_fastrtps_cpp }
           - { distro: humble, rmw: rmw_cyclonedds_cpp }
         toolchain: [stable, 1.89.0]
-        profile: ["release", "debug"]
+        profile: ["release", "dev"]
         exclude:
           - toolchain: stable
-            profile: "debug"
+            profile: "dev"
     uses: ./.github/workflows/reuse_ros2.yml
     with:
       ros-distro: ${{ matrix.ros.distro }}
@@ -112,18 +112,18 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
         toolchain: [beta, nightly]
-        profile: ["debug", "release"]
+        profile: ["dev", "release"]
         include:
           - toolchain: nightly
-            profile: "debug"
+            profile: "dev"
             os: ubuntu-24.04-arm
         exclude:
           - os: ubuntu-latest # Already run in Pull-Requests
             toolchain: beta
-            profile: "debug"
+            profile: "dev"
           - os: ubuntu-latest # Already run in Pull-Requests
             toolchain: nightly
-            profile: "debug"
+            profile: "dev"
     uses: ./.github/workflows/reuse_unstable.yml
     with:
       os: ${{ matrix.os }}
@@ -138,7 +138,7 @@ jobs:
       matrix:
         freebsd_version: ["15.0"]
         toolchain: ["stable"]
-        mode: ["debug"]
+        mode: ["dev"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # version v7.0.1

--- a/.github/workflows/reuse_c_cxx_bindings.yml
+++ b/.github/workflows/reuse_c_cxx_bindings.yml
@@ -1,0 +1,163 @@
+name: Reusable workflow for stable
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      toolchain:
+        required: true
+        type: string
+      profile:
+        required: true
+        type: string
+
+jobs:
+  stable:
+    timeout-minutes: 90
+    runs-on: ${{ inputs.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # version v7.0.1
+
+      - name: Install just
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # version: v4.0.0
+
+      - name: Setup cmake
+        if: ${{ runner.os != 'Windows' }}
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # version: v2.2.0
+        with:
+          cmake-version: "3.31.x"
+
+      - name: Use cmake
+        run: cmake --version
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # version: v1
+        with:
+          toolchain: ${{ inputs.toolchain }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # version: v0.0.11
+
+      - name: Set caching env vars on non-Windows
+        if: ${{ runner.os != 'Windows' }}
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
+      - name: Set caching env vars on Windows
+        if: ${{ runner.os == 'Windows' }}
+        run: |
+          Add-Content -Path $env:GITHUB_ENV -Value "SCCACHE_GHA_ENABLED=true"
+          Add-Content -Path $env:GITHUB_ENV -Value "RUSTC_WRAPPER=sccache"
+
+      - name: Prepare Windows
+        if: ${{ runner.os == 'Windows' }}
+        run: internal\scripts\ci_prepare_windows.ps1
+
+      - name: Prepare Linux
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          internal/scripts/ci_prepare_ubuntu.sh
+          uname -a
+
+      - name: Additional setup for libc platform binding
+        if: ${{ runner.os == 'Linux' }}
+        run: sudo apt remove -y --purge '^libclang-.*-dev' # remove libclang to force a compile error if libc binding is not used correctly and bindgen is invoked
+
+      - name: Save disk space
+        uses: ./.github/actions/save-disk-space
+        with:
+          mode: "remove-unneeded-software-from-runner"
+
+      - name: Set build flags
+        id: set-build-flags
+        uses: ./.github/actions/set-build-flags
+        with:
+          profile: ${{ inputs.profile }}
+
+      - name: Build iceoryx2-ffi-c crate
+        shell: bash
+        run: |
+          rustc --version
+          just build iceoryx2-ffi-c +${{ inputs.toolchain }} --profile ${{ inputs.profile }}
+
+      - name: Cleanup build artifacts
+        uses: ./.github/actions/save-disk-space
+        with:
+          mode: "cleanup-rust-build-files-from-cargo-target-folder"
+
+      - name: Print native libs of FFI target
+        if: false # This step takes 1 to 2 minutes; only enable if there are linker issues with the FFI target
+        run: |
+          cd iceoryx2-ffi/c
+          cargo rustc -q -- --print=native-static-libs
+
+      - name: Get CPU count
+        id: cpu
+        uses: ./.github/actions/cpu-count
+
+      - name: Build language bindings
+        shell: bash
+        run: |
+          cmake -S . \
+                -B target/ff/cc/build \
+                -DBUILD_EXAMPLES=ON \
+                -DBUILD_TESTING=ON \
+                -DIOX2_FEATURE_FLATBUFFERS=ON \
+                -DWARNING_AS_ERROR=ON \
+                ${{ steps.set-build-flags.outputs.cmake-build-type }} \
+                -DCMAKE_INSTALL_PREFIX=target/ff/cc/install \
+                -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/${{ steps.set-build-flags.outputs.c-binding-artifacts-folder-name }}" \
+                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          cmake --build target/ff/cc/build \
+                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
+                --parallel ${{ steps.cpu.outputs.count }}
+          cmake --install target/ff/cc/build \
+                ${{ steps.set-build-flags.outputs.cmake-build-config }}
+
+      - name: Run C++ iceoryx2-bb tests
+        run: target/ff/cc/build/tests/iceoryx2-bb-cxx-tests
+
+      - name: Run C language binding tests
+        run: target/ff/cc/build/tests/iceoryx2-c-tests
+
+      - name: Run C++ language binding tests
+        run: target/ff/cc/build/tests/iceoryx2-cxx-tests
+
+      - name: Remove language binding build artifacts
+        shell: bash
+        run: rm -rf target/ff/cc/build
+
+      - name: Build C language binding examples in out-of-tree configuration
+        shell: bash
+        run: |
+          cmake -S examples/c \
+                -B target/ff/out-of-tree-c \
+                ${{ steps.set-build-flags.outputs.cmake-build-type }} \
+                -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ff/cc/install" \
+                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          cmake --build target/ff/out-of-tree-c \
+                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
+                --parallel ${{ steps.cpu.outputs.count }}
+
+      - name: Build C++ language binding examples in out-of-tree configuration
+        shell: bash
+        run: |
+          cmake -S examples/cxx \
+                -B target/ff/out-of-tree-cxx \
+                -DIOX2_FEATURE_FLATBUFFERS=ON \
+                ${{ steps.set-build-flags.outputs.cmake-build-type }} \
+                -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ff/cc/install" \
+                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
+                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
+          cmake --build target/ff/out-of-tree-cxx \
+                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
+                --parallel ${{ steps.cpu.outputs.count }}
+
+      - name: Check for changed files after CI run
+        uses: ./.github/actions/check-repo-changes

--- a/.github/workflows/reuse_cxx_vocabulary_types.yml
+++ b/.github/workflows/reuse_cxx_vocabulary_types.yml
@@ -28,6 +28,10 @@ jobs:
           internal/scripts/ci_prepare_ubuntu.sh
           uname -a
 
+      - name: Get CPU count
+        id: cpu
+        uses: ./.github/actions/cpu-count
+
       - name: Build iceoryx2-ffi-c
         run: cargo build --package iceoryx2-ffi-c
 
@@ -43,7 +47,7 @@ jobs:
                 -DIOX2_BB_CXX_CONFIG_USE_STD_OPTIONAL=OFF \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/build
+          cmake --build target/ff/cc/build --parallel ${{ steps.cpu.outputs.count }}
           cmake --install target/ff/cc/build --prefix target/ff/cc/install
 
           target/ff/cc/build/tests/iceoryx2-bb-cxx-tests
@@ -54,7 +58,7 @@ jobs:
                 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/target/ff/cc/install \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/out-of-tree
+          cmake --build target/ff/cc/out-of-tree --parallel ${{ steps.cpu.outputs.count }}
 
           rm -rf target/ff/cc
 
@@ -69,7 +73,7 @@ jobs:
                 -DIOX2_BB_CXX_CONFIG_USE_STD_OPTIONAL=OFF \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/build
+          cmake --build target/ff/cc/build --parallel ${{ steps.cpu.outputs.count }}
           cmake --install target/ff/cc/build --prefix target/ff/cc/install
 
           target/ff/cc/build/tests/iceoryx2-bb-cxx-tests
@@ -80,7 +84,7 @@ jobs:
                 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/target/ff/cc/install \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/out-of-tree
+          cmake --build target/ff/cc/out-of-tree --parallel ${{ steps.cpu.outputs.count }}
 
           rm -rf target/ff/cc
 
@@ -95,7 +99,7 @@ jobs:
                 -DIOX2_BB_CXX_CONFIG_USE_STD_OPTIONAL=ON \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/build
+          cmake --build target/ff/cc/build --parallel ${{ steps.cpu.outputs.count }}
           cmake --install target/ff/cc/build --prefix target/ff/cc/install
 
           target/ff/cc/build/tests/iceoryx2-bb-cxx-tests
@@ -106,7 +110,7 @@ jobs:
                 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/target/ff/cc/install \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/out-of-tree
+          cmake --build target/ff/cc/out-of-tree --parallel ${{ steps.cpu.outputs.count }}
 
           rm -rf target/ff/cc
 
@@ -121,7 +125,7 @@ jobs:
                 -DIOX2_BB_CXX_CONFIG_USE_STD_OPTIONAL=ON \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/build
+          cmake --build target/ff/cc/build --parallel ${{ steps.cpu.outputs.count }}
           cmake --install target/ff/cc/build --prefix target/ff/cc/install
 
           target/ff/cc/build/tests/iceoryx2-bb-cxx-tests
@@ -132,7 +136,7 @@ jobs:
                 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/target/ff/cc/install \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/out-of-tree
+          cmake --build target/ff/cc/out-of-tree --parallel ${{ steps.cpu.outputs.count }}
 
           rm -rf target/ff/cc
 
@@ -152,7 +156,7 @@ jobs:
                 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/target/ff/cc/install \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/build
+          cmake --build target/ff/cc/build --parallel ${{ steps.cpu.outputs.count }}
           cmake --install target/ff/cc/build --prefix target/ff/cc/install
 
           target/ff/cc/build/tests/iceoryx2-bb-cxx-tests
@@ -163,6 +167,6 @@ jobs:
                 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/target/ff/cc/install \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/out-of-tree
+          cmake --build target/ff/cc/out-of-tree --parallel ${{ steps.cpu.outputs.count }}
 
           rm -rf target/ff/cc

--- a/.github/workflows/reuse_cxx_vocabulary_types.yml
+++ b/.github/workflows/reuse_cxx_vocabulary_types.yml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/cpu-count
 
       - name: Build iceoryx2-ffi-c
-        run: cargo build --package iceoryx2-ffi-c
+        run: cargo build --package iceoryx2-ffi-c --profile dev-fast-build
 
       - name: Build build and test iceoryx2 C++ bindings with C++23
         run: |
@@ -41,7 +41,7 @@ jobs:
                 -B target/ff/cc/build \
                 -DBUILD_EXAMPLES=ON \
                 -DBUILD_TESTING=ON \
-                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/debug \
+                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/dev-fast-build \
                 -DIOX2_CXX_STD_VERSION=23 \
                 -DIOX2_BB_CXX_CONFIG_USE_STD_EXPECTED=OFF \
                 -DIOX2_BB_CXX_CONFIG_USE_STD_OPTIONAL=OFF \
@@ -68,7 +68,7 @@ jobs:
                 -B target/ff/cc/build \
                 -DBUILD_EXAMPLES=ON \
                 -DBUILD_TESTING=ON \
-                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/debug \
+                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/dev-fast-build \
                 -DIOX2_BB_CXX_CONFIG_USE_STD_EXPECTED=ON \
                 -DIOX2_BB_CXX_CONFIG_USE_STD_OPTIONAL=OFF \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
@@ -94,7 +94,7 @@ jobs:
                 -B target/ff/cc/build \
                 -DBUILD_EXAMPLES=ON \
                 -DBUILD_TESTING=ON \
-                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/debug \
+                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/dev-fast-build \
                 -DIOX2_BB_CXX_CONFIG_USE_STD_EXPECTED=OFF \
                 -DIOX2_BB_CXX_CONFIG_USE_STD_OPTIONAL=ON \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
@@ -120,7 +120,7 @@ jobs:
                 -B target/ff/cc/build \
                 -DBUILD_EXAMPLES=ON \
                 -DBUILD_TESTING=ON \
-                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/debug \
+                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/dev-fast-build \
                 -DIOX2_BB_CXX_CONFIG_USE_STD_EXPECTED=ON \
                 -DIOX2_BB_CXX_CONFIG_USE_STD_OPTIONAL=ON \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
@@ -150,7 +150,7 @@ jobs:
                 -B target/ff/cc/build \
                 -DBUILD_EXAMPLES=ON \
                 -DBUILD_TESTING=ON \
-                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/debug \
+                -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/dev-fast-build \
                 -DIOX2_BB_CXX_CONFIG_USE_CUSTOM_VOCABULARY_TYPES=ON \
                 -DIOX2_BB_CXX_CONFIG_CUSTOM_VOCABULARY_TYPES_CMAKE_TARGET="custom-vocabulary-types" \
                 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/target/ff/cc/install \

--- a/.github/workflows/reuse_ros2.yml
+++ b/.github/workflows/reuse_ros2.yml
@@ -82,20 +82,20 @@ jobs:
         run: |
           source /opt/ros/${{ inputs.ros-distro }}/setup.bash
           rustc --version
-          just build integrations-ros2 +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets
+          just build integrations-ros2 +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets
 
       - name: Check clippy
         shell: bash
         run: |
           source /opt/ros/${{ inputs.ros-distro }}/setup.bash
-          just verify integrations-ros2 clippy ${{ steps.set-build-flags.outputs.cargo-build-mode }}
+          just verify integrations-ros2 clippy --profile ${{ inputs.profile }}
 
       - name: Test workspace
         shell: bash
         run: |
           source /opt/ros/${{ inputs.ros-distro }}/setup.bash
           echo "Using RMW: $RMW_IMPLEMENTATION"
-          just test integrations-ros2 +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets --no-fail-fast
+          just test integrations-ros2 +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
 
       - name: End-to-end test workspace
         shell: bash

--- a/.github/workflows/reuse_stable.yml
+++ b/.github/workflows/reuse_stable.yml
@@ -127,6 +127,10 @@ jobs:
           cd iceoryx2-ffi/c
           cargo rustc -q -- --print=native-static-libs
 
+      - name: Get CPU count
+        id: cpu
+        uses: ./.github/actions/cpu-count
+
       - name: Build language bindings
         if: ${{ inputs.workspace == 'sdk' }}
         shell: bash
@@ -142,8 +146,11 @@ jobs:
                 -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/${{ inputs.profile }}" \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/build ${{ steps.set-build-flags.outputs.cmake-build-config }}
-          cmake --install target/ff/cc/build ${{ steps.set-build-flags.outputs.cmake-build-config }}
+          cmake --build target/ff/cc/build \
+                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
+                --parallel ${{ steps.cpu.outputs.count }}
+          cmake --install target/ff/cc/build \
+                ${{ steps.set-build-flags.outputs.cmake-build-config }}
 
       - name: Run C++ iceoryx2-bb tests
         if: ${{ inputs.workspace == 'sdk' }}
@@ -172,7 +179,9 @@ jobs:
                 -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ff/cc/install" \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/out-of-tree-c ${{ steps.set-build-flags.outputs.cmake-build-config }}
+          cmake --build target/ff/out-of-tree-c \
+                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
+                --parallel ${{ steps.cpu.outputs.count }}
 
       - name: Build C++ language binding examples in out-of-tree configuration
         if: ${{ inputs.workspace == 'sdk' }}
@@ -185,7 +194,9 @@ jobs:
                 -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ff/cc/install" \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/out-of-tree-cxx ${{ steps.set-build-flags.outputs.cmake-build-config }}
+          cmake --build target/ff/out-of-tree-cxx \
+                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
+                --parallel ${{ steps.cpu.outputs.count }}
 
       - name: Check for changed files after CI run
         uses: ./.github/actions/check-repo-changes

--- a/.github/workflows/reuse_stable.yml
+++ b/.github/workflows/reuse_stable.yml
@@ -27,16 +27,6 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # version: v4.0.0
 
-      - name: Setup cmake
-        if: ${{ inputs.workspace == 'sdk' && runner.os != 'Windows' }}
-        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # version: v2.2.0
-        with:
-          cmake-version: "3.31.x"
-
-      - name: Use cmake
-        if: ${{ inputs.workspace == 'sdk' }}
-        run: cmake --version
-
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # version: v1
         with:
@@ -72,10 +62,6 @@ jobs:
         run: |
           internal/scripts/ci_prepare_ubuntu.sh
           uname -a
-
-      - name: Additional setup for libc platform binding
-        if: ${{ runner.os == 'Linux' && inputs.workspace == 'sdk' }}
-        run: sudo apt remove -y --purge '^libclang-.*-dev' # remove libclang to force a compile error if libc binding is not used correctly and bindgen is invoked
 
       - name: Save disk space
         uses: ./.github/actions/save-disk-space
@@ -115,88 +101,3 @@ jobs:
         run: |
           rustc --version
           just test integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
-
-      - name: Cleanup build artifacts
-        uses: ./.github/actions/save-disk-space
-        with:
-          mode: "cleanup-rust-build-files-from-cargo-target-folder"
-
-      - name: Print native libs of FFI target
-        if: false # This step takes 1 to 2 minutes; only enable if there are linker issues with the FFI target
-        run: |
-          cd iceoryx2-ffi/c
-          cargo rustc -q -- --print=native-static-libs
-
-      - name: Get CPU count
-        id: cpu
-        uses: ./.github/actions/cpu-count
-
-      - name: Build language bindings
-        if: ${{ inputs.workspace == 'sdk' }}
-        shell: bash
-        run: |
-          cmake -S . \
-                -B target/ff/cc/build \
-                -DBUILD_EXAMPLES=ON \
-                -DBUILD_TESTING=ON \
-                -DIOX2_FEATURE_FLATBUFFERS=ON \
-                -DWARNING_AS_ERROR=ON \
-                ${{ steps.set-build-flags.outputs.cmake-build-type }} \
-                -DCMAKE_INSTALL_PREFIX=target/ff/cc/install \
-                -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/${{ steps.set-build-flags.outputs.c-binding-artifacts-folder-name }}" \
-                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/build \
-                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
-                --parallel ${{ steps.cpu.outputs.count }}
-          cmake --install target/ff/cc/build \
-                ${{ steps.set-build-flags.outputs.cmake-build-config }}
-
-      - name: Run C++ iceoryx2-bb tests
-        if: ${{ inputs.workspace == 'sdk' }}
-        run: target/ff/cc/build/tests/iceoryx2-bb-cxx-tests
-
-      - name: Run C language binding tests
-        if: ${{ inputs.workspace == 'sdk' }}
-        run: target/ff/cc/build/tests/iceoryx2-c-tests
-
-      - name: Run C++ language binding tests
-        if: ${{ inputs.workspace == 'sdk' }}
-        run: target/ff/cc/build/tests/iceoryx2-cxx-tests
-
-      - name: Remove language binding build artifacts
-        if: ${{ inputs.workspace == 'sdk' }}
-        shell: bash
-        run: rm -rf target/ff/cc/build
-
-      - name: Build C language binding examples in out-of-tree configuration
-        if: ${{ inputs.workspace == 'sdk' }}
-        shell: bash
-        run: |
-          cmake -S examples/c \
-                -B target/ff/out-of-tree-c \
-                ${{ steps.set-build-flags.outputs.cmake-build-type }} \
-                -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ff/cc/install" \
-                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/out-of-tree-c \
-                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
-                --parallel ${{ steps.cpu.outputs.count }}
-
-      - name: Build C++ language binding examples in out-of-tree configuration
-        if: ${{ inputs.workspace == 'sdk' }}
-        shell: bash
-        run: |
-          cmake -S examples/cxx \
-                -B target/ff/out-of-tree-cxx \
-                -DIOX2_FEATURE_FLATBUFFERS=ON \
-                ${{ steps.set-build-flags.outputs.cmake-build-type }} \
-                -DCMAKE_PREFIX_PATH="${{ github.workspace }}/target/ff/cc/install" \
-                -DCMAKE_C_COMPILER_LAUNCHER=sccache \
-                -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/out-of-tree-cxx \
-                ${{ steps.set-build-flags.outputs.cmake-build-config }} \
-                --parallel ${{ steps.cpu.outputs.count }}
-
-      - name: Check for changed files after CI run
-        uses: ./.github/actions/check-repo-changes

--- a/.github/workflows/reuse_stable.yml
+++ b/.github/workflows/reuse_stable.yml
@@ -93,28 +93,28 @@ jobs:
         shell: bash
         run: |
           rustc --version
-          just build sdk +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets
+          just build sdk +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets
 
       - name: Test sdk workspace
         if: ${{ inputs.workspace == 'sdk' }}
         shell: bash
         run: |
           rustc --version
-          just test sdk +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets --no-fail-fast
+          just test sdk +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
 
       - name: Build zenoh workspace
         if: ${{ inputs.workspace == 'zenoh' }}
         shell: bash
         run: |
           rustc --version
-          just build integrations-zenoh +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets
+          just build integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets
 
       - name: Test zenoh workspace
         if: ${{ inputs.workspace == 'zenoh' }}
         shell: bash
         run: |
           rustc --version
-          just test integrations-zenoh +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets --no-fail-fast
+          just test integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
 
       - name: Cleanup build artifacts
         uses: ./.github/actions/save-disk-space
@@ -143,7 +143,7 @@ jobs:
                 -DWARNING_AS_ERROR=ON \
                 ${{ steps.set-build-flags.outputs.cmake-build-type }} \
                 -DCMAKE_INSTALL_PREFIX=target/ff/cc/install \
-                -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/${{ inputs.profile }}" \
+                -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/${{ steps.set-build-flags.outputs.c-binding-artifacts-folder-name }}" \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
           cmake --build target/ff/cc/build \

--- a/.github/workflows/reuse_static_code_analysis.yml
+++ b/.github/workflows/reuse_static_code_analysis.yml
@@ -75,7 +75,6 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           just verify sdk clippy --target x86_64-unknown-linux-musl --profile dev-fast-build
-          just verify integrations-zenoh clippy --target x86_64-unknown-linux-musl --profile dev-fast-build
 
       - name: Setup miri
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # version: v1

--- a/.github/workflows/reuse_static_code_analysis.yml
+++ b/.github/workflows/reuse_static_code_analysis.yml
@@ -39,13 +39,13 @@ jobs:
 
       - name: Run cargo clippy with default features for 'std' in debug mode
         run: |
-          just verify sdk clippy
-          just verify integrations-zenoh clippy
+          just verify sdk clippy --profile dev-fast-build
+          just verify integrations-zenoh clippy --profile dev-fast-build
 
       - name: Run cargo clippy with default features for 'std' in release mode
         run: |
-          just verify sdk clippy --release
-          just verify integrations-zenoh clippy --release
+          just verify sdk clippy --profile release-fast-build
+          just verify integrations-zenoh clippy --profile release-fast-build
 
       - name: Run cargo clippy with no-default features for 'no_std' in debug mode
         if: ${{ runner.os == 'Linux' }}
@@ -54,6 +54,7 @@ jobs:
         #       * iceoryx2-cli -> the CLI requires std
         run: |
             just verify sdk clippy --no_std \
+                --profile dev-fast-build \
                 -- \
                 --exclude iceoryx2-ffi-c \
                 --exclude iceoryx2-cli
@@ -65,7 +66,7 @@ jobs:
         #       * iceoryx2-cli -> the CLI requires std
         run: |
             just verify sdk clippy --no_std \
-                --release \
+                --profile release-fast-build \
                 -- \
                 --exclude iceoryx2-ffi-c \
                 --exclude iceoryx2-cli
@@ -73,8 +74,8 @@ jobs:
       - name: Run cargo clippy with default features for target x86_64-unknown-linux-musl in debug mode
         if: ${{ runner.os == 'Linux' }}
         run: |
-          just verify sdk clippy --target x86_64-unknown-linux-musl
-          just verify integrations-zenoh clippy --target x86_64-unknown-linux-musl
+          just verify sdk clippy --target x86_64-unknown-linux-musl --profile dev-fast-build
+          just verify integrations-zenoh clippy --target x86_64-unknown-linux-musl --profile dev-fast-build
 
       - name: Setup miri
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # version: v1

--- a/.github/workflows/reuse_unstable.yml
+++ b/.github/workflows/reuse_unstable.yml
@@ -83,15 +83,15 @@ jobs:
         shell: bash
         run: |
           rustc --version
-          just build sdk +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets
-          just build integrations-zenoh +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets
+          just build sdk +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets
+          just build integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets
 
       - name: Test workspaces
         shell: bash
         run: |
           rustc --version
-          just test sdk +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets --no-fail-fast
-          just test integrations-zenoh +${{ inputs.toolchain }} ${{ steps.set-build-flags.outputs.cargo-build-mode }} -- --all-targets --no-fail-fast
+          just test sdk +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
+          just test integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
 
       - name: Cleanup build artifacts
         uses: ./.github/actions/save-disk-space

--- a/.github/workflows/reuse_x86_32.yml
+++ b/.github/workflows/reuse_x86_32.yml
@@ -84,7 +84,7 @@ jobs:
         shell: bash
         run: |
           rustc --version
-          just build sdk +${{ inputs.toolchain }} --target i686-unknown-linux-gnu ${{ steps.set-build-flags.outputs.cargo-build-mode }} \
+          just build sdk +${{ inputs.toolchain }} --target i686-unknown-linux-gnu --profile ${{ inputs.profile }} \
           -- \
           --all-targets \
           --exclude iceoryx2-ffi-python
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         run: |
           rustc --version
-          just test sdk +${{ inputs.toolchain }} --target i686-unknown-linux-gnu ${{ steps.set-build-flags.outputs.cargo-build-mode }} \
+          just test sdk +${{ inputs.toolchain }} --target i686-unknown-linux-gnu --profile ${{ inputs.profile }} \
           -- \
           --all-targets \
           --exclude iceoryx2-ffi-python \
@@ -118,7 +118,7 @@ jobs:
                 -DBUILD_TESTING=ON \
                 -DCMAKE_C_FLAGS="-m32" \
                 -DCMAKE_CXX_FLAGS="-m32" \
-                -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/i686-unknown-linux-gnu/${{ inputs.profile }}" \
+                -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/i686-unknown-linux-gnu/${{ steps.set-build-flags.outputs.c-binding-artifacts-folder-name }}" \
                 ${{ steps.set-build-flags.outputs.cmake-build-type }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache

--- a/.github/workflows/reuse_x86_32.yml
+++ b/.github/workflows/reuse_x86_32.yml
@@ -104,6 +104,10 @@ jobs:
         with:
           mode: "cleanup-rust-build-files-from-cargo-target-folder"
 
+      - name: Get CPU count
+        id: cpu
+        uses: ./.github/actions/cpu-count
+
       - name: Build language bindings
         shell: bash
         run: |
@@ -118,7 +122,7 @@ jobs:
                 ${{ steps.set-build-flags.outputs.cmake-build-type }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/cc/build
+          cmake --build target/ff/cc/build --parallel ${{ steps.cpu.outputs.count }}
           cmake --install target/ff/cc/build
 
       - name: Run C++ iceoryx2-bb tests
@@ -142,7 +146,7 @@ jobs:
                 ${{ steps.set-build-flags.outputs.cmake-build-type }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/out-of-tree-c
+          cmake --build target/ff/out-of-tree-c --parallel ${{ steps.cpu.outputs.count }}
 
       - name: Build C++ language binding examples in out-of-tree configuration
         shell: bash
@@ -155,4 +159,4 @@ jobs:
                 ${{ steps.set-build-flags.outputs.cmake-build-type }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=sccache \
                 -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-          cmake --build target/ff/out-of-tree-cxx
+          cmake --build target/ff/out-of-tree-cxx --parallel ${{ steps.cpu.outputs.count }}

--- a/.just/build.just
+++ b/.just/build.just
@@ -21,6 +21,7 @@ _parse-build-args *flags:
 
     TOOLCHAIN=""
     TARGET_TRIPLET=""
+    BUILD_TYPE=""
     PROFILE=""
     HAS_NOSTD="false"
     HAS_TESTS="false"
@@ -33,12 +34,24 @@ _parse-build-args *flags:
             +*)         TOOLCHAIN="$1";                    shift ;;
             --target)   TARGET_TRIPLET="$2";               shift 2 ;;
             --target=*) TARGET_TRIPLET="${1#--target=}";   shift ;;
-            --release)  PROFILE="--release";               shift ;;
+            --release)  BUILD_TYPE="--release";            shift ;;
+            --profile)  PROFILE="$2";                      shift 2 ;;
             --no_std)   HAS_NOSTD="true";                  shift ;;
             --tests)    HAS_TESTS="true";                  shift ;;
-            *)          shift ;;
+            *)          echo "Invalid argument '$1'! Try 'just build --help' for options." >&2; exit 1 ;;
         esac
     done
+
+    if [[ -n "$BUILD_TYPE" && -n "$PROFILE" ]]; then
+        echo "Error: --release and --profile cannot be used together." >&2
+        exit 1
+    fi
+
+    if [[ -n "$BUILD_TYPE" ]]; then
+        PROFILE="release"
+    elif [[ -z "$PROFILE" ]]; then
+        PROFILE="dev"
+    fi
 
     echo "TOOLCHAIN='$TOOLCHAIN'"
     echo "TARGET_TRIPLET='$TARGET_TRIPLET'"
@@ -52,26 +65,44 @@ _build-dispatch what *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    eval $(just _parse-build-args {{flags}})
+    show_help() {
+        echo "Usage: just build <scope> [flags]"
+        echo ""
+        echo "Scope:"
+        echo "  sdk                    build the main workspace"
+        echo "  integrations-zenoh     build the zenoh workspace"
+        echo "  integrations-ros2      build the ros2 workspace (requires a sourced ROS 2 env)"
+        echo "  <package>              build a specific package"
+        echo ""
+        echo "Flags:"
+        echo "  +<toolchain>           use a specific toolchain"
+        echo "  --target <triplet>     cross-compile for target"
+        echo "  --release              build in release mode (default: debug)"
+        echo "                         note: cannot be used in combination with --profile <profile>"
+        echo "  --profile <profile>    build with the specified cargo profile"
+        echo "                         note: cannot be used in combination with --release"
+        echo "  --no_std               build without std"
+        echo "  --tests                also build tests"
+        echo "  -- <args>              forward remaining args to cargo"
+    }
+
+    PARSED_ARGS=$(just _parse-build-args {{flags}}) || exit $?
+    eval "$PARSED_ARGS"
 
     case "{{what}}" in
         "")
-            echo "Usage: just build <scope> [flags]"
-            echo ""
-            echo "Scope:"
-            echo "  sdk                    build the main workspace"
-            echo "  integrations-zenoh     build the zenoh workspace"
-            echo "  integrations-ros2      build the ros2 workspace (requires a sourced ROS 2 env)"
-            echo "  <package>              build a specific package"
-            echo ""
-            echo "Flags:"
-            echo "  +<toolchain>           use a specific toolchain"
-            echo "  --target <triplet>     cross-compile for target"
-            echo "  --release              build in release profile (default: debug)"
-            echo "  --no_std               build without std"
-            echo "  --tests                also build tests"
-            echo "  -- <args>              forward remaining args to cargo"
+            show_help
             exit 1
+            ;;
+        -*|+*)
+            echo "Invalid argument '{{what}}'!"
+            echo ""
+            show_help
+            exit 1
+            ;;
+        --help|-h)
+            show_help
+            exit 0
             ;;
         sdk)
             just _build-sdk "$TOOLCHAIN" "$TARGET_TRIPLET" "$PROFILE" "$HAS_NOSTD" "$HAS_TESTS" "$EXTRA_ARGS"
@@ -132,7 +163,7 @@ _build-sdk toolchain target_triplet profile has_nostd has_tests extra_args:
             TARGET_ARG="--target {{target_triplet}}"
         fi
 
-        cargo {{toolchain}} build --workspace {{profile}} $TESTS_FLAG $TARGET_ARG {{extra_args}}
+        cargo {{toolchain}} build --workspace --profile {{profile}} $TESTS_FLAG $TARGET_ARG {{extra_args}}
     fi
 
 [private]
@@ -157,7 +188,7 @@ _build-integrations-zenoh toolchain target_triplet profile has_nostd has_tests e
 
     MANIFEST_ARG=$(just _workspace-manifest-arg integrations-zenoh)
 
-    cargo {{toolchain}} build --workspace $MANIFEST_ARG {{profile}} $TESTS_FLAG $TARGET_ARG {{extra_args}}
+    cargo {{toolchain}} build --workspace $MANIFEST_ARG --profile {{profile}} $TESTS_FLAG $TARGET_ARG {{extra_args}}
 
 [private]
 _build-integrations-ros2 toolchain target_triplet profile has_nostd has_tests extra_args:
@@ -181,7 +212,7 @@ _build-integrations-ros2 toolchain target_triplet profile has_nostd has_tests ex
 
     MANIFEST_ARG=$(just _workspace-manifest-arg integrations-ros2)
 
-    cargo {{toolchain}} build --workspace $MANIFEST_ARG {{profile}} $TESTS_FLAG $TARGET_ARG {{extra_args}}
+    cargo {{toolchain}} build --workspace $MANIFEST_ARG --profile {{profile}} $TESTS_FLAG $TARGET_ARG {{extra_args}}
 
 [private]
 _build-package package toolchain target_triplet profile has_nostd extra_args:
@@ -207,11 +238,11 @@ _build-package package toolchain target_triplet profile has_nostd extra_args:
                     $MANIFEST_ARG \
                     --no-default-features \
                     -Zbuild-std=core,alloc \
-                    {{profile}} \
+                    --profile {{profile}} \
                     $TARGET_ARG \
                     {{extra_args}}
         else
-            cargo {{toolchain}} build --package {{package}} $MANIFEST_ARG --no-default-features {{profile}} {{extra_args}}
+            cargo {{toolchain}} build --package {{package}} $MANIFEST_ARG --no-default-features --profile {{profile}} {{extra_args}}
         fi
     else
         TARGET_ARG=""
@@ -219,5 +250,5 @@ _build-package package toolchain target_triplet profile has_nostd extra_args:
             TARGET_ARG="--target {{target_triplet}}"
         fi
 
-        cargo {{toolchain}} build --package {{package}} $MANIFEST_ARG {{profile}} $TARGET_ARG {{extra_args}}
+        cargo {{toolchain}} build --package {{package}} $MANIFEST_ARG --profile {{profile}} $TARGET_ARG {{extra_args}}
     fi

--- a/.just/bundle.just
+++ b/.just/bundle.just
@@ -21,46 +21,75 @@ _parse-bundle-args *flags:
 
     TOOLCHAIN=""
     TARGET_TRIPLET=""
+    BUILD_TYPE=""
+    PROFILE=""
     DO_STRIP="false"
     DO_COMPRESS="false"
     HAS_NOSTD="false"
+    EXTRA_ARGS=""
 
     set -- {{flags}}
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            --)         shift; EXTRA_ARGS="$*";            break ;;
             +*)         TOOLCHAIN="$1";                    shift ;;
             --no_std)   HAS_NOSTD="true";                  shift ;;
+            --target)   TARGET_TRIPLET="$2";               shift 2 ;;
             --target=*) TARGET_TRIPLET="${1#--target=}";   shift ;;
+            --release)  BUILD_TYPE="--release";            shift ;;
+            --profile)  PROFILE="$2";                      shift 2 ;;
             --strip)    DO_STRIP="true";                   shift ;;
             --compress) DO_COMPRESS="true";                shift ;;
-            *)          shift ;;
+            *)          echo "Invalid argument '$1'! Try 'just bundle --help' for options." >&2; exit 1 ;;
         esac
     done
 
+    if [[ -n "$BUILD_TYPE" && -n "$PROFILE" ]]; then
+        echo "Error: --release and --profile cannot be used together." >&2
+        exit 1
+    fi
+
+    if [[ -n "$BUILD_TYPE" ]]; then
+        PROFILE="release"
+    elif [[ -z "$PROFILE" ]]; then
+        PROFILE="dev"
+    fi
+
     echo "TOOLCHAIN='$TOOLCHAIN'"
     echo "TARGET_TRIPLET='$TARGET_TRIPLET'"
+    echo "PROFILE='$PROFILE'"
     echo "DO_STRIP='$DO_STRIP'"
     echo "DO_COMPRESS='$DO_COMPRESS'"
     echo "HAS_NOSTD='$HAS_NOSTD'"
+    echo "EXTRA_ARGS='$EXTRA_ARGS'"
 
 [private]
 _bundle-dispatch what *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    show_help() {
+        echo "Usage: just bundle <what> [flags]"
+        echo ""
+        echo "  tests                  bundle no_std tests for deployment"
+        echo ""
+        echo "Flags:"
+        echo "  --no_std               bundle without std"
+        echo "  --strip                strip debug symbols"
+        echo "  --compress             create compressed tarball"
+        echo "  +<toolchain>           use a specific toolchain"
+        echo "  --target <triplet>     bundle for target"
+        echo "  -- <args>              forward remaining args to cargo"
+    }
+
     case "{{what}}" in
         "")
-            echo "Usage: just bundle <what> [flags]"
-            echo ""
-            echo "  tests                  bundle no_std tests for deployment"
-            echo ""
-            echo "Flags:"
-            echo "  --no_std               bundle without std"
-            echo "  --strip                strip debug symbols"
-            echo "  --compress             create compressed tarball"
-            echo "  +<toolchain>           use a specific toolchain"
-            echo "  --target=<triplet>     bundle for target"
+            show_help
             exit 1
+            ;;
+        --help|-h)
+            show_help
+            exit 0
             ;;
         tests) ;;
         *)
@@ -69,17 +98,18 @@ _bundle-dispatch what *flags:
             ;;
     esac
 
-    eval $(just _parse-bundle-args {{flags}})
+    PARSED_ARGS=$(just _parse-bundle-args {{flags}}) || exit $?
+    eval "$PARSED_ARGS"
 
     if [ "$HAS_NOSTD" != "true" ]; then
         echo "Error: bundle command currently only supports 'tests --no_std'" >&2
         exit 1
     fi
 
-    just _bundle-nostd-tests "$TOOLCHAIN" "$TARGET_TRIPLET" "$DO_STRIP" "$DO_COMPRESS"
+    just _bundle-nostd-tests "$TOOLCHAIN" "$TARGET_TRIPLET" "$PROFILE" "$DO_STRIP" "$DO_COMPRESS" "$EXTRA_ARGS"
 
 [private]
-_bundle-nostd-tests toolchain target_triplet do_strip do_compress:
+_bundle-nostd-tests toolchain target_triplet profile do_strip do_compress extra_args:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -96,7 +126,7 @@ _bundle-nostd-tests toolchain target_triplet do_strip do_compress:
         echo "Using toolchain: {{toolchain}}"
     fi
 
-    just _build-sdk "{{toolchain}}" "{{target_triplet}}" "true" "true"
+    just _build-sdk "{{toolchain}}" "{{target_triplet}}" "{{profile}}" "true" "true" "{{extra_args}}"
 
     BUNDLE_DIR="target/{{target_triplet}}/tests-nostd"
     just _create-bundle-dir "$TARGET_DIR" "$BUNDLE_DIR"

--- a/.just/coverage.just
+++ b/.just/coverage.just
@@ -53,7 +53,7 @@ _parse-coverage-args *flags:
             --lcov)      HAS_LCOV="true";        shift ;;
             --detailed)  HAS_DETAILED="true";    shift ;;
             --package)   PACKAGES+=("$2");       shift 2 ;;
-            *)           shift ;;
+            *)          echo "Invalid argument '$1'! Try 'just build --help' for options." >&2; exit 1 ;;
         esac
     done
 
@@ -67,18 +67,27 @@ _coverage-dispatch action *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    eval "$(just _parse-coverage-args {{flags}})"
+    show_help() {
+        echo "Usage: just coverage <command> [flags]"
+        echo ""
+        echo "Commands:"
+        echo "  generate-profile                      generate coverage profile"
+        echo "  generate-report --html|--lcov         generate rendered report"
+        echo "  summarize [--detailed] [--package X]  show coverage summary"
+        echo "  clean                                 remove all coverage data"
+    }
+
+    PARSED_ARGS=$(just _parse-coverage-args {{flags}}) || exit $?
+    eval "$PARSED_ARGS"
 
     case "{{action}}" in
         "")
-            echo "Usage: just coverage <command> [flags]"
-            echo ""
-            echo "Commands:"
-            echo "  generate-profile                      generate coverage profile"
-            echo "  generate-report --html|--lcov         generate rendered report"
-            echo "  summarize [--detailed] [--package X]  show coverage summary"
-            echo "  clean                                 remove all coverage data"
+            show_help
             exit 1
+            ;;
+        --help|-h)
+            show_help
+            exit 0
             ;;
         generate-profile)
             if [ "${#PACKAGES[@]}" -gt 0 ]; then

--- a/.just/coverage.just
+++ b/.just/coverage.just
@@ -125,7 +125,7 @@ _coverage-profile-cmake:
     set -euo pipefail
 
     cmake . -B"{{CMAKE_COV_DIR}}" -DCOVERAGE=ON -DBUILD_TESTING=ON -DIOX2_FEATURE_FLATBUFFERS=ON -DCMAKE_BUILD_TYPE=Debug
-    cmake --build "{{CMAKE_COV_DIR}}" -j
+    cmake --build "{{CMAKE_COV_DIR}}" --parallel $(nproc)
     ctest --test-dir "{{CMAKE_COV_DIR}}" --output-on-failure
 
 [private]

--- a/.just/coverage.just
+++ b/.just/coverage.just
@@ -18,8 +18,8 @@ COLOR_OFF    := "\\033[0m"
 COLOR_GREEN  := "\\033[1;32m"
 COLOR_YELLOW := "\\033[1;33m"
 
-LLVM_PROFILE_PATH := "target/debug/llvm-profile-files"
-RUST_COV_DIR      := "target/debug/rust_cov_build"
+LLVM_PROFILE_PATH := "target/dev-fast-build/llvm-profile-files"
+RUST_COV_DIR      := "target/dev-fast-build/rust_cov_build"
 CMAKE_COV_DIR     := "target/ff/cc/cmake_cov_build"
 COVERAGE_OUT_DIR  := "target/ff/coverage"
 
@@ -133,7 +133,14 @@ _coverage-profile-cmake:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    cmake . -B"{{CMAKE_COV_DIR}}" -DCOVERAGE=ON -DBUILD_TESTING=ON -DIOX2_FEATURE_FLATBUFFERS=ON -DCMAKE_BUILD_TYPE=Debug
+    just build iceoryx2-ffi-c --profile dev-fast-build
+    cmake -S . \
+          -B "{{CMAKE_COV_DIR}}" \
+          -DCOVERAGE=ON \
+          -DBUILD_TESTING=ON \
+          -DIOX2_FEATURE_FLATBUFFERS=ON \
+          -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/dev-fast-build \
+          -DCMAKE_BUILD_TYPE=Debug
     cmake --build "{{CMAKE_COV_DIR}}" --parallel $(nproc)
     ctest --test-dir "{{CMAKE_COV_DIR}}" --output-on-failure
 
@@ -152,7 +159,7 @@ _coverage-profile-rust:
         echo -e "{{COLOR_YELLOW}}no rust nightly compiler found, MC/DC coverage is not available only line coverage{{COLOR_OFF}}"
         export RUSTFLAGS="-C instrument-coverage"
     fi
-    just test sdk
+    just test sdk --profile dev-fast-build -- --all-targets
 
 # --- generate-report ---------------------------------------------------------
 
@@ -208,7 +215,7 @@ _coverage-generate-report-impl output_type grcov_output gcovr_flag gcovr_output:
     grcov \
         **/{{LLVM_PROFILE_PATH}} \
         **/**/{{LLVM_PROFILE_PATH}} \
-        --binary-path target/debug \
+        --binary-path target/dev-fast-build \
         --source-dir . \
         --output-type {{output_type}} \
         --branch \
@@ -244,7 +251,7 @@ _coverage-summarize detailed *packages:
 
     just _coverage-merge-profiles
 
-    FILES=$(find ./target/debug/deps/ -type f -executable)
+    FILES=$(find ./target/dev-fast-build/deps/ -type f -executable)
 
     IGNORE_PATTERNS=('/\.cargo/registry' '/target/')
     for pattern in {{COVERAGE_IGNORE}}; do

--- a/.just/doc.just
+++ b/.just/doc.just
@@ -66,7 +66,7 @@ _doc-rust workspace:
     for WS in $WORKSPACES; do
         MANIFEST_ARG=$(just _workspace-manifest-arg "$WS")
 
-        cargo doc --no-deps --workspace $MANIFEST_ARG
+        cargo doc --no-deps --workspace --profile dev-fast-build $MANIFEST_ARG
 
         echo ""
         case "$WS" in
@@ -87,7 +87,7 @@ _doc-c workspace:
 
     just _parse-workspace "{{workspace}}" > /dev/null
 
-    cargo build --release --package iceoryx2-ffi-c
+    cargo build --profile dev-fast-build --package iceoryx2-ffi-c
     make -C {{justfile_directory()}}/doc/api/c html
 
     echo ""

--- a/.just/lint.just
+++ b/.just/lint.just
@@ -28,7 +28,7 @@ _parse-lint-args *flags:
             --)      shift; EXTRA_ARGS="$*"; break ;;
             --fix)   MODE="fix";   shift ;;
             --check) MODE="check"; shift ;;
-            *)       shift ;;
+            *)       echo "Invalid argument '$1'! Try 'just lint --help' for options." >&2; exit 1 ;;
         esac
     done
 
@@ -36,13 +36,11 @@ _parse-lint-args *flags:
     echo "EXTRA_ARGS='$EXTRA_ARGS'"
 
 [private]
-_lint-dispatch workspace target *flags:
+_lint-dispatch what target *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    eval $(just _parse-lint-args {{flags}})
-
-    if [ -z "{{workspace}}" ] || [ -z "{{target}}" ]; then
+    show_help() {
         echo "Usage: just lint <workspace> <target> [flags]"
         echo ""
         echo "Workspace:"
@@ -56,13 +54,32 @@ _lint-dispatch workspace target *flags:
         echo "  markdown            markdownlint check / fix"
         echo ""
         echo "Flags:"
+        echo "  --check             check for linting issues"
         echo "  --fix               fix linting issues when possible"
-        exit 1
-    fi
+    }
+
+    PARSED_ARGS=$(just _parse-lint-args {{flags}}) || exit $?
+    eval "$PARSED_ARGS"
+
+    case "{{what}}" in
+        sdk|integrations-zenoh|integrations-ros2|all)
+            WORKSPACE="{{what}}"
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Invalid argument '{{what}}'!"
+            echo ""
+            show_help
+            exit 1
+            ;;
+    esac
 
     case "{{target}}" in
-        rust)     just _lint-rust "{{workspace}}" "$MODE" "$EXTRA_ARGS" ;;
-        markdown) just _lint-markdown "{{workspace}}" "$MODE" ;;
+        rust)     just _lint-rust "$WORKSPACE" "$MODE" "$EXTRA_ARGS" ;;
+        markdown) just _lint-markdown "$WORKSPACE" "$MODE" ;;
         *)
             echo "Error: unknown target '{{target}}' (expected: rust|markdown)" >&2
             exit 1

--- a/.just/prepare-release.just
+++ b/.just/prepare-release.just
@@ -29,20 +29,18 @@ _parse-prepare-release-args *flags:
         case "$1" in
             --version)   NEW_VERSION="$2";              shift 2 ;;
             --version=*) NEW_VERSION="${1#--version=}"; shift ;;
-            *)           shift ;;
+            *)           echo "Invalid argument '$1'! Try 'just prepare-release --help' for options." >&2; exit 1 ;;
         esac
     done
 
     echo "NEW_VERSION='$NEW_VERSION'"
 
 [private]
-_prepare-release-dispatch workspace action *flags:
+_prepare-release-dispatch what action *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    eval "$(just _parse-prepare-release-args {{flags}})"
-
-    if [ -z "{{workspace}}" ] || [ -z "{{action}}" ]; then
+    show_help() {
         echo "Usage: just prepare-release <workspace> <action> [flags]"
         echo ""
         echo "Workspace:"
@@ -53,13 +51,25 @@ _prepare-release-dispatch workspace action *flags:
         echo ""
         echo "Flags:"
         echo "  --version <X.Y.Z>    the new version to set"
-        exit 1
-    fi
+    }
 
-    if [ "{{workspace}}" != "all" ]; then
-        echo "Error: only 'all' is supported for prepare-release (got: {{workspace}})" >&2
-        exit 1
-    fi
+    PARSED_ARGS=$(just _parse-prepare-release-args {{flags}}) || exit $?
+    eval "$PARSED_ARGS"
+
+    case "{{what}}" in
+        all)
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Error: only 'all' is supported for prepare-release (got: {{what}})" >&2
+            echo ""
+            show_help
+            exit 1
+            ;;
+    esac
 
     case "{{action}}" in
         versions) just _prepare-release-all-versions "$NEW_VERSION" ;;

--- a/.just/test.just
+++ b/.just/test.just
@@ -21,6 +21,8 @@ _parse-test-args *flags:
 
     TOOLCHAIN=""
     TARGET_TRIPLET=""
+    BUILD_TYPE=""
+    PROFILE=""
     HAS_NOSTD="false"
     HAS_DOC="false"
     EXTRA_ARGS=""
@@ -32,14 +34,28 @@ _parse-test-args *flags:
             +*)         TOOLCHAIN="$1";                    shift ;;
             --target)   TARGET_TRIPLET="$2";               shift 2 ;;
             --target=*) TARGET_TRIPLET="${1#--target=}";   shift ;;
+            --release)  BUILD_TYPE="--release";            shift ;;
+            --profile)  PROFILE="$2";                      shift 2 ;;
             --no_std)   HAS_NOSTD="true";                  shift ;;
             --doc)      HAS_DOC="true";                    shift ;;
-            *)          shift ;;
+            *)          echo "Invalid argument '$1'! Try 'just test --help' for options." >&2; exit 1 ;;
         esac
     done
 
+    if [[ -n "$BUILD_TYPE" && -n "$PROFILE" ]]; then
+        echo "Error: --release and --profile cannot be used together." >&2
+        exit 1
+    fi
+
+    if [[ -n "$BUILD_TYPE" ]]; then
+        PROFILE="release"
+    elif [[ -z "$PROFILE" ]]; then
+        PROFILE="dev"
+    fi
+
     echo "TOOLCHAIN='$TOOLCHAIN'"
     echo "TARGET_TRIPLET='$TARGET_TRIPLET'"
+    echo "PROFILE='$PROFILE'"
     echo "HAS_NOSTD='$HAS_NOSTD'"
     echo "HAS_DOC='$HAS_DOC'"
     echo "EXTRA_ARGS='$EXTRA_ARGS'"
@@ -49,41 +65,60 @@ _test-dispatch what *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    eval $(just _parse-test-args {{flags}})
+    show_help() {
+        echo "Usage: just test <scope> [flags]"
+        echo ""
+        echo "Scope:"
+        echo "  sdk                    run all tests for the main workspace"
+        echo "  integrations-zenoh     run all tests for the zenoh workspace"
+        echo "  integrations-ros2      run all tests for the ros2 workspace (requires a sourced ROS 2 env)"
+        echo "  <package>              run tests for a specific package"
+        echo ""
+        echo "Flags:"
+        echo "  +<toolchain>           use a specific toolchain"
+        echo "  --target <triplet>     cross-compile for target"
+        echo "  --release              test in release mode (default: debug)"
+        echo "                         note: cannot be used in combination with --profile <profile>"
+        echo "  --profile <profile>    test with the specified cargo profile"
+        echo "                         note: cannot be used in combination with --release"
+        echo "  --no_std               test without std"
+        echo "  --doc                  run documentation tests"
+    }
+
+    PARSED_ARGS=$(just _parse-test-args {{flags}}) || exit $?
+    eval "$PARSED_ARGS"
 
     case "{{what}}" in
         "")
-            echo "Usage: just test <scope> [flags]"
+            show_help
+            exit 1
+            ;;
+        -*|+*)
+            echo "Invalid argument '{{what}}'!"
             echo ""
-            echo "Scope:"
-            echo "  sdk                    run all tests for the main workspace"
-            echo "  integrations-zenoh     run all tests for the zenoh workspace"
-            echo "  integrations-ros2      run all tests for the ros2 workspace (requires a sourced ROS 2 env)"
-            echo "  <package>              run tests for a specific package"
-            echo ""
-            echo "Flags:"
-            echo "  +<toolchain>           use a specific toolchain"
-            echo "  --target <triplet>     cross-compile for target"
-            echo "  --no_std               test without std"
-            echo "  --doc                  run documentation tests"
+            show_help
+            exit 1
+            ;;
+        --help|-h)
+            show_help
             exit 1
             ;;
         sdk)
-            just _test-sdk "$TOOLCHAIN" "$TARGET_TRIPLET" "$HAS_NOSTD" "$HAS_DOC" "$EXTRA_ARGS"
+            just _test-sdk "$TOOLCHAIN" "$TARGET_TRIPLET" "$PROFILE" "$HAS_NOSTD" "$HAS_DOC" "$EXTRA_ARGS"
             ;;
         integrations-zenoh)
-            just _test-integrations-zenoh "$TOOLCHAIN" "$TARGET_TRIPLET" "$HAS_NOSTD" "$HAS_DOC" "$EXTRA_ARGS"
+            just _test-integrations-zenoh "$TOOLCHAIN" "$TARGET_TRIPLET" "$PROFILE" "$HAS_NOSTD" "$HAS_DOC" "$EXTRA_ARGS"
             ;;
         integrations-ros2)
-            just _test-integrations-ros2 "$TOOLCHAIN" "$TARGET_TRIPLET" "$HAS_NOSTD" "$HAS_DOC" "$EXTRA_ARGS"
+            just _test-integrations-ros2 "$TOOLCHAIN" "$TARGET_TRIPLET" "$PROFILE" "$HAS_NOSTD" "$HAS_DOC" "$EXTRA_ARGS"
             ;;
         *)
-            just _test-package "{{what}}" "$TOOLCHAIN" "$TARGET_TRIPLET" "$HAS_NOSTD" "$HAS_DOC" "$EXTRA_ARGS"
+            just _test-package "{{what}}" "$TOOLCHAIN" "$TARGET_TRIPLET" "$PROFILE" "$HAS_NOSTD" "$HAS_DOC" "$EXTRA_ARGS"
             ;;
     esac
 
 [private]
-_test-sdk toolchain target_triplet has_nostd has_doc extra_args:
+_test-sdk toolchain target_triplet profile has_nostd has_doc extra_args:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -92,7 +127,7 @@ _test-sdk toolchain target_triplet has_nostd has_doc extra_args:
             echo "Error: --doc cannot be combined with --no_std" >&2
             exit 1
         fi
-        cargo {{toolchain}} test --workspace --doc {{extra_args}}
+        cargo {{toolchain}} test --workspace --profile {{profile}} --doc {{extra_args}}
         exit 0
     fi
 
@@ -115,7 +150,7 @@ _test-sdk toolchain target_triplet has_nostd has_doc extra_args:
             echo "[$((PASSED + FAILED + 1))/$CRATE_COUNT] Running tests for $crate..."
             echo "------------------------------------------"
 
-            if just _test-package "$crate" "{{toolchain}}" "{{target_triplet}}" "true" "false" "{{extra_args}}"; then
+            if just _test-package "$crate" "{{toolchain}}" "{{target_triplet}}" "{{profile}}" "true" "false" "{{extra_args}}"; then
                 echo "✓ $crate PASSED"
                 PASSED=$((PASSED + 1))
                 PASSED_CRATES+=("$crate")
@@ -152,11 +187,11 @@ _test-sdk toolchain target_triplet has_nostd has_doc extra_args:
             exit 1
         fi
     else
-        cargo {{toolchain}} nextest run --workspace {{extra_args}}
+        cargo {{toolchain}} nextest run --workspace --cargo-profile {{profile}} {{extra_args}}
     fi
 
 [private]
-_test-integrations-zenoh toolchain target_triplet has_nostd has_doc extra_args:
+_test-integrations-zenoh toolchain target_triplet profile has_nostd has_doc extra_args:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -168,13 +203,13 @@ _test-integrations-zenoh toolchain target_triplet has_nostd has_doc extra_args:
     MANIFEST_ARG=$(just _workspace-manifest-arg integrations-zenoh)
 
     if [ "{{has_doc}}" = "true" ]; then
-        cargo {{toolchain}} test --workspace --doc $MANIFEST_ARG {{extra_args}}
+        cargo {{toolchain}} test --workspace --profile {{profile}} --doc $MANIFEST_ARG {{extra_args}}
     else
-        cargo {{toolchain}} nextest run --workspace $MANIFEST_ARG {{extra_args}}
+        cargo {{toolchain}} nextest run --workspace --cargo-profile {{profile}} $MANIFEST_ARG {{extra_args}}
     fi
 
 [private]
-_test-integrations-ros2 toolchain target_triplet has_nostd has_doc extra_args:
+_test-integrations-ros2 toolchain target_triplet profile has_nostd has_doc extra_args:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -186,13 +221,13 @@ _test-integrations-ros2 toolchain target_triplet has_nostd has_doc extra_args:
     MANIFEST_ARG=$(just _workspace-manifest-arg integrations-ros2)
 
     if [ "{{has_doc}}" = "true" ]; then
-        cargo {{toolchain}} test --workspace --doc $MANIFEST_ARG {{extra_args}}
+        cargo {{toolchain}} test --workspace --profile {{profile}} --doc $MANIFEST_ARG {{extra_args}}
     else
-        cargo {{toolchain}} nextest run --workspace $MANIFEST_ARG {{extra_args}}
+        cargo {{toolchain}} nextest run --workspace --cargo-profile {{profile}} $MANIFEST_ARG {{extra_args}}
     fi
 
 [private]
-_test-package package toolchain target_triplet has_nostd has_doc extra_args:
+_test-package package toolchain target_triplet profile has_nostd has_doc extra_args:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -204,7 +239,7 @@ _test-package package toolchain target_triplet has_nostd has_doc extra_args:
             echo "Error: --doc cannot be combined with --no_std" >&2
             exit 1
         fi
-        cargo {{toolchain}} test --package {{package}} $MANIFEST_ARG --doc {{extra_args}}
+        cargo {{toolchain}} test --package {{package}} --profile {{profile}} $MANIFEST_ARG --doc {{extra_args}}
         exit 0
     fi
 
@@ -225,8 +260,9 @@ _test-package package toolchain target_triplet has_nostd has_doc extra_args:
                 $MANIFEST_ARG \
                 --no-default-features \
                 -Zbuild-std=core,alloc \
+                --profile {{profile}} \
                 $TARGET_ARG \
                 {{extra_args}}
     else
-        cargo {{toolchain}} nextest run --package {{package}} $MANIFEST_ARG {{extra_args}}
+        cargo {{toolchain}} nextest run --package {{package}} --cargo-profile {{profile}} $MANIFEST_ARG {{extra_args}}
     fi

--- a/.just/verify.just
+++ b/.just/verify.just
@@ -19,6 +19,8 @@ _parse-verify-args *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
+    TARGET_TRIPLET=""
+    BUILD_TYPE=""
     PROFILE=""
     HAS_NOSTD="false"
     EXTRA_ARGS=""
@@ -26,13 +28,28 @@ _parse-verify-args *flags:
     set -- {{flags}}
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --)        shift; EXTRA_ARGS="$*"; break ;;
-            --release) PROFILE="--release"; shift ;;
-            --no_std)  HAS_NOSTD="true";    shift ;;
-            *)         shift ;;
+            --)         shift; EXTRA_ARGS="$*";            break ;;
+            --target)   TARGET_TRIPLET="$2";               shift 2 ;;
+            --target=*) TARGET_TRIPLET="${1#--target=}";   shift ;;
+            --release)  BUILD_TYPE="--release";            shift ;;
+            --profile)  PROFILE="$2";                      shift 2 ;;
+            --no_std)   HAS_NOSTD="true";                  shift ;;
+            *)          echo "Invalid argument '$1'! Try 'just verify --help' for options." >&2; exit 1 ;;
         esac
     done
 
+    if [[ -n "$BUILD_TYPE" && -n "$PROFILE" ]]; then
+        echo "Error: --release and --profile cannot be used together." >&2
+        exit 1
+    fi
+
+    if [[ -n "$BUILD_TYPE" ]]; then
+        PROFILE="release"
+    elif [[ -z "$PROFILE" ]]; then
+        PROFILE="dev"
+    fi
+
+    echo "TARGET_TRIPLET='$TARGET_TRIPLET'"
     echo "PROFILE='$PROFILE'"
     echo "HAS_NOSTD='$HAS_NOSTD'"
     echo "EXTRA_ARGS='$EXTRA_ARGS'"
@@ -42,9 +59,7 @@ _verify-dispatch what tool *flags:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    eval $(just _parse-verify-args {{flags}})
-
-    if [ -z "{{what}}" ] || [ -z "{{tool}}" ]; then
+    show_help() {
         echo "Usage: just verify <what> <tool> [flags]"
         echo ""
         echo "Scope:"
@@ -60,13 +75,38 @@ _verify-dispatch what tool *flags:
         echo "  std-propagation        verify std feature propagation"
         echo ""
         echo "Flags (clippy):"
-        echo "  --release              run in release profile (default: debug)"
+        echo "  --target <triplet>     cross-compile for target"
+        echo "  --release              build in release mode (default: debug)"
+        echo "                         note: cannot be used in combination with --profile <profile>"
+        echo "  --profile <profile>    build with the specified cargo profile"
+        echo "                         note: cannot be used in combination with --release"
         echo "  --no_std               run with --no-default-features (sdk only)"
-        exit 1
-    fi
+    }
+
+    PARSED_ARGS=$(just _parse-verify-args {{flags}}) || exit $?
+    eval "$PARSED_ARGS"
+
+    case "{{what}}" in
+        "")
+            show_help
+            exit 1
+            ;;
+        -*|+*)
+            echo "Invalid argument '{{what}}'!"
+            echo ""
+            show_help
+            exit 1
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            ;;
+    esac
 
     case "{{tool}}" in
-        clippy)          just _verify-clippy "{{what}}" "$PROFILE" "$HAS_NOSTD" "$EXTRA_ARGS" ;;
+        clippy)          just _verify-clippy "{{what}}" "$TARGET_TRIPLET" "$PROFILE" "$HAS_NOSTD" "$EXTRA_ARGS" ;;
         miri)            just _verify-miri "{{what}}" "$EXTRA_ARGS" ;;
         std-propagation) just _verify-std-propagation "{{what}}" ;;
         *)
@@ -80,7 +120,7 @@ _verify-dispatch what tool *flags:
 # -----------------------------------------------------------------------------
 
 [private]
-_verify-clippy workspace profile has_nostd extra_args:
+_verify-clippy workspace target_triplet profile has_nostd extra_args:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -94,18 +134,24 @@ _verify-clippy workspace profile has_nostd extra_args:
 
         MANIFEST_ARG=$(just _workspace-manifest-arg "$WS")
 
+        TARGET_ARG=""
+        if [ -n "{{target_triplet}}" ]; then
+            TARGET_ARG="--target {{target_triplet}}"
+        fi
+
         # TODO: Only run on subset of crates included in the no_std deployment
         if [ "{{has_nostd}}" = "true" ]; then
             echo "Running clippy for '$WS' (no_std {{profile}})..."
-            cargo clippy --no-deps --workspace --all-targets {{profile}} \
+            cargo clippy --no-deps --workspace --all-targets --profile {{profile}} \
                 --no-default-features \
                 --exclude iceoryx2-ffi-c \
                 --exclude iceoryx2-cli \
+                $TARGET_ARG \
                 {{extra_args}} \
                 -- -D warnings
         else
             echo "Running clippy for '$WS' (std {{profile}})..."
-            cargo clippy --no-deps --workspace --all-targets $MANIFEST_ARG {{profile}} {{extra_args}} -- -D warnings
+            cargo clippy --no-deps --workspace --all-targets $MANIFEST_ARG --profile {{profile}} $TARGET_ARG {{extra_args}} -- -D warnings
         fi
     done
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,12 +254,23 @@ windows-sys = { version = "0.48.0", features = [
 [profile.dev]
 panic = "abort"
 
+[profile.dev-fast-build]
+inherits = "dev"
+debug = "line-tables-only"
+incremental = false
+
 [profile.release]
 codegen-units = 1
 strip = true
 lto = true
 # opt-level = "z"
 panic = "abort"
+
+[profile.release-fast-build]
+inherits = "release"
+codegen-units = 16
+lto = false
+incremental = false
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/doc/api/c/Doxyfile
+++ b/doc/api/c/Doxyfile
@@ -45,10 +45,10 @@ ENABLE_PREPROCESSING            = YES
 PREDEFINED                     += DOXYGEN_MACRO_FIX
 
 # Input
-INPUT                           = "../../../target/release/iceoryx2-ffi-c-cbindgen/include" \
+INPUT                           = "../../../target/dev-fast-build/iceoryx2-ffi-c-cbindgen/include" \
                                   "mainpage.md"
 
-STRIP_FROM_PATH                 = "../../../target/release/iceoryx2-ffi-c-cbindgen/include" \
+STRIP_FROM_PATH                 = "../../../target/dev-fast-build/iceoryx2-ffi-c-cbindgen/include" \
                                   "../../../doc/api/c"
 FILE_PATTERNS                   = *.h \
                                   *.c \

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -23,7 +23,7 @@
 * [#1707](https://github.com/eclipse-iceoryx/iceoryx2/issues/1707) Expose `CustomHeaderMarker` and `CustomPayloadMarker` in C++ bindings
 * [#1722](https://github.com/eclipse-iceoryx/iceoryx2/issues/1722) Remove allocations in tunnel hot path
 * [#1773](https://github.com/eclipse-iceoryx/iceoryx2/issues/1773) Make ports identifiable by name
-* [#1798](https://github.com/eclipse-iceoryx/iceoryx2/issues/1798) Add musl support
+* [#1798](https://github.com/eclipse-iceoryx/iceoryx2/issues/1798) Add support for musl 1.2.x
 * [#1813](https://github.com/eclipse-iceoryx/iceoryx2/issues/1813) Add API to deliver events to specific listener only
 
 ### Bugfixes

--- a/iceoryx2-pal/posix/src/linux/types.rs
+++ b/iceoryx2-pal/posix/src/linux/types.rs
@@ -54,8 +54,17 @@ pub type siginfo_t = libc::siginfo_t;
 pub type size_t = usize;
 pub type socklen_t = libc::socklen_t;
 pub type ssize_t = isize;
+
+#[cfg(not(target_env = "musl"))]
 pub type suseconds_t = libc::suseconds_t;
+#[cfg(target_env = "musl")]
+pub type suseconds_t = i64; // changed from 32 to 64 bit with musl 1.2; libc::time_t is deprecated until libc adopts the breaking change in musl
+
+#[cfg(not(target_env = "musl"))]
 pub type time_t = libc::time_t;
+#[cfg(target_env = "musl")]
+pub type time_t = i64; // changed from 32 to 64 bit with musl 1.2; libc::time_t is deprecated until libc adopts the breaking change in musl
+
 pub type timer_t = libc::timer_t;
 pub type uchar = core::ffi::c_uchar;
 pub type uid_t = libc::uid_t;

--- a/integrations/ros2/Cargo.toml
+++ b/integrations/ros2/Cargo.toml
@@ -47,9 +47,20 @@ toml = { version = "0.9.8", default-features = false, features = ["serde", "pars
 [profile.dev]
 panic = "abort"
 
+[profile.dev-fast-build]
+inherits = "dev"
+debug = "line-tables-only"
+incremental = false
+
 [profile.release]
 codegen-units = 1
 strip = true
 lto = true
 # opt-level = "z"
 panic = "abort"
+
+[profile.release-fast-build]
+inherits = "release"
+codegen-units = 16
+lto = false
+incremental = false

--- a/integrations/zenoh/Cargo.toml
+++ b/integrations/zenoh/Cargo.toml
@@ -63,9 +63,20 @@ zenoh = { version = "1.9.0", default-features = false, features = [
 [profile.dev]
 panic = "abort"
 
+[profile.dev-fast-build]
+inherits = "dev"
+debug = "line-tables-only"
+incremental = false
+
 [profile.release]
 codegen-units = 1
 strip = true
 lto = true
 # opt-level = "z"
 panic = "abort"
+
+[profile.release-fast-build]
+inherits = "release"
+codegen-units = 16
+lto = false
+incremental = false

--- a/internal/scripts/ci_build_and_run_end_to_end_tests.sh
+++ b/internal/scripts/ci_build_and_run_end_to_end_tests.sh
@@ -91,7 +91,7 @@ if [[ ${BUILD_END_TO_END_TESTS} == true ]]; then
         -DBUILD_EXAMPLES=ON \
         -DBUILD_TESTING=ON \
         -DIOX2_FEATURE_FLATBUFFERS=ON
-    cmake --build target/ff/cc/build -j$NUM_JOBS
+    cmake --build target/ff/cc/build --parallel $NUM_JOBS
 
     # Build the Python bindings
     if [[ ${PYTHON_END_TO_END_TESTS} == true ]]; then

--- a/internal/scripts/ci_build_and_test_freebsd.bash
+++ b/internal/scripts/ci_build_and_test_freebsd.bash
@@ -14,7 +14,7 @@
 set -e
 
 RUST_TOOLCHAIN="stable"
-RUST_BUILD_TYPE_FLAG=""
+CARGO_PROFILE="dev-fast-build"
 CMAKE_BUILD_TYPE_FLAG="-DCMAKE_BUILD_TYPE=Debug"
 BUILD_ARGS="--workspace --all-targets"
 TEST_ARGS="--workspace --all-targets --no-fail-fast"
@@ -24,7 +24,7 @@ while (( "$#" )); do
   case "$1" in
     --mode)
         if [[ "$2" == "release" ]]; then
-            RUST_BUILD_TYPE_FLAG="--release"
+            CARGO_PROFILE="release-fast-build"
             CMAKE_BUILD_TYPE_FLAG="-DCMAKE_BUILD_TYPE=Release"
         fi
         shift 2
@@ -94,13 +94,13 @@ echo "###################"
 echo "# Run cargo build #"
 echo "###################"
 echo "BUILD_ARGS: $BUILD_ARGS"
-cargo build $RUST_BUILD_TYPE_FLAG $BUILD_ARGS
+cargo build --profile $CARGO_PROFILE $BUILD_ARGS
 
 echo "######################"
 echo "# Run cargo nextest #"
 echo "#####################"
 echo "TEST_ARGS: $TEST_ARGS"
-cargo nextest run $RUST_BUILD_TYPE_FLAG $TEST_ARGS
+cargo nextest run --cargo-profile $CARGO_PROFILE $TEST_ARGS
 
 if [ "$CMAKE_BUILD" = true ]
 then
@@ -120,9 +120,14 @@ then
     echo "Using $CPU_COUNT CPU cores"
 
     # Build examples only in out-of-tree, else we are running out of disk space on the VM
-    cmake -S . -B target/ff/cc/build $CMAKE_BUILD_TYPE_FLAG -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=target/ff/cc/install
+    cmake -S . \
+          -B target/ff/cc/build \
+          $CMAKE_BUILD_TYPE_FLAG \
+          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_TESTING=ON \
+          -DRUST_BUILD_ARTIFACT_PATH=$(pwd)/target/$CARGO_PROFILE
     cmake --build target/ff/cc/build --parallel $CPU_COUNT
-    cmake --install target/ff/cc/build
+    cmake --install target/ff/cc/build --prefix target/ff/cc/install
 
     echo "##############################"
     echo "# Run language binding tests #"

--- a/internal/scripts/ci_build_and_test_freebsd.bash
+++ b/internal/scripts/ci_build_and_test_freebsd.bash
@@ -114,9 +114,12 @@ then
     echo "# Build language bindings #"
     echo "###########################"
 
+    CPU_COUNT=$(sysctl -n hw.ncpu)
+    echo "Using $CPU_COUNT CPU cores"
+
     # Build examples only in out-of-tree, else we are running out of disk space on the VM
     cmake -S . -B target/ff/cc/build $CMAKE_BUILD_TYPE_FLAG -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=ON -DCMAKE_INSTALL_PREFIX=target/ff/cc/install
-    cmake --build target/ff/cc/build
+    cmake --build target/ff/cc/build --parallel $CPU_COUNT
     cmake --install target/ff/cc/build
 
     echo "##############################"
@@ -132,10 +135,10 @@ then
 
     rm -rf target/ff/cc/build
     cmake -S examples/c -B target/ff/out-of-tree-c $CMAKE_BUILD_TYPE_FLAG -DCMAKE_PREFIX_PATH="$(pwd)/target/ff/cc/install"
-    cmake --build target/ff/out-of-tree-c
+    cmake --build target/ff/out-of-tree-c --parallel $CPU_COUNT
     rm -rf target/ff/out-of-tree-c
 
     cmake -S examples/cxx -B target/ff/out-of-tree-cxx $CMAKE_BUILD_TYPE_FLAG -DCMAKE_PREFIX_PATH="$(pwd)/target/ff/cc/install"
-    cmake --build target/ff/out-of-tree-cxx
+    cmake --build target/ff/out-of-tree-cxx --parallel $CPU_COUNT
     rm -rf target/ff/out-of-tree-cxx
 fi

--- a/internal/scripts/ci_build_and_test_freebsd.bash
+++ b/internal/scripts/ci_build_and_test_freebsd.bash
@@ -108,7 +108,9 @@ then
     echo "# Clean the target directory to reduce memory usage on VM #"
     echo "###########################################################"
 
-    cargo clean
+    # remove unimportant build artifacts but keep the generated lib and headers for the C binding
+    rm -rf ./target/{debug,release}/{deps,incremental}
+    rm -rf ./target/*/{debug,release}/{deps,incremental} # Cleanup subfolders for target triples
 
     echo "###########################"
     echo "# Build language bindings #"

--- a/internal/scripts/clang_tidy_scan.sh
+++ b/internal/scripts/clang_tidy_scan.sh
@@ -169,7 +169,7 @@ cmake -S . -B target/clang-tidy-scan \
     -DBUILD_EXAMPLES=ON \
     -DBUILD_TESTING=ON \
     -DIOX2_FEATURE_FLATBUFFERS=ON
-cmake --build target/clang-tidy-scan -j$NUM_JOBS
+cmake --build target/clang-tidy-scan --parallel $NUM_JOBS
 
 echo "Using clang-tidy version: $(clang-tidy --version | sed -n "s/.*version \([0-9.]*\)/\1/p" )"
 

--- a/internal/scripts/clang_tidy_scan.sh
+++ b/internal/scripts/clang_tidy_scan.sh
@@ -161,9 +161,9 @@ echo -e "${COLOR_YELLOW}Building iceoryx-ffi and C/C++ bindings as preparation f
 export CXX=clang++
 export CC=clang
 
-cargo build --package iceoryx2-ffi-c
+cargo build --package iceoryx2-ffi-c --profile dev-fast-build
 cmake -S . -B target/clang-tidy-scan \
-    -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/debug" \
+    -DRUST_BUILD_ARTIFACT_PATH="$(pwd)/target/dev-fast-build" \
     -DCMAKE_BUILD_TYPE=Debug \
     -DBUILD_CXX=ON \
     -DBUILD_EXAMPLES=ON \


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR utilizes all cores for the C and C++ binding and also adds new profiles for Rust which speeds up the builds.

In order to achieve this, the `just` files were extended to accept a `profile` parameter. While doing that, I noticed that they silently dropped unknown parameter and also fixed that.

As a final measure to improve the build times, the C and C++ bindings are build separately.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #3 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
