### PR TITLE
[#1872] register FileDescriptor pyclass with the python module

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -53,6 +53,7 @@
 * [#1807](https://github.com/eclipse-iceoryx/iceoryx2/issues/1807) Fix generated C FFI strings for `UPPER_SNAKE_CASE` enum variants.
 * [#1810](https://github.com/eclipse-iceoryx/iceoryx2/issues/1810) Make mgmt segment globally accessible
 * [#1844](https://github.com/eclipse-iceoryx/iceoryx2/issues/1844) Fix `semantic_string` macro for `rust-analyzer` auto-completion
+* [#1872](https://github.com/eclipse-iceoryx/iceoryx2/issues/1872) Register FileDescriptor pyclass with the python module
 
 ### Refactoring
 

--- a/iceoryx2-ffi/python/src/lib.rs
+++ b/iceoryx2-ffi/python/src/lib.rs
@@ -146,6 +146,7 @@ fn _iceoryx2(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::entry_value_uninit::EntryValueUninit>()?;
     m.add_class::<crate::event_activation::EventActivation>()?;
     m.add_class::<crate::event_id::EventId>()?;
+    m.add_class::<crate::file_descriptor::FileDescriptor>()?;
     m.add_class::<crate::file_name::FileName>()?;
     m.add_class::<crate::file_path::FilePath>()?;
     m.add_class::<crate::header_publish_subscribe::HeaderPublishSubscribe>()?;


### PR DESCRIPTION
WaitSet::attach_notification_fd() and WaitSet::attach_deadline_fd() take a &FileDescriptor, but the FileDescriptor pyclass was never registered with the _iceoryx2 module via add_class(). The class is fully implemented in file_descriptor.rs and the module is declared in lib.rs, yet the type is absent from the python module and no other binding returns or yields one, so it cannot be constructed from python at all.

As a consequence both fd attachment methods have been unreachable from python since they were introduced, and users have no way to wake a WaitSet from python other than through an iceoryx event service.

Register the class so that FileDescriptor.non_owning_new() can be used to attach arbitrary file descriptors, e.g. an eventfd used as a wakeup channel.

<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1872

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
