### PR TITLE
[#1878] Fix race in 'pthread_create' on macOS and Windows

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -54,6 +54,7 @@
 * [#1810](https://github.com/eclipse-iceoryx/iceoryx2/issues/1810) Make mgmt segment globally accessible
 * [#1844](https://github.com/eclipse-iceoryx/iceoryx2/issues/1844) Fix `semantic_string` macro for `rust-analyzer` auto-completion
 * [#1872](https://github.com/eclipse-iceoryx/iceoryx2/issues/1872) Register FileDescriptor pyclass with the python module
+* [#1878](https://github.com/eclipse-iceoryx/iceoryx2/issues/1878) Fix race in `pthread_create` on macOS and Windows
 
 ### Refactoring
 

--- a/iceoryx2-pal/posix/src/macos/pthread.rs
+++ b/iceoryx2-pal/posix/src/macos/pthread.rs
@@ -25,6 +25,8 @@ use iceoryx2_pal_concurrency_sync::strategy::mutex::Mutex;
 use iceoryx2_pal_concurrency_sync::strategy::rwlock::*;
 use iceoryx2_pal_concurrency_sync::{WaitAction, WaitResult};
 
+use alloc::sync::Arc;
+
 #[derive(Clone, Copy)]
 struct ThreadState {
     id: u64,
@@ -290,14 +292,18 @@ struct CallbackArguments {
     start_routine: unsafe extern "C" fn(*mut void) -> *mut void,
     arg: *mut void,
 }
+// safe for our usage since we access only the barrier from both threads
+unsafe impl Send for CallbackArguments {}
+unsafe impl Sync for CallbackArguments {}
 
 unsafe extern "C" fn thread_callback(args: *mut void) -> *mut void {
-    let thread = args as *mut CallbackArguments;
     unsafe {
-        let start_routine = (*thread).start_routine;
-        let arg = (*thread).arg;
-        let startup_barrier = &(*thread).startup_barrier;
-        startup_barrier.wait(|_, _| {}, |_| {});
+        let thread_args = Arc::from_raw(args as *const CallbackArguments);
+        let start_routine = thread_args.start_routine;
+        let arg = thread_args.arg;
+        thread_args.startup_barrier.wait(|_, _| {}, |_| {});
+        // drop thread args right away to prevent leaks in case a thread dies
+        drop(thread_args);
 
         start_routine(arg);
 
@@ -311,22 +317,26 @@ pub unsafe fn pthread_create(
     start_routine: unsafe extern "C" fn(*mut void) -> *mut void,
     arg: *mut void,
 ) -> int {
-    let mut thread_args = CallbackArguments {
+    let thread_args = Arc::new(CallbackArguments {
         startup_barrier: Barrier::new(2),
         start_routine,
         arg,
-    };
+    });
     unsafe {
+        let thread_args_spawned = Arc::into_raw(thread_args.clone());
         let result = crate::internal::pthread_create(
             thread,
             &(*attr).attr,
             Some(thread_callback),
-            (&mut thread_args as *mut CallbackArguments).cast(),
+            (thread_args_spawned as *mut CallbackArguments).cast(),
         );
         if result == 0 {
             ThreadStates::get_instance().add(*thread);
             ThreadStates::get_instance().get_mut(*thread).affinity = (*attr).affinity;
             thread_args.startup_barrier.wait(|_, _| {}, |_| {});
+        } else {
+            // the creation of the thread failed and we need to re-take ownership of the raw pointer
+            let _ = Arc::from_raw(thread_args_spawned);
         }
         result
     }

--- a/iceoryx2-pal/posix/src/macos/pthread.rs
+++ b/iceoryx2-pal/posix/src/macos/pthread.rs
@@ -292,7 +292,8 @@ struct CallbackArguments {
     start_routine: unsafe extern "C" fn(*mut void) -> *mut void,
     arg: *mut void,
 }
-// safe for our usage since we access only the barrier from both threads
+// safe for our usage since we access only the barrier concurrently form two threads,
+// the one that spawns the new thread and the new thread itself
 unsafe impl Send for CallbackArguments {}
 unsafe impl Sync for CallbackArguments {}
 

--- a/iceoryx2-pal/posix/src/windows/pthread.rs
+++ b/iceoryx2-pal/posix/src/windows/pthread.rs
@@ -14,13 +14,17 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(unused_variables)]
 
+use alloc::sync::Arc;
 use core::panic;
+
 use iceoryx2_pal_concurrency_sync::atomic::Ordering;
 use std::{
     os::windows::prelude::OsStrExt, os::windows::prelude::OsStringExt, time::SystemTime,
     time::UNIX_EPOCH,
 };
-use windows_sys::Win32::Foundation::ERROR_INVALID_HANDLE;
+use windows_sys::Win32::Foundation::{
+    ERROR_ACCESS_DENIED, ERROR_INVALID_HANDLE, ERROR_INVALID_PARAMETER,
+};
 
 use iceoryx2_pal_concurrency_sync::atomic::AtomicU64;
 use iceoryx2_pal_concurrency_sync::cell::UnsafeCell;
@@ -293,13 +297,17 @@ struct CallbackArguments {
     arg: *mut void,
 }
 
-unsafe extern "system" fn thread_callback(args: *mut void) -> u32 {
-    let thread = args as *mut CallbackArguments;
-    unsafe {
-        let start_routine = (*thread).start_routine;
-        let arg = (*thread).arg;
+// safe for our usage since we access only the barrier from both threads
+unsafe impl Send for CallbackArguments {}
+unsafe impl Sync for CallbackArguments {}
 
-        barrier_wait(&(*thread).startup_barrier);
+unsafe extern "system" fn thread_callback(args: *mut void) -> u32 {
+    unsafe {
+        let thread_args = Arc::from_raw(args as *const CallbackArguments);
+        let start_routine = thread_args.start_routine;
+        let arg = thread_args.arg;
+
+        barrier_wait(&thread_args.startup_barrier);
 
         start_routine(arg);
     }
@@ -315,20 +323,32 @@ pub unsafe fn pthread_create(
     unsafe {
         thread.write(pthread_t::new_zeroed());
 
-        let mut thread_args = CallbackArguments {
+        let thread_args = Arc::new(CallbackArguments {
             startup_barrier: Barrier::new(2),
             start_routine,
             arg,
-        };
+        });
 
-        let (handle, _) = win32call! {CreateThread(
+        let thread_args_spawned = Arc::into_raw(thread_args.clone());
+        let (handle, error) = win32call! {CreateThread(
             core::ptr::null(),
             (*attributes).stacksize,
             Some(thread_callback),
-            (&mut thread_args as *mut CallbackArguments) as *mut void,
+            (thread_args_spawned as *mut CallbackArguments).cast(),
             0,
             core::ptr::null_mut(),
         )};
+
+        if handle == 0 {
+            // the creation of the thread failed and we need to re-take ownership of the raw pointer
+            let _ = Arc::from_raw(thread_args_spawned);
+            let errno = match error {
+                ERROR_INVALID_PARAMETER => Errno::EINVAL,
+                ERROR_ACCESS_DENIED => Errno::EPERM,
+                _ => Errno::EAGAIN,
+            };
+            return errno as int;
+        }
 
         win32call! { SetThreadPriority(handle, to_win_priority((*attributes).priority)) };
         win32call! { SetThreadAffinityMask(handle, usize::from_ne_bytes((*attributes).affinity.__bits) )};

--- a/iceoryx2-pal/posix/src/windows/pthread.rs
+++ b/iceoryx2-pal/posix/src/windows/pthread.rs
@@ -296,8 +296,8 @@ struct CallbackArguments {
     start_routine: unsafe extern "C" fn(*mut void) -> *mut void,
     arg: *mut void,
 }
-
-// safe for our usage since we access only the barrier from both threads
+// safe for our usage since we access only the barrier concurrently form two threads,
+// the one that spawns the new thread and the new thread itself
 unsafe impl Send for CallbackArguments {}
 unsafe impl Sync for CallbackArguments {}
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

See #1878 for explanation of the race. This PR moves the thread args on the heap and ensures they are living long enough for all participants.

I guess this was the root cause for some of the flaky tests on macOS.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1878 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
