### PR TITLE
[#81] Re-enable FetchableSignal::Continue (SIGCONT)

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -33,6 +33,7 @@
     conflicts when merging.
 -->
 
+* [#81](https://github.com/eclipse-iceoryx/iceoryx2/issues/81) Re-enable the `FetchableSignal::Continue` (`SIGCONT`) signal variant.
 * [#156](https://github.com/eclipse-iceoryx/iceoryx2/issues/156) Remove `fchmod`/`shm_open` macOS workarounds; route permissions through a trampoline state file.
 * [#588](https://github.com/eclipse-iceoryx/iceoryx2/issues/588) Replace deprecated `serde_yaml` dependency with `yaml_serde`.
 * [#1152](https://github.com/eclipse-iceoryx/iceoryx2/issues/1152) Fix `no_std` build of the console logger on platforms other than linux and nto.

--- a/iceoryx2-bb/posix/src/signal.rs
+++ b/iceoryx2-bb/posix/src/signal.rs
@@ -198,9 +198,7 @@ macro_rules! define_signals {
 
 define_signals! {
   fetchable:
-    //TODO: https://github.com/eclipse-iceoryx/iceoryx2/issues/81
-    //  comment in Continue again when the bindgen bug is fixed
-    //Continue = posix::SIGCONT,
+    Continue = posix::SIGCONT,
     Abort = posix::SIGABRT,
     Interrupt = posix::SIGINT,
     TerminalQuit = posix::SIGQUIT,

--- a/iceoryx2-bb/posix/tests-common/src/signal_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/signal_tests.rs
@@ -81,6 +81,23 @@ pub fn register_single_handler_works() {
 }
 
 #[test]
+pub fn register_continue_handler_works() {
+    // Regression guard for #81: when `Continue` was mapped via a bindgen
+    // binding that emitted swapped SIGCONT/SIGSTOP values, registering it
+    // actually registered the uncatchable SIGSTOP and `sigaction` failed.
+    // Linux now resolves `SIGCONT` through the `libc` crate, so the signal
+    // must register and be deliverable like any other fetchable signal.
+    test_requires!(POSIX_SUPPORT_ADVANCED_SIGNAL_HANDLING);
+
+    let test = TestFixture::new();
+    let _guard =
+        SignalHandler::register(FetchableSignal::Continue, &TestFixture::signal_callback);
+
+    Process::from_self().send_signal(Signal::Continue).ok();
+    test.verify(NonFatalFetchableSignal::Continue, 1)
+}
+
+#[test]
 pub fn register_multiple_handler_works() {
     test_requires!(POSIX_SUPPORT_ADVANCED_SIGNAL_HANDLING);
 

--- a/iceoryx2-bb/posix/tests-common/src/signal_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/signal_tests.rs
@@ -90,8 +90,7 @@ pub fn register_continue_handler_works() {
     test_requires!(POSIX_SUPPORT_ADVANCED_SIGNAL_HANDLING);
 
     let test = TestFixture::new();
-    let _guard =
-        SignalHandler::register(FetchableSignal::Continue, &TestFixture::signal_callback);
+    let _guard = SignalHandler::register(FetchableSignal::Continue, &TestFixture::signal_callback);
 
     Process::from_self().send_signal(Signal::Continue).ok();
     test.verify(NonFatalFetchableSignal::Continue, 1)


### PR DESCRIPTION
The `Continue` variant was commented out in `define_signals!` as a workaround for [#81](https://github.com/eclipse-iceoryx/iceoryx2/issues/81): bindgen emitted SIGCONT/SIGSTOP with swapped values on glibc (`bits/signum.h` undef/redefine), so registering `Continue` registered the uncatchable SIGSTOP and `sigaction` failed with EINVAL.

The TODO's stated gate ("when the bindgen bug is fixed") no longer applies. rust-bindgen#2722 is still open, but #1374 migrated Linux from bindgen to the `libc` crate, which carries correct SIGCONT values. The #81 failure mode was Linux/glibc-specific and is structurally gone on that platform; macOS (Darwin `signal.h` has no such redefine) and Windows (hardcoded value) are unaffected.

Add `register_continue_handler_works` as an end-to-end regression guard: it registers `Continue`, exercising the `sigaction` path that panicked in #81, sends it, and verifies delivery.

## Notes for Reviewer

**TL;DR:** the upstream bindgen bug ([rust-bindgen#2722](https://github.com/rust-lang/rust-bindgen/issues/2722)) is *not* fixed, but it no longer matters, [#1374](https://github.com/eclipse-iceoryx/iceoryx2/pull/1374) moved Linux from bindgen to the `libc` crate, so the swapped SIGCONT/SIGSTOP value failure cannot occur on the platform where #81 was originally reported.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

Relates to [#81](https://github.com/eclipse-iceoryx/iceoryx2/issues/81)