### PR TITLE
[#1458] Fix deadlock in SignalHandler::call_and_fetch

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -36,6 +36,7 @@
 * [#156](https://github.com/eclipse-iceoryx/iceoryx2/issues/156) Remove `fchmod`/`shm_open` macOS workarounds; route permissions through a trampoline state file.
 * [#588](https://github.com/eclipse-iceoryx/iceoryx2/issues/588) Replace deprecated `serde_yaml` dependency with `yaml_serde`.
 * [#1152](https://github.com/eclipse-iceoryx/iceoryx2/issues/1152) Fix `no_std` build of the console logger on platforms other than linux and nto.
+* [#1458](https://github.com/eclipse-iceoryx/iceoryx2/issues/1458) Fix deadlock in `SignalHandler::call_and_fetch` when the callable raises a signal with a registered callback; the global signal-handler mutex is no longer held across the user-provided callable.
 * [#1548](https://github.com/eclipse-iceoryx/iceoryx2/issues/1548) Fix Payload data lifetime tracking in python ffi by anchoring views to their owning Sample.
 * [#1673](https://github.com/eclipse-iceoryx/iceoryx2/issues/1673) Thread-stack-size is the same as process-stack-size on all platforms.
 * [#1695](https://github.com/eclipse-iceoryx/iceoryx2/issues/1695) Remove port_tag when stale resources of port are removed.

--- a/iceoryx2-bb/posix/src/signal.rs
+++ b/iceoryx2-bb/posix/src/signal.rs
@@ -402,9 +402,11 @@ impl SignalHandler {
         {
             let _sighandle = Self::instance();
             LAST_SIGNAL.store(posix::MAX_SIGNAL_VALUE, Ordering::Relaxed);
-
-            call();
         }
+
+        // `call()` must run outside the lock: it may raise a signal whose
+        // handler re-locks this mutex (iox2 #1458).
+        call();
 
         match LAST_SIGNAL.load(Ordering::Relaxed) {
             posix::MAX_SIGNAL_VALUE => None,

--- a/iceoryx2-bb/posix/tests-common/src/signal_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/signal_tests.rs
@@ -160,8 +160,6 @@ pub fn call_and_fetch_works() {
     assert_that!(result, eq Some(NonFatalFetchableSignal::Interrupt));
 }
 
-// TODO: #1458
-#[ignore]
 #[test]
 pub fn call_and_fetch_with_registered_handler_works() {
     test_requires!(POSIX_SUPPORT_ADVANCED_SIGNAL_HANDLING);


### PR DESCRIPTION

Fixes the single-thread deadlock tracked in #1458.

**Root cause.** `SignalHandler::call_and_fetch` held the global `SignalHandler` mutex across the user-provided callable. When the callable raised a signal that had a registered callback, the C signal handler ran synchronously on the same (only) thread and tried to re-acquire that same non-reentrant mutex to dispatch the callback, deadlocking. The custom test runner runs each test on the main thread (unlike `libtest`'s worker thread), which is what exposed it.

**Fix.** `call()` now runs outside the locked scope; the `LAST_SIGNAL` reset stays under the lock. It also removes a latent deadlock for the production caller in `shared_memory.rs` (`call_and_fetch(memset_call)`).

**Test.** Un-ignores `call_and_fetch_with_registered_handler_works`, now passes in ~0.1s (previously hung until the watchdog aborted). 

## Notes for Reviewer

TL;DR Fixes a signal handler mutex deadlock.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

Closes #1458
