### PR TITLE
[#1906] Do no set the exec bit for created resources

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -58,6 +58,7 @@
 * [#1872](https://github.com/eclipse-iceoryx/iceoryx2/issues/1872) Register FileDescriptor pyclass with the python module
 * [#1878](https://github.com/eclipse-iceoryx/iceoryx2/issues/1878) Fix race in `pthread_create` on macOS and Windows
 * [#1893](https://github.com/eclipse-iceoryx/iceoryx2/issues/1893) Fix C language `ipc` and `local` mapping for payload types
+* [#1906](https://github.com/eclipse-iceoryx/iceoryx2/issues/1906) Do not set the exec bit for created resources
 
 ### Refactoring
 

--- a/iceoryx2-bb/posix/src/file.rs
+++ b/iceoryx2-bb/posix/src/file.rs
@@ -498,18 +498,12 @@ impl Abandonable for File {
 impl Drop for File {
     fn drop(&mut self) {
         if self.has_ownership.load(Ordering::Relaxed) {
-            let set_permission_result = self.set_permission(Permission::ALL);
-
             match &self.path {
                 None => {
                     warn!(from self, "Files created from file descriptors cannot remove themselves.")
                 }
                 Some(p) => match File::remove(p) {
                     Ok(false) | Err(_) => {
-                        if let Err(e) = set_permission_result {
-                            warn!(from self,
-                                  "Unable to adjust the files permission as preparation to remove the file ({e:?}).");
-                        }
                         warn!(from self, "Failed to remove owned file");
                     }
                     Ok(true) => (),

--- a/iceoryx2-bb/posix/src/file.rs
+++ b/iceoryx2-bb/posix/src/file.rs
@@ -24,7 +24,7 @@
 //! let file_name = FilePath::new(b"ooh_makes_the_file.md").unwrap();
 //! let mut file = FileBuilder::new(&file_name)
 //!                                  .creation_mode(CreationMode::CreateExclusive)
-//!                                  .permission(Permission::OWNER_ALL | Permission::GROUP_READ)
+//!                                  .permission(Permission::OWNER_READ_WRITE | Permission::GROUP_READ)
 //!                                  .truncate_size(1024)
 //!                                  .create().expect("Failed to create file");
 //!
@@ -307,7 +307,7 @@ pub enum FileReadLineState {
 /// let file = FileBuilder::new(&file_name)
 ///                              .creation_mode(CreationMode::CreateExclusive)
 ///                              // BEGIN: optional settings
-///                              .permission(Permission::OWNER_ALL | Permission::GROUP_READ)
+///                              .permission(Permission::OWNER_READ_WRITE | Permission::GROUP_READ)
 ///                              .owner("testuser1".as_user().unwrap().uid())
 ///                              .group("testgroup2".as_group().unwrap().gid())
 ///                              .truncate_size(1024)
@@ -332,7 +332,7 @@ impl FileBuilder {
         FileBuilder {
             file_path: *file_path,
             access_mode: AccessMode::Read,
-            permission: Permission::OWNER_ALL,
+            permission: Permission::OWNER_READ_WRITE,
             has_ownership: false,
             owner: None,
             group: None,
@@ -387,7 +387,7 @@ impl FileCreationBuilder {
     /// let file_name = FilePath::new(b"someFileName.txt").unwrap();
     /// let file = FileBuilder::new(&file_name)
     ///                              .creation_mode(CreationMode::CreateExclusive)
-    ///                              .permission(Permission::OWNER_ALL | Permission::GROUP_READ)
+    ///                              .permission(Permission::OWNER_READ_WRITE | Permission::GROUP_READ)
     ///                              .create().expect("failed to create file");
     /// ```
     pub fn permission(mut self, value: Permission) -> Self {

--- a/iceoryx2-bb/posix/src/file_descriptor.rs
+++ b/iceoryx2-bb/posix/src/file_descriptor.rs
@@ -67,7 +67,7 @@
 //!         .gid("testgroup1".as_group().unwrap().gid()).create());
 //!
 //! // set new permissions
-//! file.set_permission(Permission::ALL);
+//! file.set_permission(Permission::OWNER_READ_WRITE);
 //! ```
 
 use core::fmt::Debug;

--- a/iceoryx2-bb/posix/src/permission.rs
+++ b/iceoryx2-bb/posix/src/permission.rs
@@ -33,16 +33,25 @@ impl Permission {
     pub const OWNER_READ: Self = Self(0o0400);
     pub const OWNER_WRITE: Self = Self(0o0200);
     pub const OWNER_EXEC: Self = Self(0o0100);
+    pub const OWNER_READ_WRITE: Self = Self::OWNER_READ.const_bitor(Self::OWNER_WRITE);
+    pub const OWNER_READ_EXEC: Self = Self::OWNER_READ.const_bitor(Self::OWNER_EXEC);
+    pub const OWNER_WRITE_EXEC: Self = Self::OWNER_WRITE.const_bitor(Self::OWNER_EXEC);
     pub const OWNER_ALL: Self = Self(0o0700);
 
     pub const GROUP_READ: Self = Self(0o0040);
     pub const GROUP_WRITE: Self = Self(0o0020);
     pub const GROUP_EXEC: Self = Self(0o0010);
+    pub const GROUP_READ_WRITE: Self = Self::GROUP_READ.const_bitor(Self::GROUP_WRITE);
+    pub const GROUP_READ_EXEC: Self = Self::GROUP_READ.const_bitor(Self::GROUP_EXEC);
+    pub const GROUP_WRITE_EXEC: Self = Self::GROUP_WRITE.const_bitor(Self::GROUP_EXEC);
     pub const GROUP_ALL: Self = Self(0o0070);
 
     pub const OTHERS_READ: Self = Self(0o0004);
     pub const OTHERS_WRITE: Self = Self(0o0002);
     pub const OTHERS_EXEC: Self = Self(0o0001);
+    pub const OTHERS_READ_WRITE: Self = Self::OTHERS_READ.const_bitor(Self::OTHERS_WRITE);
+    pub const OTHERS_READ_EXEC: Self = Self::OTHERS_READ.const_bitor(Self::OTHERS_EXEC);
+    pub const OTHERS_WRITE_EXEC: Self = Self::OTHERS_WRITE.const_bitor(Self::OTHERS_EXEC);
     pub const OTHERS_ALL: Self = Self(0o0007);
 
     pub const ALL: Self = Self(0o0777);
@@ -77,7 +86,7 @@ impl BitOr for Permission {
     type Output = Self;
 
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self(self.0 | rhs.0)
+        self.const_bitor(rhs)
     }
 }
 

--- a/iceoryx2-bb/posix/src/process_state.rs
+++ b/iceoryx2-bb/posix/src/process_state.rs
@@ -427,10 +427,8 @@ impl ProcessGuardBuilder {
     pub fn new() -> Self {
         Self {
             directory_permissions: Permission::OWNER_ALL
-                | Permission::GROUP_READ
-                | Permission::GROUP_EXEC
-                | Permission::OTHERS_READ
-                | Permission::OTHERS_EXEC,
+                | Permission::GROUP_READ_EXEC
+                | Permission::OTHERS_READ_EXEC,
             guard_permissions: Permission::OWNER_READ | Permission::OWNER_WRITE,
         }
     }
@@ -735,7 +733,7 @@ impl Drop for StateFiles {
                 let file_path = *file
                     .path()
                     .expect("created from path therefore it always contains a value");
-                if let Err(e) = file.set_permission(Permission::OWNER_ALL) {
+                if let Err(e) = file.set_permission(Permission::OWNER_READ_WRITE) {
                     warn!(from origin,
                         "{msg} since the access rights of the file \"{:?}\" could not be elevated to grant permissions to remove the file. [{e:?}]",
                         file_path);

--- a/iceoryx2-bb/posix/src/semaphore.rs
+++ b/iceoryx2-bb/posix/src/semaphore.rs
@@ -271,7 +271,7 @@ pub trait SemaphoreInterface: internal::SemaphoreHandle + Debug {
 ///     // the semaphore is created, if there already exists a semaphore it is deleted
 ///                     .creation_mode(CreationMode::PurgeAndCreate)
 ///                     .initial_value(5)
-///                     .permission(Permission::OWNER_ALL | Permission::GROUP_ALL)
+///                     .permission(Permission::OWNER_READ_WRITE | Permission::GROUP_READ_WRITE)
 ///                     .create()
 ///                     .expect("failed to create semaphore");
 /// ```
@@ -306,7 +306,7 @@ impl NamedSemaphoreBuilder {
             creation_mode: None,
             name: *name,
             initial_value: 0,
-            permission: Permission::OWNER_ALL,
+            permission: Permission::OWNER_READ_WRITE,
             clock_type: ClockType::default(),
         }
     }
@@ -378,7 +378,7 @@ impl NamedSemaphoreCreationBuilder {
 /// let name = FileName::new(b"mySemaphoreName").unwrap();
 /// let semaphore = NamedSemaphoreBuilder::new(&name)
 ///                     .creation_mode(CreationMode::PurgeAndCreate)
-///                     .permission(Permission::OWNER_ALL)
+///                     .permission(Permission::OWNER_READ_WRITE)
 ///                     .create()
 ///                     .expect("failed to create semaphore");
 ///

--- a/iceoryx2-bb/posix/src/shared_memory.rs
+++ b/iceoryx2-bb/posix/src/shared_memory.rs
@@ -35,7 +35,7 @@
 //!           // the SharedMemoryCreationBuilder is used from here on
 //!                     .creation_mode(CreationMode::PurgeAndCreate)
 //!                     .size(1024)
-//!                     .permission(Permission::OWNER_ALL)
+//!                     .permission(Permission::OWNER_READ_WRITE)
 //!                     .zero_memory(true)
 //!                     .create()
 //!                     .expect("failed to create shared memory");
@@ -149,7 +149,7 @@ impl SharedMemoryBuilder {
             name: *name,
             size: 0,
             is_memory_locked: false,
-            permission: Permission::OWNER_ALL,
+            permission: Permission::OWNER_READ_WRITE,
             access_mode: AccessMode::None,
             has_ownership: true,
             creation_mode: None,
@@ -434,7 +434,7 @@ impl Abandonable for SharedMemory {
 impl Drop for SharedMemory {
     fn drop(&mut self) {
         if self.has_ownership() {
-            let set_permission_result = self.set_permission(Permission::OWNER_ALL);
+            let set_permission_result = self.set_permission(Permission::OWNER_READ_WRITE);
 
             match Self::remove(&self.name) {
                 Ok(_) => {}

--- a/iceoryx2-bb/posix/src/unix_datagram_socket.rs
+++ b/iceoryx2-bb/posix/src/unix_datagram_socket.rs
@@ -27,7 +27,7 @@
 //!
 //! let socket_name = FilePath::new(b"mySocket").unwrap();
 //! let receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-//!                         .permission(Permission::OWNER_ALL)
+//!                         .permission(Permission::OWNER_READ_WRITE)
 //!                         .creation_mode(CreationMode::PurgeAndCreate)
 //!                         .create().unwrap();
 //!
@@ -744,7 +744,7 @@ impl UnixDatagramReceiverBuilder {
     pub fn new(name: &FilePath) -> Self {
         Self {
             name: *name,
-            permission: Permission::OWNER_ALL,
+            permission: Permission::OWNER_READ_WRITE,
             creation_mode: CreationMode::CreateExclusive,
         }
     }

--- a/iceoryx2-bb/posix/tests-common/src/file_descriptor_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/file_descriptor_tests.rs
@@ -100,12 +100,9 @@ pub mod generic {
         test_requires!(POSIX_SUPPORT_PERMISSIONS);
         let mut sut = Sut::sut();
 
-        let rw_all = Permission::OWNER_READ
-            | Permission::OWNER_WRITE
-            | Permission::GROUP_READ
-            | Permission::GROUP_WRITE
-            | Permission::OTHERS_READ
-            | Permission::OTHERS_WRITE;
+        let rw_all = Permission::OWNER_READ_WRITE
+            | Permission::GROUP_READ_WRITE
+            | Permission::OTHERS_READ_WRITE;
 
         assert_that!(sut.set_permission(rw_all), is_ok);
         let permission = sut.permission().unwrap();
@@ -125,25 +122,22 @@ pub mod generic {
             assert_that!(metadata.permission(), eq perms);
         };
 
-        test(Permission::OWNER_READ | Permission::OWNER_WRITE);
+        test(Permission::OWNER_READ_WRITE);
         test(Permission::OWNER_READ);
         test(Permission::OWNER_WRITE);
 
-        test(Permission::GROUP_READ | Permission::GROUP_WRITE);
+        test(Permission::GROUP_READ_WRITE);
         test(Permission::GROUP_READ);
         test(Permission::GROUP_WRITE);
 
-        test(Permission::OTHERS_READ | Permission::OTHERS_WRITE);
+        test(Permission::OTHERS_READ_WRITE);
         test(Permission::OTHERS_READ);
         test(Permission::OTHERS_WRITE);
 
         test(
-            Permission::OWNER_READ
-                | Permission::OWNER_WRITE
-                | Permission::GROUP_READ
-                | Permission::GROUP_WRITE
-                | Permission::OTHERS_READ
-                | Permission::OTHERS_WRITE,
+            Permission::OWNER_READ_WRITE
+                | Permission::GROUP_READ_WRITE
+                | Permission::OTHERS_READ_WRITE,
         );
     }
 

--- a/iceoryx2-bb/posix/tests-common/src/process_state_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/process_state_tests.rs
@@ -277,7 +277,7 @@ pub fn monitor_detects_initialized_state() {
 
     let monitor = ProcessMonitor::new(&path).unwrap();
     assert_that!(monitor.state().unwrap(), eq ProcessState::Starting);
-    file.set_permission(Permission::OWNER_ALL).unwrap();
+    file.set_permission(Permission::OWNER_READ_WRITE).unwrap();
     file.remove_self().unwrap();
     assert_that!(monitor.state().unwrap(), eq ProcessState::DoesNotExist);
 }

--- a/iceoryx2-bb/posix/tests-common/src/semaphore_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/semaphore_tests.rs
@@ -49,7 +49,7 @@ impl NamedSemaphoreTest {
                 })
                 .creation_mode(CreationMode::PurgeAndCreate)
                 .initial_value(0)
-                .permission(Permission::OWNER_ALL)
+                .permission(Permission::OWNER_READ_WRITE)
                 .create()
                 .unwrap(),
             monotonic_named_sut2: NamedSemaphoreBuilder::new(&monotonic_name)
@@ -64,7 +64,7 @@ impl NamedSemaphoreTest {
                 .clock_type(ClockType::Realtime)
                 .creation_mode(CreationMode::PurgeAndCreate)
                 .initial_value(0)
-                .permission(Permission::OWNER_ALL)
+                .permission(Permission::OWNER_READ_WRITE)
                 .create()
                 .unwrap(),
             realtime_named_sut2: NamedSemaphoreBuilder::new(&realtime_name)
@@ -111,7 +111,7 @@ pub fn named_semaphore_initializes_correctly() {
         .clock_type(ClockType::Realtime)
         .creation_mode(CreationMode::PurgeAndCreate)
         .initial_value(initial_value)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .create()
         .unwrap();
 
@@ -133,7 +133,7 @@ pub fn named_semaphore_opens_correctly() {
     let _creator = NamedSemaphoreBuilder::new(&sem_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .initial_value(initial_value)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .create()
         .unwrap();
 
@@ -451,7 +451,7 @@ pub fn abandoning_named_semaphore_keeps_semaphore() {
     let creator = NamedSemaphoreBuilder::new(&sem_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .initial_value(initial_value)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .create()
         .unwrap();
 

--- a/iceoryx2-bb/posix/tests-common/src/shared_memory_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/shared_memory_tests.rs
@@ -25,7 +25,7 @@ pub fn create_and_open_works() {
     let mut sut_create = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .size(1024)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .zero_memory(true)
         .create()
         .unwrap();
@@ -57,7 +57,7 @@ pub fn create_and_modify_open_works() {
     let sut_create = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .size(1024)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .zero_memory(true)
         .create()
         .unwrap();
@@ -89,7 +89,7 @@ pub fn opening_with_non_fitting_size_fails() {
     let sut_create = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .size(1024)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .zero_memory(true)
         .create()
         .unwrap();
@@ -97,14 +97,14 @@ pub fn opening_with_non_fitting_size_fails() {
     let sut_open1 = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::OpenOrCreate)
         .size(sut_create.size() + 1)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .zero_memory(true)
         .create();
 
     let sut_open2 = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::OpenOrCreate)
         .size(sut_create.size() * 2)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .zero_memory(true)
         .create();
 
@@ -129,7 +129,7 @@ pub fn release_ownership_works() {
     let mut sut_create = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .size(1024)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .zero_memory(true)
         .create()
         .unwrap();
@@ -173,7 +173,7 @@ pub fn create_without_ownership_works() {
     let mut sut_create = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .size(1024)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .zero_memory(true)
         .has_ownership(false)
         .create()
@@ -216,7 +216,7 @@ pub fn acquire_ownership_works() {
     let sut_create = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .size(1024)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .zero_memory(true)
         .has_ownership(false)
         .create()
@@ -240,7 +240,7 @@ pub fn existing_shm_can_be_listed() {
             SharedMemoryBuilder::new(&shm_name)
                 .creation_mode(CreationMode::PurgeAndCreate)
                 .size(1024)
-                .permission(Permission::OWNER_ALL)
+                .permission(Permission::OWNER_READ_WRITE)
                 .zero_memory(true)
                 .create()
                 .unwrap(),
@@ -277,7 +277,7 @@ pub fn abandoning_shared_memory_keeps_resources() {
     let sut_create = SharedMemoryBuilder::new(&shm_name)
         .creation_mode(CreationMode::PurgeAndCreate)
         .size(1024)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .has_ownership(true)
         .zero_memory(true)
         .create()

--- a/iceoryx2-bb/posix/tests-common/src/unix_datagram_socket_tests.rs
+++ b/iceoryx2-bb/posix/tests-common/src/unix_datagram_socket_tests.rs
@@ -73,7 +73,7 @@ pub fn send_receive_works() {
     create_test_directory();
     let socket_name = generate_file_path();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
         .unwrap();
@@ -98,7 +98,7 @@ pub fn adjust_buffer_size_works() {
     create_test_directory();
     let socket_name = generate_file_path();
     let mut sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
         .unwrap();
@@ -119,7 +119,7 @@ pub fn non_blocking_mode_returns_zero_when_nothing_was_received() {
     create_test_directory();
     let socket_name = generate_file_path();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
         .unwrap();
@@ -149,7 +149,7 @@ fn blocking_receive_blocks() {
         s.thread_builder()
             .spawn(|| {
                 let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-                    .permission(Permission::OWNER_ALL)
+                    .permission(Permission::OWNER_READ_WRITE)
                     .creation_mode(CreationMode::PurgeAndCreate)
                     .create()
                     .unwrap();
@@ -197,7 +197,7 @@ fn timed_receive_blocks_at_least_for_timeout() {
         s.thread_builder()
             .spawn(|| {
                 let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-                    .permission(Permission::OWNER_ALL)
+                    .permission(Permission::OWNER_READ_WRITE)
                     .creation_mode(CreationMode::PurgeAndCreate)
                     .create()
                     .unwrap();
@@ -232,7 +232,7 @@ pub fn sending_receiving_with_single_fd_works() {
     create_test_directory();
     let socket_name = generate_file_path();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
         .unwrap();
@@ -280,7 +280,7 @@ pub fn sending_receiving_credentials_works() {
     create_test_directory();
     let socket_name = generate_file_path();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
         .unwrap();
@@ -312,7 +312,7 @@ pub fn sending_receiving_with_max_supported_fd_and_credentials_works() {
     create_test_directory();
     let socket_name = generate_file_path();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
         .unwrap();
@@ -362,7 +362,7 @@ pub fn abandoning_receiver_leaves_the_socket_but_closes_the_file_descriptor() {
     create_test_directory();
     let socket_name = generate_file_path();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
         .unwrap();
@@ -386,7 +386,7 @@ pub fn abandoning_sender_closes_file_descriptor_and_socket_is_still_cleaned_up_f
     create_test_directory();
     let socket_name = generate_file_path();
     let sut_receiver = UnixDatagramReceiverBuilder::new(&socket_name)
-        .permission(Permission::OWNER_ALL)
+        .permission(Permission::OWNER_READ_WRITE)
         .creation_mode(CreationMode::PurgeAndCreate)
         .create()
         .unwrap();

--- a/iceoryx2-cal/src/communication_channel/unix_datagram.rs
+++ b/iceoryx2-cal/src/communication_channel/unix_datagram.rs
@@ -33,14 +33,16 @@ use crate::static_storage::file::{
 };
 
 #[cfg(not(feature = "dev_permissions"))]
-const SOCKET_PERMISSIONS: Permission = Permission::OWNER_ALL;
+const SOCKET_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE;
 #[cfg(not(feature = "dev_permissions"))]
 const DIR_PERMISSIONS: Permission = Permission::OWNER_ALL
     .const_bitor(Permission::GROUP_READ)
     .const_bitor(Permission::GROUP_EXEC);
 
 #[cfg(feature = "dev_permissions")]
-const SOCKET_PERMISSIONS: Permission = Permission::ALL;
+const SOCKET_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE
+    .const_bitor(Permission::GROUP_READ_WRITE)
+    .const_bitor(Permission::OTHERS_READ_WRITE);
 #[cfg(feature = "dev_permissions")]
 const DIR_PERMISSIONS: Permission = Permission::ALL;
 

--- a/iceoryx2-cal/src/dynamic_storage/file.rs
+++ b/iceoryx2-cal/src/dynamic_storage/file.rs
@@ -56,14 +56,18 @@ use self::dynamic_storage_configuration::DynamicStorageConfiguration;
 const INIT_PERMISSIONS: Permission = Permission::OWNER_WRITE;
 
 #[cfg(not(feature = "dev_permissions"))]
-const FINAL_PERMISSIONS: Permission = Permission::OWNER_ALL;
+const FINAL_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE;
 #[cfg(not(feature = "dev_permissions"))]
 const DIR_PERMISSIONS: Permission = Permission::OWNER_ALL
     .const_bitor(Permission::GROUP_READ)
     .const_bitor(Permission::GROUP_EXEC);
 
+const FINAL_PERMISSIONS_GLOBAL_ACCESS: Permission = Permission::OWNER_READ_WRITE
+    .const_bitor(Permission::GROUP_READ_WRITE)
+    .const_bitor(Permission::OTHERS_READ_WRITE);
+
 #[cfg(feature = "dev_permissions")]
-const FINAL_PERMISSIONS: Permission = Permission::ALL;
+const FINAL_PERMISSIONS: Permission = FINAL_PERMISSIONS_GLOBAL_ACCESS;
 #[cfg(feature = "dev_permissions")]
 const DIR_PERMISSIONS: Permission = Permission::ALL;
 
@@ -419,7 +423,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
         unsafe { (*version_ptr).store(PackageVersion::get().to_u64(), Ordering::SeqCst) };
 
         let final_permissions = if self.enable_global_access {
-            Permission::ALL
+            FINAL_PERMISSIONS_GLOBAL_ACCESS
         } else {
             FINAL_PERMISSIONS
         };

--- a/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
+++ b/iceoryx2-cal/src/dynamic_storage/posix_shared_memory.rs
@@ -80,10 +80,14 @@ use self::dynamic_storage_configuration::DynamicStorageConfiguration;
 const INIT_PERMISSIONS: Permission = Permission::OWNER_WRITE;
 
 #[cfg(not(feature = "dev_permissions"))]
-const FINAL_PERMISSIONS: Permission = Permission::OWNER_ALL;
+const FINAL_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE;
+
+const FINAL_PERMISSIONS_GLOBAL_ACCESS: Permission = Permission::OWNER_READ_WRITE
+    .const_bitor(Permission::GROUP_READ_WRITE)
+    .const_bitor(Permission::OTHERS_READ_WRITE);
 
 #[cfg(feature = "dev_permissions")]
-const FINAL_PERMISSIONS: Permission = Permission::ALL;
+const FINAL_PERMISSIONS: Permission = FINAL_PERMISSIONS_GLOBAL_ACCESS;
 
 /// The builder of [`Storage`].
 #[derive(Debug)]
@@ -371,7 +375,7 @@ impl<T: Send + Sync + Debug + ZeroCopySend> Builder<'_, T> {
         unsafe { (*version_ptr).store(PackageVersion::get().to_u64(), Ordering::SeqCst) };
 
         let final_permission = if self.enable_global_access {
-            Permission::ALL
+            FINAL_PERMISSIONS_GLOBAL_ACCESS
         } else {
             FINAL_PERMISSIONS
         };

--- a/iceoryx2-cal/src/event/trigger/unix_datagram_socket.rs
+++ b/iceoryx2-cal/src/event/trigger/unix_datagram_socket.rs
@@ -43,14 +43,16 @@ use iceoryx2_log::{fail, trace};
 const RECEIVE_BUFFER_SIZE: u64 = 32;
 
 #[cfg(not(feature = "dev_permissions"))]
-const SOCKET_PERMISSIONS: Permission = Permission::OWNER_ALL;
+const SOCKET_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE;
 #[cfg(not(feature = "dev_permissions"))]
 const DIR_PERMISSIONS: Permission = Permission::OWNER_ALL
     .const_bitor(Permission::GROUP_READ)
     .const_bitor(Permission::GROUP_EXEC);
 
 #[cfg(feature = "dev_permissions")]
-const SOCKET_PERMISSIONS: Permission = Permission::ALL;
+const SOCKET_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE
+    .const_bitor(Permission::GROUP_READ_WRITE)
+    .const_bitor(Permission::OTHERS_READ_WRITE);
 #[cfg(feature = "dev_permissions")]
 const DIR_PERMISSIONS: Permission = Permission::ALL;
 

--- a/iceoryx2-cal/src/monitoring/file_lock.rs
+++ b/iceoryx2-cal/src/monitoring/file_lock.rs
@@ -45,17 +45,17 @@ use super::{
 };
 
 #[cfg(not(feature = "dev_permissions"))]
-const GUARD_PERMISSIONS: Permission = Permission::OWNER_ALL;
+const GUARD_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE;
 
 #[cfg(not(feature = "dev_permissions"))]
 const DIR_PERMISSIONS: Permission = Permission::OWNER_ALL
-    .const_bitor(Permission::GROUP_READ)
-    .const_bitor(Permission::GROUP_EXEC)
-    .const_bitor(Permission::OTHERS_READ)
-    .const_bitor(Permission::OTHERS_EXEC);
+    .const_bitor(Permission::GROUP_READ_EXEC)
+    .const_bitor(Permission::OTHERS_READ_EXEC);
 
 #[cfg(feature = "dev_permissions")]
-const GUARD_PERMISSIONS: Permission = Permission::ALL;
+const GUARD_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE
+    .const_bitor(Permission::GROUP_READ_WRITE)
+    .const_bitor(Permission::OTHERS_READ_WRITE);
 
 #[cfg(feature = "dev_permissions")]
 const DIR_PERMISSIONS: Permission = Permission::ALL;

--- a/iceoryx2-cal/src/static_storage/file.rs
+++ b/iceoryx2-cal/src/static_storage/file.rs
@@ -63,13 +63,13 @@ use iceoryx2_bb_posix::{
 };
 use iceoryx2_log::{fail, trace, warn};
 
+const INIT_PERMISSIONS: Permission = Permission::OWNER_READ_WRITE;
+
 #[cfg(not(feature = "dev_permissions"))]
 const FINAL_PERMISSIONS: Permission = Permission::OWNER_READ;
 
 #[cfg(not(feature = "dev_permissions"))]
-const DIR_PERMISSIONS: Permission = Permission::OWNER_ALL
-    .const_bitor(Permission::GROUP_READ)
-    .const_bitor(Permission::GROUP_EXEC);
+const DIR_PERMISSIONS: Permission = Permission::OWNER_ALL.const_bitor(Permission::GROUP_READ_EXEC);
 
 #[cfg(feature = "dev_permissions")]
 const FINAL_PERMISSIONS: Permission = Permission::OWNER_READ
@@ -310,7 +310,7 @@ impl crate::named_concept::NamedConceptMgmt for Storage {
             .iter()
             .filter(|entry| {
                 let metadata = entry.metadata();
-                metadata.file_type() == FileType::File && metadata.permission() == FINAL_PERMISSIONS
+                metadata.file_type() == FileType::File && metadata.permission() != INIT_PERMISSIONS
             })
             .filter_map(|entry| config.extract_name_from_file(entry.name()))
             .collect())
@@ -370,7 +370,7 @@ impl crate::named_concept::NamedConceptMgmt for Storage {
         }
         let metadata = metadata.unwrap();
 
-        if metadata.file_type() == FileType::File && metadata.permission() == FINAL_PERMISSIONS {
+        if metadata.file_type() == FileType::File && metadata.permission() != INIT_PERMISSIONS {
             return Ok(true);
         }
 
@@ -529,7 +529,7 @@ impl crate::static_storage::StaticStorageBuilder<Storage> for Builder {
         // create File
         let file = match FileBuilder::new(&self.config.path_for(&self.storage_name))
             .creation_mode(CreationMode::CreateExclusive)
-            .permission(Permission::OWNER_ALL)
+            .permission(INIT_PERMISSIONS)
             .create()
         {
             Ok(file) => file,
@@ -613,7 +613,7 @@ impl crate::static_storage::StaticStorageBuilder<Storage> for Builder {
                 }
             };
 
-            if metadata.permission() != FINAL_PERMISSIONS {
+            if metadata.permission() == INIT_PERMISSIONS {
                 if elapsed_time > timeout {
                     fail!(from origin,
                         with StaticStorageOpenError::InitializationNotYetFinalized,

--- a/iceoryx2-cli/iox2-config/src/command/generate.rs
+++ b/iceoryx2-cli/iox2-config/src/command/generate.rs
@@ -68,10 +68,8 @@ fn generate(config_dir: Path, filepath: FilePath, force: bool) -> Result<()> {
             Directory::create(
                 &config_dir,
                 file::Permission::OWNER_ALL
-                    | Permission::GROUP_READ
-                    | Permission::GROUP_EXEC
-                    | Permission::OTHERS_READ
-                    | Permission::OTHERS_EXEC,
+                    | Permission::GROUP_READ_EXEC
+                    | Permission::OTHERS_READ_EXEC,
             )
             .map_err(|e| anyhow::anyhow!("{:?}", e))?;
         }

--- a/iceoryx2-cli/iox2-config/src/commands.rs
+++ b/iceoryx2-cli/iox2-config/src/commands.rs
@@ -140,7 +140,7 @@ pub fn generate_local() -> Result<()> {
         None => {
             return Err(anyhow::anyhow!(
                 "User config directory not available on this platform!"
-            ))
+            ));
         }
     };
     user_config_path.add_path_entry(&iceoryx2::config::Config::relative_config_path())?;
@@ -169,10 +169,8 @@ fn generate(config_dir: Path, filepath: FilePath) -> Result<()> {
             Directory::create(
                 &config_dir,
                 file::Permission::OWNER_ALL
-                    | Permission::GROUP_READ
-                    | Permission::GROUP_EXEC
-                    | Permission::OTHERS_READ
-                    | Permission::OTHERS_EXEC,
+                    | Permission::GROUP_READ_EXEC
+                    | Permission::OTHERS_READ_EXEC,
             )
             .map_err(|e| anyhow::anyhow!("{:?}", e))?;
         }

--- a/iceoryx2-gateway/testing/src/backend/session.rs
+++ b/iceoryx2-gateway/testing/src/backend/session.rs
@@ -230,7 +230,7 @@ impl Session {
             .map_err(CreationError::Path)?;
 
         let guard = ProcessGuardBuilder::new()
-            .guard_permissions(Permission::OWNER_ALL)
+            .guard_permissions(Permission::OWNER_READ_WRITE)
             .create(&lockfile_path)
             .map_err(CreationError::ProcessGuard)?;
 
@@ -247,7 +247,7 @@ impl Session {
             file_path_in_directory(SOCKET_NAME, &session_dir_path).map_err(CreationError::Path)?;
         let receiver = UnixDatagramReceiverBuilder::new(&sock_path)
             .creation_mode(CreationMode::PurgeAndCreate)
-            .permission(Permission::OWNER_ALL)
+            .permission(Permission::OWNER_READ_WRITE)
             .create()
             .map_err(CreationError::SocketBind)?;
 
@@ -289,7 +289,7 @@ impl Session {
 
         let mut file = FileBuilder::new(&path)
             .creation_mode(CreationMode::CreateExclusive)
-            .permission(Permission::OWNER_ALL)
+            .permission(Permission::OWNER_READ_WRITE)
             .create()
             .map_err(AnnounceError::FileCreate)?;
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The resources created for the endpoints have the exec bit set. This is not necessary and this PR removes the exec bit from the permissions when the files are crated.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1906

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
