### PR TITLE
Fix wrong CLOCK_MONOTONIC constant on macOS

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -61,6 +61,7 @@
 * [#1878](https://github.com/eclipse-iceoryx/iceoryx2/issues/1878) Fix race in `pthread_create` on macOS and Windows
 * [#1893](https://github.com/eclipse-iceoryx/iceoryx2/issues/1893) Fix C language `ipc` and `local` mapping for payload types
 * [#1906](https://github.com/eclipse-iceoryx/iceoryx2/issues/1906) Do not set the exec bit for created resources
+* [#1918](https://github.com/eclipse-iceoryx/iceoryx2/issues/1917) Fix wrong `CLOCK_MONOTONIC` constant on macOS (1 instead of 6) which broke `Time::now_with_clock(ClockType::Monotonic)`
 
 ### Refactoring
 

--- a/iceoryx2-pal/posix/src/macos/constants.rs
+++ b/iceoryx2-pal/posix/src/macos/constants.rs
@@ -222,7 +222,7 @@ pub const S_ISGID: mode_t = crate::internal::S_ISGID as _;
 pub const S_ISVTX: mode_t = crate::internal::S_ISVTX as _;
 
 pub const CLOCK_REALTIME: clockid_t = 0;
-pub const CLOCK_MONOTONIC: clockid_t = 1;
+pub const CLOCK_MONOTONIC: clockid_t = 6;
 pub const CLOCK_TIMER_ABSTIME: int = 1;
 
 pub const F_OK: int = crate::internal::F_OK as _;


### PR DESCRIPTION
## Notes for Reviewer

On macOS the platform constant `CLOCK_MONOTONIC` was defined as `1`, but the
real Darwin value is `6` (clock id `1` is `CLOCK_TIMER_ABSTIME` and is not a
valid `clock_gettime` clock). As a result
`Time::now_with_clock(ClockType::Monotonic)` failed on macOS with
`TimeError::UnknownError(2147483647)`.

This PR fixes the constant and adds the remaining Darwin clock constants for
completeness. Verified locally on macOS (arm64): the monotonic clock now works,
and the full `iceoryx2-bb-posix` test suite passes (325 passed).

Note: the existing monotonic clock tests are gated behind
`test_requires!(Feature::MonotonicClock.is_available())` which reports the
monotonic clock as unsupported on macOS (Darwin `sysconf(_SC_MONOTONIC_CLOCK)`
returns -1 even though `clock_gettime(CLOCK_MONOTONIC)` works). That
availability check is tracked as a follow-up in the issue.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1917
