### PR TITLE
[#1916] open service without acquiring type definition

### DIFF
--- a/iceoryx2/conformance-tests/src/service_publish_subscribe_flatbuffer.rs
+++ b/iceoryx2/conformance-tests/src/service_publish_subscribe_flatbuffer.rs
@@ -926,7 +926,7 @@ pub mod service_publish_subscribe_flatbuffer {
     }
 
     #[conformance_test]
-    pub fn open_service_without_specifying_type_definition<Sut: Service + 'static>() {
+    pub fn open_service_without_specifying_type_definition_works<Sut: Service + 'static>() {
         let test = Test::<Sut>::new();
         let node = test.create_node();
         let service_name = generate_service_name();

--- a/iceoryx2/conformance-tests/src/service_publish_subscribe_flatbuffer.rs
+++ b/iceoryx2/conformance-tests/src/service_publish_subscribe_flatbuffer.rs
@@ -23,6 +23,8 @@ pub mod service_publish_subscribe_flatbuffer {
     use iceoryx2::service::builder::publish_subscribe::{
         PublishSubscribeCreateError, PublishSubscribeOpenError,
     };
+    use iceoryx2::service::marker::CustomPayloadMarker;
+    use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
     use iceoryx2::service::{Service, marker::Flatbuffer};
     use iceoryx2_bb_elementary::allocation_strategy::AllocationStrategy;
     use iceoryx2_bb_posix::config::TEST_DIRECTORY;
@@ -921,5 +923,44 @@ pub mod service_publish_subscribe_flatbuffer {
 
         let sample = subscriber.receive().unwrap().unwrap();
         assert_that!(sample.payload_bytes(), eq & bytes);
+    }
+
+    #[conformance_test]
+    pub fn open_service_without_specifying_type_definition<Sut: Service + 'static>() {
+        let test = Test::<Sut>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+        let schema_file = create_file_with_content(SCHEMA);
+
+        let _sut_create = node
+            .service_builder(&service_name)
+            .publish_subscribe::<Flatbuffer<UnboundedData>>()
+            .flatbuffer_schema_path(schema_file.path().unwrap())
+            .create()
+            .unwrap();
+
+        let sut = unsafe {
+            node.service_builder(&service_name)
+                .publish_subscribe::<[CustomPayloadMarker]>()
+                .__internal_set_payload_type_details(
+                    &TypeDetail::__internal_new_from_parts(
+                        TypeVariant::FixedSize,
+                        "iox2::Flatbuffer",
+                        1,
+                        1,
+                    )
+                    .unwrap(),
+                )
+                .__internal_skip_type_definition_verification()
+                .open()
+                .unwrap()
+        };
+
+        let type_definition = sut.type_definition().unwrap();
+        assert_that!(type_definition.len(), eq SCHEMA.len() as u64);
+        let mut buffer = vec![0u8; type_definition.len() as usize];
+        type_definition.read(&mut buffer).unwrap();
+
+        assert_that!(SCHEMA.as_bytes(), eq buffer.as_slice());
     }
 }

--- a/iceoryx2/conformance-tests/src/service_request_response_flatbuffer.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response_flatbuffer.rs
@@ -22,6 +22,8 @@ pub mod service_request_response_flatbuffer {
     use iceoryx2::service::builder::request_response::{
         RequestResponseCreateError, RequestResponseOpenError,
     };
+    use iceoryx2::service::marker::CustomPayloadMarker;
+    use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
     use iceoryx2::service::{Service, marker::Flatbuffer};
     use iceoryx2_bb_elementary::allocation_strategy::AllocationStrategy;
     use iceoryx2_bb_posix::config::TEST_DIRECTORY;
@@ -1692,5 +1694,61 @@ pub mod service_request_response_flatbuffer {
         Sut: Service + 'static,
     >() {
         response_with_user_header_and_dynamic_reallocation::<Sut>(AllocationStrategy::BestFit);
+    }
+
+    #[conformance_test]
+    pub fn open_service_without_specifying_type_definition_works<Sut: Service + 'static>() {
+        let test = Test::<Sut>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+        let request_schema_file = create_file_with_content(UNBOUND_DATA_SCHEMA);
+        let response_schema_file = create_file_with_content(DATA_PROPS_SCHEMA);
+
+        let _sut_create = node
+            .service_builder(&service_name)
+            .request_response::<Flatbuffer<example::UnboundedData>, Flatbuffer<example::DataProps>>(
+            )
+            .request_flatbuffer_schema_path(request_schema_file.path().unwrap())
+            .response_flatbuffer_schema_path(response_schema_file.path().unwrap())
+            .create()
+            .unwrap();
+
+        let sut = unsafe {
+            node.service_builder(&service_name)
+                .request_response::<[CustomPayloadMarker], [CustomPayloadMarker]>()
+                .__internal_set_request_payload_type_details(
+                    &TypeDetail::__internal_new_from_parts(
+                        TypeVariant::FixedSize,
+                        "iox2::Flatbuffer",
+                        1,
+                        1,
+                    )
+                    .unwrap(),
+                )
+                .__internal_set_response_payload_type_details(
+                    &TypeDetail::__internal_new_from_parts(
+                        TypeVariant::FixedSize,
+                        "iox2::Flatbuffer",
+                        1,
+                        1,
+                    )
+                    .unwrap(),
+                )
+                .__internal_skip_type_definition_verification()
+                .open()
+                .unwrap()
+        };
+
+        let request_type_definition = sut.request_type_definition().unwrap();
+        assert_that!(request_type_definition.len(), eq UNBOUND_DATA_SCHEMA.len() as u64);
+        let mut buffer = vec![0u8; request_type_definition.len() as usize];
+        request_type_definition.read(&mut buffer).unwrap();
+        assert_that!(UNBOUND_DATA_SCHEMA.as_bytes(), eq buffer.as_slice());
+
+        let response_type_definition = sut.response_type_definition().unwrap();
+        assert_that!(response_type_definition.len(), eq DATA_PROPS_SCHEMA.len() as u64);
+        let mut buffer = vec![0u8; response_type_definition.len() as usize];
+        response_type_definition.read(&mut buffer).unwrap();
+        assert_that!(DATA_PROPS_SCHEMA.as_bytes(), eq buffer.as_slice());
     }
 }

--- a/iceoryx2/src/service/builder/publish_subscribe.rs
+++ b/iceoryx2/src/service/builder/publish_subscribe.rs
@@ -386,6 +386,7 @@ pub struct Builder<
     override_user_header_type: Option<TypeDetail>,
     flatbuffer_schema_path: Option<FilePath>,
     type_definition_name_hint: TypeName,
+    skip_type_definition_verification: bool,
     verify: Verify,
     _data: PhantomData<Payload>,
     _user_header: PhantomData<UserHeader>,
@@ -406,6 +407,7 @@ impl<
             flatbuffer_schema_path: self.flatbuffer_schema_path,
             type_definition_name_hint: self.type_definition_name_hint,
             verify: self.verify,
+            skip_type_definition_verification: self.skip_type_definition_verification,
             _data: PhantomData,
             _user_header: PhantomData,
         }
@@ -441,6 +443,7 @@ impl<
             override_user_header_type: None,
             flatbuffer_schema_path: None,
             type_definition_name_hint: TypeName::new::<Payload>(),
+            skip_type_definition_verification: false,
             _data: PhantomData,
             _user_header: PhantomData,
         };
@@ -742,6 +745,7 @@ impl<
                             use_type_definition: self.has_flatbuffer_payload(),
                             schema_path: self.flatbuffer_schema_path,
                             type_name: self.type_definition_name_hint,
+                            skip_type_definition_verification: false,
                         },
                         shared_node: self.base.shared_node.clone(),
                     },
@@ -776,6 +780,8 @@ impl<
                             use_type_definition: self.has_flatbuffer_payload(),
                             schema_path: self.flatbuffer_schema_path,
                             type_name: self.type_definition_name_hint,
+                            skip_type_definition_verification: self
+                                .skip_type_definition_verification,
                         },
                         shared_node: self.base.shared_node.clone(),
                     },
@@ -839,6 +845,12 @@ impl<UserHeader: Debug + ZeroCopySend, ServiceType: service::Service>
     #[doc(hidden)]
     pub unsafe fn __internal_set_payload_type_details(mut self, value: &TypeDetail) -> Self {
         self.override_payload_type = Some(*value);
+        self
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn __internal_skip_type_definition_verification(mut self) -> Self {
+        self.skip_type_definition_verification = true;
         self
     }
 }

--- a/iceoryx2/src/service/builder/request_response.rs
+++ b/iceoryx2/src/service/builder/request_response.rs
@@ -1578,12 +1578,16 @@ impl<
     }
 }
 
-impl<ServiceType: Service>
+impl<
+    ServiceType: Service,
+    RequestHeader: Debug + ZeroCopySend,
+    ResponseHeader: Debug + ZeroCopySend,
+>
     Builder<
         [CustomPayloadMarker],
-        CustomHeaderMarker,
+        RequestHeader,
         [CustomPayloadMarker],
-        CustomHeaderMarker,
+        ResponseHeader,
         ServiceType,
     >
 {
@@ -1630,6 +1634,19 @@ impl<ServiceType: Service>
     }
 
     #[doc(hidden)]
+    pub unsafe fn __internal_skip_type_definition_verification(mut self) -> Self {
+        self.skip_type_definition_verification = true;
+        self
+    }
+}
+
+impl<
+    RequestPayload: IceoryxSend + Debug + ?Sized,
+    ResponsePayload: Debug + IceoryxSend + ?Sized,
+    ServiceType: Service,
+> Builder<RequestPayload, CustomHeaderMarker, ResponsePayload, CustomHeaderMarker, ServiceType>
+{
+    #[doc(hidden)]
     pub unsafe fn __internal_set_request_header_type_details(mut self, value: &TypeDetail) -> Self {
         self.override_request_header_type = Some(*value);
         self
@@ -1641,12 +1658,6 @@ impl<ServiceType: Service>
         value: &TypeDetail,
     ) -> Self {
         self.override_response_header_type = Some(*value);
-        self
-    }
-
-    #[doc(hidden)]
-    pub unsafe fn __internal_skip_type_definition_verification(mut self) -> Self {
-        self.skip_type_definition_verification = true;
         self
     }
 }

--- a/iceoryx2/src/service/builder/request_response.rs
+++ b/iceoryx2/src/service/builder/request_response.rs
@@ -399,6 +399,7 @@ pub struct Builder<
     request_type_definition_name_hint: TypeName,
     response_flatbuffer_schema_path: Option<FilePath>,
     response_type_definition_name_hint: TypeName,
+    skip_type_definition_verification: bool,
     verify: Verify,
 
     _request_payload: PhantomData<RequestPayload>,
@@ -428,6 +429,7 @@ impl<
             response_flatbuffer_schema_path: self.response_flatbuffer_schema_path,
             request_type_definition_name_hint: self.request_type_definition_name_hint,
             response_type_definition_name_hint: self.response_type_definition_name_hint,
+            skip_type_definition_verification: self.skip_type_definition_verification,
             verify: self.verify,
             _request_payload: PhantomData,
             _request_header: PhantomData,
@@ -458,6 +460,7 @@ impl<
             response_flatbuffer_schema_path: None,
             request_type_definition_name_hint: TypeName::new::<RequestPayload>(),
             response_type_definition_name_hint: TypeName::new::<ResponsePayload>(),
+            skip_type_definition_verification: false,
             verify: Verify::default(),
             _request_payload: PhantomData,
             _request_header: PhantomData,
@@ -888,11 +891,13 @@ impl<
                             use_type_definition: self.request_has_flatbuffer_payload(),
                             schema_path: self.request_flatbuffer_schema_path,
                             type_name: self.request_type_definition_name_hint,
+                            skip_type_definition_verification: false,
                         },
                         response: TypeDefinition {
                             use_type_definition: self.response_has_flatbuffer_payload(),
                             schema_path: self.response_flatbuffer_schema_path,
                             type_name: self.response_type_definition_name_hint,
+                            skip_type_definition_verification: false,
                         },
                         shared_node: self.base.shared_node.clone(),
                     },
@@ -933,11 +938,15 @@ impl<
                             use_type_definition: self.request_has_flatbuffer_payload(),
                             schema_path: self.request_flatbuffer_schema_path,
                             type_name: self.request_type_definition_name_hint,
+                            skip_type_definition_verification: self
+                                .skip_type_definition_verification,
                         },
                         response: TypeDefinition {
                             use_type_definition: self.response_has_flatbuffer_payload(),
                             schema_path: self.response_flatbuffer_schema_path,
                             type_name: self.response_type_definition_name_hint,
+                            skip_type_definition_verification: self
+                                .skip_type_definition_verification,
                         },
                         shared_node: self.base.shared_node.clone(),
                     },
@@ -1632,6 +1641,12 @@ impl<ServiceType: Service>
         value: &TypeDetail,
     ) -> Self {
         self.override_response_header_type = Some(*value);
+        self
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn __internal_skip_type_definition_verification(mut self) -> Self {
+        self.skip_type_definition_verification = true;
         self
     }
 }

--- a/iceoryx2/src/service/port_factory/publish_subscribe.rs
+++ b/iceoryx2/src/service/port_factory/publish_subscribe.rs
@@ -49,7 +49,6 @@ use super::{publisher::PortFactoryPublisher, subscriber::PortFactorySubscriber};
 use crate::identifiers::UniqueServiceId;
 use crate::node::NodeListFailure;
 use crate::service::attribute::AttributeSet;
-use crate::service::marker::Flatbuffer;
 use crate::service::resource::publish_subscribe::PublishSubscribeResources;
 use crate::service::service_hash::ServiceHash;
 use crate::service::service_name::ServiceName;
@@ -214,12 +213,9 @@ impl<
     pub fn publisher_builder(&self) -> PortFactoryPublisher<'_, Service, Payload, UserHeader> {
         PortFactoryPublisher::new(self)
     }
-}
 
-impl<Service: service::Service, Payload, UserHeader: Debug + ZeroCopySend>
-    PortFactory<Service, Flatbuffer<Payload>, UserHeader>
-{
     /// Returns the [`StaticStorageView`](iceoryx2_cal::static_storage::StaticStorageView) that contains the type definition.
+    /// If the [`Service`](crate::service::Service) has no type definition it return [`None`].
     pub fn type_definition(&self) -> Option<&<Service::StaticStorage as StaticStorage>::View> {
         self.service
             .additional_resource()

--- a/iceoryx2/src/service/port_factory/request_response.rs
+++ b/iceoryx2/src/service/port_factory/request_response.rs
@@ -46,7 +46,7 @@ use crate::{
     node::NodeListFailure,
     prelude::AttributeSet,
     service::{
-        self, ServiceState, SharedServiceState, dynamic_config, marker::Flatbuffer,
+        self, ServiceState, SharedServiceState, dynamic_config,
         resource::request_response::RequestResponseResources, service_hash::ServiceHash,
         service_name::ServiceName, static_config,
     },
@@ -269,17 +269,8 @@ impl<
     > {
         PortFactoryServer::new(self)
     }
-}
 
-impl<
-    Service: service::Service,
-    RequestPayload: Debug,
-    RequestHeader: Debug + ZeroCopySend,
-    ResponsePayload: Debug + IceoryxSend + ?Sized,
-    ResponseHeader: Debug + ZeroCopySend,
-> PortFactory<Service, Flatbuffer<RequestPayload>, RequestHeader, ResponsePayload, ResponseHeader>
-{
-    /// Returns the [`StaticStorageView`](iceoryx2_cal::static_storage::StaticStorageView) that contains the request's type definition.
+    /// Returns the [`StaticStorageView`](iceoryx2_cal::static_storage::StaticStorageView) that contains the request's type definition. If the request type has no definition file stored, this function returns [`None`].
     pub fn request_type_definition(
         &self,
     ) -> Option<&<Service::StaticStorage as StaticStorage>::View> {
@@ -288,17 +279,8 @@ impl<
             .request_type_definition()
             .map(|v| v.view())
     }
-}
 
-impl<
-    Service: service::Service,
-    RequestPayload: Debug + IceoryxSend + ?Sized,
-    RequestHeader: Debug + ZeroCopySend,
-    ResponsePayload: Debug,
-    ResponseHeader: Debug + ZeroCopySend,
-> PortFactory<Service, RequestPayload, RequestHeader, Flatbuffer<ResponsePayload>, ResponseHeader>
-{
-    /// Returns the [`StaticStorageView`](iceoryx2_cal::static_storage::StaticStorageView) that contains the response's type definition.
+    /// Returns the [`StaticStorageView`](iceoryx2_cal::static_storage::StaticStorageView) that contains the response's type definition. If the response type has no definition file stored, this function returns [`None`].
     pub fn response_type_definition(
         &self,
     ) -> Option<&<Service::StaticStorage as StaticStorage>::View> {

--- a/iceoryx2/src/service/resource/publish_subscribe.rs
+++ b/iceoryx2/src/service/resource/publish_subscribe.rs
@@ -109,11 +109,13 @@ impl<ServiceType: service::Service> ServiceResource for PublishSubscribeResource
         static_config: &crate::service::static_config::StaticConfig,
         resource_config: &Self::Config,
     ) -> Result<Self, crate::service::builder::ServiceOpenError> {
-        match resource_config.type_definition.open_storage::<ServiceType>(
-            &PAYLOAD_TYPE_DEFINITION,
-            resource_config.shared_node.config(),
-            static_config,
-        ) {
+        match resource_config
+            .type_definition
+            .open_and_verify_storage::<ServiceType>(
+                &PAYLOAD_TYPE_DEFINITION,
+                resource_config.shared_node.config(),
+                static_config,
+            ) {
             Ok(Some(v)) => Ok(Self {
                 type_definition_storage: Some(v.storage),
                 path_hint: Some(v.path_hint),

--- a/iceoryx2/src/service/resource/request_response.rs
+++ b/iceoryx2/src/service/resource/request_response.rs
@@ -217,7 +217,7 @@ impl<ServiceType: service::Service> RequestResponseResources<ServiceType> {
         config: &crate::config::Config,
         static_config: &crate::service::static_config::StaticConfig,
     ) -> Result<Option<TypeDefinitionStorage<ServiceType>>, ServiceOpenError> {
-        match type_definition.open_storage::<ServiceType>(name, config, static_config) {
+        match type_definition.open_and_verify_storage::<ServiceType>(name, config, static_config) {
             Ok(v) => Ok(v),
             Err(e) => {
                 fail!(from "RequestResponseResources::open_type_storage()",

--- a/iceoryx2/src/service/resource/type_definition.rs
+++ b/iceoryx2/src/service/resource/type_definition.rs
@@ -83,6 +83,7 @@ pub struct TypeDefinition {
     pub use_type_definition: bool,
     pub schema_path: Option<FilePath>,
     pub type_name: TypeName,
+    pub skip_type_definition_verification: bool,
 }
 
 impl TypeDefinition {
@@ -126,7 +127,7 @@ impl TypeDefinition {
         }))
     }
 
-    pub fn open_storage<S: crate::service::Service>(
+    fn open_storage<S: crate::service::Service>(
         &self,
         name: &FileName,
         config: &crate::config::Config,
@@ -134,6 +135,57 @@ impl TypeDefinition {
     ) -> Result<Option<TypeDefinitionStorage<S>>, ServiceOpenError> {
         if !self.use_type_definition {
             return Ok(None);
+        }
+
+        let msg = "Unable to open type definition storage";
+        let static_storage_config =
+            Self::type_definition_static_storage_config::<S>(config, static_config);
+
+        let static_storage = match
+                <<S::StaticStorage as iceoryx2_cal::static_storage::StaticStorage>::Builder as NamedConceptBuilder::<S::StaticStorage>>::new(name).config(&static_storage_config).open(Duration::ZERO) {
+                    Ok(static_storage) => static_storage,
+                    Err(StaticStorageOpenError::InsufficientPermissions) => {
+                        fail!(from self, with ServiceOpenError::InsufficientPermissions,
+                            "{msg} since the type definition could not be opened.");
+                    }
+                    Err(StaticStorageOpenError::Interrupt) => {
+                        fail!(from self, with ServiceOpenError::Interrupt,
+                            "{msg} since the operation was interrupted by a signal.");
+                    }
+                    Err(StaticStorageOpenError::InitializationNotYetFinalized) => {
+                        fail!(from self, with ServiceOpenError::HangsInCreation,
+                            "{msg} since the type definition file is not yet initialized.");
+                    }
+                    Err(StaticStorageOpenError::DoesNotExist) => {
+                        fail!(from self, with ServiceOpenError::ServiceInCorruptedState,
+                            "{msg} since the type definition file does not exist but it should be available.");
+                    }
+                    Err(e) => {
+                        fail!(from self, with ServiceOpenError::InternalFailure,
+                            "{msg} due to an internal failure while opening the type definition storage. [{e:?}]");
+                    }
+                };
+
+        static_storage.release_ownership();
+
+        Ok(Some(TypeDefinitionStorage {
+            storage: static_storage,
+            path_hint: *static_storage_config.get_path_hint(),
+        }))
+    }
+
+    pub fn open_and_verify_storage<S: crate::service::Service>(
+        &self,
+        name: &FileName,
+        config: &crate::config::Config,
+        static_config: &crate::service::static_config::StaticConfig,
+    ) -> Result<Option<TypeDefinitionStorage<S>>, ServiceOpenError> {
+        if !self.use_type_definition {
+            return Ok(None);
+        }
+
+        if self.skip_type_definition_verification {
+            return self.open_storage(name, config, static_config);
         }
 
         let msg = "Unable to open type definition storage";


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Adds ability to open a service with flatbuffer payload without the need to specify the schema file. One needs to use `[CustomPayloadMarker]` and `__internal_skip_type_definition_verification()` in the service builder.

Two unit tests for pubsub and reqres demonstrate how to use this.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1916 

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
