### PR TITLE
[#3] Fix clippy warnings for Rust 1.98

### DIFF
--- a/iceoryx2-ffi/c/src/api/active_request.rs
+++ b/iceoryx2-ffi/c/src/api/active_request.rs
@@ -268,17 +268,16 @@ pub unsafe extern "C" fn iox2_active_request_payload(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let active_request = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match active_request.service_type {
+        let number_of_elements_value = match active_request.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = active_request.value.as_mut().ipc.payload().as_ptr().cast();
-                number_of_elements_value = active_request
+                active_request
                     .value
                     .as_mut()
                     .ipc
                     .header()
-                    .number_of_elements();
+                    .number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = active_request
@@ -288,12 +287,12 @@ pub unsafe extern "C" fn iox2_active_request_payload(
                     .payload()
                     .as_ptr()
                     .cast();
-                number_of_elements_value = active_request
+                active_request
                     .value
                     .as_mut()
                     .local
                     .header()
-                    .number_of_elements();
+                    .number_of_elements()
             }
         };
 

--- a/iceoryx2-ffi/c/src/api/pending_response.rs
+++ b/iceoryx2-ffi/c/src/api/pending_response.rs
@@ -332,9 +332,8 @@ pub unsafe extern "C" fn iox2_pending_response_payload(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let pending_response = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match pending_response.service_type {
+        let number_of_elements_value = match pending_response.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = pending_response
                     .value
@@ -343,12 +342,12 @@ pub unsafe extern "C" fn iox2_pending_response_payload(
                     .payload()
                     .as_ptr()
                     .cast();
-                number_of_elements_value = pending_response
+                pending_response
                     .value
                     .as_mut()
                     .ipc
                     .header()
-                    .number_of_elements();
+                    .number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = pending_response
@@ -358,12 +357,12 @@ pub unsafe extern "C" fn iox2_pending_response_payload(
                     .payload()
                     .as_ptr()
                     .cast();
-                number_of_elements_value = pending_response
+                pending_response
                     .value
                     .as_mut()
                     .local
                     .header()
-                    .number_of_elements();
+                    .number_of_elements()
             }
         };
 

--- a/iceoryx2-ffi/c/src/api/request_mut.rs
+++ b/iceoryx2-ffi/c/src/api/request_mut.rs
@@ -368,12 +368,11 @@ pub unsafe extern "C" fn iox2_request_mut_payload_mut(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let request = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match request.service_type {
+        let number_of_elements_value = match request.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = request.value.as_mut().ipc.payload_mut().as_mut_ptr().cast();
-                number_of_elements_value = request.value.as_mut().ipc.header().number_of_elements();
+                request.value.as_mut().ipc.header().number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = request
@@ -383,8 +382,8 @@ pub unsafe extern "C" fn iox2_request_mut_payload_mut(
                     .payload_mut()
                     .as_mut_ptr()
                     .cast();
-                number_of_elements_value =
-                    request.value.as_mut().local.header().number_of_elements();
+
+                request.value.as_mut().local.header().number_of_elements()
             }
         };
 
@@ -411,17 +410,15 @@ pub unsafe extern "C" fn iox2_request_mut_payload(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let request = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match request.service_type {
+        let number_of_elements_value = match request.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = request.value.as_ref().ipc.payload().as_ptr().cast();
-                number_of_elements_value = request.value.as_ref().ipc.header().number_of_elements();
+                request.value.as_ref().ipc.header().number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = request.value.as_mut().local.payload().as_ptr().cast();
-                number_of_elements_value =
-                    request.value.as_ref().local.header().number_of_elements();
+                request.value.as_ref().local.header().number_of_elements()
             }
         };
 

--- a/iceoryx2-ffi/c/src/api/response.rs
+++ b/iceoryx2-ffi/c/src/api/response.rs
@@ -225,17 +225,15 @@ pub unsafe extern "C" fn iox2_response_payload(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let sample = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match sample.service_type {
+        let number_of_elements_value = match sample.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = sample.value.as_ref().ipc.payload().as_ptr().cast();
-                number_of_elements_value = sample.value.as_ref().ipc.header().number_of_elements();
+                sample.value.as_ref().ipc.header().number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = sample.value.as_ref().local.payload().as_ptr().cast();
-                number_of_elements_value =
-                    sample.value.as_ref().local.header().number_of_elements();
+                sample.value.as_ref().local.header().number_of_elements()
             }
         };
 

--- a/iceoryx2-ffi/c/src/api/response_mut.rs
+++ b/iceoryx2-ffi/c/src/api/response_mut.rs
@@ -269,18 +269,15 @@ pub unsafe extern "C" fn iox2_response_mut_payload(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let response = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match response.service_type {
+        let number_of_elements_value = match response.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = response.value.as_ref().ipc.payload().as_ptr().cast();
-                number_of_elements_value =
-                    response.value.as_mut().ipc.header().number_of_elements();
+                response.value.as_mut().ipc.header().number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = response.value.as_ref().local.payload().as_ptr().cast();
-                number_of_elements_value =
-                    response.value.as_mut().local.header().number_of_elements();
+                response.value.as_mut().local.header().number_of_elements()
             }
         };
 
@@ -307,9 +304,8 @@ pub unsafe extern "C" fn iox2_response_mut_payload_mut(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let response = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match response.service_type {
+        let number_of_elements_value = match response.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = response
                     .value
@@ -318,8 +314,7 @@ pub unsafe extern "C" fn iox2_response_mut_payload_mut(
                     .payload_mut()
                     .as_mut_ptr()
                     .cast();
-                number_of_elements_value =
-                    response.value.as_mut().ipc.header().number_of_elements();
+                response.value.as_mut().ipc.header().number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = response
@@ -329,8 +324,7 @@ pub unsafe extern "C" fn iox2_response_mut_payload_mut(
                     .payload_mut()
                     .as_mut_ptr()
                     .cast();
-                number_of_elements_value =
-                    response.value.as_mut().local.header().number_of_elements();
+                response.value.as_mut().local.header().number_of_elements()
             }
         };
 

--- a/iceoryx2-ffi/c/src/api/sample.rs
+++ b/iceoryx2-ffi/c/src/api/sample.rs
@@ -230,17 +230,15 @@ pub unsafe extern "C" fn iox2_sample_payload(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let sample = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match sample.service_type {
+        let number_of_elements_value = match sample.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = sample.value.as_mut().ipc.payload().as_ptr().cast();
-                number_of_elements_value = sample.value.as_mut().ipc.header().number_of_elements();
+                sample.value.as_mut().ipc.header().number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = sample.value.as_mut().local.payload().as_ptr().cast();
-                number_of_elements_value =
-                    sample.value.as_mut().local.header().number_of_elements();
+                sample.value.as_mut().local.header().number_of_elements()
             }
         };
 

--- a/iceoryx2-ffi/c/src/api/sample_mut.rs
+++ b/iceoryx2-ffi/c/src/api/sample_mut.rs
@@ -260,13 +260,11 @@ pub unsafe extern "C" fn iox2_sample_mut_payload_mut(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let sample = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match sample.service_type {
+        let number_of_elements_value = match sample.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = sample.value.as_mut().ipc.payload_mut().as_mut_ptr().cast();
-                number_of_elements_value =
-                    sample.value.as_mut().ipc.header().number_of_elements() as c_size_t;
+                sample.value.as_mut().ipc.header().number_of_elements() as c_size_t
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = sample
@@ -276,8 +274,7 @@ pub unsafe extern "C" fn iox2_sample_mut_payload_mut(
                     .payload_mut()
                     .as_mut_ptr()
                     .cast();
-                number_of_elements_value =
-                    sample.value.as_mut().local.header().number_of_elements() as c_size_t;
+                sample.value.as_mut().local.header().number_of_elements() as c_size_t
             }
         };
 
@@ -304,12 +301,11 @@ pub unsafe extern "C" fn iox2_sample_mut_payload(
     debug_assert!(!payload_ptr.is_null());
     unsafe {
         let sample = &mut *handle.as_type();
-        let number_of_elements_value;
 
-        match sample.service_type {
+        let number_of_elements_value = match sample.service_type {
             iox2_service_type_e::IPC => {
                 *payload_ptr = sample.value.as_mut().ipc.payload_mut().as_mut_ptr().cast();
-                number_of_elements_value = sample.value.as_mut().ipc.header().number_of_elements();
+                sample.value.as_mut().ipc.header().number_of_elements()
             }
             iox2_service_type_e::LOCAL => {
                 *payload_ptr = sample
@@ -319,8 +315,7 @@ pub unsafe extern "C" fn iox2_sample_mut_payload(
                     .payload_mut()
                     .as_mut_ptr()
                     .cast();
-                number_of_elements_value =
-                    sample.value.as_mut().local.header().number_of_elements();
+                sample.value.as_mut().local.header().number_of_elements()
             }
         };
 

--- a/iceoryx2-gateway/gateway/src/builder.rs
+++ b/iceoryx2-gateway/gateway/src/builder.rs
@@ -60,7 +60,7 @@ pub struct Reactive;
 pub struct GatewayBuilder<S, B, M = Unconfigured>
 where
     S: Service,
-    B: for<'b> Backend<S> + Debug,
+    B: Backend<S> + Debug,
 {
     gateway_config: Option<Config>,
     iceoryx_config: Option<iceoryx2::config::Config>,
@@ -73,7 +73,7 @@ where
 impl<S, B, M> GatewayBuilder<S, B, M>
 where
     S: Service,
-    B: for<'b> Backend<S> + Debug,
+    B: Backend<S> + Debug,
 {
     /// Sets the [`Config`] for the [`Gateway`].
     pub fn gateway_config(mut self, config: Config) -> Self {
@@ -112,7 +112,7 @@ where
 impl<S, B> GatewayBuilder<S, B, Unconfigured>
 where
     S: Service,
-    B: for<'b> Backend<S> + Debug,
+    B: Backend<S> + Debug,
 {
     /// Creates a new builder. All configurations default to
     /// [`Default::default()`] unless overridden via the chained setters.
@@ -144,7 +144,7 @@ where
 impl<S, B> GatewayBuilder<S, B, Unconfigured>
 where
     S: Service,
-    B: for<'b> Backend<S> + Debug,
+    B: Backend<S> + Debug,
     for<'b> B::Builder<'b>: ReactiveBackendBuilder<S>,
 {
     /// Selects reactive mode. Only available when the chosen [`Backend`]'s
@@ -164,7 +164,7 @@ where
 impl<S, B> Default for GatewayBuilder<S, B, Unconfigured>
 where
     S: Service,
-    B: for<'b> Backend<S> + Debug,
+    B: Backend<S> + Debug,
 {
     fn default() -> Self {
         Self::new()
@@ -174,7 +174,7 @@ where
 impl<S, B> GatewayBuilder<S, B, Polled>
 where
     S: Service,
-    B: for<'b> Backend<S> + Debug,
+    B: Backend<S> + Debug,
 {
     /// Builds the gateway in polled mode.
     pub fn create(self) -> Result<Gateway<S, B>, CreationError> {
@@ -191,7 +191,7 @@ where
 impl<S, B> GatewayBuilder<S, B, Reactive>
 where
     S: Service,
-    B: for<'b> Backend<S> + Debug,
+    B: Backend<S> + Debug,
     for<'b> B::Builder<'b>: ReactiveBackendBuilder<S>,
 {
     /// Builds the gateway in reactive mode.
@@ -220,7 +220,7 @@ fn create_polled<S, B>(
 ) -> Result<Gateway<S, B>, CreationError>
 where
     S: Service,
-    B: for<'a> Backend<S> + Debug,
+    B: Backend<S> + Debug,
 {
     let origin = "GatewayBuilder::<Polled>::create";
 
@@ -248,7 +248,7 @@ fn create_reactive<S, B, W>(
 where
     S: Service,
     W: Service,
-    B: for<'a> Backend<S> + Debug,
+    B: Backend<S> + Debug,
     for<'b> B::Builder<'b>: ReactiveBackendBuilder<S, WakeService = W>,
 {
     let origin = "GatewayBuilder::<Reactive>::create";
@@ -320,7 +320,7 @@ fn create<S, B>(
 ) -> Result<Gateway<S, B>, CreationError>
 where
     S: Service,
-    B: for<'a> Backend<S> + Debug,
+    B: Backend<S> + Debug,
 {
     let origin = format!(
         "GatewayBuilder<{}, {}>::create",

--- a/iceoryx2-gateway/gateway/src/gateway.rs
+++ b/iceoryx2-gateway/gateway/src/gateway.rs
@@ -116,7 +116,7 @@ impl<S: Service, B: Backend<S>> BridgeState<S, B> {
 }
 
 #[derive(Debug)]
-pub struct Gateway<S: Service, B: for<'a> Backend<S> + Debug> {
+pub struct Gateway<S: Service, B: Backend<S> + Debug> {
     node: Node<S>,
     backend: B,
     discovery_state: DiscoveryState,
@@ -124,7 +124,7 @@ pub struct Gateway<S: Service, B: for<'a> Backend<S> + Debug> {
     discovery_strategy: LocalDiscoveryStrategy<S>,
 }
 
-impl<S: Service, B: for<'a> Backend<S> + Debug> Gateway<S, B> {
+impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
     /// Returns a builder for configuring and constructing a [`Gateway`].
     #[allow(clippy::new_ret_no_self)] // entry point to the type-state builder
     pub fn new() -> crate::builder::GatewayBuilder<S, B, crate::builder::Unconfigured> {

--- a/iceoryx2-gateway/gateway/src/ports/event.rs
+++ b/iceoryx2-gateway/gateway/src/ports/event.rs
@@ -118,7 +118,7 @@ impl<S: Service> EventPorts<S> {
         mut ingest: IngestFn,
     ) -> Result<bool, SendError>
     where
-        IngestFn: for<'a> FnMut() -> Result<Option<EventId>, IngestError>,
+        IngestFn: FnMut() -> Result<Option<EventId>, IngestError>,
     {
         let mut ingested = false;
         loop {


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Fix clippy warnings for the upcoming Rust 1.98. Tested only locally on Linux with the 1.98 pre-release, so once 1.98 is released, there might be more clippy warnings in the platform abstractions.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #3

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
