### PR TITLE
[#3] Fix more clippy warnings for Rust 1.98

### DIFF
--- a/iceoryx2-bb/posix/src/process_state.rs
+++ b/iceoryx2-bb/posix/src/process_state.rs
@@ -194,12 +194,10 @@ impl<'a> Drop for TrackerGuard<'a> {
     fn drop(&mut self) {
         if self.has_ownership.load(Ordering::Relaxed) {
             self.state.remove(self.path);
-        } else {
-            if let Some(entry) = self.state.get(self.path)
-                && !entry.owned_by_process
-            {
-                self.state.remove(self.path);
-            }
+        } else if let Some(entry) = self.state.get(self.path)
+            && !entry.owned_by_process
+        {
+            self.state.remove(self.path);
         }
     }
 }

--- a/iceoryx2-cli/iox2-gateway/src/main.rs
+++ b/iceoryx2-cli/iox2-gateway/src/main.rs
@@ -44,10 +44,8 @@ fn main() -> anyhow::Result<()> {
         if let Err(e) = command::execute(command_name, command_args) {
             eprintln!("Failed to execute command: {e}");
         }
-    } else {
-        if let Err(e) = command::list() {
-            eprintln!("Failed to list commands: {e}");
-        }
+    } else if let Err(e) = command::list() {
+        eprintln!("Failed to list commands: {e}");
     }
 
     Ok(())

--- a/iceoryx2-pal/posix/src/lib.rs
+++ b/iceoryx2-pal/posix/src/lib.rs
@@ -88,6 +88,14 @@ pub(crate) mod internal {
     #![allow(unknown_lints)]
     #![allow(unnecessary_transmutes)]
     #![allow(unsafe_op_in_unsafe_fn)]
+    // the 'suspicious_runtime_symbol_definitions' warning was introduced with the Rust 1.98 update;
+    // the bindgen generated code did not change, so it seems the warning was newly introduced in clippy;
+    // the warning only occurs on the Windows and macOS platforms;
+    // this suppression will be removed once #1928 and #1929 (port Windows and macOS from bindgen to libc crate) will be implemented
+    #![cfg_attr(
+        any(target_os = "macos", target_os = "windows"),
+        allow(suspicious_runtime_symbol_definitions)
+    )]
     #![allow(clippy::all)]
     #[cfg(not(bazel_build))]
     include!(concat!(env!("OUT_DIR"), "/posix_generated.rs"));

--- a/iceoryx2-pal/posix/src/windows/fcntl.rs
+++ b/iceoryx2-pal/posix/src/windows/fcntl.rs
@@ -148,11 +148,11 @@ pub unsafe fn fstat(fd: int, buf: *mut stat_t) -> int {
             }
         };
 
-        if let Some(file_path) = handle_to_file_path(permission_handle) {
-            if let Some(mode) = acquire_mode_from_path(&file_path) {
-                file_stat.st_mode |= mode;
-            }
-        };
+        if let Some(file_path) = handle_to_file_path(permission_handle)
+            && let Some(mode) = acquire_mode_from_path(&file_path)
+        {
+            file_stat.st_mode |= mode;
+        }
 
         buf.write(file_stat);
 

--- a/iceoryx2-pal/posix/src/windows/pthread.rs
+++ b/iceoryx2-pal/posix/src/windows/pthread.rs
@@ -132,10 +132,10 @@ impl ThreadStates {
 
     fn get_index_of(&self, id: u32) -> usize {
         for i in 0..MAX_NUMBER_OF_THREADS {
-            if let Some(ref state) = unsafe { *self.states[i].get() } {
-                if state.id == id {
-                    return i;
-                }
+            if let Some(ref state) = unsafe { *self.states[i].get() }
+                && state.id == id
+            {
+                return i;
             }
         }
 

--- a/iceoryx2-pal/posix/src/windows/win32_handle_translator.rs
+++ b/iceoryx2-pal/posix/src/windows/win32_handle_translator.rs
@@ -226,14 +226,14 @@ impl HandleTranslator {
             *self.free_fd_list_start.get() = next_free_fd;
         }
 
-        if let FdHandleEntry::UdsDatagramSocket(_) = entry {
-            if self.uds_datagram_counter.fetch_add(1, Ordering::Relaxed) == 0 {
-                unsafe {
-                    *self.port_to_uds_translator.get() = Some(
-                        PortToUds::new()
-                            .expect("Unable to create port to uds datagram name translator."),
-                    )
-                };
+        if let FdHandleEntry::UdsDatagramSocket(_) = entry
+            && self.uds_datagram_counter.fetch_add(1, Ordering::Relaxed) == 0
+        {
+            unsafe {
+                *self.port_to_uds_translator.get() = Some(
+                    PortToUds::new()
+                        .expect("Unable to create port to uds datagram name translator."),
+                );
             }
         }
 

--- a/iceoryx2-pal/posix/src/windows/win32_security_attributes.rs
+++ b/iceoryx2-pal/posix/src/windows/win32_security_attributes.rs
@@ -411,10 +411,10 @@ fn parse_ace_string_rights(ace_rights: &[u8]) -> u8 {
 }
 
 fn ace_rights_to_bits(ace_rights: &[u8]) -> u8 {
-    if ace_rights.starts_with(b"0x") {
-        if let Ok(hex_str) = core::str::from_utf8(&ace_rights[2..]) {
-            return parse_hex_rights(hex_str);
-        }
+    if ace_rights.starts_with(b"0x")
+        && let Ok(hex_str) = core::str::from_utf8(&ace_rights[2..])
+    {
+        return parse_hex_rights(hex_str);
     }
     parse_ace_string_rights(ace_rights)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This time triggered on macOS and Windows.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [ ] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #3

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
