### PR TITLE
[#1880] Avoid panic when cleanup finds live node

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -59,6 +59,7 @@
 * [#1868](https://github.com/eclipse-iceoryx/iceoryx2/issues/1868) Automatically create windows platform directories
 * [#1872](https://github.com/eclipse-iceoryx/iceoryx2/issues/1872) Register FileDescriptor pyclass with the python module
 * [#1878](https://github.com/eclipse-iceoryx/iceoryx2/issues/1878) Fix race in `pthread_create` on macOS and Windows
+* [#1880](https://github.com/eclipse-iceoryx/iceoryx2/issues/1880) Avoid terminating processes when a node is found alive during stale resource cleanup.
 * [#1893](https://github.com/eclipse-iceoryx/iceoryx2/issues/1893) Fix C language `ipc` and `local` mapping for payload types
 * [#1906](https://github.com/eclipse-iceoryx/iceoryx2/issues/1906) Do not set the exec bit for created resources
 * [#1918](https://github.com/eclipse-iceoryx/iceoryx2/issues/1917) Fix wrong `CLOCK_MONOTONIC` constant on macOS (1 instead of 6) which broke `Time::now_with_clock(ClockType::Monotonic)`

--- a/iceoryx2-cxx/include/iox2/node_failure_enums.hpp
+++ b/iceoryx2-cxx/include/iox2/node_failure_enums.hpp
@@ -63,7 +63,7 @@ enum class NodeCleanupFailure : uint8_t {
     InsufficientPermissions,
     /// Trying to cleanup resources from a [`Node`] node which was using a different iceoryx2 version.
     VersionMismatch,
-    /// Another instance has successfully cleaned up all resources.
+    /// There are no stale resources to remove.
     ResourcesAlreadyCleanedUp,
     /// Another instance has acquired the ownership of all resources and is currently cleaning up.
     AnotherInstanceIsCleaningUpTheNode,

--- a/iceoryx2-ffi/c/src/api/node.rs
+++ b/iceoryx2-ffi/c/src/api/node.rs
@@ -121,7 +121,7 @@ pub enum iox2_node_cleanup_failure_e {
     INSUFFICIENT_PERMISSIONS,
     /// Trying to cleanup resources from a dead node which was using a different iceoryx2 version.
     VERSION_MISMATCH,
-    /// Another instance has successfully cleaned up all resources.
+    /// There are no stale resources to remove.
     RESOURCES_ALREADY_CLEANED_UP,
     /// Another instance has acquired the ownership of all resources and is currently cleaning up.
     ANOTHER_INSTANCE_IS_CLEANING_UP_THE_NODE,

--- a/iceoryx2/conformance-tests/src/node.rs
+++ b/iceoryx2/conformance-tests/src/node.rs
@@ -23,7 +23,7 @@ pub mod node {
 
     use iceoryx2::config::Config;
     use iceoryx2::node::{
-        NodeCleanupFailure, NodeCreationFailure, NodeListFailure, NodeState, NodeView,
+        DeadNodeView, NodeCleanupFailure, NodeCreationFailure, NodeListFailure, NodeState, NodeView,
     };
     use iceoryx2::prelude::*;
     use iceoryx2::service::Service;
@@ -387,6 +387,48 @@ pub mod node {
         } else {
             test_fail!("Process internal nodes shall be always detected as alive.");
         }
+    }
+
+    #[conformance_test]
+    pub fn removing_stale_resources_of_live_node_does_not_remove_node<S: Service>() {
+        let test = Test::<S>::new();
+        let node = NodeBuilder::new()
+            .config(test.config())
+            .create::<S>()
+            .unwrap();
+
+        let mut node_details = None;
+        Node::<S>::list(node.config(), |node_state| {
+            if let NodeState::Alive(node_view) = node_state
+                && node_view.id() == node.id()
+            {
+                node_details = node_view.details().clone();
+            }
+            CallbackProgression::Continue
+        })
+        .unwrap();
+
+        let result = DeadNodeView::<S>::__internal_try_remove_stale_resources(
+            *node.id(),
+            node_details.unwrap(),
+        );
+        assert_that!(
+            result.err(),
+            eq Some(NodeCleanupFailure::ResourcesAlreadyCleanedUp)
+        );
+
+        let mut node_is_alive = false;
+        Node::<S>::list(node.config(), |node_state| {
+            if let NodeState::Alive(node_view) = node_state
+                && node_view.id() == node.id()
+            {
+                node_is_alive = true;
+            }
+            CallbackProgression::Continue
+        })
+        .unwrap();
+
+        assert_that!(node_is_alive, eq true);
     }
 
     #[conformance_test]

--- a/iceoryx2/src/node/mod.rs
+++ b/iceoryx2/src/node/mod.rs
@@ -275,7 +275,7 @@ pub enum NodeCleanupFailure {
     InsufficientPermissions,
     /// Trying to cleanup resources from a dead [`Node`] which was using a different iceoryx2 version.
     VersionMismatch,
-    /// Another instance has successfully cleaned up all resources.
+    /// There are no stale resources to remove.
     ResourcesAlreadyCleanedUp,
     /// Another instance has acquired the ownership of all resources and is currently cleaning up.
     AnotherInstanceIsCleaningUpTheNode,
@@ -750,8 +750,8 @@ impl<Service: service::Service> DeadNodeView<Service> {
                     "{} due to an internal error while acquiring monitoring cleaner.", msg);
             }
             Err(MonitoringCreateCleanerError::InstanceStillAlive) => {
-                fatal_panic!(from self,
-                        "This should never happen! {} since the Node is still alive.", msg);
+                fail!(from self, with NodeCleanupFailure::ResourcesAlreadyCleanedUp,
+                    "{} since the Node is still alive and has no stale resources.", msg);
             }
         }
     }


### PR DESCRIPTION
## Notes for Reviewer

During concurrent node creation on Windows, a starting node can temporarily be classified as dead. When stale-resource cleanup rechecks the node state, the monitoring layer correctly returns `MonitoringCreateCleanerError::InstanceStillAlive`.

This result was previously handled with `fatal_panic!`, terminating the unrelated process performing the cleanup.

This PR:

- maps `InstanceStillAlive` to `NodeCleanupFailure::ResourcesAlreadyCleanedUp`;
- prevents cleanup from continuing against a live node;
- avoids adding a new public error variant or changing the existing ABI;
- updates the Rust, C, and C++ error documentation;
- adds a deterministic conformance test covering IPC, local, and their thread-safe variants;
- adds the fix to the unreleased changelog.

Windows reproducer before the fix:

```text
total=64 ok=36 returned_err=0 killed=28
```

After the fix:

```text
total=64 ok=64 returned_err=0 killed=0
```

The same reproducer was also exercised on macOS/aarch64, Linux/aarch64 (Jetson Orin), and Linux/x86_64. Across 5,760 concurrent node creations, no processes were killed.

### Validation

- `cargo fmt --all -- --check`
- Clippy with warnings denied
- Conformance test: 4 passed, 0 failed
- Windows concurrent reproducer: 64 passed, 0 killed

## Pre-Review Checklist for the PR Author

- [x] Add sensible notes for the reviewer
- [x] PR title is short, expressive and meaningful
- [x] Relevant issues are linked in the References section
- [x] Branch follows the naming format
- [x] Commit message contains the issue ID
- [x] Tests cover the new behavior
- [x] Changelog updated

## References

Closes #1880