### PR TITLE
[#1938] Use old trait solver on nightly for the zenoh gateway

### DIFF
--- a/.github/workflows/reuse_unstable.yml
+++ b/.github/workflows/reuse_unstable.yml
@@ -81,18 +81,46 @@ jobs:
         with:
           profile: ${{ inputs.profile }}
 
-      - name: Run workspaces
+      - name: Build sdk workspace
         shell: bash
         run: |
           rustc --version
           just build sdk +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets
+
+      - name: Build integrations-zenoh workspace [beta]
+        if: inputs.toolchain != 'nightly'
+        shell: bash
+        run: |
+          rustc --version
           just build integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets
 
-      - name: Test workspaces
+      - name: Build integrations-zenoh workspace [nightly]
+        if: inputs.toolchain == 'nightly'
+        shell: bash
+        run: |
+          rustc --version
+          export RUSTFLAGS=-Znext-solver=coherence # Zenoh has issues with the new trait solver
+          just build integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets
+
+      - name: Test sdk workspace
         shell: bash
         run: |
           rustc --version
           just test sdk +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
+
+      - name: Test integrations-zenoh workspaces [beta]
+        if: inputs.toolchain != 'nightly'
+        shell: bash
+        run: |
+          rustc --version
+          just test integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
+
+      - name: Test integrations-zenoh workspaces [nightly]
+        if: inputs.toolchain == 'nightly'
+        shell: bash
+        run: |
+          rustc --version
+          export RUSTFLAGS=-Znext-solver=coherence # Zenoh has issues with the new trait solver
           just test integrations-zenoh +${{ inputs.toolchain }} --profile ${{ inputs.profile }} -- --all-targets --no-fail-fast
 
       - name: Cleanup build artifacts


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

The new trait solver on the nightly Rust compiler has issues with the `zenoh` crate and therefore also with our zenoh gateway. This PR deactivates the new solver on nightly Rust for the zenoh gateway.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1938

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
