### PR TITLE
[#1940] Fix private rustdoc link diagnostics

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -63,6 +63,7 @@
 * [#1906](https://github.com/eclipse-iceoryx/iceoryx2/issues/1906) Do not set the exec bit for created resources
 * [#1918](https://github.com/eclipse-iceoryx/iceoryx2/issues/1917) Fix wrong `CLOCK_MONOTONIC` constant on macOS (1 instead of 6) which broke `Time::now_with_clock(ClockType::Monotonic)`
 * [#1924](https://github.com/eclipse-iceoryx/iceoryx2/issues/1924) Ensure discovery service node resources are removed during shutdown.
+* [#1940](https://github.com/eclipse-iceoryx/iceoryx2/issues/1940) Fix private rustdoc link diagnostics.
 
 ### Refactoring
 

--- a/iceoryx2-bb/loggers/src/null.rs
+++ b/iceoryx2-bb/loggers/src/null.rs
@@ -14,7 +14,7 @@ use iceoryx2_log_types::{Log, LogLevel};
 
 /// A logger that discards all log messages.
 ///
-/// This is the default logger used before [`set_logger`](crate::set_logger) is called.
+/// This is the default logger used before `iceoryx2_log::set_logger()` is called.
 /// It silently discards all log messages, ensuring that logging calls have no effect
 /// until a real logger is registered.
 #[allow(dead_code)]

--- a/iceoryx2-bb/posix/src/ipc_capable.rs
+++ b/iceoryx2-bb/posix/src/ipc_capable.rs
@@ -77,7 +77,7 @@ pub(crate) mod internal {
         ///
         /// # Safety
         ///  * The handle must be uninitialized
-        ///  * Must not be shared with other threads before calling [`IpcCapable::initialize()`]
+        ///  * Must not be shared with other threads before calling [`HandleStorage::initialize()`]
         ///
         pub unsafe fn initialize<E, F: FnOnce(*mut T) -> Result<Capability, E>>(
             &self,
@@ -110,7 +110,7 @@ pub(crate) mod internal {
         /// # Safety
         ///  * The handle must be initialized
         ///  * Must not be used concurrently. Only one thread - the one that calls
-        ///    [`IpcCapable::cleanup()`] - is allowed to operate on the [`IpcCapable`].
+        ///    [`HandleStorage::cleanup()`] - is allowed to operate on the [`IpcCapable`].
         ///
         pub unsafe fn cleanup<F: FnOnce(&mut T)>(&self, cleanup: F) {
             debug_assert!(

--- a/iceoryx2-ffi/c/src/api/backpressure_handler.rs
+++ b/iceoryx2-ffi/c/src/api/backpressure_handler.rs
@@ -67,7 +67,7 @@ fn backpressure_info_as_type<'a>(info: iox2_backpressure_info_h_ref) -> &'a Back
 /// # Arguments
 ///
 /// * `info_handle` - Must be a valid [`iox2_backpressure_info_h_ref`] provided as parameter by [`iox2_backpressure_handler`]
-/// * `service_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`](crate::api::iox2_buffer_16_align_4_t)
+/// * `service_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`]
 ///
 /// # Safety
 ///
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn iox2_backpressure_info_service_id(
 /// # Arguments
 ///
 /// * `info_handle` - Must be a valid [`iox2_backpressure_info_h_ref`] provided as parameter by [`iox2_backpressure_handler`]
-/// * `service_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`](crate::api::iox2_buffer_16_align_4_t)
+/// * `service_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`]
 ///
 /// # Safety
 ///
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn iox2_backpressure_info_receiver_port_id(
 /// # Arguments
 ///
 /// * `info_handle` - Must be a valid [`iox2_backpressure_info_h_ref`] provided as parameter by [`iox2_backpressure_handler`]
-/// * `service_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`](crate::api::iox2_buffer_16_align_4_t)
+/// * `service_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`]
 ///
 /// # Safety
 ///
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn iox2_backpressure_info_elapsed_time(
 ///
 /// * [`iox2_backpressure_info_h_ref`] is a handle to obtain some information for the incident;
 ///   to be used with the `iox2_backpressure_info_*` functions
-/// * [`iox2_callback_context`](crate::iox2_callback_context) is a user defined callback context
+/// * [`iox2_callback_context`] is a user defined callback context
 ///   to provide additional information
 ///
 /// # Returns

--- a/iceoryx2-ffi/c/src/api/client.rs
+++ b/iceoryx2-ffi/c/src/api/client.rs
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn iox2_client_id(
     }
 }
 
-/// Returns the [`iox2_port_name_ptr`](crate::iox2_port_name_ptr), an immutable pointer to the port name.
+/// Returns the [`iox2_port_name_ptr`], an immutable pointer to the port name.
 ///
 /// # Arguments
 ///

--- a/iceoryx2-ffi/c/src/api/client_details.rs
+++ b/iceoryx2-ffi/c/src/api/client_details.rs
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn iox2_client_details_client_id(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/degradation_handler.rs
+++ b/iceoryx2-ffi/c/src/api/degradation_handler.rs
@@ -93,7 +93,7 @@ fn degradation_info_as_type<'a>(info: iox2_degradation_info_h_ref) -> &'a Degrad
 /// # Arguments
 ///
 /// * `info_handle` - Must be a valid [`iox2_degradation_info_h_ref`] provided as parameter by [`iox2_degradation_handler`]
-/// * `service_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`](crate::api::iox2_buffer_16_align_4_t)
+/// * `service_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`]
 ///
 /// # Safety
 ///
@@ -119,7 +119,7 @@ pub unsafe extern "C" fn iox2_degradation_info_service_id(
 /// # Arguments
 ///
 /// * `info_handle` - Must be a valid [`iox2_degradation_info_h_ref`] provided as parameter by [`iox2_degradation_handler`]
-/// * `receiver_port_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`](crate::api::iox2_buffer_16_align_4_t)
+/// * `receiver_port_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`]
 ///
 /// # Safety
 ///
@@ -145,7 +145,7 @@ pub unsafe extern "C" fn iox2_degradation_info_receiver_port_id(
 /// # Arguments
 ///
 /// * `info_handle` - Must be a valid [`iox2_degradation_info_h_ref`] provided as parameter by [`iox2_degradation_handler`]
-/// * `sender_port_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`](crate::api::iox2_buffer_16_align_4_t)
+/// * `sender_port_id` - Must be a pointer to a [`iox2_buffer_16_align_4_t`]
 ///
 /// # Safety
 ///
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn iox2_degradation_info_sender_port_id(
 /// * [`iox2_degradation_cause_e`] is the cause for the degradation
 /// * [`iox2_degradation_info_h_ref`] is a handle to obtain some information for the degradation;
 ///   to be used with the `iox2_degradation_info_*` functions
-/// * [`iox2_callback_context`](crate::iox2_callback_context) is a user defined handler context
+/// * [`iox2_callback_context`] is a user defined handler context
 ///   to provide additional information
 ///
 /// # Returns

--- a/iceoryx2-ffi/c/src/api/entry_value_uninit.rs
+++ b/iceoryx2-ffi/c/src/api/entry_value_uninit.rs
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn iox2_entry_value_uninit_value_mut(
 /// # Safety
 ///
 /// * `entry_value_uninit_handle` obtained by [`iox2_entry_handle_mut_loan_uninit()`](crate::iox2_entry_handle_mut_loan_uninit()), it's invalid after the return of this function
-/// * `entry_handle_mut_struct_ptr` must be either a NULL pointer or a pointer to a valid [`iox2_entry_handle_mut_t`](crate::iox2_entry_handle_mut_t)
+/// * `entry_handle_mut_struct_ptr` must be either a NULL pointer or a pointer to a valid [`iox2_entry_handle_mut_t`]
 /// * `entry_handle_mut_handle_ptr` a valid, non-null [`*mut iox2_entry_handle_mut_h`] pointer which will be initialized by this function call
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn iox2_entry_value_uninit_update(

--- a/iceoryx2-ffi/c/src/api/listener.rs
+++ b/iceoryx2-ffi/c/src/api/listener.rs
@@ -400,7 +400,7 @@ pub unsafe extern "C" fn iox2_listener_id(
     }
 }
 
-/// Returns the [`iox2_port_name_ptr`](crate::iox2_port_name_ptr), an immutable pointer to the port name.
+/// Returns the [`iox2_port_name_ptr`], an immutable pointer to the port name.
 ///
 /// # Arguments
 ///

--- a/iceoryx2-ffi/c/src/api/listener_details.rs
+++ b/iceoryx2-ffi/c/src/api/listener_details.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn iox2_listener_details_listener_id(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/node.rs
+++ b/iceoryx2-ffi/c/src/api/node.rs
@@ -243,11 +243,11 @@ pub enum iox2_node_state_e {
 ///
 /// * [`iox2_node_state_e`]
 /// * [`iox2_unique_node_id_ptr`]
-/// * [`iox2_node_name_ptr`](crate::iox2_node_name_ptr) -> `NULL` for `iox2_node_state_e::INACCESSIBLE` and `iox2_node_state_e::UNDEFINED`
-/// * [`iox2_config_ptr`](crate::iox2_config_ptr) -> `NULL` for `iox2_node_state_e::INACCESSIBLE` and `iox2_node_state_e::UNDEFINED`
+/// * [`iox2_node_name_ptr`] -> `NULL` for `iox2_node_state_e::INACCESSIBLE` and `iox2_node_state_e::UNDEFINED`
+/// * [`iox2_config_ptr`] -> `NULL` for `iox2_node_state_e::INACCESSIBLE` and `iox2_node_state_e::UNDEFINED`
 /// * [`iox2_callback_context`] -> provided by the user to [`iox2_node_list`] and can be `NULL`
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_node_list_callback = extern "C" fn(
     iox2_node_state_e,
     iox2_unique_node_id_ptr,
@@ -300,7 +300,7 @@ pub unsafe extern "C" fn iox2_node_wait_failure_string(
     error.as_const_cstr().as_ptr() as *const c_char
 }
 
-/// Returns the [`iox2_node_name_ptr`](crate::iox2_node_name_ptr), an immutable pointer to the node name.
+/// Returns the [`iox2_node_name_ptr`], an immutable pointer to the node name.
 ///
 /// # Safety
 ///
@@ -348,7 +348,7 @@ pub unsafe extern "C" fn iox2_node_wait(
     }
 }
 
-/// Returns the [`iox2_config_ptr`](crate::iox2_config_ptr), an immutable pointer to the config.
+/// Returns the [`iox2_config_ptr`], an immutable pointer to the config.
 ///
 /// # Safety
 ///
@@ -386,7 +386,7 @@ pub unsafe extern "C" fn iox2_node_signal_handling_mode(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///
@@ -622,12 +622,12 @@ pub(crate) fn iox2_node_list_impl<S: Service>(
 }
 
 /// Calls the callback repeatedly with an [`iox2_node_state_e`], [`iox2_unique_node_id_ptr`], [´iox2_node_name_ptr´] and [`iox2_config_ptr`] for
-/// all [`Node`](iceoryx2::node::Node)s in the system under a given [`Config`](iceoryx2::config::Config).
+/// all [`Node`]s in the system under a given [`Config`].
 ///
 /// # Arguments
 ///
 /// * `service_type` - A [`iox2_service_type_e`]
-/// * `config_ptr` - A valid [`iox2_config_ptr`](crate::iox2_config_ptr)
+/// * `config_ptr` - A valid [`iox2_config_ptr`]
 /// * `callback` - A valid callback with [`iox2_node_list_callback`} signature
 /// * `callback_ctx` - An optional callback context [`iox2_callback_context`} to e.g. store information across callback iterations
 ///

--- a/iceoryx2-ffi/c/src/api/node_name.rs
+++ b/iceoryx2-ffi/c/src/api/node_name.rs
@@ -94,7 +94,7 @@ impl HandleToType for iox2_node_name_h_ref {
 /// * `node_name_len` - The length of the node name string, not including a null termination.
 /// * `node_name_handle_ptr` - An uninitialized or dangling [`iox2_node_name_h`] handle which will be initialized by this function call.
 ///
-/// Returns IOX2_OK on success, an [`iox2_semantic_string_error_e`](crate::iox2_semantic_string_error_e) otherwise.
+/// Returns IOX2_OK on success, an [`iox2_semantic_string_error_e`] otherwise.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/notifier.rs
+++ b/iceoryx2-ffi/c/src/api/notifier.rs
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn iox2_notifier_id(
     }
 }
 
-/// Returns the [`iox2_port_name_ptr`](crate::iox2_port_name_ptr), an immutable pointer to the port name.
+/// Returns the [`iox2_port_name_ptr`], an immutable pointer to the port name.
 ///
 /// # Arguments
 ///
@@ -307,7 +307,7 @@ pub unsafe extern "C" fn iox2_notifier_notify(
 ///
 /// * notifier_handle -  Must be a valid [`iox2_notifier_h_ref`]
 ///   obtained by [`iox2_port_factory_notifier_builder_create`](crate::iox2_port_factory_notifier_builder_create)
-/// * custom_event_id_ptr - Must be a pointer to an initialized [`iox2_event_id_t`](crate::iox2_event_id_t)
+/// * custom_event_id_ptr - Must be a pointer to an initialized [`iox2_event_id_t`]
 /// * number_of_notified_listener_ptr - Must be either a NULL pointer or a pointer to a `size_t` to store the number of notified listener
 ///
 /// Returns IOX2_OK on success, an [`iox2_notifier_notify_error_e`] otherwise.

--- a/iceoryx2-ffi/c/src/api/notifier_details.rs
+++ b/iceoryx2-ffi/c/src/api/notifier_details.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn iox2_notifier_details_notifier_id(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/port_factory_blackboard.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_blackboard.rs
@@ -125,7 +125,7 @@ impl HandleToType for iox2_port_factory_blackboard_h_ref {
 /// * [`iox2_callback_context`] -> provided by the user and can be `NULL`
 /// * [`iox2_reader_details_ptr`] -> a pointer to the details struct of the port
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_list_readers_callback =
     extern "C" fn(iox2_callback_context, iox2_reader_details_ptr) -> iox2_callback_progression_e;
 
@@ -136,7 +136,7 @@ pub type iox2_list_readers_callback =
 /// * [`iox2_callback_context`] -> provided by the user and can be `NULL`
 /// * [`iox2_writer_details_ptr`] -> a pointer to the details struct of the port
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_list_writers_callback =
     extern "C" fn(iox2_callback_context, iox2_writer_details_ptr) -> iox2_callback_progression_e;
 

--- a/iceoryx2-ffi/c/src/api/port_factory_client_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_client_builder.rs
@@ -313,8 +313,8 @@ pub unsafe extern "C" fn iox2_port_factory_client_builder_set_allocation_strateg
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_client_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_client_builder`](crate::iox2_port_factory_request_response_client_builder).
-/// * `handler` is the [`iox2_degradation_handler`](crate::iox2_degradation_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_degradation_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///
@@ -365,8 +365,8 @@ pub unsafe extern "C" fn iox2_port_factory_client_builder_set_request_degradatio
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_client_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_client_builder`](crate::iox2_port_factory_request_response_client_builder).
-/// * `handler` is the [`iox2_degradation_handler`](crate::iox2_degradation_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_degradation_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///
@@ -417,8 +417,8 @@ pub unsafe extern "C" fn iox2_port_factory_client_builder_set_response_degradati
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_client_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_client_builder`](crate::iox2_port_factory_request_response_client_builder).
-/// * `handler` is the [`iox2_backpressure_handler`](crate::iox2_backpressure_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_backpressure_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/port_factory_event.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_event.rs
@@ -126,7 +126,7 @@ impl HandleToType for iox2_port_factory_event_h_ref {
 /// * [`iox2_callback_context`] -> provided by the user and can be `NULL`
 /// * [`iox2_notifier_details_ptr`] -> a pointer to the details struct of the port
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_list_notifiers_callback =
     extern "C" fn(iox2_callback_context, iox2_notifier_details_ptr) -> iox2_callback_progression_e;
 
@@ -137,7 +137,7 @@ pub type iox2_list_notifiers_callback =
 /// * [`iox2_callback_context`] -> provided by the user and can be `NULL`
 /// * [`iox2_listener_details_ptr`] -> a pointer to the details struct of the port
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_list_listeners_callback =
     extern "C" fn(iox2_callback_context, iox2_listener_details_ptr) -> iox2_callback_progression_e;
 // END type definition

--- a/iceoryx2-ffi/c/src/api/port_factory_listener_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_listener_builder.rs
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn iox2_port_factory_listener_builder_set_name(
 /// # Safety
 ///
 /// * The `port_factory_handle` is invalid after the return of this function and leads to undefined behavior if used in another function call!
-/// * The corresponding [`iox2_port_factory_listener_builder_t`](crate::iox2_port_factory_listener_builder_t)
+/// * The corresponding [`iox2_port_factory_listener_builder_t`]
 ///   can be re-used with a call to  [`iox2_port_factory_event_listener_builder`](crate::iox2_port_factory_event_listener_builder)!
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn iox2_port_factory_listener_builder_create(

--- a/iceoryx2-ffi/c/src/api/port_factory_pub_sub.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_pub_sub.rs
@@ -138,7 +138,7 @@ impl HandleToType for iox2_port_factory_pub_sub_h_ref {
 /// * [`iox2_callback_context`] -> provided by the user and can be `NULL`
 /// * [`iox2_subscriber_details_ptr`] -> a pointer to the details struct of the port
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_list_subscribers_callback = extern "C" fn(
     iox2_callback_context,
     iox2_subscriber_details_ptr,
@@ -151,7 +151,7 @@ pub type iox2_list_subscribers_callback = extern "C" fn(
 /// * [`iox2_callback_context`] -> provided by the user and can be `NULL`
 /// * [`iox2_publisher_details_ptr`] -> a pointer to the details struct of the port
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_list_publishers_callback =
     extern "C" fn(iox2_callback_context, iox2_publisher_details_ptr) -> iox2_callback_progression_e;
 

--- a/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_publisher_builder.rs
@@ -342,8 +342,8 @@ pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_allocation_stra
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder).
-/// * `handler` is the [`iox2_degradation_handler`](crate::iox2_degradation_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_degradation_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///
@@ -394,8 +394,8 @@ pub unsafe extern "C" fn iox2_port_factory_publisher_builder_set_degradation_han
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_publisher_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_pub_sub_publisher_builder`](crate::iox2_port_factory_pub_sub_publisher_builder).
-/// * `handler` is the [`iox2_backpressure_handler`](crate::iox2_backpressure_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_backpressure_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/port_factory_request_response.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_request_response.rs
@@ -151,7 +151,7 @@ impl HandleToType for iox2_port_factory_request_response_h_ref {
 /// * [`iox2_callback_context`] -> provided by the user and can be `NULL`
 /// * [`iox2_server_details_ptr`] -> a pointer to the details struct of the port
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_list_servers_callback =
     extern "C" fn(iox2_callback_context, iox2_server_details_ptr) -> iox2_callback_progression_e;
 
@@ -162,7 +162,7 @@ pub type iox2_list_servers_callback =
 /// * [`iox2_callback_context`] -> provided by the user and can be `NULL`
 /// * [`iox2_client_details_ptr`] -> a pointer to the details struct of the port
 ///
-/// Returns a [`iox2_callback_progression_e`](crate::iox2_callback_progression_e)
+/// Returns a [`iox2_callback_progression_e`]
 pub type iox2_list_clients_callback =
     extern "C" fn(iox2_callback_context, iox2_client_details_ptr) -> iox2_callback_progression_e;
 

--- a/iceoryx2-ffi/c/src/api/port_factory_server_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_server_builder.rs
@@ -315,8 +315,8 @@ pub unsafe extern "C" fn iox2_port_factory_server_builder_set_allocation_strateg
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_server_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_server_builder`](crate::iox2_port_factory_request_response_server_builder).
-/// * `handler` is the [`iox2_degradation_handler`](crate::iox2_degradation_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_degradation_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///
@@ -367,8 +367,8 @@ pub unsafe extern "C" fn iox2_port_factory_server_builder_set_request_degradatio
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_server_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_server_builder`](crate::iox2_port_factory_request_response_server_builder).
-/// * `handler` is the [`iox2_degradation_handler`](crate::iox2_degradation_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_degradation_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///
@@ -419,8 +419,8 @@ pub unsafe extern "C" fn iox2_port_factory_server_builder_set_response_degradati
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_server_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_request_response_server_builder`](crate::iox2_port_factory_request_response_server_builder).
-/// * `handler` is the [`iox2_backpressure_handler`](crate::iox2_backpressure_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_backpressure_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/port_factory_subscriber_builder.rs
+++ b/iceoryx2-ffi/c/src/api/port_factory_subscriber_builder.rs
@@ -269,8 +269,8 @@ pub unsafe extern "C" fn iox2_port_factory_subscriber_builder_set_history_reques
 ///
 /// * `port_factory_handle` - Must be a valid [`iox2_port_factory_subscriber_builder_h_ref`]
 ///   obtained by [`iox2_port_factory_pub_sub_subscriber_builder`](crate::iox2_port_factory_pub_sub_subscriber_builder).
-/// * `handler` is the [`iox2_degradation_handler`](crate::iox2_degradation_handler)
-/// * `ctx` is an user defined [`iox2_callback_context`](crate::iox2_callback_context)
+/// * `handler` is the [`iox2_degradation_handler`]
+/// * `ctx` is an user defined [`iox2_callback_context`]
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/port_name.rs
+++ b/iceoryx2-ffi/c/src/api/port_name.rs
@@ -94,7 +94,7 @@ impl HandleToType for iox2_port_name_h_ref {
 /// * `port_name_len` - The length of the port name string, not including a null termination.
 /// * `port_name_handle_ptr` - An uninitialized or dangling [`iox2_port_name_h`] handle which will be initialized by this function call.
 ///
-/// Returns IOX2_OK on success, an [`iox2_semantic_string_error_e`](crate::iox2_semantic_string_error_e) otherwise.
+/// Returns IOX2_OK on success, an [`iox2_semantic_string_error_e`] otherwise.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/publisher.rs
+++ b/iceoryx2-ffi/c/src/api/publisher.rs
@@ -393,7 +393,7 @@ pub unsafe extern "C" fn iox2_publisher_id(
     }
 }
 
-/// Returns the [`iox2_port_name_ptr`](crate::iox2_port_name_ptr), an immutable pointer to the port name.
+/// Returns the [`iox2_port_name_ptr`], an immutable pointer to the port name.
 ///
 /// # Arguments
 ///

--- a/iceoryx2-ffi/c/src/api/publisher_details.rs
+++ b/iceoryx2-ffi/c/src/api/publisher_details.rs
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn iox2_publisher_details_publisher_id(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/reader.rs
+++ b/iceoryx2-ffi/c/src/api/reader.rs
@@ -194,7 +194,7 @@ pub unsafe extern "C" fn iox2_reader_id(
     }
 }
 
-/// Returns the [`iox2_port_name_ptr`](crate::iox2_port_name_ptr), an immutable pointer to the port name.
+/// Returns the [`iox2_port_name_ptr`], an immutable pointer to the port name.
 ///
 /// # Arguments
 ///

--- a/iceoryx2-ffi/c/src/api/reader_details.rs
+++ b/iceoryx2-ffi/c/src/api/reader_details.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn iox2_reader_details_reader_id(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/server.rs
+++ b/iceoryx2-ffi/c/src/api/server.rs
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn iox2_server_id(
     }
 }
 
-/// Returns the [`iox2_port_name_ptr`](crate::iox2_port_name_ptr), an immutable pointer to the port name.
+/// Returns the [`iox2_port_name_ptr`], an immutable pointer to the port name.
 ///
 /// # Arguments
 ///

--- a/iceoryx2-ffi/c/src/api/server_details.rs
+++ b/iceoryx2-ffi/c/src/api/server_details.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn iox2_server_details_server_id(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/service_builder_blackboard.rs
+++ b/iceoryx2-ffi/c/src/api/service_builder_blackboard.rs
@@ -826,11 +826,11 @@ pub unsafe extern "C" fn iox2_service_builder_blackboard_open_with_attributes(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_blackboard_creator_h`](crate::iox2_service_builder_blackboard_creator_h)
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_blackboard_creator_h`]
 ///   obtained by
 ///   [`iox2_service_builder_blackboard_creator`](crate::iox2_service_builder_blackboard_creator)
 /// * `port_factory_struct_ptr` - Must be either a NULL pointer or a pointer to a valid
-///   [`iox2_port_factory_blackboard_t`](crate::iox2_port_factory_blackboard_t). If it is a NULL pointer, the storage will be allocated on the heap.
+///   [`iox2_port_factory_blackboard_t`]. If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `port_factory_handle_ptr` - An uninitialized or dangling [`iox2_port_factory_blackboard_h`] handle which will be initialized by this function call.
 ///
 /// Returns IOX2_OK on success, an [`iox2_blackboard_create_error_e`] otherwise.

--- a/iceoryx2-ffi/c/src/api/service_builder_event.rs
+++ b/iceoryx2-ffi/c/src/api/service_builder_event.rs
@@ -856,10 +856,10 @@ pub unsafe extern "C" fn iox2_service_builder_event_open_with_attributes(
 ///
 /// # Arguments
 ///
-/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_event_h`](crate::iox2_service_builder_event_h)
+/// * `service_builder_handle` - Must be a valid [`iox2_service_builder_event_h`]
 ///   obtained by [`iox2_service_builder_event`](crate::iox2_service_builder_event)
 /// * `port_factory_struct_ptr` - Must be either a NULL pointer or a pointer to a valid
-///   [`iox2_port_factory_event_t`](crate::iox2_port_factory_event_t). If it is a NULL pointer, the storage will be allocated on the heap.
+///   [`iox2_port_factory_event_t`]. If it is a NULL pointer, the storage will be allocated on the heap.
 /// * `port_factory_handle_ptr` - An uninitialized or dangling [`iox2_port_factory_event_h`] handle which will be initialized by this function call.
 ///
 /// Returns IOX2_OK on success, an [`iox2_event_open_or_create_error_e`] otherwise. Note, only the errors annotated with `O_` are relevant.

--- a/iceoryx2-ffi/c/src/api/service_builder_pub_sub.rs
+++ b/iceoryx2-ffi/c/src/api/service_builder_pub_sub.rs
@@ -1129,7 +1129,7 @@ unsafe fn iox2_service_builder_pub_sub_open_create_impl<E: IntoCInt>(
     IOX2_OK
 }
 
-/// Returns the [`iox2_config_ptr`](crate::iox2_config_ptr), an immutable pointer to the config.
+/// Returns the [`iox2_config_ptr`], an immutable pointer to the config.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/service_name.rs
+++ b/iceoryx2-ffi/c/src/api/service_name.rs
@@ -115,7 +115,7 @@ impl HandleToType for iox2_service_name_h_ref {
 /// * `service_name_len` - The length of the node name string, not including a null termination.
 /// * `service_name_handle_ptr` - An uninitialized or dangling [`iox2_service_name_h`] handle which will be initialized by this function call.
 ///
-/// Returns IOX2_OK on success, an [`iox2_semantic_string_error_e`](crate::iox2_semantic_string_error_e) otherwise.
+/// Returns IOX2_OK on success, an [`iox2_semantic_string_error_e`] otherwise.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/subscriber.rs
+++ b/iceoryx2-ffi/c/src/api/subscriber.rs
@@ -270,7 +270,7 @@ pub unsafe extern "C" fn iox2_subscriber_id(
     }
 }
 
-/// Returns the [`iox2_port_name_ptr`](crate::iox2_port_name_ptr), an immutable pointer to the port name.
+/// Returns the [`iox2_port_name_ptr`], an immutable pointer to the port name.
 ///
 /// # Arguments
 ///

--- a/iceoryx2-ffi/c/src/api/subscriber_details.rs
+++ b/iceoryx2-ffi/c/src/api/subscriber_details.rs
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn iox2_subscriber_details_subscriber_id(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///

--- a/iceoryx2-ffi/c/src/api/writer.rs
+++ b/iceoryx2-ffi/c/src/api/writer.rs
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn iox2_writer_id(
     }
 }
 
-/// Returns the [`iox2_port_name_ptr`](crate::iox2_port_name_ptr), an immutable pointer to the port name.
+/// Returns the [`iox2_port_name_ptr`], an immutable pointer to the port name.
 ///
 /// # Arguments
 ///

--- a/iceoryx2-ffi/c/src/api/writer_details.rs
+++ b/iceoryx2-ffi/c/src/api/writer_details.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn iox2_writer_details_writer_id(
     }
 }
 
-/// Returns the [`iox2_unique_node_id_ptr`](crate::iox2_unique_node_id_ptr), an immutable pointer to the node id.
+/// Returns the [`iox2_unique_node_id_ptr`], an immutable pointer to the node id.
 ///
 /// # Safety
 ///


### PR DESCRIPTION
Remove redundant explicit intra-doc link targets that rustdoc can resolve from their labels directly.

  Replace broken private-doc links to unavailable methods/items with plain text descriptions so `cargo doc --no-deps --document-private-items` passes with `-D warnings`.

  <!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
  <!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

  ## Testing

  * `cargo fmt --all -- --check`
  * `XDG_RUNTIME_DIR=/tmp just test sdk --doc`
  * `XDG_RUNTIME_DIR=/tmp RUSTDOCFLAGS='-D warnings' just doc sdk rust`
  * `XDG_RUNTIME_DIR=/tmp just doc sdk c`
  * `git ls-files '*.md' | grep -v '^integrations/' | xargs env npm_config_cache=/tmp/npm-cache npx -y markdownlint-cli -c .markdownlint.yaml`

  ## Pre-Review Checklist for the PR Author

  * [x] Add sensible notes for the reviewer
  * [x] PR title is short, expressive and meaningful
  * [ ] Consider switching the PR to a draft (`Convert to draft`)
      * as draft PR, the CI will be skipped for pushes
  * [x] Relevant issues are linked in the [References](#references) section
  * [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
  * [x] Commits messages are according to this [guideline][commit-guidelines]
      * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
      * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
  * [x] Tests follow the [best practice for testing][testing]
  * [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

  [commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
  [eca]: http://www.eclipse.org/legal/ECA.php
  [testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
  [changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

  ## PR Reviewer Reminders

  * Commits are properly organized and messages are according to the guideline
  * Unit tests have been written for new behavior
  * Public API is documented
  * PR title describes the changes

  ## References

  Closes #1940

  <!-- markdownlint-enable MD041 -->
  <!-- markdownlint-enable MD013 -->