### PR TITLE
[#1942] Improve execution time of zenoh gateway test suite

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -90,6 +90,7 @@
 * [#1815](https://github.com/eclipse-iceoryx/iceoryx2/issues/1815) Set Rust minimum required version (MSRV) to version 1.89.0
 * [#1884](https://github.com/eclipse-iceoryx/iceoryx2/issues/1884) Bump `googletest` to 1.16.0
 * [#1885](https://github.com/eclipse-iceoryx/iceoryx2/issues/1885) Bump bazel modules `bazel_features` to 1.32.0, `bazel_skylib` to 1.9.2, `platforms` to 1.1.0, `rules_cc` to 0.2.17, `rules_rust`/`rules_rust_bindgen` to 0.73.0 and `toolchains_llvm` to 1.8.0 with `llvm_version` 21.1.6
+* [#1942](https://github.com/eclipse-iceoryx/iceoryx2/issues/1942) Reduce exeuction time of gateway backend tests
 
 ### New API features
 

--- a/iceoryx2-gateway/backend/src/traits/testing.rs
+++ b/iceoryx2-gateway/backend/src/traits/testing.rs
@@ -19,6 +19,14 @@ use alloc::{format, string::String};
 use iceoryx2_bb_posix::adaptive_wait::AdaptiveWaitBuilder;
 
 pub trait Testing {
+    /// Configuration type of the backend under test.
+    type BackendConfig: Default;
+
+    /// Backend configuration the conformance tests create gateways with.
+    fn backend_config() -> Self::BackendConfig {
+        Self::BackendConfig::default()
+    }
+
     fn sync(_id: String, _timeout: Duration) -> bool {
         true
     }

--- a/iceoryx2-gateway/backend/src/traits/testing.rs
+++ b/iceoryx2-gateway/backend/src/traits/testing.rs
@@ -16,43 +16,50 @@ use alloc::collections::btree_set::BTreeSet;
 use alloc::vec::Vec;
 use alloc::{format, string::String};
 
-use iceoryx2_bb_posix::clock::nanosleep;
+use iceoryx2_bb_posix::adaptive_wait::AdaptiveWaitBuilder;
 
 pub trait Testing {
     fn sync(_id: String, _timeout: Duration) -> bool {
         true
     }
 
-    fn retry<F>(mut f: F, period: Duration, max_attempts: Option<usize>) -> Result<(), String>
+    /// Polls `f` with an adaptive backoff until it succeeds or `timeout`
+    /// elapses. The distinct failure reasons observed are listed in the error.
+    fn retry<F>(mut f: F, timeout: Duration) -> Result<(), String>
     where
         F: FnMut() -> Result<(), &'static str>,
     {
-        let mut attempt = 0;
-
         let mut errors = BTreeSet::<&'static str>::new();
 
-        loop {
-            match f() {
-                Ok(_) => return Ok(()),
-                Err(failure) => {
-                    errors.insert(failure);
-                    if let Some(max_attempts) = max_attempts
-                        && attempt >= max_attempts
-                    {
-                        errors.insert("Retry attempts exceeded.");
+        let mut adaptive_wait = AdaptiveWaitBuilder::new()
+            .create()
+            .expect("failed to create adaptive wait");
 
-                        let errors_formatted = errors
-                            .iter()
-                            .map(|e| format!("  - {}", e))
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        return Err(errors_formatted);
+        let succeeded = adaptive_wait
+            .timed_wait_while(
+                || -> Result<bool, ()> {
+                    match f() {
+                        Ok(()) => Ok(false),
+                        Err(failure) => {
+                            errors.insert(failure);
+                            Ok(true)
+                        }
                     }
-                }
-            }
+                },
+                timeout,
+            )
+            .expect("failed to wait");
 
-            nanosleep(period).unwrap();
-            attempt += 1;
+        if succeeded {
+            return Ok(());
         }
+
+        errors.insert("Timeout exceeded.");
+        let errors_formatted = errors
+            .iter()
+            .map(|e| format!("  - {}", e))
+            .collect::<Vec<_>>()
+            .join("\n");
+        Err(errors_formatted)
     }
 }

--- a/iceoryx2-gateway/conformance-tests/src/event_discovery.rs
+++ b/iceoryx2-gateway/conformance-tests/src/event_discovery.rs
@@ -155,8 +155,7 @@ pub mod event_discovery {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -212,8 +211,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to discover remote services")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -237,8 +235,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to detect remote service removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -252,8 +249,8 @@ pub mod event_discovery {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        const DISCOVERY_ATTEMPTS: usize = 5;
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -316,8 +313,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to discover remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
         assert_that!(gateway_a.bridged_services().len(), eq 1);
@@ -328,7 +324,7 @@ pub mod event_discovery {
         assert_that!(gateway_b.bridged_services().len(), eq 0);
 
         // Host A keeps the service since one remote still offering service
-        for _ in 0..MAX_RETRIES {
+        for _ in 0..DISCOVERY_ATTEMPTS {
             gateway_a.discover_over_backend().unwrap();
         }
         assert_that!(gateway_a.bridged_services().contains(&service_hash), eq true);
@@ -347,16 +343,14 @@ pub mod event_discovery {
                 }
                 Err("Failed to detect remote service removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }
 
     #[conformance_test]
     pub fn detects_ungraceful_remote_departure<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(500);
-        const MAX_RETRIES: usize = 20;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -399,8 +393,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to discover remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -419,16 +412,14 @@ pub mod event_discovery {
                 }
                 Err("Failed to detect ungraceful remote departure")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }
 
     #[conformance_test]
     pub fn discovers_pre_existing_remote_services<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP — Host B announces FIRST ===
         let service_name = generate_service_name();
@@ -471,8 +462,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to discover pre-existing remote service via history replay")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -481,8 +471,7 @@ pub mod event_discovery {
 
     #[conformance_test]
     pub fn rediscovers_service_after_removal<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -525,8 +514,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to discover remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -543,8 +531,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to detect remote service removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -568,8 +555,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to rediscover service after removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }
@@ -634,8 +620,7 @@ pub mod event_discovery {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -678,8 +663,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to discover remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -702,8 +686,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to detect local service removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -716,8 +699,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to tear down mirrored service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }
@@ -728,8 +710,7 @@ pub mod event_discovery {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -776,8 +757,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to mirror remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -826,8 +806,7 @@ pub mod event_discovery {
                 }
                 Err("Failed to tear down service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }

--- a/iceoryx2-gateway/conformance-tests/src/event_discovery.rs
+++ b/iceoryx2-gateway/conformance-tests/src/event_discovery.rs
@@ -48,7 +48,7 @@ pub mod event_discovery {
     pub fn discovers_added_and_removed_services_via_subscriber<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         // === SETUP ===
         let iceoryx_config = generate_isolated_config();
@@ -85,6 +85,7 @@ pub mod event_discovery {
             discovery_service: Some(DISCOVERY_TOPIC.into()),
         };
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .gateway_config(gateway_config.clone())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
@@ -114,12 +115,13 @@ pub mod event_discovery {
     pub fn discovers_added_and_removed_services_via_tracker<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         // === SETUP ===
         let iceoryx_config = generate_isolated_config();
         let service_name = generate_service_name();
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
             .create()
@@ -153,7 +155,7 @@ pub mod event_discovery {
     pub fn discovers_added_and_removed_services_via_backend<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -163,6 +165,7 @@ pub mod event_discovery {
         // Host A
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -172,6 +175,7 @@ pub mod event_discovery {
         // Host B
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -247,7 +251,7 @@ pub mod event_discovery {
     pub fn aggregates_announcements_from_multiple_hosts<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
         const DISCOVERY_ATTEMPTS: usize = 5;
@@ -258,6 +262,7 @@ pub mod event_discovery {
         // Host A — observer, announces nothing locally.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -266,6 +271,7 @@ pub mod event_discovery {
         // Host B — announces the service.
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -285,6 +291,7 @@ pub mod event_discovery {
         // Host C — announces the same service (same name → same hash).
         let iceoryx_config_c = generate_isolated_config();
         let mut gateway_c = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_c.clone())
             .polled()
             .create()
@@ -349,7 +356,11 @@ pub mod event_discovery {
     }
 
     #[conformance_test]
-    pub fn detects_ungraceful_remote_departure<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn detects_ungraceful_remote_departure<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -358,6 +369,7 @@ pub mod event_discovery {
         // Host A
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -366,6 +378,7 @@ pub mod event_discovery {
         // Host B
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -418,7 +431,11 @@ pub mod event_discovery {
     }
 
     #[conformance_test]
-    pub fn discovers_pre_existing_remote_services<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn discovers_pre_existing_remote_services<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP — Host B announces FIRST ===
@@ -426,6 +443,7 @@ pub mod event_discovery {
 
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -449,6 +467,7 @@ pub mod event_discovery {
         // Host A is created after Host B has already announced.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -470,7 +489,11 @@ pub mod event_discovery {
     }
 
     #[conformance_test]
-    pub fn rediscovers_service_after_removal<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn rediscovers_service_after_removal<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -479,6 +502,7 @@ pub mod event_discovery {
         // Host A — observer.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -487,6 +511,7 @@ pub mod event_discovery {
         // Host B — announces, removes, re-announces the same service.
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -561,7 +586,11 @@ pub mod event_discovery {
     }
 
     #[conformance_test]
-    pub fn ignores_duplicate_added_events<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn ignores_duplicate_added_events<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         // === SETUP ===
         let iceoryx_config = generate_isolated_config();
         let service_name = generate_service_name();
@@ -594,6 +623,7 @@ pub mod event_discovery {
             discovery_service: Some(DISCOVERY_TOPIC.into()),
         };
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .gateway_config(gateway_config.clone())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
@@ -618,7 +648,7 @@ pub mod event_discovery {
     pub fn lifecycle_with_local_service_on_one_host<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -628,6 +658,7 @@ pub mod event_discovery {
         // Host A — no local user; mirrors Host B's service in via the backend.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -636,6 +667,7 @@ pub mod event_discovery {
         // Host B — will own the service.
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -708,7 +740,7 @@ pub mod event_discovery {
     pub fn lifecycle_with_local_service_on_two_hosts<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -718,6 +750,7 @@ pub mod event_discovery {
         // Host A — will own the service first.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -727,6 +760,7 @@ pub mod event_discovery {
         // offerer appears
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -812,7 +846,11 @@ pub mod event_discovery {
     }
 
     #[conformance_test]
-    pub fn no_allowlist_forwards_all_services<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn no_allowlist_forwards_all_services<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         // === SETUP ===
         let iceoryx_config = generate_isolated_config();
         let name_a = generate_service_name();
@@ -833,6 +871,7 @@ pub mod event_discovery {
             .unwrap();
 
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
             .create()

--- a/iceoryx2-gateway/conformance-tests/src/event_propagation.rs
+++ b/iceoryx2-gateway/conformance-tests/src/event_propagation.rs
@@ -31,8 +31,7 @@ pub mod event_propagation {
     use iceoryx2_gateway_backend::traits::{Backend, testing::Testing};
 
     fn propagate_events<S: Service, B: Backend<S> + Debug, T: Testing>(num: usize) {
-        const TIMEOUT: Duration = Duration::from_millis(250);
-        const MAX_ATTEMPTS: usize = 25;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -81,7 +80,6 @@ pub mod event_propagation {
                 Err("Failed to discover remote services")
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
         T::sync(service_a.service_hash().as_str().to_string(), TIMEOUT);
@@ -116,7 +114,6 @@ pub mod event_propagation {
                     _ => Ok(()),
                 },
                 TIMEOUT,
-                Some(MAX_ATTEMPTS),
             )
             .unwrap();
         }
@@ -134,8 +131,7 @@ pub mod event_propagation {
 
     #[conformance_test]
     pub fn propagated_events_do_not_loop_back<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const MAX_ATTEMPTS: usize = 25;
-        const TIMEOUT: Duration = Duration::from_millis(250);
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -189,7 +185,6 @@ pub mod event_propagation {
                 Err("failed to discover remote service")
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
 
@@ -228,7 +223,6 @@ pub mod event_propagation {
                 _ => Ok(()),
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
 
@@ -247,8 +241,7 @@ pub mod event_propagation {
     // TODO: Fix flaky
     #[conformance_test]
     pub fn multiple_events_are_consolidated_by_id<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const MAX_ATTEMPTS: usize = 25;
-        const TIMEOUT: Duration = Duration::from_millis(250);
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -300,7 +293,6 @@ pub mod event_propagation {
                 Err("failed to discover remote service")
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
 
@@ -363,7 +355,6 @@ pub mod event_propagation {
                 Ok(())
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
 
@@ -374,8 +365,7 @@ pub mod event_propagation {
 
     #[conformance_test]
     pub fn events_are_routed_to_their_own_service<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const TIMEOUT: Duration = Duration::from_millis(250);
-        const MAX_ATTEMPTS: usize = 25;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name_1 = generate_service_name();
@@ -431,7 +421,6 @@ pub mod event_propagation {
                 Err("Both services not yet discovered")
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap_or_else(|e| panic!("Failed to discover remote services:\n{}", e));
 
@@ -496,7 +485,6 @@ pub mod event_propagation {
                     }
                 },
                 TIMEOUT,
-                Some(MAX_ATTEMPTS),
             )
             .unwrap_or_else(|e| panic!("{} failed: {}", label, e));
         }

--- a/iceoryx2-gateway/conformance-tests/src/event_propagation.rs
+++ b/iceoryx2-gateway/conformance-tests/src/event_propagation.rs
@@ -30,7 +30,13 @@ pub mod event_propagation {
     use iceoryx2_gateway::Gateway;
     use iceoryx2_gateway_backend::traits::{Backend, testing::Testing};
 
-    fn propagate_events<S: Service, B: Backend<S> + Debug, T: Testing>(num: usize) {
+    fn propagate_events<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >(
+        num: usize,
+    ) {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -40,6 +46,7 @@ pub mod event_propagation {
         let iceoryx_config_a = generate_isolated_config();
 
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -64,6 +71,7 @@ pub mod event_propagation {
         // --- Host B ---
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -120,17 +128,29 @@ pub mod event_propagation {
     }
 
     #[conformance_test]
-    pub fn propagates_event<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn propagates_event<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         propagate_events::<S, B, T>(1);
     }
 
     #[conformance_test]
-    pub fn propagates_event_many<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn propagates_event_many<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         propagate_events::<S, B, T>(10);
     }
 
     #[conformance_test]
-    pub fn propagated_events_do_not_loop_back<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn propagated_events_do_not_loop_back<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -140,6 +160,7 @@ pub mod event_propagation {
         let iceoryx_config_a = generate_isolated_config();
 
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -166,6 +187,7 @@ pub mod event_propagation {
         let iceoryx_config_b = generate_isolated_config();
 
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -240,7 +262,11 @@ pub mod event_propagation {
 
     // TODO: Fix flaky
     #[conformance_test]
-    pub fn multiple_events_are_consolidated_by_id<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn multiple_events_are_consolidated_by_id<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -250,6 +276,7 @@ pub mod event_propagation {
         let iceoryx_config_a = generate_isolated_config();
 
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -275,6 +302,7 @@ pub mod event_propagation {
         let iceoryx_config_b = generate_isolated_config();
 
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -364,7 +392,11 @@ pub mod event_propagation {
     }
 
     #[conformance_test]
-    pub fn events_are_routed_to_their_own_service<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn events_are_routed_to_their_own_service<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -374,6 +406,7 @@ pub mod event_propagation {
         // --- Host A: two services, one notifier each ---
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -406,6 +439,7 @@ pub mod event_propagation {
         // --- Host B ---
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()

--- a/iceoryx2-gateway/conformance-tests/src/publish_subscribe_discovery.rs
+++ b/iceoryx2-gateway/conformance-tests/src/publish_subscribe_discovery.rs
@@ -37,7 +37,7 @@ pub mod publish_subscribe_discovery {
     pub fn discovers_added_and_removed_services_via_subscriber<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         // === SETUP ===
         let iceoryx_config = generate_isolated_config();
@@ -76,6 +76,7 @@ pub mod publish_subscribe_discovery {
             discovery_service: Some(DISCOVERY_TOPIC.into()),
         };
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .gateway_config(gateway_config.clone())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
@@ -105,12 +106,13 @@ pub mod publish_subscribe_discovery {
     pub fn discovers_added_and_removed_services_via_tracker<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         // === SETUP ===
         let iceoryx_config = generate_isolated_config();
         let service_name = generate_service_name();
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
             .create()
@@ -146,7 +148,7 @@ pub mod publish_subscribe_discovery {
     pub fn discovers_added_and_removed_services_via_backend<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -156,6 +158,7 @@ pub mod publish_subscribe_discovery {
         // Host A
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -165,6 +168,7 @@ pub mod publish_subscribe_discovery {
         // Host B
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -242,7 +246,7 @@ pub mod publish_subscribe_discovery {
     pub fn aggregates_announcements_from_multiple_hosts<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
         const DISCOVERY_ATTEMPTS: usize = 5;
@@ -253,6 +257,7 @@ pub mod publish_subscribe_discovery {
         // Host A — observer, announces nothing locally.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -261,6 +266,7 @@ pub mod publish_subscribe_discovery {
         // Host B — announces the service.
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -282,6 +288,7 @@ pub mod publish_subscribe_discovery {
         // Host C — announces the same service (same name → same hash).
         let iceoryx_config_c = generate_isolated_config();
         let mut gateway_c = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_c.clone())
             .polled()
             .create()
@@ -348,7 +355,11 @@ pub mod publish_subscribe_discovery {
     }
 
     #[conformance_test]
-    pub fn detects_ungraceful_remote_departure<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn detects_ungraceful_remote_departure<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -357,6 +368,7 @@ pub mod publish_subscribe_discovery {
         // Host A
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -365,6 +377,7 @@ pub mod publish_subscribe_discovery {
         // Host B
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -419,7 +432,11 @@ pub mod publish_subscribe_discovery {
     }
 
     #[conformance_test]
-    pub fn discovers_pre_existing_remote_services<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn discovers_pre_existing_remote_services<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP — Host B announces FIRST ===
@@ -427,6 +444,7 @@ pub mod publish_subscribe_discovery {
 
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -452,6 +470,7 @@ pub mod publish_subscribe_discovery {
         // Host A is created after Host B has already announced.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -473,7 +492,11 @@ pub mod publish_subscribe_discovery {
     }
 
     #[conformance_test]
-    pub fn rediscovers_service_after_removal<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn rediscovers_service_after_removal<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -482,6 +505,7 @@ pub mod publish_subscribe_discovery {
         // Host A — observer.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -490,6 +514,7 @@ pub mod publish_subscribe_discovery {
         // Host B — announces, removes, re-announces the same service.
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -568,7 +593,11 @@ pub mod publish_subscribe_discovery {
     }
 
     #[conformance_test]
-    pub fn ignores_duplicate_added_events<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn ignores_duplicate_added_events<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         // === SETUP ===
         let iceoryx_config = generate_isolated_config();
         let service_name = generate_service_name();
@@ -604,6 +633,7 @@ pub mod publish_subscribe_discovery {
             discovery_service: Some(DISCOVERY_TOPIC.into()),
         };
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .gateway_config(gateway_config.clone())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
@@ -628,7 +658,7 @@ pub mod publish_subscribe_discovery {
     pub fn lifecycle_with_local_service_on_one_host<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -638,6 +668,7 @@ pub mod publish_subscribe_discovery {
         // Host A — no local user; mirrors Host B's service in via the backend.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -646,6 +677,7 @@ pub mod publish_subscribe_discovery {
         // Host B — will own the service.
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -720,7 +752,7 @@ pub mod publish_subscribe_discovery {
     pub fn lifecycle_with_local_service_on_two_hosts<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -730,6 +762,7 @@ pub mod publish_subscribe_discovery {
         // Host A — will own the service first.
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -739,6 +772,7 @@ pub mod publish_subscribe_discovery {
         // offerer appears
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -828,7 +862,11 @@ pub mod publish_subscribe_discovery {
     }
 
     #[conformance_test]
-    pub fn no_allowlist_forwards_all_services<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn no_allowlist_forwards_all_services<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         // === SETUP ===
         let iceoryx_config = generate_isolated_config();
         let name_a = generate_service_name();
@@ -853,6 +891,7 @@ pub mod publish_subscribe_discovery {
             .unwrap();
 
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
             .create()

--- a/iceoryx2-gateway/conformance-tests/src/publish_subscribe_discovery.rs
+++ b/iceoryx2-gateway/conformance-tests/src/publish_subscribe_discovery.rs
@@ -148,8 +148,7 @@ pub mod publish_subscribe_discovery {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -207,8 +206,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to discover remote services")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -232,8 +230,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to detect remote service removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -247,8 +244,8 @@ pub mod publish_subscribe_discovery {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        const DISCOVERY_ATTEMPTS: usize = 5;
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -315,8 +312,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to discover remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
         assert_that!(gateway_a.bridged_services().len(), eq 1);
@@ -327,7 +323,7 @@ pub mod publish_subscribe_discovery {
         assert_that!(gateway_b.bridged_services().len(), eq 0);
 
         // Host A keeps the service since one remote still offering service
-        for _ in 0..MAX_RETRIES {
+        for _ in 0..DISCOVERY_ATTEMPTS {
             gateway_a.discover_over_backend().unwrap();
         }
         assert_that!(gateway_a.bridged_services().contains(&service_hash), eq true);
@@ -346,16 +342,14 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to detect remote service removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }
 
     #[conformance_test]
     pub fn detects_ungraceful_remote_departure<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(500);
-        const MAX_RETRIES: usize = 20;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -400,8 +394,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to discover remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -420,16 +413,14 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to detect ungraceful remote departure")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }
 
     #[conformance_test]
     pub fn discovers_pre_existing_remote_services<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP — Host B announces FIRST ===
         let service_name = generate_service_name();
@@ -474,8 +465,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to discover pre-existing remote service via history replay")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -484,8 +474,7 @@ pub mod publish_subscribe_discovery {
 
     #[conformance_test]
     pub fn rediscovers_service_after_removal<S: Service, B: Backend<S> + Debug, T: Testing>() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -530,8 +519,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to discover remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -548,8 +536,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to detect remote service removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -575,8 +562,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to rediscover service after removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }
@@ -644,8 +630,7 @@ pub mod publish_subscribe_discovery {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -690,8 +675,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to discover remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -714,8 +698,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to detect local service removal")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -728,8 +711,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to tear down mirrored service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }
@@ -740,8 +722,7 @@ pub mod publish_subscribe_discovery {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const TIME_BETWEEN_RETRIES: Duration = Duration::from_millis(250);
-        const MAX_RETRIES: usize = 5;
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -790,8 +771,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to mirror remote service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
 
@@ -842,8 +822,7 @@ pub mod publish_subscribe_discovery {
                 }
                 Err("Failed to tear down service")
             },
-            TIME_BETWEEN_RETRIES,
-            Some(MAX_RETRIES),
+            TIMEOUT,
         )
         .unwrap();
     }

--- a/iceoryx2-gateway/conformance-tests/src/publish_subscribe_propagation.rs
+++ b/iceoryx2-gateway/conformance-tests/src/publish_subscribe_propagation.rs
@@ -46,8 +46,7 @@ pub mod publish_subscribe_propagation {
     }
 
     fn propagate_struct_payloads<S: Service, B: Backend<S> + Debug, T: Testing>(num: usize) {
-        const MAX_ATTEMPTS: usize = 25;
-        const TIMEOUT: Duration = Duration::from_millis(250);
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name = generate_service_name();
@@ -95,7 +94,6 @@ pub mod publish_subscribe_propagation {
                 Err("No services discovered")
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap_or_else(|e| panic!("Failed to discover remote services:\n{}", e));
 
@@ -159,15 +157,13 @@ pub mod publish_subscribe_propagation {
                     }
                 },
                 TIMEOUT,
-                Some(MAX_ATTEMPTS),
             )
             .unwrap_or_else(|e| panic!("Failed to propagate over gateway:\n{}", e));
         }
     }
 
     fn propagate_slice_payloads<S: Service, B: Backend<S> + Debug, T: Testing>(num: usize) {
-        const MAX_ATTEMPTS: usize = 25;
-        const TIMEOUT: Duration = Duration::from_millis(250);
+        const TIMEOUT: Duration = Duration::from_secs(10);
         const PAYLOAD_DATA_LENGTH: usize = 256;
 
         // === SETUP ===
@@ -220,7 +216,6 @@ pub mod publish_subscribe_propagation {
                 Err("No services discovered")
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap_or_else(|e| panic!("Failed to discover remote services:\n{}", e));
 
@@ -285,7 +280,6 @@ pub mod publish_subscribe_propagation {
                     }
                 },
                 TIMEOUT,
-                Some(MAX_ATTEMPTS),
             )
             .unwrap_or_else(|e| panic!("Failed to propagate over gateway:\n{}", e));
         }
@@ -317,8 +311,7 @@ pub mod publish_subscribe_propagation {
         B: Backend<S> + Debug,
         T: Testing,
     >() {
-        const MAX_ATTEMPTS: usize = 25;
-        const TIMEOUT: Duration = Duration::from_millis(250);
+        const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
         let service_name_1 = generate_service_name();
@@ -376,7 +369,6 @@ pub mod publish_subscribe_propagation {
                 Err("Both services not yet discovered")
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap_or_else(|e| panic!("Failed to discover remote services:\n{}", e));
 
@@ -471,7 +463,6 @@ pub mod publish_subscribe_propagation {
                     }
                 },
                 TIMEOUT,
-                Some(MAX_ATTEMPTS),
             )
             .unwrap_or_else(|e| panic!("{} failed: {}", label, e));
         }

--- a/iceoryx2-gateway/conformance-tests/src/publish_subscribe_propagation.rs
+++ b/iceoryx2-gateway/conformance-tests/src/publish_subscribe_propagation.rs
@@ -45,7 +45,13 @@ pub mod publish_subscribe_propagation {
         active: bool,
     }
 
-    fn propagate_struct_payloads<S: Service, B: Backend<S> + Debug, T: Testing>(num: usize) {
+    fn propagate_struct_payloads<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >(
+        num: usize,
+    ) {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         // === SETUP ===
@@ -54,6 +60,7 @@ pub mod publish_subscribe_propagation {
         // --- Host A ---
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -78,6 +85,7 @@ pub mod publish_subscribe_propagation {
         // --- Host B ---
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -162,7 +170,13 @@ pub mod publish_subscribe_propagation {
         }
     }
 
-    fn propagate_slice_payloads<S: Service, B: Backend<S> + Debug, T: Testing>(num: usize) {
+    fn propagate_slice_payloads<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >(
+        num: usize,
+    ) {
         const TIMEOUT: Duration = Duration::from_secs(10);
         const PAYLOAD_DATA_LENGTH: usize = 256;
 
@@ -172,6 +186,7 @@ pub mod publish_subscribe_propagation {
         // --- Host A ---
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -200,6 +215,7 @@ pub mod publish_subscribe_propagation {
         // --- Host B ---
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -286,22 +302,38 @@ pub mod publish_subscribe_propagation {
     }
 
     #[conformance_test]
-    pub fn propagates_struct_payload<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn propagates_struct_payload<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         propagate_struct_payloads::<S, B, T>(1);
     }
 
     #[conformance_test]
-    pub fn propagates_struct_payload_many<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn propagates_struct_payload_many<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         propagate_struct_payloads::<S, B, T>(10);
     }
 
     #[conformance_test]
-    pub fn propagates_slice_payload<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn propagates_slice_payload<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         propagate_slice_payloads::<S, B, T>(1);
     }
 
     #[conformance_test]
-    pub fn propagates_slice_payload_many<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn propagates_slice_payload_many<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         propagate_slice_payloads::<S, B, T>(10);
     }
 
@@ -309,7 +341,7 @@ pub mod publish_subscribe_propagation {
     pub fn samples_are_routed_to_their_own_service<
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
     >() {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -320,6 +352,7 @@ pub mod publish_subscribe_propagation {
         // --- Host A: two services, one publisher each ---
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -354,6 +387,7 @@ pub mod publish_subscribe_propagation {
         // --- Host B ---
         let iceoryx_config_b = generate_isolated_config();
         let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .polled()
             .create()
@@ -469,7 +503,11 @@ pub mod publish_subscribe_propagation {
     }
 
     #[conformance_test]
-    pub fn propagated_payloads_do_not_loop_back<S: Service, B: Backend<S> + Debug, T: Testing>() {
+    pub fn propagated_payloads_do_not_loop_back<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
         const PAYLOAD_DATA: &str = "WhenItRegisters";
 
         // === SETUP ===
@@ -477,6 +515,7 @@ pub mod publish_subscribe_propagation {
 
         let iceoryx_config = generate_isolated_config();
         let mut gateway = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config.clone())
             .polled()
             .create()

--- a/iceoryx2-gateway/conformance-tests/src/reactive.rs
+++ b/iceoryx2-gateway/conformance-tests/src/reactive.rs
@@ -36,7 +36,7 @@ pub mod reactive {
     where
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
         W: Service,
         for<'b> B::Builder<'b>: ReactiveBackendBuilder<S, WakeService = W>,
     {
@@ -45,6 +45,7 @@ pub mod reactive {
         // === Host A: polled gateway + publisher ===
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -67,6 +68,7 @@ pub mod reactive {
         // === Host B: reactive gateway — wake listener is what we're testing ===
         let iceoryx_config_b = generate_isolated_config();
         let (mut gateway_b, wake_listener) = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .reactive()
             .create::<W>()
@@ -112,7 +114,7 @@ pub mod reactive {
     where
         S: Service,
         B: Backend<S> + Debug,
-        T: Testing,
+        T: Testing<BackendConfig = B::Config>,
         W: Service,
         for<'b> B::Builder<'b>: ReactiveBackendBuilder<S, WakeService = W>,
     {
@@ -121,6 +123,7 @@ pub mod reactive {
         // === Host A: polled gateway + notifier ===
         let iceoryx_config_a = generate_isolated_config();
         let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_a.clone())
             .polled()
             .create()
@@ -143,6 +146,7 @@ pub mod reactive {
         // === Host B: reactive gateway ===
         let iceoryx_config_b = generate_isolated_config();
         let (mut gateway_b, wake_listener) = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
             .iceoryx_config(iceoryx_config_b.clone())
             .reactive()
             .create::<W>()

--- a/iceoryx2-gateway/conformance-tests/src/reactive.rs
+++ b/iceoryx2-gateway/conformance-tests/src/reactive.rs
@@ -27,8 +27,7 @@ pub mod reactive {
     use iceoryx2_gateway::Gateway;
     use iceoryx2_gateway_backend::traits::{Backend, ReactiveBackendBuilder, testing::Testing};
 
-    const TIMEOUT: Duration = Duration::from_millis(250);
-    const MAX_ATTEMPTS: usize = 25;
+    const TIMEOUT: Duration = Duration::from_secs(10);
 
     // Two hosts: A is a polled gateway that publishes; B is a reactive gateway
     // whose wake listener must fire when A's data arrives over the backend.
@@ -87,7 +86,6 @@ pub mod reactive {
                 }
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
 
@@ -103,7 +101,6 @@ pub mod reactive {
                 }
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
     }
@@ -164,7 +161,6 @@ pub mod reactive {
                 }
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
 
@@ -180,7 +176,6 @@ pub mod reactive {
                 }
             },
             TIMEOUT,
-            Some(MAX_ATTEMPTS),
         )
         .unwrap();
     }

--- a/iceoryx2-gateway/testing/src/backend/testing.rs
+++ b/iceoryx2-gateway/testing/src/backend/testing.rs
@@ -16,4 +16,6 @@
 
 pub struct Testing;
 
-impl iceoryx2_gateway_backend::traits::testing::Testing for Testing {}
+impl iceoryx2_gateway_backend::traits::testing::Testing for Testing {
+    type BackendConfig = crate::backend::Config;
+}

--- a/integrations/ros2/gateway-backend/src/testing.rs
+++ b/integrations/ros2/gateway-backend/src/testing.rs
@@ -92,7 +92,9 @@ impl TestPeer {
 /// use in conformance tests which have no information about the gateway implementation.
 pub struct Testing;
 
-impl iceoryx2_gateway_backend::traits::testing::Testing for Testing {}
+impl iceoryx2_gateway_backend::traits::testing::Testing for Testing {
+    type BackendConfig = crate::config::Config;
+}
 
 /// Takes the next message on `subscription` as its serialized bytes, or
 /// [`None`] when the queue is empty.

--- a/integrations/ros2/gateway-backend/tests/common/mod.rs
+++ b/integrations/ros2/gateway-backend/tests/common/mod.rs
@@ -14,8 +14,7 @@ use core::time::Duration;
 
 use iceoryx2::prelude::*;
 
-pub const DISCOVERY_RETRY_PERIOD: Duration = Duration::from_millis(50);
-pub const DISCOVERY_RETRY_ATTEMPTS: usize = 200;
+pub const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub fn service_name(name: &str) -> ServiceName {
     name.try_into().expect("valid service name")

--- a/integrations/ros2/gateway-backend/tests/plain_struct_translator_gateway_tests.rs
+++ b/integrations/ros2/gateway-backend/tests/plain_struct_translator_gateway_tests.rs
@@ -12,7 +12,7 @@
 
 mod common;
 
-use common::{DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_PERIOD, service_name};
+use common::{DISCOVERY_TIMEOUT, service_name};
 
 use iceoryx2::prelude::*;
 use iceoryx2::service::Service as _;
@@ -114,8 +114,7 @@ fn translates_inbound_messages_into_fixed_size_payloads() {
                 .then_some(())
                 .ok_or("local service not yet created")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("local service for the ROS 2 topic did not appear");
 
@@ -161,8 +160,7 @@ fn translates_inbound_messages_into_fixed_size_payloads() {
                 .then_some(())
                 .ok_or("translated twist not yet received")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("translated twist did not arrive natively");
 }
@@ -213,8 +211,7 @@ fn translates_outbound_fixed_size_payloads_onto_the_wire() {
                 .then_some(())
                 .ok_or("translated twist not yet on the wire")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("translated twist did not arrive on the wire");
 }

--- a/integrations/ros2/gateway-backend/tests/prefix_mapping_gateway_tests.rs
+++ b/integrations/ros2/gateway-backend/tests/prefix_mapping_gateway_tests.rs
@@ -12,7 +12,7 @@
 
 mod common;
 
-use common::{DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_PERIOD, service_name};
+use common::{DISCOVERY_TIMEOUT, service_name};
 
 use iceoryx2::prelude::*;
 use iceoryx2::service::Service as _;
@@ -72,8 +72,7 @@ fn maps_iceoryx_services_onto_ros_topics() {
                 .then_some(())
                 .ok_or("mapped topic not yet on the ROS 2 graph")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("mapped topic did not appear on the ROS 2 graph");
 }
@@ -123,8 +122,7 @@ fn does_not_map_unprefixed_services() {
                 .then_some(())
                 .ok_or("publish_subscribe topic not yet on the ROS 2 graph")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("publish_subscribe topic did not appear");
 
@@ -178,8 +176,7 @@ fn does_not_map_event_services() {
                 .then_some(())
                 .ok_or("publish_subscribe topic not yet on the ROS 2 graph")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("publish_subscribe topic did not appear");
 
@@ -218,8 +215,7 @@ fn maps_ros_topics_onto_iceoryx2_services() {
                 .then_some(())
                 .ok_or("local service not yet created")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("local service for the ROS 2 topic did not appear");
 

--- a/integrations/ros2/gateway-backend/tests/static_mapping_gateway_tests.rs
+++ b/integrations/ros2/gateway-backend/tests/static_mapping_gateway_tests.rs
@@ -14,7 +14,7 @@ mod common;
 
 use core::time::Duration;
 
-use common::{DISCOVERY_RETRY_ATTEMPTS, DISCOVERY_RETRY_PERIOD, service_name};
+use common::{DISCOVERY_TIMEOUT, service_name};
 
 use iceoryx2::prelude::*;
 use iceoryx2::service::Service as _;
@@ -97,8 +97,7 @@ fn maps_iceoryx_services_onto_ros_topics() {
                 .then_some(())
                 .ok_or("mapped topic not yet on the ROS 2 graph")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("mapped topic did not appear on the ROS 2 graph");
 }
@@ -161,8 +160,7 @@ fn does_not_map_iceoryx_services_without_an_entry() {
                 .then_some(())
                 .ok_or("chatter topic not yet on the ROS 2 graph")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("chatter topic did not appear");
 
@@ -217,8 +215,7 @@ fn maps_ros_topics_onto_iceoryx_services() {
                 .then_some(())
                 .ok_or("local service not yet created")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("local service for the ROS 2 topic did not appear");
 
@@ -299,8 +296,7 @@ fn applies_specified_qos_to_ros_endpoints() {
             .then_some(())
             .ok_or("gateway endpoints not yet on the ROS 2 graph")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("gateway endpoints did not appear on the ROS 2 graph");
 
@@ -372,8 +368,7 @@ fn applies_specified_settings_to_iceoryx_services() {
                 .then_some(())
                 .ok_or("local service not yet created")
         },
-        DISCOVERY_RETRY_PERIOD,
-        Some(DISCOVERY_RETRY_ATTEMPTS),
+        DISCOVERY_TIMEOUT,
     )
     .expect("local service for the ROS 2 topic did not appear");
 

--- a/integrations/zenoh/gateway-backend/src/testing.rs
+++ b/integrations/zenoh/gateway-backend/src/testing.rs
@@ -15,22 +15,31 @@ use core::time::Duration;
 use zenoh::Config;
 use zenoh::Wait;
 
+/// Poll interval while waiting for the probe publisher to match.
+const POLL_PERIOD: Duration = Duration::from_millis(10);
+
 pub struct Testing;
 
 impl iceoryx2_gateway_backend::traits::testing::Testing for Testing {
+    /// Waits until the subscriber declarations made by gateways for the given
+    /// service have propagated through the zenoh mesh.
     fn sync(id: String, timeout: Duration) -> bool {
         let start_time = std::time::Instant::now();
 
-        let config = Config::default();
-        let session = zenoh::open(config.clone()).wait().unwrap();
-        let subscriber = session.declare_subscriber(id.clone()).wait().unwrap();
+        let session = zenoh::open(Config::default()).wait().unwrap();
+        let publisher = session
+            .declare_publisher(format!("iox2/*/{id}/**"))
+            .wait()
+            .unwrap();
 
-        while subscriber.sender_count() == 0 {
+        loop {
+            if publisher.matching_status().wait().unwrap().matching() {
+                return true;
+            }
             if start_time.elapsed() >= timeout {
                 return false;
             }
+            std::thread::sleep(POLL_PERIOD);
         }
-
-        true
     }
 }

--- a/integrations/zenoh/gateway-backend/src/testing.rs
+++ b/integrations/zenoh/gateway-backend/src/testing.rs
@@ -21,12 +21,28 @@ const POLL_PERIOD: Duration = Duration::from_millis(10);
 pub struct Testing;
 
 impl iceoryx2_gateway_backend::traits::testing::Testing for Testing {
+    type BackendConfig = Config;
+
+    /// Non-default config that disables waiting for scouted peers on
+    /// session initializaiton.
+    ///
+    /// The sync() method below takes care of waiting when required.
+    fn backend_config() -> Config {
+        let mut config = Config::default();
+        config
+            .open
+            .return_conditions
+            .set_connect_scouted(Some(false))
+            .expect("failed to set connect_scouted");
+        config
+    }
+
     /// Waits until the subscriber declarations made by gateways for the given
     /// service have propagated through the zenoh mesh.
     fn sync(id: String, timeout: Duration) -> bool {
         let start_time = std::time::Instant::now();
 
-        let session = zenoh::open(Config::default()).wait().unwrap();
+        let session = zenoh::open(Self::backend_config()).wait().unwrap();
         let publisher = session
             .declare_publisher(format!("iox2/*/{id}/**"))
             .wait()


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

1. Updates synchronization helper to use `AdaptiveWait`
2. Adds hook for backends to specify non-default backend configurations
    1. Disables default 500ms scouting time in zenoh suite which was running per-test

With these changes the zenoh test suite completes in < 5 seconds as opposed to > 90 seconds

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #1942  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
