### PR TITLE
[#1924] Fix discovery service node cleanup

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -62,6 +62,7 @@
 * [#1893](https://github.com/eclipse-iceoryx/iceoryx2/issues/1893) Fix C language `ipc` and `local` mapping for payload types
 * [#1906](https://github.com/eclipse-iceoryx/iceoryx2/issues/1906) Do not set the exec bit for created resources
 * [#1918](https://github.com/eclipse-iceoryx/iceoryx2/issues/1917) Fix wrong `CLOCK_MONOTONIC` constant on macOS (1 instead of 6) which broke `Time::now_with_clock(ClockType::Monotonic)`
+* [#1924](https://github.com/eclipse-iceoryx/iceoryx2/issues/1924) Ensure discovery service node resources are removed during shutdown.
 
 ### Refactoring
 

--- a/iceoryx2-services/discovery/src/service_discovery/service.rs
+++ b/iceoryx2-services/discovery/src/service_discovery/service.rs
@@ -335,12 +335,13 @@ impl Default for Config {
 pub struct Service<S: ServiceType> {
     discovery_config: Config,
     iceoryx_config: IceoryxConfig,
-    _node: Node<S>,
     publisher: Option<Publisher<S, Payload, ()>>,
     request_response: Option<PortFactory<S, (), (), [StaticConfig], ()>>,
     server: Option<Server<S, (), (), [StaticConfig], ()>>,
     notifier: Option<Notifier<S>>,
     tracker: Tracker<S>,
+    // Must remain the last field so all port tags are removed before node cleanup.
+    _node: Node<S>,
 }
 
 impl<S: ServiceType> Service<S> {
@@ -420,12 +421,12 @@ impl<S: ServiceType> Service<S> {
         Ok(Service::<S> {
             discovery_config: discovery_config.clone(),
             iceoryx_config: iceoryx_config.clone(),
-            _node: node,
             publisher,
             request_response,
             server,
             notifier,
             tracker,
+            _node: node,
         })
     }
 

--- a/iceoryx2-services/discovery/tests/service_discovery_service_tests.rs
+++ b/iceoryx2-services/discovery/tests/service_discovery_service_tests.rs
@@ -18,6 +18,7 @@ mod service_discovery_service {
     use iceoryx2::service::static_config::StaticConfig;
     use iceoryx2::testing::generate_service_name;
     use iceoryx2::testing::*;
+    use iceoryx2_bb_posix::directory::Directory;
     use iceoryx2_bb_testing::assert_that;
     use iceoryx2_bb_testing::test_fail;
     use iceoryx2_services_discovery::service_discovery::{
@@ -250,5 +251,32 @@ mod service_discovery_service {
         assert_that!(counter, eq service_names.len());
 
         Ok(())
+    }
+
+    #[test]
+    fn cleanup_removes_node_resources() {
+        let iceoryx_config = generate_isolated_config();
+        let sut = Service::<ipc::Service>::create(&Config::default(), &iceoryx_config).unwrap();
+
+        let mut node_id = None;
+        Node::<ipc::Service>::list(&iceoryx_config, |node_state| {
+            node_id = Some(node_state.node_id().value());
+            CallbackProgression::Stop
+        })
+        .unwrap();
+        let node_id = node_id.unwrap().to_string();
+
+        let node_resources_exist = || {
+            Directory::new(&iceoryx_config.global.node_dir())
+                .unwrap()
+                .contents()
+                .unwrap()
+                .iter()
+                .any(|entry| entry.name().to_string() == node_id)
+        };
+
+        assert_that!(node_resources_exist(), eq true);
+        drop(sut);
+        assert_that!(node_resources_exist(), eq false);
     }
 }


### PR DESCRIPTION
## Notes for Reviewer

Rust drops struct fields in declaration order. The discovery service previously declared `_node` before its ports, allowing node cleanup to run before the remaining port tag was removed. This caused the shutdown warning `Unable to remove node resources` and left an empty node directory behind.

This PR:

* Moves `_node` after all port-owning fields so port tags are removed before node cleanup.
* Adds a regression test verifying that the node directory exists while the discovery service is alive and is removed after it is dropped.
* Updates the unreleased changelog.

Verified on Linux aarch64 (Jetson Orin) and Linux x86_64. Discovery Added/Removed events continue to work, and the shutdown warning and remaining empty node directory are gone.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [[References](app://-/index.html#references)](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

Closes #1924