### PR TITLE
[#1745] Add flatbuffer-tests-nostd as workspace member

### DIFF
--- a/.just/publish.just
+++ b/.just/publish.just
@@ -91,6 +91,7 @@ SDK_CRATES_TO_IGNORE := `echo \
     iceoryx2-bb-posix-tests-common                  \
     iceoryx2-bb-posix-tests-nostd                   \
     iceoryx2-bb-flatbuffers-tests-common            \
+    iceoryx2-bb-flatbuffers-tests-nostd             \
     iceoryx2-cal-conformance-tests-common           \
     iceoryx2-cal-conformance-tests-nostd            \
     iceoryx2-cal-tests-common                       \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "iceoryx2-bb-flatbuffers-tests-nostd"
+version = "0.9.999"
+dependencies = [
+ "iceoryx2-bb-elementary-traits",
+ "iceoryx2-bb-flatbuffers-tests-common",
+ "iceoryx2-bb-loggers",
+ "iceoryx2-bb-memory",
+ "iceoryx2-bb-testing",
+]
+
+[[package]]
 name = "iceoryx2-bb-linux"
 version = "0.9.999"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "iceoryx2-bb/elementary/tests-nostd",
     "iceoryx2-bb/elementary-traits",
     "iceoryx2-bb/flatbuffers",
+    "iceoryx2-bb/flatbuffers/tests-nostd",
     "iceoryx2-bb/linux",
     "iceoryx2-bb/linux/tests-common",
     "iceoryx2-bb/linux/tests-nostd",

--- a/iceoryx2-bb/flatbuffers/tests-nostd/src/main.rs
+++ b/iceoryx2-bb/flatbuffers/tests-nostd/src/main.rs
@@ -21,7 +21,7 @@ use core::{
     ptr::NonNull,
 };
 
-use iceoryx2_bb_elementary_traits::allocator::BaseAllocator;
+use iceoryx2_bb_elementary_traits::allocator::{Allocate, Deallocate};
 use iceoryx2_bb_memory::heap_allocator::HeapAllocator;
 
 #[derive(Debug)]
@@ -36,7 +36,7 @@ impl GlobalHeapAllocator {
 unsafe impl GlobalAlloc for GlobalHeapAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         match self.0.allocate(layout) {
-            Ok(ptr) => ptr.as_ptr() as *mut u8,
+            Ok(ptr) => ptr.as_ptr(),
             Err(_) => core::ptr::null_mut(),
         }
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Integrate remaining crate fully into iceoryx2

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [ ] ~Changelog updated [in the unreleased section][changelog] including API breaking changes~

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #1745  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
