### PR TITLE
[#1949] Take &mut self in gateway Discovery trait

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -83,6 +83,7 @@
 * [#1930](https://github.com/eclipse-iceoryx/iceoryx2/issues/1930) Make FreeBSD platform abstraction use the `libc` crate instead of `bindgen`
 * [#1931](https://github.com/eclipse-iceoryx/iceoryx2/issues/1931) Use ANSI escape sequences in iceoryx2-cli
 * [#1942](https://github.com/eclipse-iceoryx/iceoryx2/issues/1942) Split implementation of gateway testing backend into modules
+* [#1949](https://github.com/eclipse-iceoryx/iceoryx2/issues/1949) Take `&mut self` in gateway Discovery trait
 
 ### Workflow
 

--- a/iceoryx2-gateway/backend/src/traits/backend.rs
+++ b/iceoryx2-gateway/backend/src/traits/backend.rs
@@ -108,8 +108,8 @@ pub trait Backend<S: Service>: Sized {
     /// Returns a [`BackendBuilder`] bound to the provided configuration.
     fn builder(config: &Self::Config) -> Self::Builder<'_>;
 
-    /// Returns a reference to the [`Discovery`] implementation.
-    fn discovery(&self) -> &impl Discovery;
+    /// Returns a mutable reference to the [`Discovery`] implementation.
+    fn discovery(&mut self) -> &mut impl Discovery;
 
     /// Returns a reference to the [`Mapping`] strategy.
     fn mapping(&self) -> &Self::Mapping;

--- a/iceoryx2-gateway/backend/src/traits/discovery.rs
+++ b/iceoryx2-gateway/backend/src/traits/discovery.rs
@@ -43,7 +43,7 @@ use crate::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 /// }
 /// impl core::error::Error for MyDiscoveryError {}
 ///
-/// fn list_services<DiscoveryError, ProcessingError>(discovery: &impl Discovery<DiscoveryError = DiscoveryError>) -> Result<(), DiscoveryError> {
+/// fn list_services<DiscoveryError, ProcessingError>(discovery: &mut impl Discovery<DiscoveryError = DiscoveryError>) -> Result<(), DiscoveryError> {
 ///     discovery.discover(|event| -> Result<(), MyDiscoveryError> {
 ///         println!("Discovery event: {:?}", event);
 ///         Ok(())
@@ -84,14 +84,14 @@ use crate::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 ///     type DiscoveryError = MyDiscoveryError;
 ///     type AnnouncementError = MyAnnouncementError;
 ///
-///     fn announce(&self, update: DiscoveryUpdateRef<'_>)
+///     fn announce(&mut self, update: DiscoveryUpdateRef<'_>)
 ///         -> Result<(), Self::AnnouncementError> {
 ///         // Make the described service discoverable over the backend
 ///         Ok(())
 ///     }
 ///
 ///     fn discover<E: core::error::Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-///         &self,
+///         &mut self,
 ///         process_discovery: F,
 ///     ) -> Result<(), Self::DiscoveryError> {
 ///         // Query backend for available services
@@ -119,7 +119,7 @@ pub trait Discovery {
     ///
     /// * `update` - The [`DiscoveryUpdateRef`] to announce over the
     ///   [`crate::traits::Backend`].
-    fn announce(&self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError>;
+    fn announce(&mut self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError>;
 
     /// Discovers services available remotely and processes each one with the
     /// provided callback.
@@ -135,7 +135,7 @@ pub trait Discovery {
     /// * `process_discovery` - Callback provided by the caller to process
     ///   [`DiscoveryUpdate`]s received over the [`crate::traits::Backend`].
     fn discover<E: Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         process_discovery: F,
     ) -> Result<(), Self::DiscoveryError>;
 }

--- a/iceoryx2-gateway/gateway/src/discovery/subscriber.rs
+++ b/iceoryx2-gateway/gateway/src/discovery/subscriber.rs
@@ -92,14 +92,14 @@ impl<S: Service> Discovery for DiscoverySubscriber<S> {
     type DiscoveryError = DiscoveryError;
     type AnnouncementError = AnnouncementError;
 
-    fn announce(&self, _update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
+    fn announce(&mut self, _update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
         // Nothing to do - local announcement handled by creating `iceoryx2`
         // [`Service`](iceoryx2::service::Service)s.
         Ok(())
     }
 
     fn discover<E: core::error::Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         mut process_discovery: F,
     ) -> Result<(), Self::DiscoveryError> {
         let subscriber = &self.0;

--- a/iceoryx2-gateway/gateway/src/gateway.rs
+++ b/iceoryx2-gateway/gateway/src/gateway.rs
@@ -168,7 +168,7 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
     fn backend_discovery(&mut self) -> Result<(), DiscoveryError> {
         let origin = format!("Gateway({})::backend_discovery", self.node.id());
 
-        let backend = &self.backend;
+        let backend = &mut self.backend;
         let mut update = self.discovery_state.delta_update(Origin::Remote);
 
         fail!(
@@ -187,11 +187,11 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
     fn subscriber_discovery(&mut self) -> Result<(), DiscoveryError> {
         let origin = format!("Gateway({})::subscriber_discovery", self.node.id());
 
-        let LocalDiscoveryStrategy::Subscriber(subscriber) = &self.discovery_strategy else {
+        let LocalDiscoveryStrategy::Subscriber(subscriber) = &mut self.discovery_strategy else {
             panic!("Should never happen. Discovery strategy enforced in discover().");
         };
 
-        let backend = &self.backend;
+        let backend = &mut self.backend;
         let mut update = self.discovery_state.delta_update(Origin::Local);
 
         fail!(
@@ -230,7 +230,7 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
         );
 
         let node = &self.node;
-        let backend = &self.backend;
+        let backend = &mut self.backend;
         let mapping = backend.mapping();
         let discovery_state = &mut self.discovery_state;
 
@@ -293,7 +293,7 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
     /// that are not yet announced.
     fn announce_additions(&mut self) -> Result<(), DiscoveryError> {
         let node = &self.node;
-        let backend = &self.backend;
+        let backend = &mut self.backend;
         let bridges = &self.bridges;
         let announced = &mut self.announced;
 
@@ -316,7 +316,7 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
     /// Announces removal of services no longer locally offered.
     fn announce_removals(&mut self) -> Result<(), DiscoveryError> {
         let node = &self.node;
-        let backend = &self.backend;
+        let backend = &mut self.backend;
         let discovery_state = &self.discovery_state;
 
         // Entries whose withdrawal fails are kept and retried on the next
@@ -374,7 +374,7 @@ fn on_discovery_update(
 /// Broadcasts a service's availability to remote peers over the backend.
 fn announce_added<S: Service, B: Backend<S>>(
     node: &Node<S>,
-    backend: &B,
+    backend: &mut B,
     description: &ServiceDescription,
 ) -> Result<(), DiscoveryError> {
     let origin = format!("Gateway({})::announce_added", node.id());
@@ -397,7 +397,7 @@ fn announce_added<S: Service, B: Backend<S>>(
 /// Announces a service's removal to remote peers over the backend.
 fn announce_removed<S: Service, B: Backend<S>>(
     node: &Node<S>,
-    backend: &B,
+    backend: &mut B,
     hash: &ServiceHash,
     name: &ServiceName,
 ) -> Result<(), DiscoveryError> {

--- a/iceoryx2-gateway/testing/src/backend/backend.rs
+++ b/iceoryx2-gateway/testing/src/backend/backend.rs
@@ -84,8 +84,8 @@ impl<S: Service, M: Mapping, T: Translator<EndpointDescription = M::EndpointDesc
         Builder::new(config)
     }
 
-    fn discovery(&self) -> &impl iceoryx2_gateway_backend::traits::Discovery {
-        &self.discovery
+    fn discovery(&mut self) -> &mut impl iceoryx2_gateway_backend::traits::Discovery {
+        &mut self.discovery
     }
 
     fn mapping(&self) -> &Self::Mapping {

--- a/iceoryx2-gateway/testing/src/backend/discovery.rs
+++ b/iceoryx2-gateway/testing/src/backend/discovery.rs
@@ -62,7 +62,7 @@ impl iceoryx2_gateway_backend::traits::Discovery for Discovery {
 
     type AnnouncementError = AnnouncementError;
 
-    fn announce(&self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
+    fn announce(&mut self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
         match update {
             DiscoveryUpdateRef::Added(description) => self
                 .session
@@ -76,7 +76,7 @@ impl iceoryx2_gateway_backend::traits::Discovery for Discovery {
     }
 
     fn discover<E: core::error::Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         mut process_discovery: F,
     ) -> Result<(), Self::DiscoveryError> {
         self.session.discover();

--- a/integrations/ros2/gateway-backend/src/backend.rs
+++ b/integrations/ros2/gateway-backend/src/backend.rs
@@ -97,8 +97,8 @@ impl<
         )
     }
 
-    fn discovery(&self) -> &impl iceoryx2_gateway_backend::traits::Discovery {
-        &self.discovery
+    fn discovery(&mut self) -> &mut impl iceoryx2_gateway_backend::traits::Discovery {
+        &mut self.discovery
     }
 
     fn mapping(&self) -> &Self::Mapping {

--- a/integrations/ros2/gateway-backend/src/discovery.rs
+++ b/integrations/ros2/gateway-backend/src/discovery.rs
@@ -18,7 +18,6 @@ use core::error::Error;
 use iceoryx2::service::Service;
 use iceoryx2::service::service_hash::ServiceHash;
 use iceoryx2::service::static_config::message_type_details::TypeVariant;
-use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_gateway_backend::traits::{Mapping, PayloadLayout, Translation, Translator};
 use iceoryx2_gateway_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 use iceoryx2_gateway_backend::types::service_description::PatternDescription;
@@ -75,7 +74,7 @@ pub struct Discovery<
     node: Rc<RclNode>,
     mapping: Rc<M>,
     translator: Rc<T>,
-    state: RefCell<HashMap<TopicName, TopicState>>,
+    state: HashMap<TopicName, TopicState>,
     _phantom: core::marker::PhantomData<S>,
 }
 
@@ -92,7 +91,7 @@ impl<
             node,
             mapping,
             translator,
-            state: RefCell::new(HashMap::new()),
+            state: HashMap::new(),
             _phantom: core::marker::PhantomData,
         }
     }
@@ -129,7 +128,7 @@ impl<
     /// Returns the state to track the topic under, or `Err` if querying its
     /// QoS or running `process_discovery` failed.
     fn on_discovered<E: Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         topic: &TopicName,
         type_name: &TypeName,
         process_discovery: &mut F,
@@ -187,7 +186,7 @@ impl<
     /// Returns `Ok` when the removal was processed, or `Err` if
     /// `process_discovery` failed.
     fn on_removed<E: Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         topic: &TopicName,
         service_hash: ServiceHash,
         process_discovery: &mut F,
@@ -204,7 +203,7 @@ impl<
         );
 
         // Stop tracking the service as discovered.
-        self.state.borrow_mut().remove(topic);
+        self.state.remove(topic);
 
         Ok(())
     }
@@ -215,12 +214,12 @@ impl<
     /// retried in later runs until removed from the graph. After removal,
     /// discovery logic is retried for the new instance of the topic.
     fn discover_additions<E: Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         live: &[(TopicName, TypeName)],
         process_discovery: &mut F,
     ) {
         for (topic, type_name) in live {
-            if self.state.borrow().contains_key(topic) {
+            if self.state.contains_key(topic) {
                 continue;
             }
 
@@ -232,7 +231,7 @@ impl<
                 }
             };
 
-            self.state.borrow_mut().insert(topic.clone(), state);
+            self.state.insert(topic.clone(), state);
         }
     }
 
@@ -241,7 +240,7 @@ impl<
     /// The departed set is taken before the loop so that no borrow of the
     /// tracked state is held while `process_discovery` runs.
     fn discover_removals<E: Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         live: &[(TopicName, TypeName)],
         process_discovery: &mut F,
     ) -> Result<(), DiscoveryError> {
@@ -249,7 +248,6 @@ impl<
 
         let departed: Vec<(TopicName, TopicState)> = self
             .state
-            .borrow()
             .iter()
             .filter(|(topic, _)| !is_live(topic))
             .map(|(topic, state)| (topic.clone(), *state))
@@ -263,7 +261,7 @@ impl<
                 // Forget the verdict so the topic is judged again if it
                 // is discovered again.
                 TopicState::Unmapped | TopicState::Failed => {
-                    self.state.borrow_mut().remove(&topic);
+                    self.state.remove(&topic);
                 }
             }
         }
@@ -281,7 +279,7 @@ impl<
     type DiscoveryError = DiscoveryError;
     type AnnouncementError = AnnouncementError;
 
-    fn announce(&self, _update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
+    fn announce(&mut self, _update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
         // Nothing to announce explicitly. The gateway creates a relay for
         // every service it discovers on iceoryx2, and relay creation
         // registers the ROS 2 endpoints, which DDS discovery (SEDP) broadcasts
@@ -290,7 +288,7 @@ impl<
     }
 
     fn discover<E: Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         mut process_discovery: F,
     ) -> Result<(), Self::DiscoveryError> {
         let origin = "Discovery::discover";

--- a/integrations/zenoh/gateway-backend/src/backend.rs
+++ b/integrations/zenoh/gateway-backend/src/backend.rs
@@ -92,8 +92,8 @@ impl<
         Self::RelayFactory::new(&self.session, self.wake.clone())
     }
 
-    fn discovery(&self) -> &impl iceoryx2_gateway_backend::traits::Discovery {
-        &self.discovery
+    fn discovery(&mut self) -> &mut impl iceoryx2_gateway_backend::traits::Discovery {
+        &mut self.discovery
     }
 
     fn mapping(&self) -> &Self::Mapping {

--- a/integrations/zenoh/gateway-backend/src/discovery.rs
+++ b/integrations/zenoh/gateway-backend/src/discovery.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 
 use iceoryx2::service::Service;
 use iceoryx2::service::service_hash::ServiceHash;
-use iceoryx2_bb_concurrency::cell::RefCell;
 use iceoryx2_gateway_backend::traits::Mapping;
 use iceoryx2_gateway_backend::types::discovery::{DiscoveryUpdate, DiscoveryUpdateRef};
 use iceoryx2_gateway_backend::types::service_description::ServiceDescription;
@@ -91,11 +90,11 @@ pub struct Discovery<S: Service, M: Mapping<EndpointDescription = ServiceDescrip
     // Subscribes to liveliness changes for service announcements.
     subscriber: Subscriber<FifoChannelHandler<Sample>>,
     // Keeps track of services that have been announced locally.
-    announced: RefCell<BTreeMap<ServiceHash, AnnouncedService>>,
+    announced: BTreeMap<ServiceHash, AnnouncedService>,
     // Cache for replies to requests for remote service details.
     // Replies are filled asynchronously by Zenoh but only processed on
     // subsequent discover calls. Enables non-blocking implementation.
-    pending: RefCell<BTreeMap<ServiceHash, FifoChannelHandler<Reply>>>,
+    pending: BTreeMap<ServiceHash, FifoChannelHandler<Reply>>,
     _phantom: core::marker::PhantomData<S>,
 }
 
@@ -118,8 +117,8 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
             session: session.clone(),
             mapping,
             subscriber,
-            announced: RefCell::new(BTreeMap::new()),
-            pending: RefCell::new(BTreeMap::new()),
+            announced: BTreeMap::new(),
+            pending: BTreeMap::new(),
             _phantom: core::marker::PhantomData,
         })
     }
@@ -131,7 +130,7 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>>
     type DiscoveryError = DiscoveryError;
     type AnnouncementError = AnnouncementError;
 
-    fn announce(&self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
+    fn announce(&mut self, update: DiscoveryUpdateRef<'_>) -> Result<(), Self::AnnouncementError> {
         match update {
             DiscoveryUpdateRef::Added(description) => {
                 if self.mapping.remote(description).is_none() {
@@ -144,36 +143,42 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>>
     }
 
     fn discover<E: core::error::Error, F: FnMut(DiscoveryUpdate) -> Result<(), E>>(
-        &self,
+        &mut self,
         mut process_discovery: F,
     ) -> Result<(), DiscoveryError> {
-        // Reaction to a new service being detected on the network: request
-        // its details. The reply will be handled by `process_service_details`.
-        // Subject to network latency.
-        let on_service_added =
-            |service_hash: &ServiceHash| self.request_service_details(service_hash);
+        for (service_hash, kind) in self.receive_liveliness_changes()? {
+            match kind {
+                // A new service was detected on the network. Request its
+                // details. The reply is picked up by a subsequent discover call.
+                // Subject to network latency.
+                SampleKind::Put => self.request_service_description(&service_hash)?,
+                // The service disappeared. Remove it from the gateway and
+                // cancel any in-flight details request.
+                SampleKind::Delete => {
+                    self.pending.remove(&service_hash);
 
-        // Removes a service from the gateway. Called on a liveliness Delete;
-        // also cancels any in-flight details request.
-        let on_service_removed = |service_hash: &ServiceHash| {
-            self.pending.borrow_mut().remove(service_hash);
+                    fail!(
+                        from self,
+                        when process_discovery(DiscoveryUpdate::Removed(service_hash)),
+                        with DiscoveryError::DiscoveryProcessing,
+                        "Failed to process Removed discovery event for {}", service_hash.as_str()
+                    );
+                }
+            }
+        }
 
-            fail!(
-                from self,
-                when process_discovery(DiscoveryUpdate::Removed(*service_hash)),
-                with DiscoveryError::DiscoveryProcessing,
-                "Failed to process Removed discovery event for {}", service_hash.as_str()
-            );
-            Ok(())
-        };
-
-        self.process_liveliness_changes(on_service_added, on_service_removed)?;
-
-        // Adds a service to the gateway. Called once the reply with the
-        // service details of a discovered remote service has been received.
-        let on_service_details = |description: ServiceDescription| {
+        // Poll the pending detail queries. A service is added to the
+        // gateway once the reply with its details has been received.
+        let (resolved, failed) = self.receive_service_descriptions();
+        for description in &resolved {
+            self.pending.remove(&description.service_hash);
+        }
+        for hash in failed {
+            self.request_service_description(&hash)?;
+        }
+        for description in resolved {
             let Some(description) = self.mapping.local::<S>(&description) else {
-                return Ok(());
+                continue;
             };
             let service_hash = description.service_hash;
             fail!(
@@ -182,10 +187,7 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>>
                 with DiscoveryError::DiscoveryProcessing,
                 "Failed to process Added discovery event for {}", service_hash.as_str()
             );
-            Ok(())
-        };
-
-        self.process_service_details(on_service_details)?;
+        }
 
         Ok(())
     }
@@ -196,14 +198,17 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
     /// its details and a liveliness token at its key.
     ///
     /// No-op if the service has already been announced.
-    fn announce_added(&self, description: &ServiceDescription) -> Result<(), AnnouncementError> {
+    fn announce_added(
+        &mut self,
+        description: &ServiceDescription,
+    ) -> Result<(), AnnouncementError> {
         let service_hash = description.service_hash;
 
-        if self.announced.borrow().contains_key(&service_hash) {
+        if self.announced.contains_key(&service_hash) {
             return Ok(());
         }
 
-        let key = keys::service_details(&service_hash);
+        let key = keys::service_description(&service_hash);
         let serialized = fail!(
             from self,
             when serde_json::to_string(description),
@@ -216,7 +221,7 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
         let queryable = self.declare_queryable(&key, serialized)?;
         let token = self.declare_liveliness_token(&key)?;
 
-        self.announced.borrow_mut().insert(
+        self.announced.insert(
             service_hash,
             AnnouncedService {
                 _token: token,
@@ -228,8 +233,8 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
 
     /// Withdraws a service announcement by dropping its queryable and
     /// liveliness token, propagating a liveliness Delete to remote peers.
-    fn announce_removed(&self, service_hash: &ServiceHash) -> Result<(), AnnouncementError> {
-        self.announced.borrow_mut().remove(service_hash);
+    fn announce_removed(&mut self, service_hash: &ServiceHash) -> Result<(), AnnouncementError> {
+        self.announced.remove(service_hash);
         Ok(())
     }
 
@@ -276,19 +281,11 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
         Ok(token)
     }
 
-    /// Drains the liveliness subscriber non-blocking and dispatches each
-    /// sample to one of the provided callbacks based on its kind. `Put`
-    /// samples (a service appeared on the network) go to `on_service_added`;
-    /// `Delete` samples (a service vanished) go to `on_service_removed`.
-    fn process_liveliness_changes<OnServiceAdded, OnServiceRemoved>(
-        &self,
-        mut on_service_added: OnServiceAdded,
-        mut on_service_removed: OnServiceRemoved,
-    ) -> Result<(), DiscoveryError>
-    where
-        OnServiceAdded: FnMut(&ServiceHash) -> Result<(), DiscoveryError>,
-        OnServiceRemoved: FnMut(&ServiceHash) -> Result<(), DiscoveryError>,
-    {
+    /// Drains the liveliness samples received since the last call and
+    /// returns the (service, change) pairs in order of arrival. Samples
+    /// with unparsable keys are skipped.
+    fn receive_liveliness_changes(&self) -> Result<Vec<(ServiceHash, SampleKind)>, DiscoveryError> {
+        let mut changes = Vec::new();
         loop {
             let sample = match fail!(
                 from self,
@@ -309,19 +306,20 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
                 }
             };
 
-            match sample.kind() {
-                SampleKind::Put => on_service_added(&service_hash)?,
-                SampleKind::Delete => on_service_removed(&service_hash)?,
-            }
+            changes.push((service_hash, sample.kind()));
         }
-        Ok(())
+        Ok(changes)
     }
 
-    /// Issues a Zenoh `get` for the service's ServiceDescription and queues the
-    /// reply handler under `pending`. Returns immediately; replies are
-    /// processed by [`Discovery::process_service_details`] on subsequent calls.
-    fn request_service_details(&self, service_hash: &ServiceHash) -> Result<(), DiscoveryError> {
-        let key = keys::service_details(service_hash);
+    /// Issues a Zenoh `get` for the service's [`ServiceDescription`] and stores the
+    /// reply handler.
+    /// Replies are picked up by [`Discovery::receive_service_descriptions`] on
+    /// subsequent iterations.
+    fn request_service_description(
+        &mut self,
+        service_hash: &ServiceHash,
+    ) -> Result<(), DiscoveryError> {
+        let key = keys::service_description(service_hash);
         let handler = fail!(
             from self,
             when self.session
@@ -331,55 +329,26 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
             with DiscoveryError::DiscoveryQuery,
             "Failed to query for static config of {}", key
         );
-        self.pending.borrow_mut().insert(*service_hash, handler);
+        self.pending.insert(*service_hash, handler);
         Ok(())
     }
 
-    /// Drains the cached handlers for replies received over the network and
-    /// dispatches each resolved [`ServiceDescription`] to `on_service_details`.
-    /// Re-issues the query for any handler whose channel closed without a
-    /// usable reply.
-    fn process_service_details<OnServiceDetails>(
-        &self,
-        mut on_service_details: OnServiceDetails,
-    ) -> Result<(), DiscoveryError>
-    where
-        OnServiceDetails: FnMut(ServiceDescription) -> Result<(), DiscoveryError>,
-    {
+    /// Receives service descriptions from previously-issued queries.
+    /// Returns the resolved [`ServiceDescription`]s and the services whose
+    /// query channel closed without a usable reply.
+    fn receive_service_descriptions(&self) -> (Vec<ServiceDescription>, Vec<ServiceHash>) {
         let mut resolved: Vec<ServiceDescription> = Vec::new();
         let mut failed: Vec<ServiceHash> = Vec::new();
 
-        // Check status of pending queries.
-        {
-            let pending = self.pending.borrow();
-            for (hash, handler) in pending.iter() {
-                match check_pending(hash, handler) {
-                    Ok(Some(description)) => resolved.push(description),
-                    Ok(None) => {}
-                    Err(_) => failed.push(*hash),
-                }
+        for (hash, handler) in self.pending.iter() {
+            match check_pending(hash, handler) {
+                Ok(Some(description)) => resolved.push(description),
+                Ok(None) => {}
+                Err(_) => failed.push(*hash),
             }
         }
 
-        // Drop resolved entries from pending.
-        {
-            let mut pending = self.pending.borrow_mut();
-            for description in &resolved {
-                pending.remove(&description.service_hash);
-            }
-        }
-
-        // Re-issue queries for failed requests.
-        for hash in failed {
-            self.request_service_details(&hash)?;
-        }
-
-        // Processed received service details.
-        for description in resolved {
-            on_service_details(description)?;
-        }
-
-        Ok(())
+        (resolved, failed)
     }
 }
 

--- a/integrations/zenoh/gateway-backend/src/keys.rs
+++ b/integrations/zenoh/gateway-backend/src/keys.rs
@@ -14,12 +14,12 @@ use iceoryx2::service::service_hash::ServiceHash;
 
 /// The zenoh key for discovering available service details.
 pub fn service_discovery() -> String {
-    "iox2/service_details/*".into()
+    "iox2/service_description/*".into()
 }
 
 /// The zenoh key at which the service details for the given service id can be received.
-pub fn service_details(service_hash: &ServiceHash) -> String {
-    format!("iox2/service_details/{}", service_hash.as_str())
+pub fn service_description(service_hash: &ServiceHash) -> String {
+    format!("iox2/service_description/{}", service_hash.as_str())
 }
 
 /// The zenoh key at which payloads for a given publish-subscribe service id can be received.


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Take `&mut self` in gateway Discovery trait and remove usage of interior mutability from the trait implementations.  
The result is simpler code.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] ~~Tests follow the [best practice for testing][testing]~~
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1949 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
