### PR TITLE
[#3] Small fixes in iceoryx2 env

### DIFF
--- a/internal/scripts/iceoryx2_env.sh
+++ b/internal/scripts/iceoryx2_env.sh
@@ -30,9 +30,9 @@ setup_docker_image() {
     # ubuntu/debian and derivatives
     if command -v apt &>/dev/null; then
         apt update
-        apt -y install sudo git fish curl expect vim lsb-release software-properties-common gcc libacl1-dev libclang-dev zlib1g-dev clang libpython3-all-dev
+        apt -y install sudo git fish curl expect vim lsb-release software-properties-common cmake gcc libclang-dev zlib1g-dev clang clang-format clang-tidy libpython3-all-dev
     elif command -v pacman &>/dev/null; then
-        pacman -Syu --noconfirm fish curl expect git vim clang python
+        pacman -Syu --noconfirm fish curl expect git vim cmake clang python
     else
         echo Please install the following packages to have a working iceoryx2 environment:
         echo fish curl clang python
@@ -48,7 +48,8 @@ setup_docker_image() {
     export PATH=$PATH:/root/.cargo/bin
     rustup toolchain install stable
     rustup toolchain install nightly
-    cargo install cargo-nextest
+    cargo install cargo-nextest --locked
+    cargo install just --locked
 
     mkdir -p /root/.config/fish
     echo "set -gx PATH /root/.cargo/bin \$PATH" >> /root/.config/fish/config.fish


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

This PR fixes the installation of `cargo-nextest` and adds `just`, `clang-format` and `clang-tidy` to the iceoryx2-env

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [~] Tests follow the [best practice for testing][testing]
* [~] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates to #3

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
