### PR TITLE
[#1955] Cleanup of String API

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -84,6 +84,7 @@
 * [#1931](https://github.com/eclipse-iceoryx/iceoryx2/issues/1931) Use ANSI escape sequences in iceoryx2-cli
 * [#1942](https://github.com/eclipse-iceoryx/iceoryx2/issues/1942) Split implementation of gateway testing backend into modules
 * [#1949](https://github.com/eclipse-iceoryx/iceoryx2/issues/1949) Take `&mut self` in gateway Discovery trait
+* [#1955](https://github.com/eclipse-iceoryx/iceoryx2/issues/1955) Remove `as_mut_bytes` and `deref_mut` from the `String` API in iceoryx2-bb-container
 
 ### Workflow
 
@@ -265,6 +266,19 @@
 
     // new
     iox2::CleanupState cleanup = node.try_cleanup_dead_nodes();
+    ```
+
+1. In iceoryx2-bb-container, methods `as_mut_bytes()` and `deref_mut()` are removed from the `String` API,
+   This applies equally to `PolymorphicString`, `RelocatableString` and `StaticString`.
+
+    ```rust
+    use iceoryx2_bb_container::string::*;
+    const CAPACITY: usize = 1234;
+    let my_str = StaticString::<CAPACITY>::new();
+    my_str.push_bytes(b"hello");
+    
+    let mut_str_slice = my_str.as_bytes(); // Compiler Error
+    my_str.deref_mut()[0] = b'b'; // Compiler Error
     ```
 
 <!-- markdownlint-enable MD013 -->

--- a/iceoryx2-bb/container/src/string/mod.rs
+++ b/iceoryx2-bb/container/src/string/mod.rs
@@ -11,12 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use core::mem::MaybeUninit;
-use core::{
-    fmt::Debug,
-    fmt::Display,
-    hash::Hash,
-    ops::{Deref, DerefMut},
-};
+use core::{fmt::Debug, fmt::Display, hash::Hash, ops::Deref};
 use iceoryx2_log::{fail, fatal_panic};
 
 /// Runtime fixed-capacity string where the user can provide a stateful allocator.
@@ -99,7 +94,6 @@ pub trait String:
     + Ord
     + Hash
     + Deref<Target = [u8]>
-    + DerefMut
     + PartialEq
     + Eq
 {
@@ -116,13 +110,6 @@ pub trait String:
     /// Returns a zero terminated slice of the underlying bytes
     fn as_c_str(&self) -> *const core::ffi::c_char {
         self.data().as_ptr() as *const core::ffi::c_char
-    }
-
-    /// Returns a mutable slice to the underlying bytes
-    fn as_mut_bytes(&mut self) -> &mut [u8] {
-        unsafe {
-            core::slice::from_raw_parts_mut(self.data_mut().as_mut_ptr() as *mut u8, self.len())
-        }
     }
 
     /// Returns the content as a string slice if the bytes are valid UTF-8

--- a/iceoryx2-bb/container/src/string/polymorphic_string.rs
+++ b/iceoryx2-bb/container/src/string/polymorphic_string.rs
@@ -40,7 +40,7 @@ use core::{
     fmt::{Debug, Display},
     hash::Hash,
     mem::MaybeUninit,
-    ops::{Deref, DerefMut},
+    ops::Deref,
     ptr::NonNull,
 };
 
@@ -142,14 +142,6 @@ impl<Allocator: Allocate<NonNull<u8>> + Deallocate<NonNull<u8>>> Deref
 
     fn deref(&self) -> &Self::Target {
         self.as_bytes()
-    }
-}
-
-impl<Allocator: Allocate<NonNull<u8>> + Deallocate<NonNull<u8>>> DerefMut
-    for PolymorphicString<'_, Allocator>
-{
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut_bytes()
     }
 }
 

--- a/iceoryx2-bb/container/src/string/relocatable_string.rs
+++ b/iceoryx2-bb/container/src/string/relocatable_string.rs
@@ -80,7 +80,7 @@ use core::cmp::Ordering;
 use core::fmt::{Debug, Display};
 use core::hash::Hash;
 use core::mem::MaybeUninit;
-use core::ops::{Deref, DerefMut};
+use core::ops::Deref;
 use core::ptr::NonNull;
 use iceoryx2_bb_elementary::math::unaligned_mem_size;
 use iceoryx2_bb_elementary::relocatable_pointer::RelocatablePointer;
@@ -151,12 +151,6 @@ impl Deref for RelocatableString {
 
     fn deref(&self) -> &Self::Target {
         self.as_bytes()
-    }
-}
-
-impl DerefMut for RelocatableString {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut_bytes()
     }
 }
 

--- a/iceoryx2-bb/container/src/string/static_string.rs
+++ b/iceoryx2-bb/container/src/string/static_string.rs
@@ -40,7 +40,7 @@ use core::{
     fmt::{Debug, Display},
     hash::Hash,
     mem::MaybeUninit,
-    ops::{Deref, DerefMut},
+    ops::Deref,
 };
 use iceoryx2_bb_elementary_traits::atomic_copy::AtomicCopy;
 
@@ -150,12 +150,6 @@ impl<const CAPACITY: usize> Deref for StaticString<CAPACITY> {
 
     fn deref(&self) -> &Self::Target {
         self.as_bytes()
-    }
-}
-
-impl<const CAPACITY: usize> DerefMut for StaticString<CAPACITY> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut_bytes()
     }
 }
 

--- a/iceoryx2-bb/container/tests-common/src/static_string_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/static_string_tests.rs
@@ -50,7 +50,6 @@ pub fn from_bytes_unchecked_works() {
     assert_that!(sut, eq b"let me be your toad");
     assert_that!(sut, ne b"let me be your toad fuu");
     assert_that!(sut.as_bytes(), eq b"let me be your toad");
-    assert_that!(sut.as_mut_bytes(), eq b"let me be your toad");
     assert_that!(sut.as_bytes_with_nul(), eq b"let me be your toad\0");
     assert_that!(sut.pop(), eq Some(b'd'));
 }
@@ -64,7 +63,6 @@ pub fn from_bytes_unchecked_with_empty_slice_works() {
     assert_that!(sut, len 0);
     assert_that!(sut, eq b"");
     assert_that!(sut.as_bytes(), eq b"");
-    assert_that!(sut.as_mut_bytes(), eq b"");
     assert_that!(sut.as_bytes_with_nul(), eq b"\0");
     assert_that!(sut.pop(), is_none);
 }
@@ -81,7 +79,6 @@ pub fn from_bytes_with_len_smaller_capacity_works() {
     assert_that!(sut, eq b"bonjour world");
     assert_that!(sut, ne b"bonjour world! woo");
     assert_that!(sut.as_bytes(), eq b"bonjour world");
-    assert_that!(sut.as_mut_bytes(), eq b"bonjour world");
     assert_that!(sut.as_bytes_with_nul(), eq b"bonjour world\0");
     assert_that!(sut.pop(), eq Some(b'd'));
 }
@@ -97,7 +94,6 @@ pub fn from_bytes_with_empty_slice_works() {
     assert_that!(sut, len 0);
     assert_that!(sut, eq b"");
     assert_that!(sut.as_bytes(), eq b"");
-    assert_that!(sut.as_mut_bytes(), eq b"");
     assert_that!(sut.as_bytes_with_nul(), eq b"\0");
     assert_that!(sut.pop(), is_none);
 }
@@ -118,7 +114,6 @@ pub fn from_bytes_truncated_works_with_empty_bytes() {
     assert_that!(sut, eq b"");
     assert_that!(sut, ne b"woo");
     assert_that!(sut.as_bytes(), eq b"");
-    assert_that!(sut.as_mut_bytes(), eq b"");
     assert_that!(sut.as_bytes_with_nul(), eq b"\0");
     assert_that!(sut.pop(), is_none);
 }
@@ -135,7 +130,6 @@ pub fn from_bytes_truncated_works_with_len_smaller_than_capacity() {
     assert_that!(sut, eq b"bonjour world");
     assert_that!(sut, ne b"bonjour world! woo");
     assert_that!(sut.as_bytes(), eq b"bonjour world");
-    assert_that!(sut.as_mut_bytes(), eq b"bonjour world");
     assert_that!(sut.as_bytes_with_nul(), eq b"bonjour world\0");
     assert_that!(sut.pop(), eq Some(b'd'));
 }
@@ -150,7 +144,6 @@ pub fn from_bytes_truncated_works_with_len_greater_than_capacity() {
     assert_that!(sut, eq b"peek");
     assert_that!(sut, ne b"peek woo");
     assert_that!(sut.as_bytes(), eq b"peek");
-    assert_that!(sut.as_mut_bytes(), eq b"peek");
     assert_that!(sut.as_bytes_with_nul(), eq b"peek\0");
     assert_that!(sut.pop(), eq Some(b'k'));
 }
@@ -171,7 +164,6 @@ pub fn from_str_with_len_smaller_capacity_works() {
     assert_that!(sut, eq b"a frog sits on nalas head");
     assert_that!(sut, ne b"a frog sits on nalas foot");
     assert_that!(sut.as_bytes(), eq b"a frog sits on nalas head");
-    assert_that!(sut.as_mut_bytes(), eq b"a frog sits on nalas head");
     assert_that!(sut.as_bytes_with_nul(), eq b"a frog sits on nalas head\0");
     assert_that!(sut.pop(), eq Some(b'd'));
 }
@@ -186,7 +178,6 @@ pub fn from_str_with_len_zero_works() {
     assert_that!(sut, eq b"");
     assert_that!(sut, ne b"oot");
     assert_that!(sut.as_bytes(), eq b"");
-    assert_that!(sut.as_mut_bytes(), eq b"");
     assert_that!(sut.as_bytes_with_nul(), eq b"\0");
     assert_that!(sut.pop(), is_none);
 }
@@ -207,7 +198,6 @@ pub fn from_str_truncated_with_len_smaller_capacity_works() {
     assert_that!(sut, eq b"a butterfly sits on nalas nose");
     assert_that!(sut, ne b"a butterfly sits on nalas foot");
     assert_that!(sut.as_bytes(), eq b"a butterfly sits on nalas nose");
-    assert_that!(sut.as_mut_bytes(), eq b"a butterfly sits on nalas nose");
     assert_that!(sut.as_bytes_with_nul(), eq b"a butterfly sits on nalas nose\0");
     assert_that!(sut.pop(), eq Some(b'e'));
 }
@@ -222,7 +212,6 @@ pub fn from_str_truncated_with_len_greater_than_capacity_truncates() {
     assert_that!(sut, eq b"the ");
     assert_that!(sut, ne b"foo ");
     assert_that!(sut.as_bytes(), eq b"the ");
-    assert_that!(sut.as_mut_bytes(), eq b"the ");
     assert_that!(sut.as_bytes_with_nul(), eq b"the \0");
     assert_that!(sut.pop(), eq Some(b' '));
 }

--- a/iceoryx2-bb/container/tests-common/src/string_tests.rs
+++ b/iceoryx2-bb/container/tests-common/src/string_tests.rs
@@ -20,7 +20,6 @@ use iceoryx2_bb_testing_macros::tests;
 pub mod generic {
 
     use core::cmp::Ordering;
-    use core::ops::DerefMut;
     use core::ptr::NonNull;
 
     use alloc::boxed::Box;
@@ -137,7 +136,6 @@ pub mod generic {
         assert_that!(sut, len 0);
         assert_that!(sut.pop(), is_none);
         assert_that!(sut.as_bytes(), eq b"");
-        assert_that!(sut.as_mut_bytes(), eq b"");
         assert_that!(sut.as_bytes_with_nul(), eq b"\0");
     }
 
@@ -199,7 +197,6 @@ pub mod generic {
             let byte = (n as u8) % 80 + 32;
             assert_that!(sut.as_str().as_bytes(), eq temp.as_slice());
             assert_that!(sut.as_bytes(), eq temp.as_slice());
-            assert_that!(sut.as_mut_bytes(), eq temp.as_slice());
             temp.push(0);
             assert_that!(sut.as_bytes_with_nul(), eq temp.as_slice());
             temp.pop();
@@ -1092,18 +1089,6 @@ pub mod generic {
 
         assert_that!(hash_1, eq hash_1_1);
         assert_that!(hash_1, ne hash_2);
-    }
-
-    #[test]
-    pub fn deref_mut_works<Factory: StringTestFactory>() {
-        let factory = Factory::new();
-        let mut sut = factory.create_sut();
-
-        assert_that!(sut.push_bytes(b"hello"), is_ok);
-
-        sut.deref_mut()[0] = b'b';
-
-        assert_that!(sut.as_bytes(), eq b"bello");
     }
 
     #[test]


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Remove DerefMut and mutable bytes API from **`String`**.
It can be replaced later with a `set(index, byte)` API that incorporates appropriate error handling.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Relates #1955 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
