### PR TITLE
[#1958] Add configurable Cargo build warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,12 @@ add_option(
     DEFAULT_VALUE OFF
 )
 
+add_option(
+    NAME IOX2_SUPPRESS_CARGO_BUILD_WARNING
+    DESCRIPTION "Emit a status message instead of a warning when Cargo builds the Rust part"
+    DEFAULT_VALUE OFF
+)
+
 add_param(
     NAME RUST_TARGET_TRIPLET
     DESCRIPTION "The target triplet for cross compilation when 'RUST_BUILD_ARTIFACT_PATH' is not set, e.g. 'aarch64-unknown-linux-gnu'"
@@ -153,12 +159,18 @@ endif()
 if(RUST_BUILD_ARTIFACT_PATH AND NOT "${RUST_BUILD_ARTIFACT_PATH}" STREQUAL "" )
     add_subdirectory(iceoryx2-c)
 else()
-    message(WARNING
+    set(IOX2_INTERNAL_CARGO_BUILD_MESSAGE_TYPE WARNING)
+    if(IOX2_SUPPRESS_CARGO_BUILD_WARNING)
+        set(IOX2_INTERNAL_CARGO_BUILD_MESSAGE_TYPE STATUS)
+    endif()
+
+    message(${IOX2_INTERNAL_CARGO_BUILD_MESSAGE_TYPE}
         "Using cargo to build the Rust part of iceoryx2. "
         "This is fine for development but for production, it is "
         "recommended to use an existing installation with\n"
         "'-DRUST_BUILD_ARTIFACT_PATH=/full/path/to/iceoryx2/target/release'!"
     )
+    unset(IOX2_INTERNAL_CARGO_BUILD_MESSAGE_TYPE)
 
     set(RUST_BUILD_TYPE "release")
     set(RUST_BUILD_TYPE_FLAG "--${RUST_BUILD_TYPE}")

--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -27,6 +27,7 @@
 * [#1773](https://github.com/eclipse-iceoryx/iceoryx2/issues/1773) Make ports identifiable by name
 * [#1798](https://github.com/eclipse-iceoryx/iceoryx2/issues/1798) Add support for musl 1.2.x
 * [#1813](https://github.com/eclipse-iceoryx/iceoryx2/issues/1813) Add API to deliver events to specific listener only
+* [#1958](https://github.com/eclipse-iceoryx/iceoryx2/issues/1958) Allow projects to acknowledge intentional Cargo builds from CMake
 
 ### Bugfixes
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer

This adds the opt-in CMake option `IOX2_SUPPRESS_CARGO_BUILD_WARNING`. It defaults to `OFF`, preserving the existing warning unchanged. When enabled, the same diagnostic is emitted as a status message so embedding projects that intentionally use the Cargo source-build path can acknowledge that policy without carrying a downstream patch.

The change affects diagnostic severity only. Cargo target selection, build flags, generated build recipes, artifacts, and installation behavior are unchanged.

No corresponding Bazel change is needed: Bazel builds Rust targets directly through `rules_rust` and has neither the CMake `RUST_BUILD_ARTIFACT_PATH` choice nor an equivalent Cargo source-build warning.

Focused validation covered three configurations:

* Default: configure succeeds and retains the existing warning.
* `IOX2_SUPPRESS_CARGO_BUILD_WARNING=ON`: configure succeeds, emits the diagnostic as status, and emits no CMake warning.
* `IOX2_SUPPRESS_CARGO_BUILD_WARNING=ON` with `RUST_BUILD_ARTIFACT_PATH`: configure succeeds and emits neither Cargo source-build diagnostic.

The generated `iceoryx2-ffi-c-build-step` recipes for the default and opt-in Cargo configurations are identical after normalizing their build-directory paths. `git diff --check` also passes.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * Opening ready for review because the focused configure validation passes.
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1958

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
