### PR TITLE
[#1954] Re-eneable scouting period

### DIFF
--- a/integrations/zenoh/gateway-backend/src/testing.rs
+++ b/integrations/zenoh/gateway-backend/src/testing.rs
@@ -23,17 +23,13 @@ pub struct Testing;
 impl iceoryx2_gateway_backend::traits::testing::Testing for Testing {
     type BackendConfig = Config;
 
-    /// Non-default config that disables waiting for scouted peers on
-    /// session initializaiton.
-    ///
-    /// The sync() method below takes care of waiting when required.
+    /// Non-default config reduces the per-test scouting period.
     fn backend_config() -> Config {
         let mut config = Config::default();
         config
-            .open
-            .return_conditions
-            .set_connect_scouted(Some(false))
-            .expect("failed to set connect_scouted");
+            .scouting
+            .set_delay(Some(50))
+            .expect("failed to set scouting period");
         config
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Re-enables per-test scouting period but with lower scouting period. Disabling scouting completely caused regular failures in the nightly pipeline.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [ ] ~~Tests follow the [best practice for testing][testing]~~
* [ ] ~~Changelog updated [in the unreleased section][changelog] including API breaking changes~~

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1954  <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
