### PR TITLE
[#1920] Fix max. number of reallocations and segments

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -65,6 +65,7 @@
 * [#1893](https://github.com/eclipse-iceoryx/iceoryx2/issues/1893) Fix C language `ipc` and `local` mapping for payload types
 * [#1906](https://github.com/eclipse-iceoryx/iceoryx2/issues/1906) Do not set the exec bit for created resources
 * [#1918](https://github.com/eclipse-iceoryx/iceoryx2/issues/1917) Fix wrong `CLOCK_MONOTONIC` constant on macOS (1 instead of 6) which broke `Time::now_with_clock(ClockType::Monotonic)`
+* [#1920](https://github.com/eclipse-iceoryx/iceoryx2/issues/1920) Fix max. number of reallocations and segments.
 * [#1924](https://github.com/eclipse-iceoryx/iceoryx2/issues/1924) Ensure discovery service node resources are removed during shutdown.
 * [#1940](https://github.com/eclipse-iceoryx/iceoryx2/issues/1940) Fix private rustdoc link diagnostics.
 * [#1960](https://github.com/eclipse-iceoryx/iceoryx2/issues/1960) Validate type descriptions and payload layouts received over gateway backends

--- a/iceoryx2-bb/posix/src/unique_system_id.rs
+++ b/iceoryx2-bb/posix/src/unique_system_id.rs
@@ -71,7 +71,6 @@ enum_gen! { UniqueSystemIdCreationError
     Eq, Hash, PartialEq, Clone, Copy, PartialOrd, Ord, Serialize, Deserialize, ZeroCopySend,
 )]
 #[repr(C)]
-#[repr(align(16))]
 pub struct UniqueSystemId {
     pid: u32,
     seconds: u32,

--- a/iceoryx2-bb/posix/src/unique_system_id.rs
+++ b/iceoryx2-bb/posix/src/unique_system_id.rs
@@ -71,6 +71,7 @@ enum_gen! { UniqueSystemIdCreationError
     Eq, Hash, PartialEq, Clone, Copy, PartialOrd, Ord, Serialize, Deserialize, ZeroCopySend,
 )]
 #[repr(C)]
+#[repr(align(16))]
 pub struct UniqueSystemId {
     pid: u32,
     seconds: u32,

--- a/iceoryx2-cal/src/resizable_shared_memory/dynamic.rs
+++ b/iceoryx2-cal/src/resizable_shared_memory/dynamic.rs
@@ -51,7 +51,7 @@ use super::{
     ResizableSharedMemoryViewBuilder,
 };
 
-const MAX_NUMBER_OF_REALLOCATIONS: usize = SegmentId::max_segment_id() as usize + 1;
+const MAX_NUMBER_OF_REALLOCATIONS: usize = SegmentId::max_segment_id() as usize;
 const SEGMENT_ID_SEPARATOR: &[u8] = b"__";
 const MANAGEMENT_SUFFIX: &[u8] = b"mgmt";
 const INVALID_KEY: usize = usize::MAX;

--- a/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
+++ b/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
@@ -3622,7 +3622,7 @@ pub mod service_publish_subscribe {
     fn send_and_receives_increasing_samples_works<Sut: Service>(
         allocation_strategy: AllocationStrategy,
     ) {
-        const ITERATIONS: usize = 128;
+        const ITERATIONS: usize = 30;
         let test = Test::<Sut>::new();
         let node = test.create_node();
         let service_name = generate_service_name();
@@ -3683,7 +3683,7 @@ pub mod service_publish_subscribe {
         allocation_strategy: AllocationStrategy,
     ) {
         const SUBSCRIBER_MAX_BUFFER_SIZE: usize = 5;
-        const ITERATIONS: usize = 128;
+        const ITERATIONS: usize = 50;
         const REPETITIONS: usize = 13;
         let test = Test::<Sut>::new();
         let node = test.create_node();

--- a/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
+++ b/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
@@ -3622,7 +3622,7 @@ pub mod service_publish_subscribe {
     fn send_and_receives_increasing_samples_works<Sut: Service>(
         allocation_strategy: AllocationStrategy,
     ) {
-        const ITERATIONS: usize = 30;
+        const ITERATIONS: usize = 128;
         let test = Test::<Sut>::new();
         let node = test.create_node();
         let service_name = generate_service_name();
@@ -3683,7 +3683,7 @@ pub mod service_publish_subscribe {
         allocation_strategy: AllocationStrategy,
     ) {
         const SUBSCRIBER_MAX_BUFFER_SIZE: usize = 5;
-        const ITERATIONS: usize = 50;
+        const ITERATIONS: usize = 128;
         const REPETITIONS: usize = 13;
         let test = Test::<Sut>::new();
         let node = test.create_node();
@@ -3720,12 +3720,12 @@ pub mod service_publish_subscribe {
                 }
 
                 sample.send().unwrap();
-            }
 
-            let sample = subscriber.receive().unwrap().unwrap();
-            assert_that!(sample.payload(), len sample_size);
-            for byte in sample.payload() {
-                assert_that!(*byte, eq n as u8);
+                let sample = subscriber.receive().unwrap().unwrap();
+                assert_that!(sample.payload(), len sample_size);
+                for byte in sample.payload() {
+                    assert_that!(*byte, eq n as u8);
+                }
             }
         }
     }

--- a/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
+++ b/iceoryx2/conformance-tests/src/service_publish_subscribe.rs
@@ -3748,6 +3748,41 @@ pub mod service_publish_subscribe {
         );
     }
 
+    #[conformance_test]
+    pub fn send_increasing_samples_with_best_fit_finally_leads_to_out_of_memory_error<
+        Sut: Service,
+    >() {
+        let _watchdog = Watchdog::new();
+
+        let test = Test::<Sut>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+
+        let service = node
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .create()
+            .unwrap();
+
+        let publisher = service
+            .publisher_builder()
+            .initial_max_slice_len(1)
+            .allocation_strategy(AllocationStrategy::BestFit)
+            .create()
+            .unwrap();
+
+        let mut n = 0;
+        loop {
+            let sample_size = (n + 1) * 32;
+            let sample = publisher.loan_slice(sample_size);
+            if sample.is_err() {
+                assert_that!(sample.err(), eq Some(LoanError::OutOfMemory));
+                break;
+            }
+            n += 1;
+        }
+    }
+
     fn deliver_history_with_increasing_samples_works<Sut: Service>(
         allocation_strategy: AllocationStrategy,
     ) {

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -1353,7 +1353,7 @@ pub mod service_request_response {
     fn send_and_receive_increasing_requests_works<Sut: Service>(
         allocation_strategy: AllocationStrategy,
     ) {
-        const ITERATIONS: usize = 128;
+        const ITERATIONS: usize = 10;
         let test = Test::<Sut>::new();
         let node = test.create_node();
         let service_name = generate_service_name();

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -27,6 +27,7 @@ pub mod service_request_response {
     use iceoryx2::service::port_factory::client::ClientCreateError;
     use iceoryx2::service::static_config::message_type_details::{TypeDetail, TypeVariant};
     use iceoryx2_bb_testing::assert_that;
+    use iceoryx2_bb_testing::watchdog::Watchdog;
     use iceoryx2_bb_testing_macros::conformance_test;
     use iceoryx2_testing::*;
 
@@ -1451,6 +1452,79 @@ pub mod service_request_response {
         Sut: Service,
     >() {
         send_and_receive_increasing_responses_works::<Sut>(AllocationStrategy::PowerOfTwo);
+    }
+
+    #[conformance_test]
+    pub fn send_increasing_requests_with_best_fit_finally_leads_to_out_of_memory_error<
+        Sut: Service,
+    >() {
+        let _watchdog = Watchdog::new();
+
+        let test = Test::<Sut>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<[u8], u64>()
+            .create()
+            .unwrap();
+
+        let client = service
+            .client_builder()
+            .initial_max_slice_len(1)
+            .allocation_strategy(AllocationStrategy::BestFit)
+            .create()
+            .unwrap();
+
+        let mut n = 0;
+        loop {
+            let request_size = (n + 1) * 32;
+            let request = client.loan_slice(request_size);
+            if request.is_err() {
+                assert_that!(request.err(), eq Some(LoanError::OutOfMemory));
+                break;
+            }
+            n += 1;
+        }
+    }
+
+    #[conformance_test]
+    pub fn send_increasing_responses_with_best_fit_finally_leads_to_out_of_memory_error<
+        Sut: Service,
+    >() {
+        let _watchdog = Watchdog::new();
+
+        let test = Test::<Sut>::new();
+        let node = test.create_node();
+        let service_name = generate_service_name();
+
+        let service = node
+            .service_builder(&service_name)
+            .request_response::<u64, [u8]>()
+            .create()
+            .unwrap();
+
+        let client = service.client_builder().create().unwrap();
+        let server = service
+            .server_builder()
+            .initial_max_slice_len(1)
+            .allocation_strategy(AllocationStrategy::BestFit)
+            .create()
+            .unwrap();
+        let _pending_response = client.send_copy(0).unwrap();
+        let active_request = server.receive().unwrap().unwrap();
+
+        let mut n = 0;
+        loop {
+            let response_size = (n + 1) * 32;
+            let response = active_request.loan_slice(response_size);
+            if response.is_err() {
+                assert_that!(response.err(), eq Some(LoanError::OutOfMemory));
+                break;
+            }
+            n += 1;
+        }
     }
 
     #[conformance_test]

--- a/iceoryx2/conformance-tests/src/service_request_response.rs
+++ b/iceoryx2/conformance-tests/src/service_request_response.rs
@@ -1354,7 +1354,7 @@ pub mod service_request_response {
     fn send_and_receive_increasing_requests_works<Sut: Service>(
         allocation_strategy: AllocationStrategy,
     ) {
-        const ITERATIONS: usize = 10;
+        const ITERATIONS: usize = 128;
         let test = Test::<Sut>::new();
         let node = test.create_node();
         let service_name = generate_service_name();

--- a/iceoryx2/src/port/details/data_segment.rs
+++ b/iceoryx2/src/port/details/data_segment.rs
@@ -203,7 +203,7 @@ impl<Service: service::Service> DataSegment<Service> {
         match data_segment_type {
             DataSegmentType::Static => 1,
             DataSegmentType::Dynamic => {
-                (Service::ResizableSharedMemory::max_number_of_reallocations() - 1) as u8
+                (Service::ResizableSharedMemory::max_number_of_reallocations()) as u8
             }
         }
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
The original "index-out-of-bounds" panic was caused by two off-by-one errors in the calculations of the max. number of segments and reallocations. The failing assert described in the issue was due to a faulty test setup.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1920

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
