### PR TITLE
[#1964] Resolve conflicting service descriptions on different hosts

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -68,6 +68,7 @@
 * [#1924](https://github.com/eclipse-iceoryx/iceoryx2/issues/1924) Ensure discovery service node resources are removed during shutdown.
 * [#1940](https://github.com/eclipse-iceoryx/iceoryx2/issues/1940) Fix private rustdoc link diagnostics.
 * [#1960](https://github.com/eclipse-iceoryx/iceoryx2/issues/1960) Validate type descriptions and payload layouts received over gateway backends
+* [#1964](https://github.com/eclipse-iceoryx/iceoryx2/issues/1964) Propagate a service over the gateway only when every host offers it with identical settings
 
 ### Refactoring
 

--- a/iceoryx2-gateway/backend/src/types/service_description.rs
+++ b/iceoryx2-gateway/backend/src/types/service_description.rs
@@ -111,11 +111,11 @@ pub struct PublishSubscribeSettings {
     pub safe_overflow: bool,
 }
 
-impl Default for PublishSubscribeSettings {
-    fn default() -> Self {
-        let defaults = iceoryx2::config::Config::default()
-            .defaults
-            .publish_subscribe;
+impl PublishSubscribeSettings {
+    /// The settings a publish-subscribe service created with `config`
+    /// receives by default.
+    pub fn from_config(config: &iceoryx2::config::Config) -> Self {
+        let defaults = &config.defaults.publish_subscribe;
         Self {
             max_subscribers: defaults.max_subscribers,
             max_publishers: defaults.max_publishers,
@@ -125,6 +125,12 @@ impl Default for PublishSubscribeSettings {
             subscriber_max_borrowed_samples: defaults.subscriber_max_borrowed_samples,
             safe_overflow: defaults.enable_safe_overflow,
         }
+    }
+}
+
+impl Default for PublishSubscribeSettings {
+    fn default() -> Self {
+        Self::from_config(&iceoryx2::config::Config::default())
     }
 }
 
@@ -142,6 +148,24 @@ pub struct EventSettings {
     pub notifier_created_event: Option<usize>,
     pub notifier_dropped_event: Option<usize>,
     pub notifier_dead_event: Option<usize>,
+}
+
+impl EventSettings {
+    /// The settings an event service created with `config` receives by
+    /// default.
+    pub fn from_config(config: &iceoryx2::config::Config) -> Self {
+        let defaults = &config.defaults.event;
+        Self {
+            max_notifiers: defaults.max_notifiers,
+            max_listeners: defaults.max_listeners,
+            max_nodes: defaults.max_nodes,
+            event_id_max_value: defaults.event_id_max_value,
+            deadline: defaults.deadline,
+            notifier_created_event: defaults.notifier_created_event,
+            notifier_dropped_event: defaults.notifier_dropped_event,
+            notifier_dead_event: defaults.notifier_dead_event,
+        }
+    }
 }
 
 /// A [`StaticConfig`] whose messaging pattern the gateway does not support.

--- a/iceoryx2-gateway/conformance-tests/src/publish_subscribe_discovery.rs
+++ b/iceoryx2-gateway/conformance-tests/src/publish_subscribe_discovery.rs
@@ -904,4 +904,378 @@ pub mod publish_subscribe_discovery {
         assert_that!(gateway.bridged_services().contains(service_a.service_hash()), eq true);
         assert_that!(gateway.bridged_services().contains(service_b.service_hash()), eq true);
     }
+
+    #[conformance_test]
+    pub fn conflicting_descriptions_prevent_bridging<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+
+        // === SETUP ===
+        let service_name = generate_service_name();
+
+        // Host A offers the service.
+        let iceoryx_config_a = generate_isolated_config();
+        let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_a.clone())
+            .polled()
+            .create()
+            .unwrap();
+        let node_a = NodeBuilder::new()
+            .config(&iceoryx_config_a)
+            .create::<S>()
+            .unwrap();
+        let _service_a = node_a
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .history_size(10)
+            .subscriber_max_buffer_size(10)
+            .open_or_create()
+            .unwrap();
+        let service_hash = *_service_a.service_hash();
+
+        // Host B offers the same service with differing settings.
+        let iceoryx_config_b = generate_isolated_config();
+        let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_b.clone())
+            .polled()
+            .create()
+            .unwrap();
+        let node_b = NodeBuilder::new()
+            .config(&iceoryx_config_b)
+            .create::<S>()
+            .unwrap();
+        let _service_b = node_b
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .history_size(20)
+            .subscriber_max_buffer_size(10)
+            .open_or_create()
+            .unwrap();
+
+        // Each host bridges its own service before learning of the other.
+        gateway_a.discover_over_iceoryx().unwrap();
+        gateway_b.discover_over_iceoryx().unwrap();
+        assert_that!(gateway_a.bridged_services().contains(&service_hash), eq true);
+        assert_that!(gateway_b.bridged_services().contains(&service_hash), eq true);
+
+        // === CONFLICT ===
+        // Each host observes the conflicting offer and closes its bridge.
+        T::retry(
+            || {
+                gateway_a.discover_over_backend().unwrap();
+                gateway_b.discover_over_backend().unwrap();
+                if gateway_a.bridged_services().is_empty()
+                    && gateway_b.bridged_services().is_empty()
+                {
+                    return Ok(());
+                }
+                Err("Failed to close the bridges of the conflicted service")
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+    }
+
+    #[conformance_test]
+    pub fn bridging_resumes_when_conflict_clears<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+
+        // === SETUP ===
+        let service_name = generate_service_name();
+
+        // Host A offers the service.
+        let iceoryx_config_a = generate_isolated_config();
+        let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_a.clone())
+            .polled()
+            .create()
+            .unwrap();
+        let node_a = NodeBuilder::new()
+            .config(&iceoryx_config_a)
+            .create::<S>()
+            .unwrap();
+        let _service_a = node_a
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .history_size(10)
+            .subscriber_max_buffer_size(10)
+            .open_or_create()
+            .unwrap();
+        let service_hash = *_service_a.service_hash();
+
+        // Host B offers the same service with differing settings.
+        let iceoryx_config_b = generate_isolated_config();
+        let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_b.clone())
+            .polled()
+            .create()
+            .unwrap();
+        let node_b = NodeBuilder::new()
+            .config(&iceoryx_config_b)
+            .create::<S>()
+            .unwrap();
+        let service_b = node_b
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .history_size(20)
+            .subscriber_max_buffer_size(10)
+            .open_or_create()
+            .unwrap();
+
+        gateway_a.discover_over_iceoryx().unwrap();
+        gateway_b.discover_over_iceoryx().unwrap();
+
+        T::retry(
+            || {
+                gateway_a.discover_over_backend().unwrap();
+                gateway_b.discover_over_backend().unwrap();
+                if gateway_a.bridged_services().is_empty()
+                    && gateway_b.bridged_services().is_empty()
+                {
+                    return Ok(());
+                }
+                Err("Failed to close the bridges of the conflicted service")
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+
+        // === CONFLICT CLEARS ===
+        // Host B's service is removed. Host A bridges its own service again,
+        // host B mirrors it.
+        drop(service_b);
+        gateway_b.discover_over_iceoryx().unwrap();
+
+        T::retry(
+            || {
+                gateway_a.discover_over_backend().unwrap();
+                gateway_b.discover_over_backend().unwrap();
+                if gateway_a.bridged_services().contains(&service_hash)
+                    && gateway_b.bridged_services().contains(&service_hash)
+                {
+                    return Ok(());
+                }
+                Err("Failed to bridge the service after the conflict cleared")
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+    }
+
+    #[conformance_test]
+    pub fn reannouncement_with_changed_description_replaces_the_offer<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        const OLD_HISTORY_SIZE: usize = 7;
+        const NEW_HISTORY_SIZE: usize = 13;
+
+        /// The history size of the service as materialized in `config`'s
+        /// iceoryx system, if it exists there.
+        fn history_size_of<S: Service>(
+            service_name: &ServiceName,
+            config: &iceoryx2::config::Config,
+        ) -> Option<usize> {
+            use iceoryx2::service::messaging_pattern::MessagingPattern;
+            use iceoryx2::service::static_config::messaging_pattern::MessagingPattern as Pattern;
+
+            let details =
+                S::details(service_name, config, MessagingPattern::PublishSubscribe).ok()??;
+            match details.static_details.messaging_pattern() {
+                Pattern::PublishSubscribe(config) => Some(config.history_size()),
+                _ => None,
+            }
+        }
+
+        // === SETUP ===
+        let service_name = generate_service_name();
+
+        // Host A observes, announcing nothing locally.
+        let iceoryx_config_a = generate_isolated_config();
+        let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_a.clone())
+            .polled()
+            .create()
+            .unwrap();
+
+        // Host B offers the service.
+        let iceoryx_config_b = generate_isolated_config();
+        let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_b.clone())
+            .polled()
+            .create()
+            .unwrap();
+        let node_b = NodeBuilder::new()
+            .config(&iceoryx_config_b)
+            .create::<S>()
+            .unwrap();
+        let service_b = node_b
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .history_size(OLD_HISTORY_SIZE)
+            .subscriber_max_buffer_size(10)
+            .open_or_create()
+            .unwrap();
+        let service_hash = *service_b.service_hash();
+        gateway_b.discover_over_iceoryx().unwrap();
+
+        // Host A mirrors the service with the announced settings.
+        T::retry(
+            || {
+                gateway_a.discover_over_backend().unwrap();
+                if gateway_a.bridged_services().contains(&service_hash)
+                    && history_size_of::<S>(&service_name, &iceoryx_config_a)
+                        == Some(OLD_HISTORY_SIZE)
+                {
+                    return Ok(());
+                }
+                Err("Failed to mirror the service with the announced settings")
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+
+        // === REINSTANTIATION ===
+        // Host B recreates the service with different settings.
+        drop(service_b);
+        gateway_b.discover_over_iceoryx().unwrap();
+        T::retry(
+            || {
+                gateway_a.discover_over_backend().unwrap();
+                if gateway_a.bridged_services().is_empty() {
+                    return Ok(());
+                }
+                Err("Failed to detect remote service removal")
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+
+        let _service_b = node_b
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .history_size(NEW_HISTORY_SIZE)
+            .subscriber_max_buffer_size(10)
+            .open_or_create()
+            .unwrap();
+        gateway_b.discover_over_iceoryx().unwrap();
+
+        // Host A mirrors the recreated service with the new settings.
+        T::retry(
+            || {
+                gateway_a.discover_over_backend().unwrap();
+                if gateway_a.bridged_services().contains(&service_hash)
+                    && history_size_of::<S>(&service_name, &iceoryx_config_a)
+                        == Some(NEW_HISTORY_SIZE)
+                {
+                    return Ok(());
+                }
+                Err("Failed to mirror the recreated service with the new settings")
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+    }
+
+    #[conformance_test]
+    pub fn withdrawn_services_do_not_survive_through_mirrors<
+        S: Service,
+        B: Backend<S> + Debug,
+        T: Testing<BackendConfig = B::Config>,
+    >() {
+        const TIMEOUT: Duration = Duration::from_secs(10);
+
+        // === SETUP ===
+        let service_name = generate_service_name();
+
+        // Host A offers the service.
+        let iceoryx_config_a = generate_isolated_config();
+        let mut gateway_a = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_a.clone())
+            .polled()
+            .create()
+            .unwrap();
+        let node_a = NodeBuilder::new()
+            .config(&iceoryx_config_a)
+            .create::<S>()
+            .unwrap();
+        let service_a = node_a
+            .service_builder(&service_name)
+            .publish_subscribe::<[u8]>()
+            .history_size(10)
+            .subscriber_max_buffer_size(10)
+            .open_or_create()
+            .unwrap();
+        let service_hash = *service_a.service_hash();
+        gateway_a.discover_over_iceoryx().unwrap();
+
+        // Hosts B and C mirror it.
+        let iceoryx_config_b = generate_isolated_config();
+        let mut gateway_b = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_b.clone())
+            .polled()
+            .create()
+            .unwrap();
+        let iceoryx_config_c = generate_isolated_config();
+        let mut gateway_c = Gateway::<S, B>::new()
+            .backend_config(T::backend_config())
+            .iceoryx_config(iceoryx_config_c.clone())
+            .polled()
+            .create()
+            .unwrap();
+
+        T::retry(
+            || {
+                gateway_b.discover_over_backend().unwrap();
+                gateway_c.discover_over_backend().unwrap();
+                if gateway_b.bridged_services().contains(&service_hash)
+                    && gateway_c.bridged_services().contains(&service_hash)
+                {
+                    return Ok(());
+                }
+                Err("Failed to mirror the remote service")
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+
+        // === WITHDRAWAL ===
+        // Host A withdraws. The mirrors at B and C are not own offerings and
+        // must not keep the service alive.
+        drop(service_a);
+        gateway_a.discover_over_iceoryx().unwrap();
+
+        T::retry(
+            || {
+                gateway_a.discover_over_backend().unwrap();
+                gateway_b.discover_over_backend().unwrap();
+                gateway_c.discover_over_backend().unwrap();
+                if gateway_b.bridged_services().is_empty()
+                    && gateway_c.bridged_services().is_empty()
+                {
+                    return Ok(());
+                }
+                Err("Withdrawn service survived through its mirrors")
+            },
+            TIMEOUT,
+        )
+        .unwrap();
+    }
 }

--- a/iceoryx2-gateway/gateway/README.md
+++ b/iceoryx2-gateway/gateway/README.md
@@ -1,42 +1,47 @@
 # iceoryx2-gateway
 
-The `iceoryx2` gateway extends the communication beyond the boundary of a
-host.
+The `iceoryx2` gateway extends the communication beyond the boundaries of
+shared memory. It propagates the data flowing through shared memory over a
+pluggable communication mechanism.
 
 The gateway is provided as a library so that users have the choice of embedding
 it into their own application. The implementation does not spawn any threads,
 giving the user complete control over its execution.
 
-The `iox2 gateway` CLI is provided as a convenience for spinning up gateways in
-isolated processes, e.g. with the Zenoh backend:
+Alternatively, the `iox2 gateway` CLI is provided as a convenience for spinning
+up gateways in isolated processes, e.g. with the Zenoh backend:
 
 ```bash
 iox2 gateway zenoh
 ```
 
-## Gateway Mechanisms
+## Configuration
 
-The gateway is implemented against generic traits thus has no knowledge over the
-specifics of the mechanism being used.
+### Service Configuration
 
-A custom bridging mechanism can be provided by implementing the traits in the
-`iceoryx2-gateway-backend` crate and passing the implementation when
-initializing the gateway.
+A service is propagated only while every host offering it uses identical
+settings. Settings set explicitly on the service builder and settings
+inherited from the node's [configuration](
+https://github.com/eclipse-iceoryx/iceoryx2/tree/main/config) both count, so
+hosts with differing config files may conflict even when the application code
+is the same.
 
-Ready-to-use backend implementations are available in the
-`integrations/*/gateway-backend` crates.
+Requiring identical settings is a conservative approach to ensure remote
+services are able to communicate. This may be relaxed to compatible settings in
+the future.
 
 ## Usage
 
 The gateway is driven by two operations that the user is in full control of:
 
 * `discover()` — reconciles local and remote services.
-* `propagate()` — moves data bidirectionally between shared memory and the backend.
+* `propagate()` — moves data bidirectionally between shared memory and the
+  communication mechanism used by the gateway.
 
 ### Polled mode
 
-The gateway is driven manually. Here it is paced by the node's `wait`, which also
-provides a clean shutdown signal:
+The gateway is driven manually. Here it is paced by the node's `wait`, which
+also provides a clean shutdown signal:
 
 ```rust
 use core::time::Duration;
@@ -59,9 +64,9 @@ while gateway.node().wait(POLL_INTERVAL).is_ok() {
 
 ### Reactive mode
 
-When the backend supports it, the gateway can be woken only when there is data
-ready to propagate, rather than polling. `create()` additionally returns a
-`Listener` to wait on:
+When the gateway mechanism supports it, the gateway can be woken only when
+there is data ready to propagate, rather than polling. `create()` additionally
+returns a `Listener` to wait on:
 
 ```rust
 use iceoryx2_gateway::Gateway;
@@ -76,3 +81,13 @@ while listener.blocking_wait_all(|_| {}).is_ok() {
     gateway.propagate().expect("propagation failed");
 }
 ```
+
+## Additional Gateway Mechanisms
+
+The gateway is implemented against generic traits and has no knowledge of the
+specific communication mechanism being used. The traits are available in the
+`iceoryx2-gateway-backend` crate.
+
+By implementing these traits, it is possible to extend the gateway to work with
+additional communication mechanisms. Ready-to-use backend implementations are
+available in the `integrations/*/gateway-backend` crates.

--- a/iceoryx2-gateway/gateway/src/bridge.rs
+++ b/iceoryx2-gateway/gateway/src/bridge.rs
@@ -35,10 +35,9 @@ use crate::ports::publish_subscribe::PublishSubscribePorts;
 pub(crate) struct Bridges<S: Service, B: Backend<S>> {
     publish_subscribe: BTreeMap<ServiceHash, PublishSubscribeBridge<S, B>>,
     event: BTreeMap<ServiceHash, EventBridge<S, B>>,
-    /// Services whose bridge could not be established. Remembered so that
-    /// subsequent discovery calls do not retry until the service is
-    /// reinstantiated.
-    failed: BTreeSet<ServiceHash>,
+    /// Services whose bridge could not be established, with the description
+    /// the attempt was made for.
+    failed: BTreeMap<ServiceHash, ServiceDescription>,
 }
 
 impl<S: Service, B: Backend<S>> Default for Bridges<S, B> {
@@ -46,7 +45,7 @@ impl<S: Service, B: Backend<S>> Default for Bridges<S, B> {
         Self {
             publish_subscribe: BTreeMap::new(),
             event: BTreeMap::new(),
-            failed: BTreeSet::new(),
+            failed: BTreeMap::new(),
         }
     }
 }
@@ -77,12 +76,6 @@ impl<S: Service, B: Backend<S>> Bridges<S, B> {
         }
     }
 
-    /// Whether a bridge for the specified service is tracked, both established
-    /// or failed.
-    pub(crate) fn contains(&self, hash: &ServiceHash) -> bool {
-        self.is_established(hash) || self.is_failed(hash)
-    }
-
     /// Whether an established bridge for the service exists.
     pub(crate) fn is_established(&self, hash: &ServiceHash) -> bool {
         let Bridges {
@@ -94,9 +87,14 @@ impl<S: Service, B: Backend<S>> Bridges<S, B> {
         publish_subscribe.contains_key(hash) || event.contains_key(hash)
     }
 
-    /// Whether the bridge has failed to be established for the service.
-    pub(crate) fn is_failed(&self, hash: &ServiceHash) -> bool {
-        self.failed.contains(hash)
+    /// The description a failed establishment attempt was made for.
+    pub(crate) fn failed_description(&self, hash: &ServiceHash) -> Option<&ServiceDescription> {
+        self.failed.get(hash)
+    }
+
+    /// Drops the record of a failed establishment attempt.
+    pub(crate) fn clear_failed(&mut self, hash: &ServiceHash) {
+        self.failed.remove(hash);
     }
 
     /// Number of tracked bridges, established or failed.
@@ -134,7 +132,7 @@ impl<S: Service, B: Backend<S>> Bridges<S, B> {
 
         publish_subscribe.retain(|hash, _| keep_or_close(hash));
         event.retain(|hash, _| keep_or_close(hash));
-        failed.retain(|hash| keep(hash));
+        failed.retain(|hash, _| keep(hash));
     }
 
     /// The hashes of all established bridges.
@@ -181,7 +179,8 @@ impl<S: Service, B: Backend<S>> Bridges<S, B> {
             description.name,
             error
         );
-        self.failed.insert(description.service_hash);
+        self.failed
+            .insert(description.service_hash, description.clone());
     }
 }
 

--- a/iceoryx2-gateway/gateway/src/discovery/state.rs
+++ b/iceoryx2-gateway/gateway/src/discovery/state.rs
@@ -10,48 +10,61 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::BTreeMap;
 
 use iceoryx2::service::service_hash::ServiceHash;
 use iceoryx2_gateway_backend::types::identity::GatewayId;
 use iceoryx2_gateway_backend::types::service_description::ServiceDescription;
 
-// A service offered locally.
+/// The local description of a service as seen on a specific update epoch.
 #[derive(Debug)]
-struct LocalService {
+struct LocalDescription {
     description: ServiceDescription,
     last_seen: u64,
+}
+
+impl LocalDescription {
+    // Get the description.
+    fn get(&self) -> &ServiceDescription {
+        &self.description
+    }
+
+    /// Whether the service was recorded as offered in `epoch`.
+    fn seen_in(&self, epoch: u64) -> bool {
+        self.last_seen == epoch
+    }
 }
 
 /// The set of services offered locally.
 #[derive(Debug, Default)]
 pub(crate) struct LocalServices {
-    offered: BTreeMap<ServiceHash, LocalService>,
+    offered: BTreeMap<ServiceHash, LocalDescription>,
+    // The current update epoch.
     epoch: u64,
 }
 
 impl LocalServices {
-    /// Advances and returns the epoch, beginning a new update session.
-    fn next_epoch(&mut self) -> u64 {
-        self.epoch = self.epoch.wrapping_add(1);
-        self.epoch
-    }
-
-    /// Records `description` as offered, stamping it with `epoch`. The caller
+    /// Records `description` as offered, stamping it with `epoch`. The caller                                                                                                                                                                                                                              ║
     /// passes its session epoch so all updates in a session share one stamp.
     fn insert(&mut self, description: ServiceDescription, epoch: u64) {
         self.offered.insert(
             description.service_hash,
-            LocalService {
+            LocalDescription {
                 description,
                 last_seen: epoch,
             },
         );
     }
 
-    /// Removes `hash`, returning its [`ServiceDescription`] if it was offered.
-    fn remove(&mut self, hash: &ServiceHash) -> Option<ServiceDescription> {
-        self.offered.remove(hash).map(|o| o.description)
+    /// Removes `hash` if it was offered.
+    fn remove(&mut self, hash: &ServiceHash) {
+        self.offered.remove(hash);
+    }
+
+    /// Advances and returns the epoch, beginning a new update session.
+    fn next_epoch(&mut self) -> u64 {
+        self.epoch = self.epoch.wrapping_add(1);
+        self.epoch
     }
 
     /// Whether `hash` is offered locally.
@@ -59,17 +72,23 @@ impl LocalServices {
         self.offered.contains_key(hash)
     }
 
+    // Get the description of a locally offered service.
+    fn description(&self, hash: &ServiceHash) -> Option<&ServiceDescription> {
+        self.offered.get(hash).map(LocalDescription::get)
+    }
+
+    // Iterate all locally offered services.
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&ServiceHash, &ServiceDescription)> {
         self.offered
             .iter()
-            .map(|(hash, service)| (hash, &service.description))
+            .map(|(hash, service)| (hash, service.get()))
     }
 
     /// Returns a handle for applying delta updates. Advances the epoch,
     /// beginning a new update session.
-    pub(crate) fn delta_update(&mut self) -> DeltaUpdate<'_> {
+    pub(crate) fn delta_update(&mut self) -> LocalDeltaUpdate<'_> {
         let epoch = self.next_epoch();
-        DeltaUpdate { local: self, epoch }
+        LocalDeltaUpdate { local: self, epoch }
     }
 
     /// Forces the offered services to match an external target set.
@@ -77,114 +96,175 @@ impl LocalServices {
         let epoch = self.next_epoch();
 
         for description in target {
-            let hash = description.service_hash;
-            if let Some(service) = self.offered.get_mut(&hash) {
-                service.last_seen = epoch;
-            } else {
-                self.insert(description, epoch);
-            }
+            self.insert(description, epoch);
         }
 
-        self.offered.retain(|_, service| service.last_seen == epoch);
+        self.offered.retain(|_, service| service.seen_in(epoch));
     }
 }
 
-/// A remotely offered service grouped together with the remote gateways
-/// that offer it.
-#[derive(Debug)]
-struct RemoteService {
-    description: ServiceDescription,
-    gateways: BTreeSet<GatewayId>,
+/// Handle for applying incremental (delta) updates to the locally offered
+/// services within a single epoch.
+pub(crate) struct LocalDeltaUpdate<'a> {
+    local: &'a mut LocalServices,
+    epoch: u64,
 }
 
-/// The set of services offered over the backend.
+impl LocalDeltaUpdate<'_> {
+    /// Records `description` as offered, stamped with this handle's epoch.
+    pub(crate) fn set_offered(&mut self, description: ServiceDescription) {
+        self.local.insert(description, self.epoch);
+    }
+
+    /// Marks `hash` as no longer offered.
+    pub(crate) fn set_not_offered(&mut self, hash: &ServiceHash) {
+        self.local.remove(hash)
+    }
+}
+
+/// The set of descriptions for the same service offered remotely.
+#[derive(Debug, Default)]
+struct RemoteDescriptions {
+    by_gateway: BTreeMap<GatewayId, ServiceDescription>,
+}
+
+impl RemoteDescriptions {
+    /// Records `description` as offered by `gateway`, replacing the
+    /// description it previously offered.
+    fn insert(&mut self, gateway: GatewayId, description: ServiceDescription) {
+        self.by_gateway.insert(gateway, description);
+    }
+
+    /// Removes the description offered by `gateway`.
+    fn remove(&mut self, gateway: &GatewayId) {
+        self.by_gateway.remove(gateway);
+    }
+
+    /// Whether any gateway offers the service.
+    fn offered(&self) -> bool {
+        !self.by_gateway.is_empty()
+    }
+
+    /// Resolve the set of remote descriptions of the same service to a single
+    /// description, if possible.
+    ///
+    /// Returns None if the descriptions cannot be resolved to a single
+    /// description.
+    fn resolve(&self) -> Option<&ServiceDescription> {
+        let mut descriptions = self.by_gateway.values();
+        let first = descriptions.next()?;
+        descriptions
+            .all(|description| description == first)
+            .then_some(first)
+    }
+}
+
+/// The set of services offered remotely over the backend.
 #[derive(Debug, Default)]
 pub(crate) struct RemoteServices {
-    offered: BTreeMap<ServiceHash, RemoteService>,
+    services: BTreeMap<ServiceHash, RemoteDescriptions>,
 }
 
 impl RemoteServices {
-    /// Records `gateway` as offering `description`. The description of the
-    /// first announcing gateway is kept.
-    pub(crate) fn add(&mut self, gateway: GatewayId, description: ServiceDescription) {
-        let hash = description.service_hash;
-        self.offered
-            .entry(hash)
-            .or_insert_with(|| RemoteService {
-                description,
-                gateways: BTreeSet::new(),
-            })
-            .gateways
-            .insert(gateway);
+    /// Records `gateway` as offering `description`.
+    fn insert(&mut self, gateway: GatewayId, description: &ServiceDescription) {
+        self.services
+            .entry(description.service_hash)
+            .or_default()
+            .insert(gateway, description.clone());
     }
 
-    /// Removes `gateway` from the gateways offering `hash`. Returns the
-    /// [`ServiceDescription`] once no gateway offers the service anymore.
-    pub(crate) fn remove(
-        &mut self,
-        gateway: &GatewayId,
-        hash: &ServiceHash,
-    ) -> Option<ServiceDescription> {
-        let service = self.offered.get_mut(hash)?;
-        service.gateways.remove(gateway);
-        if !service.gateways.is_empty() {
-            return None;
+    /// Removes `gateway` from the gateways offering `hash`. The service is
+    /// dropped once no gateway offers it anymore.
+    fn remove(&mut self, gateway: &GatewayId, hash: &ServiceHash) {
+        let Some(descriptions) = self.services.get_mut(hash) else {
+            return;
+        };
+        descriptions.remove(gateway);
+        if !descriptions.offered() {
+            self.services.remove(hash);
         }
-        self.offered.remove(hash).map(|service| service.description)
     }
 
-    fn contains(&self, hash: &ServiceHash) -> bool {
-        self.offered.contains_key(hash)
+    /// The descriptions of the service with `hash`, if any gateway offers
+    /// it.
+    fn descriptions(&self, hash: &ServiceHash) -> Option<&RemoteDescriptions> {
+        self.services.get(hash)
     }
 
-    fn iter(&self) -> impl Iterator<Item = (&ServiceHash, &ServiceDescription)> {
-        self.offered
-            .iter()
-            .map(|(hash, service)| (hash, &service.description))
+    /// Iterate all remote services and the offered descriptions.
+    fn iter(&self) -> impl Iterator<Item = (&ServiceHash, &RemoteDescriptions)> {
+        self.services.iter()
+    }
+
+    /// Returns a handle for applying delta updates.
+    pub(crate) fn delta_update(&mut self) -> RemoteDeltaUpdate<'_> {
+        RemoteDeltaUpdate { remote: self }
     }
 }
 
-/// A borrowed, point-in-time view of all offered services.
+/// Handle for applying incremental (delta) updates to the remotely offered
+/// services.
+pub(crate) struct RemoteDeltaUpdate<'a> {
+    remote: &'a mut RemoteServices,
+}
+
+impl RemoteDeltaUpdate<'_> {
+    /// Records `gateway` as offering `description`. A gateway's latest
+    /// announcement replaces the description it previously offered.
+    pub(crate) fn set_offered(&mut self, gateway: GatewayId, description: &ServiceDescription) {
+        self.remote.insert(gateway, description);
+    }
+
+    /// Marks `hash` as no longer offered by `gateway`.
+    pub(crate) fn set_not_offered(&mut self, gateway: &GatewayId, hash: &ServiceHash) {
+        self.remote.remove(gateway, hash);
+    }
+}
+
+/// A point-in-time view of all offered services.
 pub(crate) struct Snapshot<'a> {
     local: &'a LocalServices,
     remote: &'a RemoteServices,
 }
 
 impl<'a> Snapshot<'a> {
-    /// All offered services. A service offered by both sides
-    /// appears only once.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&'a ServiceHash, &'a ServiceDescription)> {
-        let local = self.local;
-        local.iter().chain(
+    /// Every offered hash, whichever side offers it.
+    fn hashes(&self) -> impl Iterator<Item = &'a ServiceHash> {
+        self.local.iter().map(|(hash, _)| hash).chain(
             self.remote
                 .iter()
-                .filter(move |&(hash, _)| !local.contains(hash)),
+                .map(|(hash, _)| hash)
+                .filter(|hash| !self.local.contains(hash)),
         )
     }
 
-    /// Whether `hash` is offered by either side.
-    pub(crate) fn contains(&self, hash: &ServiceHash) -> bool {
-        self.local.contains(hash) || self.remote.contains(hash)
-    }
-}
-
-/// Handle for applying incremental (delta) updates to the locally offered
-/// services within a single epoch.
-pub(crate) struct DeltaUpdate<'a> {
-    local: &'a mut LocalServices,
-    epoch: u64,
-}
-
-impl DeltaUpdate<'_> {
-    /// Records `description` as offered, stamped with this handle's epoch.
-    pub(crate) fn set_offered(&mut self, description: ServiceDescription) {
-        self.local.insert(description, self.epoch);
+    /// Resolves the local description and remote descriptions of `hash` to
+    /// a single description if possible. The local description takes
+    /// precedence over the remote descriptions.
+    ///
+    /// Returns None if the descriptions cannot be resolved.
+    fn resolved_description(&self, hash: &ServiceHash) -> Option<&'a ServiceDescription> {
+        let local = self.local.description(hash);
+        let remote = self.remote.descriptions(hash);
+        match (local, remote) {
+            (Some(local), _) => Some(local),
+            (None, Some(remote)) => remote.resolve(),
+            (None, None) => None,
+        }
     }
 
-    /// Marks `hash` as no longer offered, returning its [`ServiceDescription`]
-    /// if it was offered.
-    pub(crate) fn set_not_offered(&mut self, hash: &ServiceHash) -> Option<ServiceDescription> {
-        self.local.remove(hash)
+    /// All services that resolve to one description.
+    pub(crate) fn resolved(
+        &self,
+    ) -> impl Iterator<Item = (&'a ServiceHash, &'a ServiceDescription)> {
+        self.hashes()
+            .filter_map(|hash| Some((hash, self.resolved_description(hash)?)))
+    }
+
+    /// Whether `hash` is offered and resolves to one description.
+    pub(crate) fn resolves(&self, hash: &ServiceHash) -> bool {
+        self.resolved_description(hash).is_some()
     }
 }
 
@@ -213,6 +293,430 @@ impl DiscoveryState {
         Snapshot {
             local: &self.local,
             remote: &self.remote,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use alloc::vec::Vec;
+    use iceoryx2::node::NodeBuilder;
+    use iceoryx2::service::local;
+    use iceoryx2::service::service_name::ServiceName;
+    use iceoryx2_bb_testing::assert_that;
+    use iceoryx2_gateway_backend::types::identity::{BACKEND_ID_LENGTH, BackendId};
+    use iceoryx2_gateway_backend::types::service_description::{
+        EventDescription, EventSettings, PatternDescription, PortSettings,
+    };
+
+    fn gateway_id(discriminator: u8) -> GatewayId {
+        let node = NodeBuilder::new()
+            .create::<local::Service>()
+            .expect("node creation succeeds");
+        let backend = BackendId::new([discriminator; BACKEND_ID_LENGTH]);
+        GatewayId::new(*node.id(), backend)
+    }
+
+    /// Two descriptions of the same service whose settings differ. They share
+    /// a hash but do not compare equal.
+    fn differing_descriptions(name: &str) -> (ServiceDescription, ServiceDescription) {
+        let default_settings = ServiceDescription::new::<local::Service>(
+            ServiceName::new(name).expect("valid service name"),
+            PatternDescription::Event(EventDescription {
+                settings: PortSettings::LocalDefaults,
+            }),
+        );
+        let custom_settings = ServiceDescription::new::<local::Service>(
+            ServiceName::new(name).expect("valid service name"),
+            PatternDescription::Event(EventDescription {
+                settings: PortSettings::Value(EventSettings {
+                    max_notifiers: 1,
+                    max_listeners: 1,
+                    max_nodes: 1,
+                    event_id_max_value: 1,
+                    deadline: None,
+                    notifier_created_event: None,
+                    notifier_dropped_event: None,
+                    notifier_dead_event: None,
+                }),
+            }),
+        );
+        (default_settings, custom_settings)
+    }
+
+    mod local_services {
+        use super::*;
+
+        mod force_update {
+            use super::*;
+
+            #[test]
+            fn tracks_additions_and_removals() {
+                let first = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/local/first").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+                let second = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/local/second").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+                let third = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/local/third").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+
+                let mut sut = LocalServices::default();
+                sut.force_update([first.clone(), second.clone()].into_iter());
+                assert_that!(sut.contains(&first.service_hash), eq true);
+                assert_that!(sut.contains(&second.service_hash), eq true);
+                assert_that!(sut.contains(&third.service_hash), eq false);
+
+                sut.force_update([second.clone(), third.clone()].into_iter());
+                assert_that!(sut.contains(&first.service_hash), eq false);
+                assert_that!(sut.contains(&second.service_hash), eq true);
+                assert_that!(sut.contains(&third.service_hash), eq true);
+            }
+
+            #[test]
+            fn empty_target_removes_all_services() {
+                let first = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/local/clear-first").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+                let second = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/local/clear-second").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+
+                let mut sut = LocalServices::default();
+                sut.force_update([first.clone(), second.clone()].into_iter());
+                sut.force_update(core::iter::empty::<ServiceDescription>());
+
+                assert_that!(sut.contains(&first.service_hash), eq false);
+                assert_that!(sut.contains(&second.service_hash), eq false);
+            }
+
+            #[test]
+            fn latest_description_wins() {
+                let (stored, updated) = differing_descriptions("state/local/force-latest");
+
+                let mut sut = LocalServices::default();
+                sut.force_update([stored].into_iter());
+                sut.force_update([updated.clone()].into_iter());
+
+                let (_, kept) = sut.iter().next().expect("service is offered");
+                assert_that!(*kept, eq updated);
+            }
+        }
+
+        mod delta_update {
+            use super::*;
+
+            #[test]
+            fn tracks_additions_and_removals() {
+                let first = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/local/delta-first").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+                let second = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/local/delta-second").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+
+                let mut sut = LocalServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(first.clone());
+                update.set_offered(second.clone());
+                assert_that!(sut.contains(&first.service_hash), eq true);
+                assert_that!(sut.contains(&second.service_hash), eq true);
+
+                sut.delta_update().set_not_offered(&first.service_hash);
+                assert_that!(sut.contains(&first.service_hash), eq false);
+                assert_that!(sut.contains(&second.service_hash), eq true);
+            }
+
+            #[test]
+            fn latest_description_wins() {
+                let (stored, updated) = differing_descriptions("state/local/delta-latest");
+
+                let mut sut = LocalServices::default();
+                sut.delta_update().set_offered(stored);
+                sut.delta_update().set_offered(updated.clone());
+
+                let (_, kept) = sut.iter().next().expect("service is offered");
+                assert_that!(*kept, eq updated);
+            }
+        }
+    }
+
+    mod remote_services {
+        use super::*;
+
+        /// The description `hash` resolves to in `sut`, if it is offered
+        /// and its offers resolve.
+        fn resolved_description<'a>(
+            sut: &'a RemoteServices,
+            hash: &ServiceHash,
+        ) -> Option<&'a ServiceDescription> {
+            sut.descriptions(hash)?.resolve()
+        }
+
+        mod delta_update {
+            use super::*;
+
+            #[test]
+            fn tracks_additions_and_removals() {
+                let gateway = gateway_id(1);
+                let first = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/remote/delta-first").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+                let second = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/remote/delta-second").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+
+                let mut sut = RemoteServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(gateway, &first);
+                update.set_offered(gateway, &second);
+                assert_that!(resolved_description(&sut, &first.service_hash), is_some);
+                assert_that!(resolved_description(&sut, &second.service_hash), is_some);
+
+                sut.delta_update()
+                    .set_not_offered(&gateway, &first.service_hash);
+                assert_that!(resolved_description(&sut, &first.service_hash), is_none);
+                assert_that!(resolved_description(&sut, &second.service_hash), is_some);
+            }
+
+            #[test]
+            fn stops_tracking_only_on_matching_hash_and_gateway_id() {
+                let offering_gateway = gateway_id(1);
+                let other_gateway = gateway_id(2);
+                let description = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/remote/no-op").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+                let hash = description.service_hash;
+                let unknown_hash = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/remote/unknown").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                )
+                .service_hash;
+
+                let mut sut = RemoteServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(offering_gateway, &description);
+                update.set_not_offered(&other_gateway, &hash);
+                update.set_not_offered(&offering_gateway, &unknown_hash);
+
+                assert_that!(resolved_description(&sut, &hash), is_some);
+            }
+
+            #[test]
+            fn tracked_services_remain_until_last_gateway_withdraws() {
+                let gateway_a = gateway_id(1);
+                let gateway_b = gateway_id(2);
+                let description = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/remote/refcount").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+                let hash = description.service_hash;
+
+                let mut sut = RemoteServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(gateway_a, &description);
+                update.set_offered(gateway_b, &description);
+                assert_that!(resolved_description(&sut, &hash), is_some);
+
+                sut.delta_update().set_not_offered(&gateway_a, &hash);
+                assert_that!(resolved_description(&sut, &hash), is_some);
+
+                sut.delta_update().set_not_offered(&gateway_b, &hash);
+                assert_that!(resolved_description(&sut, &hash), is_none);
+            }
+
+            #[test]
+            fn conflicting_descriptions_hide_the_service() {
+                let gateway_a = gateway_id(1);
+                let gateway_b = gateway_id(2);
+                let (stored, conflicting) = differing_descriptions("state/remote/conflict");
+                assert_that!(conflicting.service_hash, eq stored.service_hash);
+                assert_that!(conflicting, ne stored);
+
+                let mut sut = RemoteServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(gateway_a, &stored);
+                update.set_offered(gateway_b, &conflicting);
+
+                assert_that!(resolved_description(&sut, &stored.service_hash), is_none);
+                assert_that!(
+                    sut.iter()
+                        .filter_map(|(_, descriptions)| descriptions.resolve())
+                        .count(),
+                    eq 0
+                );
+            }
+
+            #[test]
+            fn conflict_clears_when_a_disagreeing_gateway_withdraws() {
+                let gateway_a = gateway_id(1);
+                let gateway_b = gateway_id(2);
+                let (stored, conflicting) = differing_descriptions("state/remote/conflict-clears");
+                let hash = stored.service_hash;
+
+                let mut sut = RemoteServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(gateway_a, &stored);
+                update.set_offered(gateway_b, &conflicting);
+
+                // Both gateways count as offerers. Withdrawal of one restores
+                // the other's offer instead of dropping the service.
+                sut.delta_update().set_not_offered(&gateway_a, &hash);
+                let kept = resolved_description(&sut, &hash).expect("service is offered");
+                assert_that!(*kept, eq conflicting);
+
+                sut.delta_update().set_not_offered(&gateway_b, &hash);
+                assert_that!(resolved_description(&sut, &hash), is_none);
+            }
+
+            #[test]
+            fn reannouncement_replaces_the_gateways_offer() {
+                let gateway = gateway_id(1);
+                let (stored, updated) = differing_descriptions("state/remote/reannounce");
+
+                let mut sut = RemoteServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(gateway, &stored);
+                update.set_offered(gateway, &updated);
+
+                let kept =
+                    resolved_description(&sut, &stored.service_hash).expect("service is offered");
+                assert_that!(*kept, eq updated);
+            }
+
+            #[test]
+            fn repeated_offer_from_same_gateway_is_idempotent() {
+                let gateway = gateway_id(1);
+                let description = ServiceDescription::new::<local::Service>(
+                    ServiceName::new("state/remote/idempotent").expect("valid service name"),
+                    PatternDescription::Event(EventDescription {
+                        settings: PortSettings::LocalDefaults,
+                    }),
+                );
+                let hash = description.service_hash;
+
+                let mut sut = RemoteServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(gateway, &description);
+                update.set_offered(gateway, &description);
+                update.set_not_offered(&gateway, &hash);
+
+                assert_that!(resolved_description(&sut, &hash), is_none);
+            }
+        }
+    }
+
+    mod snapshot {
+        use super::*;
+
+        #[test]
+        fn contains_services_offered_by_either_side() {
+            let gateway = gateway_id(1);
+            let local_offer = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/snapshot/local-only").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::LocalDefaults,
+                }),
+            );
+            let remote_offer = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/snapshot/remote-only").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::LocalDefaults,
+                }),
+            );
+            let unknown = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/snapshot/unknown").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::LocalDefaults,
+                }),
+            );
+
+            let mut state = DiscoveryState::default();
+            state
+                .local_mut()
+                .delta_update()
+                .set_offered(local_offer.clone());
+            state
+                .remote_mut()
+                .delta_update()
+                .set_offered(gateway, &remote_offer);
+
+            let snapshot = state.snapshot();
+            assert_that!(snapshot.resolves(&local_offer.service_hash), eq true);
+            assert_that!(snapshot.resolves(&remote_offer.service_hash), eq true);
+            assert_that!(snapshot.resolves(&unknown.service_hash), eq false);
+        }
+
+        #[test]
+        fn consolidates_services_offered_both_locally_and_remotely() {
+            let gateway = gateway_id(1);
+            let (shared_local, shared_remote) = differing_descriptions("state/snapshot/shared");
+            let remote_only = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/snapshot/remote-only").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::LocalDefaults,
+                }),
+            );
+
+            let mut state = DiscoveryState::default();
+            state
+                .local_mut()
+                .delta_update()
+                .set_offered(shared_local.clone());
+            let mut remote_update = state.remote_mut().delta_update();
+            remote_update.set_offered(gateway, &shared_remote);
+            remote_update.set_offered(gateway, &remote_only);
+
+            let snapshot = state.snapshot();
+            let offered: Vec<ServiceHash> = snapshot.resolved().map(|(hash, _)| *hash).collect();
+            assert_that!(offered, len 2);
+            assert_that!(offered.contains(&shared_local.service_hash), eq true);
+            assert_that!(offered.contains(&remote_only.service_hash), eq true);
+
+            // The local description shadows the remote one.
+            let stored = snapshot
+                .resolved()
+                .find(|(hash, _)| **hash == shared_local.service_hash)
+                .map(|(_, description)| description.clone())
+                .expect("shared service is offered");
+            assert_that!(stored, eq shared_local);
         }
     }
 }

--- a/iceoryx2-gateway/gateway/src/discovery/state.rs
+++ b/iceoryx2-gateway/gateway/src/discovery/state.rs
@@ -14,7 +14,53 @@ use alloc::collections::BTreeMap;
 
 use iceoryx2::service::service_hash::ServiceHash;
 use iceoryx2_gateway_backend::types::identity::GatewayId;
-use iceoryx2_gateway_backend::types::service_description::ServiceDescription;
+use iceoryx2_gateway_backend::types::service_description::{
+    EventSettings, PatternDescription, PortSettings, PublishSubscribeSettings, ServiceDescription,
+};
+
+/// The settings a service created with the local config receives when
+/// none are specified.
+#[derive(Debug, Clone)]
+struct DefaultSettings {
+    publish_subscribe: PublishSubscribeSettings,
+    event: EventSettings,
+}
+
+impl DefaultSettings {
+    fn from_config(config: &iceoryx2::config::Config) -> Self {
+        Self {
+            publish_subscribe: PublishSubscribeSettings::from_config(config),
+            event: EventSettings::from_config(config),
+        }
+    }
+}
+
+impl Default for DefaultSettings {
+    fn default() -> Self {
+        Self::from_config(&iceoryx2::config::Config::default())
+    }
+}
+
+/// Returns `description` in its explicit representation, `LocalDefaults`
+/// replaced by the values of `defaults`.
+fn normalize_settings(
+    mut description: ServiceDescription,
+    defaults: &DefaultSettings,
+) -> ServiceDescription {
+    match &mut description.pattern {
+        PatternDescription::PublishSubscribe(pattern) => {
+            if let PortSettings::LocalDefaults = pattern.settings {
+                pattern.settings = PortSettings::Value(defaults.publish_subscribe.clone());
+            }
+        }
+        PatternDescription::Event(pattern) => {
+            if let PortSettings::LocalDefaults = pattern.settings {
+                pattern.settings = PortSettings::Value(defaults.event.clone());
+            }
+        }
+    }
+    description
+}
 
 /// The local description of a service as seen on a specific update epoch.
 #[derive(Debug)]
@@ -41,12 +87,14 @@ pub(crate) struct LocalServices {
     offered: BTreeMap<ServiceHash, LocalDescription>,
     // The current update epoch.
     epoch: u64,
+    defaults: DefaultSettings,
 }
 
 impl LocalServices {
     /// Records `description` as offered, stamping it with `epoch`. The caller                                                                                                                                                                                                                              ║
     /// passes its session epoch so all updates in a session share one stamp.
     fn insert(&mut self, description: ServiceDescription, epoch: u64) {
+        let description = normalize_settings(description, &self.defaults);
         self.offered.insert(
             description.service_hash,
             LocalDescription {
@@ -173,15 +221,17 @@ impl RemoteDescriptions {
 #[derive(Debug, Default)]
 pub(crate) struct RemoteServices {
     services: BTreeMap<ServiceHash, RemoteDescriptions>,
+    defaults: DefaultSettings,
 }
 
 impl RemoteServices {
     /// Records `gateway` as offering `description`.
     fn insert(&mut self, gateway: GatewayId, description: &ServiceDescription) {
+        let description = normalize_settings(description.clone(), &self.defaults);
         self.services
             .entry(description.service_hash)
             .or_default()
-            .insert(gateway, description.clone());
+            .insert(gateway, description);
     }
 
     /// Removes `gateway` from the gateways offering `hash`. The service is
@@ -313,6 +363,22 @@ pub(crate) struct DiscoveryState {
 }
 
 impl DiscoveryState {
+    /// Creates a state whose entering descriptions have `LocalDefaults`
+    /// resolved against `config`.
+    pub(crate) fn new(config: &iceoryx2::config::Config) -> Self {
+        let defaults = DefaultSettings::from_config(config);
+        Self {
+            local: LocalServices {
+                defaults: defaults.clone(),
+                ..LocalServices::default()
+            },
+            remote: RemoteServices {
+                defaults,
+                ..RemoteServices::default()
+            },
+        }
+    }
+
     pub(crate) fn local(&self) -> &LocalServices {
         &self.local
     }
@@ -677,6 +743,64 @@ mod tests {
 
                 assert_that!(resolved_description(&sut, &hash), is_none);
             }
+        }
+    }
+
+    mod defaults {
+        use super::*;
+
+        #[test]
+        fn local_defaults_resolve_to_the_config_values_on_entry() {
+            let spelled_default = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/defaults/resolve").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::LocalDefaults,
+                }),
+            );
+
+            let mut sut = LocalServices::default();
+            sut.delta_update().set_offered(spelled_default);
+
+            let (_, stored) = sut.iter().next().expect("service is offered");
+            let PatternDescription::Event(description) = &stored.pattern else {
+                panic!("expected an event pattern description");
+            };
+            let expected = PortSettings::Value(EventSettings::from_config(
+                &iceoryx2::config::Config::default(),
+            ));
+            assert_that!(description.settings, eq expected);
+        }
+
+        #[test]
+        fn differing_representations_of_default_settings_resolve() {
+            let gateway = gateway_id(1);
+            let spelled_default = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/defaults/spellings").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::LocalDefaults,
+                }),
+            );
+            let explicit_default = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/defaults/spellings").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::Value(EventSettings::from_config(
+                        &iceoryx2::config::Config::default(),
+                    )),
+                }),
+            );
+
+            let mut state = DiscoveryState::default();
+            state
+                .local_mut()
+                .delta_update()
+                .set_offered(spelled_default.clone());
+            state
+                .remote_mut()
+                .delta_update()
+                .set_offered(gateway, &explicit_default);
+
+            assert_that!(state.snapshot().resolves(&spelled_default.service_hash), eq true);
+            assert_that!(state.snapshot().conflicts().count(), eq 0);
         }
     }
 

--- a/iceoryx2-gateway/gateway/src/discovery/state.rs
+++ b/iceoryx2-gateway/gateway/src/discovery/state.rs
@@ -124,7 +124,7 @@ impl LocalDeltaUpdate<'_> {
 
 /// The set of descriptions for the same service offered remotely.
 #[derive(Debug, Default)]
-struct RemoteDescriptions {
+pub(crate) struct RemoteDescriptions {
     by_gateway: BTreeMap<GatewayId, ServiceDescription>,
 }
 
@@ -145,6 +145,11 @@ impl RemoteDescriptions {
         !self.by_gateway.is_empty()
     }
 
+    /// Iterate the descriptions offered by each gateway.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&GatewayId, &ServiceDescription)> {
+        self.by_gateway.iter()
+    }
+
     /// Resolve the set of remote descriptions of the same service to a single
     /// description, if possible.
     ///
@@ -156,6 +161,11 @@ impl RemoteDescriptions {
         descriptions
             .all(|description| description == first)
             .then_some(first)
+    }
+
+    /// Whether the descriptions resolve to exactly `description`.
+    fn resolves_to(&self, description: &ServiceDescription) -> bool {
+        self.resolve() == Some(description)
     }
 }
 
@@ -222,6 +232,17 @@ impl RemoteDeltaUpdate<'_> {
     }
 }
 
+/// A service whose sources disagree on its description.
+#[derive(Debug)]
+pub(crate) struct Conflict<'a> {
+    pub(crate) hash: &'a ServiceHash,
+    /// The description offered locally, if the local system offers the
+    /// service.
+    pub(crate) local: Option<&'a ServiceDescription>,
+    /// The descriptions offered by remote gateways.
+    pub(crate) remote: &'a RemoteDescriptions,
+}
+
 /// A point-in-time view of all offered services.
 pub(crate) struct Snapshot<'a> {
     local: &'a LocalServices,
@@ -240,15 +261,15 @@ impl<'a> Snapshot<'a> {
     }
 
     /// Resolves the local description and remote descriptions of `hash` to
-    /// a single description if possible. The local description takes
-    /// precedence over the remote descriptions.
+    /// a single description if possible.
     ///
     /// Returns None if the descriptions cannot be resolved.
     fn resolved_description(&self, hash: &ServiceHash) -> Option<&'a ServiceDescription> {
         let local = self.local.description(hash);
         let remote = self.remote.descriptions(hash);
         match (local, remote) {
-            (Some(local), _) => Some(local),
+            (Some(local), None) => Some(local),
+            (Some(local), Some(remote)) => remote.resolves_to(local).then_some(local),
             (None, Some(remote)) => remote.resolve(),
             (None, None) => None,
         }
@@ -265,6 +286,22 @@ impl<'a> Snapshot<'a> {
     /// Whether `hash` is offered and resolves to one description.
     pub(crate) fn resolves(&self, hash: &ServiceHash) -> bool {
         self.resolved_description(hash).is_some()
+    }
+
+    /// The services whose sources do not agree on a service description.
+    pub(crate) fn conflicts(&self) -> impl Iterator<Item = Conflict<'a>> {
+        self.remote
+            .iter()
+            .filter_map(|(hash, remote_descriptions)| {
+                if self.resolves(hash) {
+                    return None;
+                }
+                Some(Conflict {
+                    hash,
+                    local: self.local.description(hash),
+                    remote: remote_descriptions,
+                })
+            })
     }
 }
 
@@ -685,9 +722,32 @@ mod tests {
         }
 
         #[test]
-        fn consolidates_services_offered_both_locally_and_remotely() {
+        fn consolidates_services_offered_identically_by_both_sides() {
             let gateway = gateway_id(1);
-            let (shared_local, shared_remote) = differing_descriptions("state/snapshot/shared");
+            let shared = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/snapshot/shared").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::LocalDefaults,
+                }),
+            );
+
+            let mut state = DiscoveryState::default();
+            state.local_mut().delta_update().set_offered(shared.clone());
+            state
+                .remote_mut()
+                .delta_update()
+                .set_offered(gateway, &shared);
+
+            let snapshot = state.snapshot();
+            assert_that!(snapshot.resolves(&shared.service_hash), eq true);
+            let offered: Vec<ServiceHash> = snapshot.resolved().map(|(hash, _)| *hash).collect();
+            assert_that!(offered, len 1);
+        }
+
+        #[test]
+        fn hides_services_with_disagreeing_local_and_remote_descriptions() {
+            let gateway = gateway_id(1);
+            let (local_offer, remote_offer) = differing_descriptions("state/snapshot/disagree");
             let remote_only = ServiceDescription::new::<local::Service>(
                 ServiceName::new("state/snapshot/remote-only").expect("valid service name"),
                 PatternDescription::Event(EventDescription {
@@ -699,24 +759,92 @@ mod tests {
             state
                 .local_mut()
                 .delta_update()
-                .set_offered(shared_local.clone());
+                .set_offered(local_offer.clone());
             let mut remote_update = state.remote_mut().delta_update();
-            remote_update.set_offered(gateway, &shared_remote);
+            remote_update.set_offered(gateway, &remote_offer);
             remote_update.set_offered(gateway, &remote_only);
 
             let snapshot = state.snapshot();
+            assert_that!(snapshot.resolves(&local_offer.service_hash), eq false);
             let offered: Vec<ServiceHash> = snapshot.resolved().map(|(hash, _)| *hash).collect();
-            assert_that!(offered, len 2);
-            assert_that!(offered.contains(&shared_local.service_hash), eq true);
+            assert_that!(offered, len 1);
             assert_that!(offered.contains(&remote_only.service_hash), eq true);
+        }
 
-            // The local description shadows the remote one.
-            let stored = snapshot
-                .resolved()
-                .find(|(hash, _)| **hash == shared_local.service_hash)
-                .map(|(_, description)| description.clone())
-                .expect("shared service is offered");
-            assert_that!(stored, eq shared_local);
+        #[test]
+        fn hides_services_with_disagreeing_remote_descriptions() {
+            let gateway_a = gateway_id(1);
+            let gateway_b = gateway_id(2);
+            let (first, second) = differing_descriptions("state/snapshot/remote-disagree");
+
+            let mut state = DiscoveryState::default();
+            let mut remote_update = state.remote_mut().delta_update();
+            remote_update.set_offered(gateway_a, &first);
+            remote_update.set_offered(gateway_b, &second);
+
+            let snapshot = state.snapshot();
+            assert_that!(snapshot.resolves(&first.service_hash), eq false);
+            assert_that!(snapshot.resolved().count(), eq 0);
+        }
+    }
+
+    mod conflicts {
+        use super::*;
+
+        #[test]
+        fn lists_services_with_disagreeing_sources() {
+            let gateway_a = gateway_id(1);
+            let gateway_b = gateway_id(2);
+            let (local_offer, remote_offer) = differing_descriptions("state/conflicts/with-local");
+            let (remote_first, remote_second) =
+                differing_descriptions("state/conflicts/remote-only");
+
+            let mut state = DiscoveryState::default();
+            state
+                .local_mut()
+                .delta_update()
+                .set_offered(local_offer.clone());
+            let mut remote_update = state.remote_mut().delta_update();
+            remote_update.set_offered(gateway_a, &remote_offer);
+            remote_update.set_offered(gateway_a, &remote_first);
+            remote_update.set_offered(gateway_b, &remote_second);
+
+            let conflicts: Vec<_> = state.snapshot().conflicts().collect();
+            assert_that!(conflicts, len 2);
+
+            let with_local = conflicts
+                .iter()
+                .find(|conflict| *conflict.hash == local_offer.service_hash)
+                .expect("conflict with the local side is listed");
+            assert_that!(with_local.local, is_some);
+            assert_that!(with_local.remote.iter().count(), eq 1);
+
+            let remote_only = conflicts
+                .iter()
+                .find(|conflict| *conflict.hash == remote_first.service_hash)
+                .expect("conflict among remotes is listed");
+            assert_that!(remote_only.local, is_none);
+            assert_that!(remote_only.remote.iter().count(), eq 2);
+        }
+
+        #[test]
+        fn sources_that_resolve_produce_no_conflicts() {
+            let gateway = gateway_id(1);
+            let shared = ServiceDescription::new::<local::Service>(
+                ServiceName::new("state/conflicts/resolve").expect("valid service name"),
+                PatternDescription::Event(EventDescription {
+                    settings: PortSettings::LocalDefaults,
+                }),
+            );
+
+            let mut state = DiscoveryState::default();
+            state.local_mut().delta_update().set_offered(shared.clone());
+            state
+                .remote_mut()
+                .delta_update()
+                .set_offered(gateway, &shared);
+
+            assert_that!(state.snapshot().conflicts().count(), eq 0);
         }
     }
 }

--- a/iceoryx2-gateway/gateway/src/discovery/state.rs
+++ b/iceoryx2-gateway/gateway/src/discovery/state.rs
@@ -72,14 +72,8 @@ impl LocalServices {
         DeltaUpdate { local: self, epoch }
     }
 
-    /// Forces the offered services to match an external target set, calling
-    /// the provided callbacks on addition or removal.
-    pub(crate) fn force_update<E>(
-        &mut self,
-        target: impl Iterator<Item = ServiceDescription>,
-        mut on_added: impl FnMut(&ServiceDescription) -> Result<(), E>,
-        mut on_removed: impl FnMut(&ServiceDescription) -> Result<(), E>,
-    ) -> Result<(), E> {
+    /// Forces the offered services to match an external target set.
+    pub(crate) fn force_update(&mut self, target: impl Iterator<Item = ServiceDescription>) {
         let epoch = self.next_epoch();
 
         for description in target {
@@ -87,23 +81,11 @@ impl LocalServices {
             if let Some(service) = self.offered.get_mut(&hash) {
                 service.last_seen = epoch;
             } else {
-                on_added(&description)?;
                 self.insert(description, epoch);
             }
         }
 
-        let mut result = Ok(());
-        self.offered.retain(|_, service| {
-            if service.last_seen == epoch {
-                true
-            } else {
-                if result.is_ok() {
-                    result = on_removed(&service.description);
-                }
-                false
-            }
-        });
-        result
+        self.offered.retain(|_, service| service.last_seen == epoch);
     }
 }
 

--- a/iceoryx2-gateway/gateway/src/discovery/state.rs
+++ b/iceoryx2-gateway/gateway/src/discovery/state.rs
@@ -252,6 +252,12 @@ impl RemoteServices {
         self.services.get(hash)
     }
 
+    /// Whether any gateway offers `hash`, regardless of whether the
+    /// descriptions resolve.
+    pub(crate) fn contains(&self, hash: &ServiceHash) -> bool {
+        self.services.contains_key(hash)
+    }
+
     /// Iterate all remote services and the offered descriptions.
     fn iter(&self) -> impl Iterator<Item = (&ServiceHash, &RemoteDescriptions)> {
         self.services.iter()
@@ -385,6 +391,10 @@ impl DiscoveryState {
 
     pub(crate) fn local_mut(&mut self) -> &mut LocalServices {
         &mut self.local
+    }
+
+    pub(crate) fn remote(&self) -> &RemoteServices {
+        &self.remote
     }
 
     pub(crate) fn remote_mut(&mut self) -> &mut RemoteServices {
@@ -707,6 +717,21 @@ mod tests {
 
                 sut.delta_update().set_not_offered(&gateway_b, &hash);
                 assert_that!(resolved_description(&sut, &hash), is_none);
+            }
+
+            #[test]
+            fn conflicted_services_still_tracked_as_offered() {
+                let gateway_a = gateway_id(1);
+                let gateway_b = gateway_id(2);
+                let (stored, conflicting) = differing_descriptions("state/remote/still-offered");
+
+                let mut sut = RemoteServices::default();
+                let mut update = sut.delta_update();
+                update.set_offered(gateway_a, &stored);
+                update.set_offered(gateway_b, &conflicting);
+
+                assert_that!(sut.contains(&stored.service_hash), eq true);
+                assert_that!(resolved_description(&sut, &stored.service_hash), is_none);
             }
 
             #[test]

--- a/iceoryx2-gateway/gateway/src/gateway.rs
+++ b/iceoryx2-gateway/gateway/src/gateway.rs
@@ -124,11 +124,12 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
         discovery_strategy: LocalDiscoveryStrategy<S>,
     ) -> Self {
         let gateway_id = GatewayId::new(*node.id(), backend.id());
+        let discovery_state = DiscoveryState::new(node.config());
         Self {
             node,
             backend,
             gateway_id,
-            discovery_state: DiscoveryState::default(),
+            discovery_state,
             bridges: Bridges::default(),
             discovery_strategy,
             announced: BTreeMap::new(),

--- a/iceoryx2-gateway/gateway/src/gateway.rs
+++ b/iceoryx2-gateway/gateway/src/gateway.rs
@@ -334,9 +334,18 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
 
         // Open bridges for newly-offered services.
         for (hash, description) in snapshot.resolved() {
-            if self.bridges.contains(hash) {
+            if self.bridges.is_established(hash) {
                 continue;
             }
+            // A failed bridge is not retried unless the service disappears
+            // and reappears.
+            if self.bridges.failed_description(hash) == Some(description) {
+                continue;
+            }
+            // Clear any previous failures that occured with a different
+            // description.
+            self.bridges.clear_failed(hash);
+
             info!(
                 from log_origin,
                 "Opening bridge: {}({})",
@@ -344,9 +353,6 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
                 description.name
             );
 
-            // Bridges that fail to be established are remembered so that subsequent
-            // discovery calls do not waste time retrying. If however the service
-            // disappears then reappears, a retry will occur.
             self.bridges.open(&self.node, &self.backend, description);
         }
     }
@@ -413,9 +419,9 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
             let snapshot = self.discovery_state.snapshot();
             let same_count =
                 self.bridges.number_of_tracked_services() == snapshot.resolved().count();
-            let all_services_tracked = snapshot
-                .resolved()
-                .all(|(hash, _)| self.bridges.contains(hash));
+            let all_services_tracked = snapshot.resolved().all(|(hash, _)| {
+                self.bridges.is_established(hash) || self.bridges.failed_description(hash).is_some()
+            });
 
             debug_assert!(
                 same_count && all_services_tracked,

--- a/iceoryx2-gateway/gateway/src/gateway.rs
+++ b/iceoryx2-gateway/gateway/src/gateway.rs
@@ -365,6 +365,10 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
             if !bridges.is_established(hash) || announced.contains_key(hash) {
                 continue;
             }
+            // Do not announce services already offered remotely.
+            if self.discovery_state.remote().contains(hash) {
+                continue;
+            }
             if let Err(error) = announce_added::<S, B>(node, backend, gateway_id, description) {
                 if result.is_ok() {
                     result = Err(error);

--- a/iceoryx2-gateway/gateway/src/gateway.rs
+++ b/iceoryx2-gateway/gateway/src/gateway.rs
@@ -268,9 +268,9 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
                 .filter(|details| is_locally_offered(details, node.id()))
                 .filter_map(|details| ServiceDescription::try_from(&details.static_details).ok())
                 .filter(|description| mapping.remote(description).is_some()),
-            |_| Ok(()),
-            |_| Ok(()),
-        )
+        );
+
+        Ok(())
     }
 
     /// Reconciles the bridges and announcements with the discovery state.

--- a/iceoryx2-gateway/gateway/src/gateway.rs
+++ b/iceoryx2-gateway/gateway/src/gateway.rs
@@ -173,17 +173,17 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
 
         let backend = &mut self.backend;
         let gateway_id = self.gateway_id;
-        let remote_discoveries = self.discovery_state.remote_mut();
+        let mut update = self.discovery_state.remote_mut().delta_update();
 
         fail!(
             from origin,
-            when backend.discovery().discover(gateway_id, |update| {
-                match update {
+            when backend.discovery().discover(gateway_id, |discovered| {
+                match discovered {
                     DiscoveryUpdate::Added(gateway, description) => {
-                        remote_discoveries.add(gateway, description);
+                        update.set_offered(gateway, &description);
                     }
                     DiscoveryUpdate::Removed(gateway, hash) => {
-                        remote_discoveries.remove(&gateway, &hash);
+                        update.set_not_offered(&gateway, &hash);
                     }
                 }
                 Ok::<(), DiscoveryError>(())
@@ -291,12 +291,12 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
 
         // Drop bridges to services no longer offered by any side.
         self.bridges.retain(
-            |hash| snapshot.contains(hash),
+            |hash| snapshot.resolves(hash),
             |hash| info!(from log_origin, "Closing bridge: {}", hash.as_str()),
         );
 
         // Open bridges for newly-offered services.
-        for (hash, description) in snapshot.iter() {
+        for (hash, description) in snapshot.resolved() {
             if self.bridges.contains(hash) {
                 continue;
             }
@@ -370,8 +370,11 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
         #[cfg(debug_assertions)]
         {
             let snapshot = self.discovery_state.snapshot();
-            let same_count = self.bridges.number_of_tracked_services() == snapshot.iter().count();
-            let all_services_tracked = snapshot.iter().all(|(hash, _)| self.bridges.contains(hash));
+            let same_count =
+                self.bridges.number_of_tracked_services() == snapshot.resolved().count();
+            let all_services_tracked = snapshot
+                .resolved()
+                .all(|(hash, _)| self.bridges.contains(hash));
 
             debug_assert!(
                 same_count && all_services_tracked,

--- a/iceoryx2-gateway/gateway/src/gateway.rs
+++ b/iceoryx2-gateway/gateway/src/gateway.rs
@@ -14,7 +14,8 @@ use core::fmt::Debug;
 
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::format;
-use alloc::string::String;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 use iceoryx2::identifiers::UniqueNodeId;
 use iceoryx2::node::{Node, NodeState, NodeView};
@@ -26,12 +27,12 @@ use iceoryx2_gateway_backend::traits::{Backend, Discovery, Mapping};
 use iceoryx2_gateway_backend::types::discovery::{Announcement, DiscoveryUpdate};
 use iceoryx2_gateway_backend::types::identity::GatewayId;
 use iceoryx2_gateway_backend::types::service_description::ServiceDescription;
-use iceoryx2_log::{debug, fail, info};
+use iceoryx2_log::{debug, error, fail, info};
 use iceoryx2_services_discovery::service_discovery::DiscoveryEvent;
 
 use crate::bridge::Bridges;
 use crate::discovery::LocalDiscoveryStrategy;
-use crate::discovery::state::DiscoveryState;
+use crate::discovery::state::{Conflict, DiscoveryState};
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum CreationError {
@@ -100,6 +101,7 @@ pub struct Gateway<S: Service, B: Backend<S> + Debug> {
     bridges: Bridges<S, B>,
     discovery_strategy: LocalDiscoveryStrategy<S>,
     announced: BTreeMap<ServiceHash, ServiceName>,
+    reported_conflicts: BTreeSet<ServiceHash>,
 }
 
 impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
@@ -130,6 +132,7 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
             bridges: Bridges::default(),
             discovery_strategy,
             announced: BTreeMap::new(),
+            reported_conflicts: BTreeSet::new(),
         }
     }
 
@@ -275,12 +278,45 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
 
     /// Reconciles the bridges and announcements with the discovery state.
     fn reconcile(&mut self) -> Result<(), DiscoveryError> {
+        self.report_conflicts();
+
         // Removals announced first to minimize window for remote services
         // to communicate with a service no longer offered.
         let removals = self.announce_removals();
         self.reconcile_bridges();
         let additions = self.announce_additions();
         removals.and(additions)
+    }
+
+    /// Reports changes in the set of services whose sources disagree on a
+    /// description. A conflict is reported once when it appears and once
+    /// when it clears.
+    fn report_conflicts(&mut self) {
+        let origin = format!("Gateway({})::report_conflicts", self.node.id());
+
+        let snapshot = self.discovery_state.snapshot();
+        let current: BTreeSet<ServiceHash> = snapshot
+            .conflicts()
+            .map(|conflict| *conflict.hash)
+            .collect();
+
+        let appeared = snapshot
+            .conflicts()
+            .filter(|conflict| !self.reported_conflicts.contains(conflict.hash));
+        for conflict in appeared {
+            report_conflict(&origin, &conflict);
+        }
+
+        let cleared = self.reported_conflicts.difference(&current);
+        for hash in cleared {
+            info!(
+                from origin,
+                "Description conflict resolved for service {}",
+                hash.as_str()
+            );
+        }
+
+        self.reported_conflicts = current;
     }
 
     /// Reconciles the opened bridges with a snapshot of the discovery state.
@@ -382,6 +418,32 @@ impl<S: Service, B: Backend<S> + Debug> Gateway<S, B> {
             );
         }
     }
+}
+
+/// Logs a service whose sources disagree on its description.
+fn report_conflict(origin: &str, conflict: &Conflict) {
+    let Some((_, description)) = conflict.remote.iter().next() else {
+        return;
+    };
+    let gateways = conflict
+        .remote
+        .iter()
+        .map(|(gateway, _)| gateway.to_string())
+        .collect::<Vec<String>>()
+        .join(", ");
+    let locally = if conflict.local.is_some() {
+        " and locally"
+    } else {
+        ""
+    };
+    error!(
+        from origin,
+        "Service {} is offered with conflicting descriptions by gateway(s) {}{}. \
+        It is not bridged until the configurations are aligned",
+        description.name,
+        gateways,
+        locally
+    );
 }
 
 /// Broadcasts a service's availability to remote peers over the backend.

--- a/integrations/zenoh/gateway-backend/src/discovery.rs
+++ b/integrations/zenoh/gateway-backend/src/discovery.rs
@@ -66,6 +66,10 @@ impl core::error::Error for DiscoveryError {}
 // A local service announced to be remotely discoverable.
 #[derive(Debug)]
 struct AnnouncedService {
+    // The service as offered locally.
+    description: ServiceDescription,
+    // The descriptor the service is announced under.
+    descriptor: ServiceDescriptor,
     // A liveliness token which zenoh makes visible to all remotes. Declaring
     // it triggers a `Put` event, dropping it triggers a `Delete` event.
     _token: LivelinessToken,
@@ -105,6 +109,15 @@ impl LocalAnnouncements {
     /// Remove a local service that had been announced from the tracked set.
     fn remove(&mut self, local_hash: &ServiceHash) {
         self.services.remove(local_hash);
+    }
+
+    /// The local description of the service announced under `descriptor`,
+    /// if any.
+    fn announced_under(&self, descriptor: &ServiceDescriptor) -> Option<&ServiceDescription> {
+        self.services
+            .values()
+            .find(|service| service.descriptor == *descriptor)
+            .map(|service| &service.description)
     }
 }
 
@@ -348,6 +361,8 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
         self.local_announcements.insert(
             local_hash,
             AnnouncedService {
+                description: local_description.clone(),
+                descriptor,
                 _token: token,
                 _queryable: queryable,
             },
@@ -485,11 +500,17 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
         E: core::error::Error,
         F: FnMut(DiscoveryUpdate) -> Result<(), E>,
     {
-        // Track the discovered description. Request it if not yet known.
+        // Track the discovered service. Request the description if not
+        // already known.
         if !self.remote_descriptions.contains(&remote_descriptor) {
-            let query = self.request_service_description(&remote_descriptor)?;
+            let description = match self.local_announcements.announced_under(&remote_descriptor) {
+                Some(local_description) => RemoteDescription::Resolved(local_description.clone()),
+                None => RemoteDescription::Pending(
+                    self.request_service_description(&remote_descriptor)?,
+                ),
+            };
             self.remote_descriptions
-                .set(remote_descriptor.clone(), RemoteDescription::Pending(query));
+                .set(remote_descriptor.clone(), description);
         }
 
         // Track that the gateway is offering the description.

--- a/integrations/zenoh/gateway-backend/src/discovery.rs
+++ b/integrations/zenoh/gateway-backend/src/discovery.rs
@@ -150,12 +150,30 @@ impl RemoteOffers {
         self.gateways.contains_key(remote_descriptor)
     }
 
+    /// Returns true if `gateway` offers the description.
+    fn is_offered_by(&self, remote_descriptor: &ServiceDescriptor, gateway: &GatewayId) -> bool {
+        self.gateways
+            .get(remote_descriptor)
+            .is_some_and(|gateways| gateways.contains(gateway))
+    }
+
     /// The gateways offering the description.
     fn gateways(&self, remote_descriptor: &ServiceDescriptor) -> Vec<GatewayId> {
         self.gateways
             .get(remote_descriptor)
             .map(|gateways| gateways.iter().copied().collect())
             .unwrap_or_default()
+    }
+
+    /// The offered descriptors of the service with `remote_hash`. More than
+    /// one means the service is announced with conflicting descriptions.
+    fn descriptors_of(
+        &self,
+        remote_hash: &ServiceHash,
+    ) -> impl Iterator<Item = &ServiceDescriptor> {
+        self.gateways
+            .keys()
+            .filter(move |descriptor| descriptor.service_hash == *remote_hash)
     }
 }
 
@@ -529,6 +547,20 @@ impl<S: Service, M: Mapping<EndpointDescription = ServiceDescription>> Discovery
             self.remote_descriptions.remove(&remote_descriptor);
         }
 
+        // A gateway that re-announced the service under another description
+        // had its offer replaced when that description was resolved. Its
+        // stale token must not withdraw the new offer.
+        let offer_replaced = self
+            .remote_offers
+            .descriptors_of(&remote_descriptor.service_hash)
+            .any(|descriptor| {
+                self.remote_offers.is_offered_by(descriptor, &gateway)
+                    && self.remote_descriptions.resolved(descriptor).is_some()
+            });
+        if offer_replaced {
+            return Ok(());
+        }
+
         // Provide the update to the caller.
         if let Some(local_hash) = local_hash {
             fail!(
@@ -737,8 +769,8 @@ mod tests {
             assert_that!(sut.add(descriptor.clone(), first), eq false);
             assert_that!(sut.add(descriptor.clone(), second), eq true);
 
-            assert_that!(sut.is_offered(&descriptor), eq true);
-            assert_that!(sut.gateways(&descriptor), len 2);
+            assert_that!(sut.is_offered_by(&descriptor, &first), eq true);
+            assert_that!(sut.is_offered_by(&descriptor, &second), eq true);
         }
 
         #[test]
@@ -754,6 +786,24 @@ mod tests {
             assert_that!(sut.remove(&descriptor, &gateway), eq true);
             assert_that!(sut.is_offered(&descriptor), eq false);
             assert_that!(sut.remove(&descriptor, &gateway), eq false);
+        }
+
+        #[test]
+        fn descriptors_of_yields_every_descriptor_of_the_service() {
+            let gateway = gateway_id(1);
+            let (first, second) = differing_descriptions("discovery/two-descriptors");
+            let (other, _) = differing_descriptions("discovery/other-service");
+
+            let mut sut = RemoteOffers::new();
+            sut.add(describe(&first).expect("description is encodable"), gateway);
+            sut.add(
+                describe(&second).expect("description is encodable"),
+                gateway,
+            );
+            sut.add(describe(&other).expect("description is encodable"), gateway);
+
+            assert_that!(sut.descriptors_of(&first.service_hash).count(), eq 2);
+            assert_that!(sut.descriptors_of(&other.service_hash).count(), eq 1);
         }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->

Updates the gateway to resolve different configurations for the same service on different hosts. For now, all hosts **must have the same settings** for a service with the same `ServiceHash`.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [x] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1964 <!-- Add issue number after '#' -->

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
