### PR TITLE
[#1967] Remove leftover port_tag files during dead-node cleanup

### DIFF
--- a/iceoryx2/src/node/mod.rs
+++ b/iceoryx2/src/node/mod.rs
@@ -664,7 +664,23 @@ impl<Service: service::Service> DeadNodeView<Service> {
         // now, everything not belonging to a service can be removed
         match Node::<Service>::port_tags(config, self.id(), |port_id| {
             match unsafe { remove_stale_port_resources::<Service>(self.id(), port_id, config) } {
-                Ok(()) => CallbackProgression::Continue,
+                Ok(()) => {
+                    // Remove the port tag file explicitly. For a dead node with
+                    // no registered services, the service cleanup path never runs
+                    // and would otherwise leavethe tag file behind, preventing the node directory
+                    // removal (`RemoveDirectoryA` -> ERROR_DIR_NOT_EMPTY).
+                    if let Ok(tag_name) = FileName::new(port_id.to_string().as_bytes()) {
+                        if let Err(e) = unsafe {
+                            <Service::StaticStorage as NamedConceptMgmt>::remove_cfg(
+                                &tag_name,
+                                &port_tag_config::<Service>(config, self.id()),
+                            )
+                        } {
+                            debug!(from self, "Unable to remove port tag {port_id}: {e:?}");
+                        }
+                    }
+                    CallbackProgression::Continue
+                }
                 Err(RemoveStalePortResourcesError::InsufficientPermissions) => {
                     cleanup_failure = Err(NodeCleanupFailure::InsufficientPermissions);
                     debug!(from self,


### PR DESCRIPTION
Dead nodes without registered services (e.g., pure consumers) never had their port_tag files removed: tag removal only happened through the service removal path, which is skipped for service-less nodes. The node directory therefore stayed non-empty and remove_node() failed with ERROR_DIR_NOT_EMPTY.

This patch explicitly removes the port_tag file in remove_stale_resources_impl() after the port resources are cleaned, so the node directory can be removed completely.