### PR TITLE
[#1969] Release request resources after failed delivery

### DIFF
--- a/doc/release-notes/iceoryx2-unreleased.md
+++ b/doc/release-notes/iceoryx2-unreleased.md
@@ -71,6 +71,7 @@
 * [#1924](https://github.com/eclipse-iceoryx/iceoryx2/issues/1924) Ensure discovery service node resources are removed during shutdown.
 * [#1940](https://github.com/eclipse-iceoryx/iceoryx2/issues/1940) Fix private rustdoc link diagnostics.
 * [#1960](https://github.com/eclipse-iceoryx/iceoryx2/issues/1960) Validate type descriptions and payload layouts received over gateway backends
+* [#1969](https://github.com/eclipse-iceoryx/iceoryx2/issues/1969) Release active-request capacity and close response channels when request delivery fails.
 * [#1971](https://github.com/eclipse-iceoryx/iceoryx2/issues/1971) Ensure destruction order even when service and node are explicitly dropped
 
 ### Refactoring

--- a/iceoryx2/conformance-tests/src/client.rs
+++ b/iceoryx2/conformance-tests/src/client.rs
@@ -637,6 +637,132 @@ pub mod client {
     }
 
     #[conformance_test]
+    pub fn failed_request_send_does_not_consume_active_request_capacity<Sut: Service>() {
+        for capacity in [1, 4] {
+            let test = Test::<Sut>::new();
+            let node = test.create_node();
+            let service = node
+                .service_builder(&generate_service_name())
+                .request_response::<u64, u64>()
+                .enable_safe_overflow_for_requests(false)
+                .enable_fire_and_forget_requests(true)
+                .max_active_requests_per_client(capacity)
+                .create()
+                .unwrap();
+            let server = service.server_builder().create().unwrap();
+            let sut = service
+                .client_builder()
+                .set_backpressure_handler(|_| BackpressureAction::DiscardDataAndFail)
+                .create()
+                .unwrap();
+            server.update_connections().unwrap();
+
+            for _ in 0..3 {
+                for value in 0..capacity {
+                    drop(sut.send_copy(value as u64).unwrap());
+                }
+
+                for _ in 0..capacity + 1 {
+                    assert_that!(sut.send_copy(123).err(),
+                        eq Some(RequestSendError::SendError(SendError::UnableToDeliver)));
+                }
+
+                for value in 0..capacity {
+                    assert_that!(*server.receive().unwrap().unwrap(), eq value as u64);
+                }
+
+                let pending = sut.send_copy(456).unwrap();
+                let request = server.receive().unwrap().unwrap();
+                assert_that!(*request, eq 456);
+                request.send_copy(789).unwrap();
+                assert_that!(*pending.receive().unwrap().unwrap(), eq 789);
+            }
+        }
+    }
+
+    #[conformance_test]
+    pub fn failed_request_send_closes_partially_delivered_response_channels<Sut: Service>() {
+        for fire_and_forget in [false, true] {
+            let test = Test::<Sut>::new();
+            let node = test.create_node();
+            let service = node
+                .service_builder(&generate_service_name())
+                .request_response::<u64, u64>()
+                .enable_safe_overflow_for_requests(false)
+                .enable_fire_and_forget_requests(fire_and_forget)
+                .max_active_requests_per_client(1)
+                .create()
+                .unwrap();
+            let slow_server = service.server_builder().create().unwrap();
+            let healthy_server = service.server_builder().create().unwrap();
+            let sut = service
+                .client_builder()
+                .set_backpressure_handler(|_| BackpressureAction::DiscardDataAndFail)
+                .create()
+                .unwrap();
+            slow_server.update_connections().unwrap();
+            healthy_server.update_connections().unwrap();
+
+            drop(sut.send_copy(1).unwrap());
+            drop(healthy_server.receive().unwrap());
+            assert_that!(sut.send_copy(2).err(),
+                eq Some(RequestSendError::SendError(SendError::UnableToDeliver)));
+
+            let delivered = healthy_server.receive().unwrap();
+            if fire_and_forget {
+                let request = delivered.unwrap();
+                assert_that!(*request, eq 2);
+                assert_that!(request.is_connected(), eq false);
+            } else {
+                assert_that!(delivered, is_none);
+            }
+        }
+    }
+
+    #[conformance_test]
+    pub fn failed_request_send_preserves_other_pending_responses<Sut: Service>() {
+        let test = Test::<Sut>::new();
+        let node = test.create_node();
+        let service = node
+            .service_builder(&generate_service_name())
+            .request_response::<u64, u64>()
+            .enable_safe_overflow_for_requests(false)
+            .enable_fire_and_forget_requests(true)
+            .max_active_requests_per_client(2)
+            .create()
+            .unwrap();
+        let server = service.server_builder().create().unwrap();
+        let sut = service
+            .client_builder()
+            .set_backpressure_handler(|_| BackpressureAction::DiscardDataAndFail)
+            .create()
+            .unwrap();
+        server.update_connections().unwrap();
+
+        let pending = sut.send_copy(1).unwrap();
+        drop(sut.send_copy(2).unwrap());
+        assert_that!(sut.send_copy(3).err(),
+            eq Some(RequestSendError::SendError(SendError::UnableToDeliver)));
+
+        let request = server.receive().unwrap().unwrap();
+        assert_that!(*request, eq 1);
+        assert_that!(request.is_connected(), eq true);
+        request.send_copy(11).unwrap();
+        assert_that!(*pending.receive().unwrap().unwrap(), eq 11);
+        drop(server.receive().unwrap().unwrap());
+
+        let recovered = sut.send_copy(4).unwrap();
+        let recovered_request = server.receive().unwrap().unwrap();
+        assert_that!(recovered_request.is_connected(), eq true);
+        recovered_request.send_copy(44).unwrap();
+        assert_that!(*recovered.receive().unwrap().unwrap(), eq 44);
+        assert_that!(sut.send_copy(5).err(), eq Some(RequestSendError::ExceedsMaxActiveRequests));
+
+        drop(pending);
+        assert_that!(sut.send_copy(6), is_ok);
+    }
+
+    #[conformance_test]
     pub fn client_with_backpressure_handler_follows_backpressure_strategy_with_discard_data<
         Sut: Service,
     >() {

--- a/iceoryx2/src/port/client.rs
+++ b/iceoryx2/src/port/client.rs
@@ -305,13 +305,23 @@ impl<Service: service::Service> ClientSharedState<Service> {
 
         self.prepare_channel_to_receive_responses(channel_id, request_id);
 
-        self.active_request_counter.fetch_add(1, Ordering::Relaxed);
-        Ok(self.request_sender.deliver_offset(
+        let number_of_recipients = match self.request_sender.deliver_offset(
             chunk,
             // All requests are delivered on the same channel, therefore we can use
             // ChannelId::new(0).
             ChannelId::new(0),
-        )?)
+        ) {
+            Ok(number_of_recipients) => number_of_recipients,
+            Err(error) => {
+                // No PendingResponse will be created to close this channel, even if
+                // the request reached some of the servers before delivery failed.
+                self.response_receiver.close_channel(channel_id, request_id);
+                return Err(error.into());
+            }
+        };
+
+        self.active_request_counter.fetch_add(1, Ordering::Relaxed);
+        Ok(number_of_recipients)
     }
 
     pub(crate) fn update_connections(


### PR DESCRIPTION
<!-- markdownlint-disable MD013 Line breaks on the bullet list lines are also present on the github renderer, therefore no line length limitation -->
<!-- markdownlint-disable MD041 On the github PR template we want to start with '## Headline' -->

## Notes for Reviewer
Failed request sends consume an active-request slot without creating a `PendingResponse`. After enough failures, the client cannot send again even when the server queue is drained. Requests delivered to another server also retain an open response channel.

Count active requests only after successful delivery and close the response channel on error. The tests cover repeated failures, partial delivery with and without fire-and-forget, and preservation of other pending responses.

All 12 new conformance cases fail on the original code. After rebasing onto `05a3a8fa`, all 3,104 conformance tests and 26 core tests pass on Linux, as do Clippy, formatting and a `--no-default-features` check. A separate IPC process test with two servers and 1, 8 or 32 clients passed 100 recovery cycles per configuration.

## Pre-Review Checklist for the PR Author

* [x] Add sensible notes for the reviewer
* [x] PR title is short, expressive and meaningful
* [ ] Consider switching the PR to a draft (`Convert to draft`)
    * as draft PR, the CI will be skipped for pushes
* [x] Relevant issues are linked in the [References](#references) section
* [x] Branch follows the naming format (`iox2-123-introduce-posix-ipc-example`)
* [x] Commits messages are according to this [guideline][commit-guidelines]
    * [x] Commit messages have the issue ID (`[#123] Add posix ipc example`)
    * Keep in mind to use the same email that was used to sign the [Eclipse Contributor Agreement][eca]
* [x] Tests follow the [best practice for testing][testing]
* [x] Changelog updated [in the unreleased section][changelog] including API breaking changes

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php
[testing]: https://github.com/eclipse-iceoryx/iceoryx/blob/master/doc/website/concepts/best-practice-for-testing.md
[changelog]: https://github.com/eclipse-iceoryx/iceoryx2/blob/main/doc/release-notes/iceoryx2-unreleased.md

## PR Reviewer Reminders

* Commits are properly organized and messages are according to the guideline
* Unit tests have been written for new behavior
* Public API is documented
* PR title describes the changes

## References

<!-- Use either 'Closes #123' or 'Relates to #123' to reference the corresponding issue. -->

Closes #1969

<!-- markdownlint-enable MD041 -->
<!-- markdownlint-enable MD013 -->
